### PR TITLE
clean up the descriptions for cl_khr_gl_sharing

### DIFF
--- a/ext/cl_khr_gl_sharing__context.txt
+++ b/ext/cl_khr_gl_sharing__context.txt
@@ -8,15 +8,12 @@
 [[cl_khr_gl_sharing-overview]]
 === Overview
 
-This section describes the *cl_khr_gl_sharing* extension.
-The section <<cl_khr_gl_sharing__memobjs,Creating OpenCL Memory Objects from
-OpenGL Objects>> defines how to share data with texture and buffer objects
-in a parallel OpenGL implementation, but does not define how the association
-between an OpenCL context and an OpenGL context or share group is
-established.
-This extension defines optional attributes to OpenCL context creation
-routines which associate a OpenGL context or share group object with a newly
-created OpenCL context.
+This section describes functionality in the *cl_khr_gl_sharing* extension
+to associate an OpenCL context with an OpenGL context or share group object.
+Once an OpenCL context is associated with an OpenGL context or share group
+object, the functionality described in the section
+<<cl_khr_gl_sharing__memobjs,Creating OpenCL Memory Objects from OpenGL Objects>>
+may be used to share OpenGL buffer, texture, and renderbuffer objects with the OpenCL context.
 
 An OpenGL implementation supporting buffer objects and sharing of texture
 and buffer object images with OpenCL is required by this extension.

--- a/ext/cl_khr_gl_sharing__memobjs.txt
+++ b/ext/cl_khr_gl_sharing__memobjs.txt
@@ -5,34 +5,19 @@
 [[cl_khr_gl_sharing__memobjs]]
 == Creating OpenCL Memory Objects from OpenGL Objects
 
-This section describes OpenCL functions that allow applications to use
-OpenGL buffer, texture and renderbuffer objects as OpenCL memory objects.
-This allows efficient sharing of data between OpenCL and OpenGL.
-The OpenCL API may be used to execute kernels that read and/or write memory
-objects that are also OpenGL objects.
+This section describes functionality in the *cl_khr_gl_sharing* extension
+to use OpenGL buffer, texture, and renderbuffer objects as OpenCL memory objects.
+OpenCL memory objects may be created from OpenGL objects if and only if the
+OpenCL context is associated with an OpenGL context or share group object.
+The section <<cl_khr_gl_sharing,Creating an OpenCL Context from an OpenGL Context or Share Group>>
+describes how to create an OpenCL context associated with an OpenGL context or share group object.
 
-An OpenCL image object may be created from an OpenGL texture or renderbuffer
-object.
+An OpenCL image object may be created from an OpenGL texture or renderbuffer object.
 An OpenCL buffer object may be created from an OpenGL buffer object.
 
-OpenCL memory objects may be created from OpenGL objects if and only if the
-OpenCL context has been created from an OpenGL share group object or
-context.
-OpenGL share groups and contexts are created using platform specific APIs
-such as EGL, CGL, WGL, and GLX.
-On MacOS X, an OpenCL context may be created from an OpenGL share group
-object using the OpenCL platform extension *cl_apple_gl_sharing*.
-On other platforms including Microsoft Windows, Linux/Unix, and others, an
-OpenCL context may be created from an OpenGL context using the extension
-*cl_khr_gl_sharing*.
-Refer to the platform documentation for your OpenCL implementation, or visit
-the Khronos Registry at http://www.khronos.org/registry/cl/ for more
-information.
-
-Any supported OpenGL object defined within the GL share group object, or the
-share group associated with the GL context from which the OpenCL context is
-created, may be shared, with the exception of the default OpenGL objects
-(i.e. objects named zero), which may not be shared.
+Any supported OpenGL object defined within the associated OpenGL context
+or share group object may be shared, with the exception of the default
+OpenGL objects (i.e. objects named zero), which may not be shared.
 
 [[cl_khr_gl_sharing__memobjs-lifetime-of-shared-objects]]
 === Lifetime of Shared Objects


### PR DESCRIPTION
This change rewrites the intro sections to Chapters 10 and 11 in the OpenCL Extensions Spec so it is more clear that they are describing functions in the **cl_khr_gl_sharing** extension.

These changes should address internal issue 157.

