### PR TITLE
minor formatting fixes in OpenCL API and OpenCL C

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -20,6 +20,15 @@ Khronos{R} OpenCL Working Group
 // Needed for expressing C math in unary ops section
 :pp: ++
 
+:private: pass:[__private]
+:global: pass:[__global]
+:local: pass:[__local]
+:constant: pass:[__constant]
+:rte: pass:[_rte]
+:rtz: pass:[_rtz]
+:rtn: pass:[_rtn]
+:rtp: pass:[_rtp]
+
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
 
@@ -5045,8 +5054,8 @@ Specification>>.
 [cols=",",]
 |====
 | *Function* | *Description*
-| gentype__n__ **vload__n__**(size_t _offset_, const gentype *__p__) +
-  gentype__n__ **vload__n__**(size_t _offset_, const constant gentype *_p_)
+| gentype__n__ **vload__n__**(size_t _offset_, const gentype *_p_) +
+  gentype__n__ **vload__n__**(size_t _offset_, const {constant} gentype *_p_)
     | Return `sizeof(gentype__n__)` bytes of data, where the first `(__n__ *
       sizeof(gentype))` bytes are read from the address
       computed as `(_p_ {plus} (_offset_ * _n_))`.
@@ -5061,9 +5070,8 @@ Specification>>.
       `uchar`; 16-bit aligned if `gentype` is `short` or `ushort`; 32-bit
       aligned if `gentype` is `int`, `uint`, or `float`; and 64-bit aligned
       if `gentype` is `long` or `ulong`.
-| |
 | float **vload_half**(size_t _offset_, const half *_p_) +
-  float **vload_half**(size_t _offset_, const constant half *_p_)
+  float **vload_half**(size_t _offset_, const {constant} half *_p_)
     | Read `sizeof(half)` bytes of data from the address computed as `(_p_
       {plus} _offset_)`.
       The data read is interpreted as a `half` value.
@@ -5071,7 +5079,7 @@ Specification>>.
       is returned.
       The computed read address must be 16-bit aligned.
 | float__n__ **vload_half__n__**(size_t _offset_, const half *_p_) +
-  float__n__ **vload_half__n__**(size_t _offset_, const constant half *_p_)
+  float__n__ **vload_half__n__**(size_t _offset_, const {constant} half *_p_)
     | Read `(_n_ * sizeof(half))` bytes of data from the address computed as
       `(_p_ {plus} (_offset * n_))`.
       The data read is interpreted as a `half__n__` value.
@@ -5079,10 +5087,10 @@ Specification>>.
       the `float__n__` value is returned.
       The computed read address must be 16-bit aligned.
 | void **vstore_half**(float _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rte__**(float _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtz__**(float _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtp__**(float _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtn__**(float _data_, size_t _offset_, half *_p_)
+  void **vstore_half{rte}**(float _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtz}**(float _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtp}**(float _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtn}**(float _data_, size_t _offset_, half *_p_)
     | The `float` value given by _data_ is first converted to a `half` value
       using the appropriate rounding mode.
       The `half` value is then written to the address computed as `(_p_
@@ -5092,10 +5100,10 @@ Specification>>.
       *vstore_half* uses the default rounding mode.
       The default rounding mode is round to nearest even.
 | void **vstore_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rte__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtz__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtp__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtn__**(float__n__ _data_, size_t _offset_, half *_p_)
+  void **vstore_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtz}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtp}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtn}**(float__n__ _data_, size_t _offset_, half *_p_)
     | The `float__n__` value given by _data_ is converted to a `half__n__`
       value using the appropriate rounding mode.
       `_n_ * sizeof(half)` bytes from the `half__n__` value are then written to
@@ -5106,10 +5114,10 @@ Specification>>.
       *vstore_half__n__* uses the default rounding mode.
       The default rounding mode is round to nearest even.
 | void **vstore_half**(double _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rte__**(double _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtz__**(double _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtp__**(double _data_, size_t _offset_, half *_p_) +
-  void **vstore_half___rtn__**(double _data_, size_t _offset_, half *_p_)
+  void **vstore_half{rte}**(double _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtz}**(double _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtp}**(double _data_, size_t _offset_, half *_p_) +
+  void **vstore_half{rtn}**(double _data_, size_t _offset_, half *_p_)
     | The `double` value given by _data_ is first converted to a `half`
       value using the appropriate rounding mode.
       The `half` value is then written to the address computed as `(_p_
@@ -5119,10 +5127,10 @@ Specification>>.
       *vstore_half* uses the default rounding mode.
       The default rounding mode is round to nearest even.
 | void **vstore_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rte__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtz__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtp__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstore_half__n_rtn__**(double__n__ _data_, size_t _offset_, half *_p_)
+  void **vstore_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtz}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtp}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstore_half__n__{rtn}**(double__n__ _data_, size_t _offset_, half *_p_)
     | The `double__n__` value given by _data_ is converted to a `half__n__`
       value using the appropriate rounding mode.
       `_n_ * sizeof(half)` bytes from the `half__n__` value are then written to
@@ -5133,7 +5141,7 @@ Specification>>.
       The default rounding mode is round to nearest even.
 | |
 | float__n__ **vloada_half__n__**(size_t _offset_, const half *_p_) +
-  float__n__ **vloada_half__n__**(size_t _offset_, const constant half *_p_)
+  float__n__ **vloada_half__n__**(size_t _offset_, const {constant} half *_p_)
     | For n = 2, 4, 8 and 16, read `sizeof(half__n__)` bytes of data from
       the address computed as (_p_ + (_offset_ * _n_)).
       The data read is interpreted as a `half__n__` value.
@@ -5146,10 +5154,10 @@ Specification>>.
       The computed address must be aligned to `sizeof(half)` * 4 bytes.
 
 | void **vstorea_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rte__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtz__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtp__**(float__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtn__**(float__n__ _data_, size_t _offset_, half *_p_)
+  void **vstorea_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtz}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtp}**(float__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtn}**(float__n__ _data_, size_t _offset_, half *_p_)
     | The `float__n__` value given by _data_ is converted to a `half__n__`
       value using the appropriate rounding mode.
 
@@ -5164,10 +5172,10 @@ Specification>>.
       *vstorea_half__n__* uses the default rounding mode.
       The default rounding mode is round to nearest even.
 | void **vstorea_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rte__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtz__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtp__**(double__n__ _data_, size_t _offset_, half *_p_) +
-  void **vstorea_half__n_rtn__**(double__n__ _data_, size_t _offset_, half *_p_)
+  void **vstorea_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtz}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtp}**(double__n__ _data_, size_t _offset_, half *_p_) +
+  void **vstorea_half__n__{rtn}**(double__n__ _data_, size_t _offset_, half *_p_)
     | The `double__n__` value is converted to a `half__n__` value using the
       appropriate rounding mode.
 
