### PR TITLE
Define error tolerances for geometric functions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9152,6 +9152,9 @@ currently undefined.
 | *cos*                 | {leq} 4 ulp
 | *cosh*                | {leq} 4 ulp
 | *cospi*               | {leq} 4 ulp
+| *cross*               | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+| *dot*                 | absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+| *distance*            | {leq} 3 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 | *erfc*                | {leq} 16 ulp
 | *erf*                 | {leq} 16 ulp
 | *exp*                 | {leq} 3 ulp
@@ -9169,6 +9172,7 @@ currently undefined.
 | *frexp*               | 0 ulp
 | *hypot*               | {leq} 4 ulp
 | *ilogb*               | 0 ulp
+| *length*              | {leq} 3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
 | *ldexp*               | Correctly rounded
 | *log*                 | {leq} 3 ulp
 | *log2*                | {leq} 3 ulp
@@ -9183,6 +9187,7 @@ currently undefined.
 | *modf*                | 0 ulp
 | *nan*                 | 0 ulp
 | *nextafter*           | 0 ulp
+| *normalize*           | {leq} 2.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 | *pow*(_x_, _y_)       | {leq} 16 ulp
 | *pown*(_x_, _y_)      | {leq} 16 ulp
 | *powr*(_x_, _y_)      | {leq} 16 ulp
@@ -9217,6 +9222,10 @@ currently undefined.
 | *half_sin*            | {leq} 8192 ulp
 | *half_sqrt*           | {leq} 8192 ulp
 | *half_tan*            | {leq} 8192 ulp
+| |
+| *fast_distance*       | {leq} 8192 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| *fast_length*         | {leq} 8192 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| *fast_normalize*      | {leq} 8192.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 | |
 | *native_cos*          | Implementation-defined
 | *native_divide*       | Implementation-defined
@@ -9270,6 +9279,9 @@ is the infinitely precise result.
 | *cos*             | {leq} 4 ulp
 | *cosh*            | {leq} 4 ulp
 | *cospi*           | {leq} 4 ulp
+| *cross*           | Implementation-defined
+| *dot*             | Implementation-defined
+| *distance*        | Implementation-defined
 | *erfc*            | {leq} 16 ulp
 | *erf*             | {leq} 16 ulp
 | *exp*             | {leq} 4 ulp
@@ -9288,6 +9300,7 @@ is the infinitely precise result.
 | *hypot*           | {leq} 4 ulp
 | *ilogb*           | 0 ulp
 | *ldexp*           | Correctly rounded
+| *length*          | Implementation-defined
 | *log*             | {leq} 4 ulp
 | *log2*            | {leq} 4 ulp
 | *log10*           | {leq} 4 ulp
@@ -9298,6 +9311,7 @@ is the infinitely precise result.
 | *minmag*          | 0 ulp
 | *modf*            | 0 ulp
 | *nan*             | 0 ulp
+| *normalize*       | Implementation-defined
 | *nextafter*       | 0 ulp
 | *pow*(_x_, _y_)       | {leq} 16 ulp
 | *pown*(_x_, _y_)      | {leq} 16 ulp
@@ -9333,6 +9347,10 @@ is the infinitely precise result.
 | *half_sin*        | {leq} 8192 ulp
 | *half_sqrt*       | {leq} 8192 ulp
 | *half_tan*        | {leq} 8192 ulp
+| |
+| *fast_distance*   | Implementation-defined
+| *fast_length*     | Implementation-defined
+| *fast_normalize*  | Implementation-defined
 | |
 | *native_cos*      | Implementation-defined
 | *native_divide*   | Implementation-defined
@@ -9543,6 +9561,9 @@ is the infinitely precise result.
 | *cos*             | {leq} 4 ulp
 | *cosh*            | {leq} 4 ulp
 | *cospi*           | {leq} 4 ulp
+| *cross*           | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+| *dot*             | absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+| *distance*        | {leq} 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) For vector width n
 | *erfc*            | {leq} 16 ulp
 | *erf*             | {leq} 16 ulp
 | *exp*             | {leq} 3 ulp
@@ -9560,6 +9581,7 @@ is the infinitely precise result.
 | *frexp*           | 0 ulp
 | *hypot*           | {leq} 4 ulp
 | *ilogb*           | 0 ulp
+| *length*          | {leq} 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) For vector width n
 | *ldexp*           | Correctly rounded
 | *log*             | {leq} 3 ulp
 | *log2*            | {leq} 3 ulp
@@ -9572,6 +9594,7 @@ is the infinitely precise result.
 | *modf*            | 0 ulp
 | *nan*             | 0 ulp
 | *nextafter*       | 0 ulp
