### PR TITLE
Define error tolerances for common functions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9148,10 +9148,12 @@ currently undefined.
 | *atanh*               | {leq} 5 ulp
 | *cbrt*                | {leq} 2 ulp
 | *ceil*                | Correctly rounded
+| *clamp*               | 0 ulp
 | *copysign*            | 0 ulp
 | *cos*                 | {leq} 4 ulp
 | *cosh*                | {leq} 4 ulp
 | *cospi*               | {leq} 4 ulp
+| *degrees*             | {leq} 2 ulp
 | *erfc*                | {leq} 16 ulp
 | *erf*                 | {leq} 16 ulp
 | *exp*                 | {leq} 3 ulp
@@ -9178,25 +9180,32 @@ currently undefined.
 | *mad*                 | Implemented either as a correctly rounded fma or
                           as a multiply followed by an add both of which are
                           correctly rounded
+| *max*                 | 0 ulp
 | *maxmag*              | 0 ulp
+| *min*                 | 0 ulp
 | *minmag*              | 0 ulp
+| *mix*                 | absolute error tolerance of 1e-3
 | *modf*                | 0 ulp
 | *nan*                 | 0 ulp
 | *nextafter*           | 0 ulp
 | *pow*(_x_, _y_)       | {leq} 16 ulp
 | *pown*(_x_, _y_)      | {leq} 16 ulp
 | *powr*(_x_, _y_)      | {leq} 16 ulp
+| *radians*             | {leq} 2 ulp
 | *remainder*           | 0 ulp
 | *remquo*              | 0 ulp
 | *rint*                | Correctly rounded
 | *rootn*               | {leq} 16 ulp
 | *round*               | Correctly rounded
 | *rsqrt*               | {leq} 2 ulp
+| *sign*                | 0 ulp
 | *sin*                 | {leq} 4 ulp
 | *sincos*              | {leq} 4 ulp for sine and cosine values
 | *sinh*                | {leq} 4 ulp
 | *sinpi*               | {leq} 4 ulp
+| *smoothstep*          | absolute error tolerance of 1e-5
 | *sqrt*                | {leq} 3 ulp
+| *step*                | 0 ulp
 | *tan*                 | {leq} 5 ulp
 | *tanh*                | {leq} 5 ulp
 | *tanpi*               | {leq} 6 ulp
@@ -9266,10 +9275,12 @@ is the infinitely precise result.
 | *atanh*           | {leq} 5 ulp
 | *cbrt*            | {leq} 4 ulp
 | *ceil*            | Correctly rounded
+| *clamp*           | 0 ulp
 | *copysign*        | 0 ulp
 | *cos*             | {leq} 4 ulp
 | *cosh*            | {leq} 4 ulp
 | *cospi*           | {leq} 4 ulp
+| *degrees*         | {leq} 2 ulp
 | *erfc*            | {leq} 16 ulp
 | *erf*             | {leq} 16 ulp
 | *exp*             | {leq} 4 ulp
@@ -9294,25 +9305,32 @@ is the infinitely precise result.
 | *log1p*           | {leq} 4 ulp
 | *logb*            | 0 ulp
 | *mad*             | Any value allowed (infinite ulp)
+| *max*             | 0 ulp
 | *maxmag*          | 0 ulp
+| *min*             | 0 ulp
 | *minmag*          | 0 ulp
+| *mix*             | Implementation-defined
 | *modf*            | 0 ulp
 | *nan*             | 0 ulp
 | *nextafter*       | 0 ulp
 | *pow*(_x_, _y_)       | {leq} 16 ulp
 | *pown*(_x_, _y_)      | {leq} 16 ulp
 | *powr*(_x_, _y_)      | {leq} 16 ulp
+| *radians*         | {leq} 2 ulp
 | *remainder*       | 0 ulp
 | *remquo*          | 0 ulp
 | *rint*            | Correctly rounded
 | *rootn*           | {leq} 16 ulp
 | *round*           | Correctly rounded
 | *rsqrt*           | {leq} 4 ulp
