### PR TITLE
changes for SPV_KHR_no_integer_wrap_decoration

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -85,6 +85,15 @@ include::ext/cl_khr_throttle_hints.txt[]
 
 include::ext/cl_khr_subgroup_named_barrier.txt[]
 
+// NOTE: To keep meaningful section numbers, new
+// extension documents should be added above here!
+
+// These are SPIR-V Extensions:
+
+include::ext/spirv_extensions.txt[]
+
+// Index and Appendices:
+
 ifdef::backend-pdf[]
 include::ext/index.txt[]
 endif::backend-pdf[]

--- a/env/extensions.txt
+++ b/env/extensions.txt
@@ -171,6 +171,12 @@ that declare the following SPIR-V capabilities:
 
   * *NamedBarrier*
 
+==== `cl_khr_spirv_no_integer_wrap_decoration`
+
+If the OpenCL environment supports the extension `cl_khr_spirv_no_integer_wrap_decoration`, then the environment must accept modules that declare use of the extension `SPV_KHR_no_integer_wrap_decoration` via *OpExtension*.
+
+If the OpenCL environment supports the extension `cl_khr_spirv_no_integer_wrap_decoration` and use of the SPIR-V extension `SPV_KHR_no_integer_wrap_decoration` is declared in the module via *OpExtension*, then the environment must accept modules that include the *NoSignedWrap* or *NoUnsignedWrap* decorations.
+
 === Embedded Profile Extensions
 
 ==== `cles_khr_int64`

--- a/ext/spirv_extensions.txt
+++ b/ext/spirv_extensions.txt
@@ -1,0 +1,12 @@
+// Copyright 2017-2018 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[spirv_extensions]]
+== Extensions to the OpenCL SPIR-V Environment
+
+An OpenCL SPIR-V environment may be modified by OpenCL extensions.
+Please refer to the OpenCL SPIR-V Environment Specification for descriptions how OpenCL extensions modify an OpenCL SPIR-V environment.
+In addition to the extensions described in this document, the OpenCL SPIR-V Environment Specification also describes how the following OpenCL extensions modify an OpenCL SPIR-V environment:
+
+* `cl_khr_spirv_no_integer_wrap_decoration`


### PR DESCRIPTION
This change describes the `cl_khr_spirv_no_integer_wrap_decoration` extension, which enables consumption of SPIR-V modules using the `SPV_KHR_no_integer_wrap_decoration` extension and capabilities in an OpenCL environment.