### PR TITLE
fix description of derived pow and pown

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9448,18 +9448,18 @@ is the infinitely precise result.
       Undefined for _x_ < 0 and non-integer y.
       Undefined for _x_ < 0 and _y_ outside the domain [-2^24, 2^24].
       For _x_ > 0 or _x_ < 0 and even _y_, derived implementations implement
-      this as *exp2*(y * log2(_x_)).
+      this as *exp2*(_y_ * *log2*(*fabs*(_x_))).
       For _x_ < 0 and odd _y_, derived implementations implement this as
-      *-exp2(y * *log2*(fabs(_x_))^72^.
+      -*exp2*(_y_ * *log2*(*fabs*(_x_))^72^.
       For _x_ == 0 and nonzero _y_, derived implementations return zero.
       For non-derived implementations, the error is {leq} 8192 ULP
 | *pown*(_x_, _y_)
     | Defined only for integer values of y.
       Undefined for _x_ = 0 and _y_ = 0.
       For _x_ >= 0 or _x_ < 0 and even _y_, derived implementations
-      implement this as *exp2*(_y_ * *log2*(_x_)).
+      implement this as *exp2*(_y_ * *log2*(*fabs*(_x_))).
       For _x_ < 0 and odd _y_, derived implementations implement this as
-      *-exp2*(_y_ * *log2*(*fabs*(_x_)).
+      -*exp2*(_y_ * *log2*(*fabs*(_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
 | *powr*(_x_, _y_)
     | Defined only for _x_ >= 0.

--- a/cxx/numerical_compliance/relative_error_as_ulps.txt
+++ b/cxx/numerical_compliance/relative_error_as_ulps.txt
@@ -695,15 +695,15 @@ The reference value used to compute the ULP value of an arithmetic operation is 
 | Undefined for x = 0 and y = 0.
   Undefined for x < 0 and non-integer y.
   Undefined for x < 0 and y outside the domain [-2^24^, 2^24^].
-  For x > 0 or x < 0 and even y, derived implementations implement this as exp2( y * log2(x) ).
-  For x < 0 and odd y, derived implementations implement this as -exp2( y * log2(fabs(x) ) [[ftnref33]] <<ftn33,[33]>>.
+  For x > 0 or x < 0 and even y, derived implementations implement this as exp2( y * log2( fabs(x) ) ).
+  For x < 0 and odd y, derived implementations implement this as -exp2( y * log2( fabs(x) ) [[ftnref33]] <<ftn33,[33]>>.
   For x == 0 and nonzero y, derived implementations return zero.
   For non-derived implementations, the error is \<= 8192 ULP.
 
 | pown(x, y)
 | Defined only for integer values of y.
   Undefined for x = 0 and y = 0.
-  For x >= 0 or x < 0 and even y, derived implementations implement this as exp2( y * log2(x) ).
+  For x >= 0 or x < 0 and even y, derived implementations implement this as exp2( y * log2( fabs(x) ) ).
   For x < 0 and odd y, derived implementations implement this as -exp2( y * log2( fabs(x) ) ).
   For non-derived implementations, the error is \<= 8192 ulp.
 

--- a/env/numerical_compliance.txt
+++ b/env/numerical_compliance.txt
@@ -1324,9 +1324,9 @@ profile.
   Undefined for x < 0 and non-integer y.
   Undefined for x < 0 and y outside the domain [-2^24^, 2^24^].
   For x > 0 or x < 0 and even y, derived implementations implement this as
-  exp2( y * log2(x) ).
+  exp2( y * log2( fabs(x) ) ).
   For x < 0 and odd y, derived implementations implement this as -exp2( y *
-  log2(fabs(x) ).
+  log2( fabs(x) ).
   For x == 0 and nonzero y, derived implementations return zero.
   For non-derived implementations, the error is \<= 8192 ULP.
 
@@ -1340,7 +1340,7 @@ profile.
 | Defined only for integer values of y.
   Undefined for x = 0 and y = 0.
   For x >= 0 or x < 0 and even y, derived implementations implement this as
-  exp2( y * log2(x) ).
+  exp2( y * log2( fabs(x) ) ).
   For x < 0 and odd y, derived implementations implement this as -exp2( y *
   log2( fabs(x) ) ).
   For non-derived implementations, the error is \<= 8192 ulp.


### PR DESCRIPTION
This is a proposed fix for most of #35.

The descriptions of pow and pown are missing an fabs when the input x is negative.

TODO: What about pown (and powr, and perhaps others) when x is zero and y is nonzero?