### PR TITLE
Lined up description of arguments for clSetKernelArg with the order the arguments are passed in

### DIFF
--- a/opencl_runtime_layer.txt
+++ b/opencl_runtime_layer.txt
@@ -7044,6 +7044,16 @@ For example, consider the following kernel:
 Argument index values for image_filter will be 0 for n, 1 for m, 2 for
 filter_weights, 3 for src_image and 4 for dst_image.
 
+_arg_size_ specifies the size of the argument value. If the argument is
+a memory object, the size is the size of the memory object. For
+arguments declared with the local qualifier, the size specified will be
+the size in bytes of the buffer that must be allocated for the local
+argument. If the argument is of type _sampler_t_, the _arg_size_ value
+must be equal to sizeof(cl_sampler). If the argument is of type
+_queue_t_, the _arg_size_ value must be equal to
+sizeof(cl_command_queue). For all other arguments, the size will be the
+size of argument type.
+
 _arg_value_ is a pointer to data that should be used as the argument
 value for argument specified by _arg_index_. The argument data pointed
 to by_arg_value_ is copied and the _arg_value_ pointer can therefore be
@@ -7097,16 +7107,6 @@ _image2d_array_depth_t_.
 
 For all other kernel arguments, the _arg_value_ entry must be a pointer
 to the actual data to be used as argument value.
-
-_arg_size_ specifies the size of the argument value. If the argument is
-a memory object, the size is the size of the memory object. For
-arguments declared with the local qualifier, the size specified will be
-the size in bytes of the buffer that must be allocated for the local
-argument. If the argument is of type _sampler_t_, the _arg_size_ value
-must be equal to sizeof(cl_sampler). If the argument is of type
-_queue_t_, the _arg_size_ value must be equal to
-sizeof(cl_command_queue). For all other arguments, the size will be the
-size of argument type.
 
 NOTE: A kernel object does not update the reference count for objects
 such as memory, sampler objects specified as argument values by


### PR DESCRIPTION
For function

` cl_int clSetKernelArg ( 	cl_kernel kernel,
  	cl_uint arg_index,
  	size_t arg_size,
  	const void *arg_value)`

the arguments are described in the following order

- kernel
- arg_index
- arg_value
- arg_size

I've just changed the order of the descriptions to match the actual order of the arguments

- kernel
- arg_index
- arg_size
- arg_value