+| *sign*            | 0 ulp
 | *sin*             | {leq} 4 ulp
 | *sincos*          | {leq} 4 ulp for sine and cosine values
 | *sinh*            | {leq} 4 ulp
 | *sinpi*           | {leq} 4 ulp
+| *smoothstep*      | Implementation-defined
 | *sqrt*            | {leq} 4 ulp
+| *step*            | 0 ulp
 | *tan*             | {leq} 5 ulp
 | *tanh*            | {leq} 5 ulp
 | *tanpi*           | {leq} 6 ulp
@@ -9539,10 +9557,12 @@ is the infinitely precise result.
 | *atanh*           | {leq} 5 ulp
 | *cbrt*            | {leq} 2 ulp
 | *ceil*            | Correctly rounded
+| *clamp*           | 0 ulp
 | *copysign*        | 0 ulp
 | *cos*             | {leq} 4 ulp
 | *cosh*            | {leq} 4 ulp
 | *cospi*           | {leq} 4 ulp
+| *degrees*         | {leq} 2 ulp
 | *erfc*            | {leq} 16 ulp
 | *erf*             | {leq} 16 ulp
 | *exp*             | {leq} 3 ulp
@@ -9567,24 +9587,31 @@ is the infinitely precise result.
 | *log1p*           | {leq} 2 ulp
 | *logb*            | 0 ulp
 | *mad*             | Any value allowed (infinite ulp)
+| *max*             | 0 ulp
 | *maxmag*          | 0 ulp
+| *min*             | 0 ulp
 | *minmag*          | 0 ulp
+| *mix*             | Implementation-defined
 | *modf*            | 0 ulp
 | *nan*             | 0 ulp
 | *nextafter*       | 0 ulp
 | *pow*(_x_, _y_)   | {leq} 16 ulp
 | *pown*(_x_, _y_)  | {leq} 16 ulp
 | *powr*(_x_, _y_)  | {leq} 16 ulp
+| *radians*         | {leq} 2 ulp
 | *remainder*       | 0 ulp
 | *remquo*          | 0 ulp
 | *rint*            | Correctly rounded
 | *rootn*           | {leq} 16 ulp
 | *round*           | Correctly rounded
 | *rsqrt*           | {leq} 2 ulp
+| *sign*            | 0 ulp
 | *sin*             | {leq} 4 ulp
 | *sincos*          | {leq} 4 ulp for sine and cosine values
 | *sinh*            | {leq} 4 ulp
 | *sinpi*           | {leq} 4 ulp
+| *smoothstep*      | Implementation-defined
+| *step*            | 0 ulp
 | *fsqrt*           | Correctly rounded
 | *tan*             | {leq} 5 ulp
 | *tanh*            | {leq} 5 ulp

--- a/env/numerical_compliance.txt
+++ b/env/numerical_compliance.txt
@@ -278,6 +278,11 @@ devices given as ULP values.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *degrees*
+| \<= 2 ulp
+| \<= 2 ulp
+| \<= 2 ulp
+
 | *OpExtInst* *erfc*
 | \<= 16 ulp
 | \<= 16 ulp
@@ -313,6 +318,11 @@ devices given as ULP values.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *fclamp*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *fdim*
 | Correctly rounded
 | Correctly rounded
@@ -333,7 +343,17 @@ devices given as ULP values.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *fmax_common*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *fmin*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
+| *OpExtInst* *fmin_common*
 | 0 ulp
 | 0 ulp
 | 0 ulp
@@ -421,6 +441,11 @@ devices given as ULP values.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *mix*
+| Implementation-defined
+| absolute error tolerance of 1e-3
+| Implementation-defined
+
 | *OpExtInst* *modf*
 | 0 ulp
 | 0 ulp
@@ -450,6 +475,11 @@ devices given as ULP values.
 | \<= 16 ulp
 | \<= 16 ulp
 | \<= 4 ulp
