### PR TITLE
added KHR suffix to enums for cl_khr_image2d_from_buffer

### DIFF
--- a/api/opencl_runtime_layer.txt
+++ b/api/opencl_runtime_layer.txt
@@ -1899,7 +1899,7 @@ size in bytes.
 For a 2D image created from a buffer, the pitch specified (or computed if
 pitch specified is 0) must be a multiple of the maximum of the
 CL_DEVICE_IMAGE_PITCH_ALIGNMENT value for all devices in the context
-associated with `image_desc`->`mem_object` and that support images.
+associated with the buffer specified by _mem_object_ that support images.
 
 `image_slice_pitch` is the size in bytes of each 2D slice in the 3D image or
 the size in bytes of each image in a 1D or 2D image array.
@@ -1954,11 +1954,11 @@ descriptor information associated with mem_object.
 Image elements are stored according to their image format as described in
 <<image-format-descriptor, Image Format Descriptor>>.
 
-If the buffer object specified by mem_object is created with
+If the buffer object specified by _mem_object_ was created with
 CL_MEM_USE_HOST_PTR, the _host_ptr_ specified to *clCreateBuffer* must be
-aligned to the minimum of the *CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT* value
+aligned to the maximum of the *CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT* value
 for all devices in the context associated with the buffer specified by
-mem_object and that support images.
+_mem_object_ that support images.
 
 Creating a 2D image object from another 2D image object allows users to
 create a new image object that shares the image data store with mem_object

--- a/ext/cl_khr_image2d_from_buffer.txt
+++ b/ext/cl_khr_image2d_from_buffer.txt
@@ -22,16 +22,16 @@ The following table entry describes the additions to _table 4.3,_ which allows a
 |*Description*
 
 |*CL_DEVICE_IMAGE_ +
-PITCH_ALIGNMENT*
+PITCH_ALIGNMENT_KHR*
 |cl_uint
 |The row pitch alignment size in pixels for images created from a buffer.  The value returned must be a power of 2. +
 {blank}
 If the device does not support images, this value should be 0.
 
-|*CL_DEVICE_IMAGE_ +
-BASE_ADDRESS_ALIGNMENT*
+|*CL_DEVICE_IMAGE_BASE_ +
+ADDRESS_ALIGNMENT_KHR*
 |cl_uint
-|This query should be used when an image is created from a buffer which was created using +CL_MEM_USE_HOST_PTR+. The value returned must be a power of 2. +
+|This query should be used when an image is created from a buffer which was created using `CL_MEM_USE_HOST_PTR`. The value returned must be a power of 2. +
 {blank}
 This query specifies the minimum alignment in pixels of the _host_ptr_ specified to *clCreateBuffer*. +
 {blank}
@@ -43,18 +43,16 @@ If the device does not support images, this value should be 0.
 
 Add to Section 5.3.1: Creating Image Objects:
 
-A 2D image can be created from a buffer by specifying a buffer object in the +image_desc->buffer+ passed to *clCreateImage* for +image_desc->image_type+ equal to +CL_MEM_OBJECT_IMAGE2D+. When the 2D image from buffer is created, the client must specify the width, height and image format (i.e. channel order and channel data type). If these are not specified, *clCreateImage* returns a NULL value with _errcode_ret_ set to +CL_INVALID_IMAGE_FORMAT_DESCRIPTOR+.  The pitch can be optionally specified. If the pitch is not specified, the pitch is computed as width * bytes per pixel based on the image format. 
+A 2D image can be created from a buffer by specifying a _buffer_ object in the _image_desc_ passed to *clCreateImage* for an _image_type_ equal to `CL_MEM_OBJECT_IMAGE2D`. When the 2D image from buffer is created, the client must specify the width, height and image format (i.e. channel order and channel data type). If these are not specified, *clCreateImage* returns a NULL value with _errcode_ret_ set to `CL_INVALID_IMAGE_FORMAT_DESCRIPTOR`.  The pitch can be optionally specified. If the pitch is not specified, the pitch is computed as width {times} bytes per pixel based on the image format.
 
