### PR TITLE
describe clSetKernelArg arguments in the order they are passed

### DIFF
--- a/api/opencl_runtime_layer.txt
+++ b/api/opencl_runtime_layer.txt
@@ -6746,9 +6746,21 @@ kernel void image_filter (int n,
 Argument index values for `image_filter` will be 0 for `n`, 1 for `m`, 2 for
 `filter_weights`, 3 for `src_image` and 4 for `dst_image`.
 
+_arg_size_ specifies the size of the argument value.
+If the argument is a memory object, the size is the size of the memory
+object.
+For arguments declared with the `local` qualifier, the size specified will
+be the size in bytes of the buffer that must be allocated for the `local`
+argument.
+If the argument is of type _sampler_t_, the _arg_size_ value must be equal
+to `sizeof(cl_sampler)`.
+If the argument is of type _queue_t_, the _arg_size_ value must be equal to
+`sizeof(cl_command_queue)`.
+For all other arguments, the size will be the size of argument type.
+
 _arg_value_ is a pointer to data that should be used as the argument value
 for argument specified by _arg_index_.
-The argument data pointed to by_arg_value_ is copied and the _arg_value_
+The argument data pointed to by _arg_value_ is copied and the _arg_value_
 pointer can therefore be reused by the application after *clSetKernelArg*
 returns.
 The argument value specified is the value used by all API calls that enqueue
@@ -6804,18 +6816,6 @@ type _image2d_array_depth_t_.
 
 For all other kernel arguments, the _arg_value_ entry must be a pointer to
 the actual data to be used as argument value.
-
-_arg_size_ specifies the size of the argument value.
-If the argument is a memory object, the size is the size of the memory
-object.
-For arguments declared with the `local` qualifier, the size specified will
-be the size in bytes of the buffer that must be allocated for the `local`
-argument.
-If the argument is of type _sampler_t_, the _arg_size_ value must be equal
-to `sizeof(cl_sampler)`.
-If the argument is of type _queue_t_, the _arg_size_ value must be equal to
-`sizeof(cl_command_queue)`.
-For all other arguments, the size will be the size of argument type.
 
 [NOTE]
 ====


### PR DESCRIPTION
This change is an updated version of the very old pull request #2.

It's been updated to work with the newer asciidoctor toolchain.  If/when this change is accepted we can close PR #2 as well.