+
+| *OpExtInst* *radians*
+| \<= 2 ulp
+| \<= 2 ulp
+| \<= 2 ulp
 
 | *OpExtInst* *remainder*
 | 0 ulp
@@ -481,6 +511,11 @@ devices given as ULP values.
 | \<= 2 ulp
 | \<= 1 ulp
 
+| *OpExtInst* *sign*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *sin*
 | \<= 4 ulp
 | \<= 4 ulp
@@ -501,10 +536,20 @@ devices given as ULP values.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *smoothstep*
+| Implementation-defined
+| absolute error tolerance of 1e-5
+| Implementation-defined
+
 | *OpExtInst* *sqrt*
 | Correctly rounded
 | \<= 3 ulp
 | Correctly rounded
+
+| *OpExtInst* *step*
+| 0 ulp
+| 0 ulp
+| 0 ulp
 
 | *OpExtInst* *tan*
 | \<= 5 ulp
@@ -793,6 +838,11 @@ given as ULP values for the embedded profile.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *degrees*
+| \<= 2 ulp
+| \<= 2 ulp
+| \<= 2 ulp
+
 | *OpExtInst* *erfc*
 | \<= 16 ulp
 | \<= 16 ulp
@@ -828,6 +878,11 @@ given as ULP values for the embedded profile.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *fclamp*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *fdim*
 | Correctly rounded
 | Correctly rounded
@@ -848,7 +903,17 @@ given as ULP values for the embedded profile.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *fmax_common*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *fmin*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
+| *OpExtInst* *fmin_common*
 | 0 ulp
 | 0 ulp
 | 0 ulp
@@ -933,6 +998,11 @@ given as ULP values for the embedded profile.
 | 0 ulp
 | 0 ulp
 
+| *OpExtInst* *mix*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
+
 | *OpExtInst* *modf*
 | 0 ulp
 | 0 ulp
@@ -962,6 +1032,11 @@ given as ULP values for the embedded profile.
 | \<= 16 ulp
 | \<= 16 ulp
 | \<= 5 ulp
+
+| *OpExtInst* *radians*
+| \<= 2 ulp
+| \<= 2 ulp
+| \<= 2 ulp
 
 | *OpExtInst* *remainder*
 | 0 ulp
@@ -993,6 +1068,11 @@ given as ULP values for the embedded profile.
 | \<= 4 ulp
 | \<= 1 ulp
 
+| *OpExtInst* *sign*
+| 0 ulp
+| 0 ulp
+| 0 ulp
+
 | *OpExtInst* *sin*
 | \<= 4 ulp
 | \<= 4 ulp
@@ -1013,11 +1093,21 @@ given as ULP values for the embedded profile.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *smoothstep*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
+
 // TODO: For both Float32 and Float64?
 | *OpExtInst* *sqrt*
 | \<= 4 ulp
 | \<= 4 ulp
 | \<= 1 ulp
+
+| *OpExtInst* *step*
+| 0 ulp
+| 0 ulp
+| 0 ulp
 
 | *OpExtInst* *tan*
 | \<= 5 ulp

--- a/ext/cl_khr_fp16.txt
+++ b/ext/cl_khr_fp16.txt
@@ -264,7 +264,7 @@ all arguments and the return type.
   in the embedded profile.  See the SPIR-V OpenCL environment specification
   for details. On some hardware the mad instruction may provide better
   performance than expanded computation of _a_ * _b_ + _c_.
-    
+
   Note: For some usages, e.g. *mad*(a, b, -a*b), the half precision
   definition of *mad*() is loose enough that almost any result is allowed
   from *mad*() for some values of a and b.
@@ -1471,6 +1471,10 @@ is the infinitely precise result.
 | Correctly rounded
 | Correctly rounded
 
+| *clamp*
+| 0 ulp
+| 0 ulp
+
 | *copysign*
 | 0 ulp
 | 0 ulp
@@ -1484,6 +1488,10 @@ is the infinitely precise result.
 | \<= 3 ulp
 
 | *cospi*