+| *normalize*       | {leq} 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) For vector width n
 | *pow*(_x_, _y_)   | {leq} 16 ulp
 | *pown*(_x_, _y_)  | {leq} 16 ulp
 | *powr*(_x_, _y_)  | {leq} 16 ulp

--- a/env/numerical_compliance.txt
+++ b/env/numerical_compliance.txt
@@ -278,6 +278,21 @@ devices given as ULP values.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *cross*
+| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)', where max is the maximum input operand value
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+
+| *OpExtInst* *dot*
+| absolute error tolerance of 'max * max * (2 * (n - 1)) * HLF_EPSILON', For vector width n and maximum input operand value 'max'
+| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value max
+
+| *OpExtInst* *distance*
+| \<= 0.5 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 3 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+
 | *OpExtInst* *erfc*
 | \<= 16 ulp
 | \<= 16 ulp
@@ -368,6 +383,11 @@ devices given as ULP values.
 | Correctly rounded
 | Correctly rounded
 
+| *OpExtInst* *length*
+| \<= 0.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+
 | *OpExtInst* *lgamma*
 | Implementation-defined
 | Implementation-defined
@@ -435,6 +455,11 @@ devices given as ULP values.
 | 0 ulp
 | 0 ulp
 | 0 ulp
+
+| *OpExtInst* *normalize*
+| \<= 1.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 2.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
 
 | *OpExtInst* *pow*
 | \<= 16 ulp
@@ -599,6 +624,21 @@ devices given as ULP values.
 | *OpExtInst* *half_tan*
 |
 | \<= 8192 ulp
+|
+
+| *OpExtInst* *fast_distance*
+|
+| \<= 8192 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+|
+
+| *OpExtInst* *fast_length*
+|
+| \<= 8192 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+|
+
+| *OpExtInst* *fast_normalize*
+|
+| \<= 8192.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 |
 
 | *OpExtInst* *native_cos*

--- a/ext/cl_khr_fp16.txt
+++ b/ext/cl_khr_fp16.txt
@@ -264,7 +264,7 @@ all arguments and the return type.
   in the embedded profile.  See the SPIR-V OpenCL environment specification
   for details. On some hardware the mad instruction may provide better
   performance than expanded computation of _a_ * _b_ + _c_.
-    
+
   Note: For some usages, e.g. *mad*(a, b, -a*b), the half precision
   definition of *mad*() is loose enough that almost any result is allowed
   from *mad*() for some values of a and b.
@@ -1487,6 +1487,18 @@ is the infinitely precise result.
 | \<= 2 ulp
 | \<= 2 ulp
 
+| *cross*
+| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)', where max is the maximum input operand value
+| Implementation-defined
+
+| *dot*
+| absolute error tolerance of 'max * max * (2 * (n - 1)) * HLF_EPSILON', For vector width n and maximum input operand value 'max'
+| Implementation-defined
+
+| *distance*
+| \<= 0.5 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| Implementation-defined
+
 | *erfc*
 | \<= 4 ulp
 | \<= 4 ulp
@@ -1559,6 +1571,10 @@ is the infinitely precise result.
 | Correctly rounded
 | Correctly rounded
 
+| *length*
+| \<= 0.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
+| Implementation-defined
+
 | *log*
 | \<= 2 ulp
 | \<= 3 ulp
@@ -1602,6 +1618,10 @@ is the infinitely precise result.
 | *nextafter*
 | 0 ulp
 | 0 ulp
+
+| *normalize*
+| \<= 1.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| Implementation-defined
 
 | *pow(x, y)*
 | \<= 4 ulp

--- a/ext/cl_khr_fp64.txt
+++ b/ext/cl_khr_fp64.txt
@@ -1068,6 +1068,15 @@ is the infinitely precise result.
 | *cospi*
 | \<= 4 ulp
 
+| *cross*
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+
+| *dot*
+| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+
+| *distance*
+| \<= 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+
 | *erfc*
 | \<= 16 ulp
 
@@ -1122,6 +1131,9 @@ is the infinitely precise result.
 | *ldexp*
 | Correctly rounded
 
+| *length*
+| \<= 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+
 | *log*
 | \<= 3 ulp
 
@@ -1154,6 +1166,9 @@ is the infinitely precise result.
 
 | *nextafter*
 | 0 ulp
+
+| *normalize*
+| \<= 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
 
 | *pow(x, y)*
 | \<= 16 ulp


### PR DESCRIPTION
Define accepted error thresholds for the geometric class of functions from table 6.13

These values are taken from how the CTS is doing verification, although I've inferred the values for half precision since the fp16 extension isn't tested as part of the CTS.

Made embedded-profile values implementation defined since mad() can have infinite ULP and there's the following spec note:
> The geometric functions can be implemented using contractions such as mad or fma

Related to [issue 33](https://github.com/KhronosGroup/OpenCL-Docs/issues/33)