-The pitch specified (or computed if pitch specified is 0) must be a multiple of the maximum of the +CL_DEVICE_IMAGE_PITCH_ALIGNMENT+ value for all devices in the context associated with +image_desc->buffer+ that support images.  Otherwise, *clCreateImage* returns a NULL value with _errcode_ret_ set to +CL_INVALID_IMAGE_FORMAT_DESCRIPTOR+.
+The pitch specified (or computed if pitch specified is 0) must be a multiple of the maximum of the `CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR` value for all devices in the context associated with the _buffer_ that support images.  Otherwise, *clCreateImage* returns a NULL value with _errcode_ret_ set to `CL_INVALID_IMAGE_FORMAT_DESCRIPTOR`.
 
-If +image_desc->buffer+ is created with +CL_MEM_USE_HOST_PTR+, the _host_ptr_ specified to clCreateBuffer must be aligned to the maximum of the +CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT+ value for all devices in the context associated with image_desc->buffer that support images.  Otherwise, *clCreateImage* returns a NULL value with _errcode_ret_ set to +CL_INVALID_IMAGE_FORMAT_DESCRIPTOR+.
+If the _buffer_ was created with `CL_MEM_USE_HOST_PTR`, the _host_ptr_ specified to *clCreateBuffer* must be aligned to the maximum of the `CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR` value for all devices in the context associated with the _buffer_ that support images.  Otherwise, *clCreateImage* returns a NULL value with _errcode_ret_ set to `CL_INVALID_IMAGE_FORMAT_DESCRIPTOR`.
 
 The minimum list of supported image formats described in _table 5.8_ of the OpenCL 1.2 specification must be supported for 2D images created from a buffer.
 
-The OpenCL runtime APIs that operate on images (i.e. clEnqueueReadImage, clEnqueueWriteImage, clEnqueueFillImage, clEnqueueCopyImage, clEnqueueCopyImageToBuffer, clEnqueueCopyBufferToImage and clEnqueueMapImage) are supported for a 2D image created from a buffer.
+The OpenCL runtime APIs that operate on images (i.e. *clEnqueueReadImage*, *clEnqueueWriteImage*, *clEnqueueFillImage*, *clEnqueueCopyImage*, *clEnqueueCopyImageToBuffer*, *clEnqueueCopyBufferToImage* and *clEnqueueMapImage*) are supported for a 2D image created from a buffer.
 
-When the contents of a buffer objects data store are modified, those changes are reflected in the contents of the 2D image object and vice-versa at corresponding synchronization points. The 
-image_height * image_row_pitch specified in image_desc must be <= size of buffer object data 
-store.
+When the contents of a buffer object data store are modified, those changes are reflected in the contents of the 2D image object and vice-versa at corresponding synchronization points. The _image_height_ {times} _image_row_pitch_ specified in _image_desc_ must be less than or equal to the size of the buffer object data store.
 
-NOTE: Concurrent reading from, writing to and copying between both a buffer object and the 2D image object associated with the buffer object is undefined. Only reading from both a buffer object and 2D image object associated with the buffer object is defined. A 2D image or a 2D image created form a buffer use the same image type in OpenCL C i.e. image2d_t. The image built-ins functions described in _section 6.12.14.2_, _6.12.14.3_, _6.12.14.4_ and _6.12.14.5_ for image2d_t behave the same way for a 2D image and a 2D image from a buffer.
+NOTE: Concurrent reading from, writing to, and copying between both a buffer object and the 2D image object associated with the buffer object is undefined. Only reading from both a buffer object and 2D image object associated with the buffer object is defined. A 2D image and a 2D image created from a buffer use the same image type in OpenCL C (`image2d_t`). The image built-ins functions described in _section 6.12.14.2_, _6.12.14.3_, _6.12.14.4_ and _6.12.14.5_ for `image2d_t` behave the same way for a 2D image and a 2D image from a buffer.


### PR DESCRIPTION
This change adds a KHR suffix to the enums for `cl_khr_image2d_from_buffer`.

See:

https://github.com/KhronosGroup/OpenCL-Headers/issues/42

I also tidied up the formatting for this extension, and made a few similar formatting changes to the main API spec for consistency.