+| \<= 2 ulp
+| \<= 2 ulp
+
+| *degrees*
 | \<= 2 ulp
 | \<= 2 ulp
 
@@ -1583,13 +1591,25 @@ is the infinitely precise result.
 | Implementation-defined
 | Implementation-defined
 
+| *max*
+| 0 ulp
+| 0 ulp
+
 | *maxmag*
+| 0 ulp
+| 0 ulp
+
+| *min*
 | 0 ulp
 | 0 ulp
 
 | *minmag*
 | 0 ulp
 | 0 ulp
+
+| *mix*
+| Implementation-defined
+| Implementation-defined
 
 | *modf*
 | 0 ulp
@@ -1615,6 +1635,10 @@ is the infinitely precise result.
 | \<= 4 ulp
 | \<= 5 ulp
 
+| *radians*
+| \<= 2 ulp
+| \<= 2 ulp
+
 | *remainder*
 | 0 ulp
 | 0 ulp
@@ -1639,6 +1663,10 @@ is the infinitely precise result.
 | \<=1 ulp
 | \<=1 ulp
 
+| *sign*
+| 0 ulp
+| 0 ulp
+
 | *sin*
 | \<= 2 ulp
 | \<= 2 ulp
@@ -1655,9 +1683,17 @@ is the infinitely precise result.
 | \<= 2 ulp
 | \<= 2 ulp
 
+| *smoothstep*
+| Implementation-defined
+| Implementation-defined
+
 | *sqrt*
 | Correctly rounded
 | \<= 1 ulp
+
+| *step*
+| 0 ulp
+| 0 ulp
 
 | *tan*
 | \<= 2 ulp

--- a/ext/cl_khr_fp64.txt
+++ b/ext/cl_khr_fp64.txt
@@ -1056,6 +1056,9 @@ is the infinitely precise result.
 | *ceil*
 | Correctly rounded
 
+| *clamp*
+| 0 ulp
+
 | *copysign*
 | 0 ulp
 
@@ -1067,6 +1070,9 @@ is the infinitely precise result.
 
 | *cospi*
 | \<= 4 ulp
+
+| *degrees*
+| \<= 2 ulp
 
 | *erfc*
 | \<= 16 ulp
@@ -1140,11 +1146,20 @@ is the infinitely precise result.
 | *mad*
 | Implementation-defined
 
+| *max*
+| 0 ulp
+
 | *maxmag*
+| 0 ulp
+
+| *min*
 | 0 ulp
 
 | *minmag*
 | 0 ulp
+
+| *mix*
+| Implementation-defined
 
 | *modf*
 | 0 ulp
@@ -1164,6 +1179,9 @@ is the infinitely precise result.
 | *powr(x, y)*
 | \<= 16 ulp
 
+| *radians*
+| \<= 2 ulp
+
 | *remainder*
 | 0 ulp
 
@@ -1182,6 +1200,9 @@ is the infinitely precise result.
 | *rsqrt*
 | \<= 2 ulp
 
+| *sign*
+| 0 ulp
+
 | *sin*
 | \<= 4 ulp
 
@@ -1194,8 +1215,14 @@ is the infinitely precise result.
 | *sinpi*
 | \<= 4 ulp
 
+| *smoothstep*
+| Implementation-defined
+
 | *sqrt*
 | Correctly rounded
+
+| *step*
+| 0 ulp
 
 | *tan*
 | \<= 5 ulp


### PR DESCRIPTION
Define accepted error thresholds for the common class of functions from table 6.12

Taken from how the CTS is doing verification, however coming up with values for `mix()` and `smoothstep()` is problematic for half and double, since they're only tested against 32-bit float in the CTS using an absolute error.

I've put 'Implementation defined' down for these as a placeholder due the below spec note, but not sure if that's the correct solution.

> The mix and smoothstep functions can be implemented using contractions
> such as mad or fma

Related to [issue 33](https://github.com/KhronosGroup/OpenCL-Docs/issues/33)