@@ -7975,10 +7983,10 @@ type for the arguments.
       a non-zero value if _predicate_ evaluates to non-zero for any
       work-items in the work-group.
 | gentype *work_group_broadcast*(gentype _a_, size_t _local_id_) +
-  gentype *work_group_broadcast*(gentype _a_, size_t _local_id__x,
+  gentype *work_group_broadcast*(gentype _a_, size_t _local_id_x_,
   size_t _local_id_y_) +
-  gentype *work_group_broadcast*(gentype _a_, size_t _local_id__x,
-  size_t _local_id__y, size_t _local_id_z_)
+  gentype *work_group_broadcast*(gentype _a_, size_t _local_id_x_,
+  size_t _local_id_y_, size_t _local_id_z_)
     | Broadcast the value of _x_ for work-item identified by _local_id_ to
       all work-items in the work-group.
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5225,14 +5225,23 @@ arguments which point to the generic address space are also supported.
 The OpenCL C programming language implements the following synchronization
 functions.
 
+// Editors note: The table column widths are chosen so the description
+// of these functions fits onto a single page.  This avoids an error
+// from optimize-pdf and preserves the entire contents of the table.
+// If an alternative solution to this issue is discovered then the
+// table widths can be re-adjusted.
+
 [[table-builtin-synchronization]]
 .Built-in Synchronization Functions
-[cols=",",]
+[cols="3,7",]
 |====
 | *Function* | *Description*
 
-| void *work_group_barrier*^39^(cl_mem_fence_flags _flags_) +
-  void *work_group_barrier*(cl_mem_fence_flags _flags_,
+| void *work_group_barrier*^39^( +
+  cl_mem_fence_flags _flags_) +
+  {blank}
+  void *work_group_barrier*( +
+  cl_mem_fence_flags _flags_, +
   memory_scope _scope_^40^)
     | All work-items in a work-group executing the kernel on a processor
       must execute this function before any are allowed to continue

--- a/api/opencl_runtime_layer.txt
+++ b/api/opencl_runtime_layer.txt
@@ -6896,10 +6896,10 @@ call to *clSetKernelArgSVMPointer* for _kernel_.
 The SVM pointer can only be used for arguments that are declared to be a
 pointer to `global` or `constant` memory.
 The SVM pointer value must be aligned according to the arguments type.
-For example, if the argument is declared to be `global float4 *p`, the SVM
+For example, if the argument is declared to be ``global float4 *p``, the SVM
 pointer value passed for `p` must be at a minimum aligned to a `float4`.
 The SVM pointer value specified as the argument value can be the pointer
-returned by *clSVMAlloc* or can be a pointer offset into the SVM region.
+returned by **clSVMAlloc** or can be a pointer offset into the SVM region.
 
 *clSetKernelArgSVMPointer* returns CL_SUCCESS if the function was executed
 successfully.


### PR DESCRIPTION
This PR fixes a few minor formatting issues in the API and C specs that I observed while working on other unrelated changes.  The biggest involves a table cell that is too long and gets cut off.  I'll file a separate issue to discuss a longer-term fix for this issue.

These are purely formatting change.  There are no content changes.