### PR TITLE
cl_intel_subgroups rev 7 - fixed summary typos

### DIFF
--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -39,7 +39,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -48,7 +48,7 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 6
+Revision: 7
 
 == Dependencies
 
@@ -162,8 +162,8 @@ gentype sub_group_reduce_min( gentype x )
 gentype sub_group_reduce_max( gentype x )
 
 gentype sub_group_scan_exclusive_add( gentype x )
-gentype sub_group_scan_exclusive_add( gentype x )
-gentype sub_group_scan_exclusive_add( gentype x )
+gentype sub_group_scan_exclusive_min( gentype x )
+gentype sub_group_scan_exclusive_max( gentype x )
 
 gentype sub_group_scan_inclusive_add( gentype x)
 gentype sub_group_scan_inclusive_min( gentype x)
@@ -942,6 +942,7 @@ None.
 |4|2016-08-28|Ben Ashbaugh|Added additional restrictions and programming notes for the subgroup shuffle and block read built-ins.
 |5|2018-11-15|Ben Ashbaugh|Converted to asciidoc.
 |6|2018-12-02|Ben Ashbaugh|Added back a section that was inadvertently removed during conversion to asciidoc.
+|7|2019-01-15|Ben Ashbaugh|Fixed a typo in the summary section of new built-in functions.
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
This PR fixes a few copy-paste typos introduced in the summary section of new built-in functions during the conversion from plaintext to asciidoc.