### PR TITLE
fix typo describing program link options

### DIFF
--- a/api/opencl_runtime_layer.txt
+++ b/api/opencl_runtime_layer.txt
@@ -6207,7 +6207,7 @@ The following options can be specified when linking a program executable.
     The linker may apply these options to all compiled program objects
     specified to *clLinkProgram*.
     The linker may apply these options only to libraries which were created
-    with the enable-link-option.
+    with the option `-enable-link-options`.
 
 
 === Unloading the OpenCL Compiler


### PR DESCRIPTION
Fixes a small typo (and adds better formatting) when describing how to apply options to libraries.

Fixes #46.