### PR TITLE
base the fp16 and fp64 clamp description on fmin and fmax

### DIFF
--- a/ext/cl_khr_fp16.txt
+++ b/ext/cl_khr_fp16.txt
@@ -478,7 +478,7 @@ These are described below.
 
   gentype *clamp* ( +
   gentype _x_, half _minval_, half _maxval_)
-| Returns *min*(*max*(_x_, _minval_), _maxval_).
+| Returns *fmin*(*fmax*(_x_, _minval_), _maxval_).
 
   Results are undefined if _minval_ > _maxval_.
 

--- a/ext/cl_khr_fp64.txt
+++ b/ext/cl_khr_fp64.txt
@@ -455,7 +455,7 @@ These are described below.
 
   gentype *clamp* ( +
   gentype _x_, double _minval_, double _maxval_)
-| Returns *min*(*max*(_x_, _minval_), _maxval_).
+| Returns *fmin*(*fmax*(_x_, _minval_), _maxval_).
 
   Results are undefined if _minval_ > _maxval_.
 


### PR DESCRIPTION
This change is a possible resolution to issue #49, for discussion.

I've marked it WIP until we know this is the right direction.