### PR TITLE
rename CL_SHORT_MIN, CL_SHORT_MAX, and CL_USHORT_MAX defines

### DIFF
--- a/api/c_appendix.txt
+++ b/api/c_appendix.txt
@@ -272,11 +272,11 @@ definitions are also available.
   | Minimum value of a type `cl_char`
 | *CL_UCHAR_MAX*
   | Maximum value of a type `cl_uchar`
-| *CL_SHORT_MAX*
+| *CL_SHRT_MAX*
   | Maximum value of a type `cl_short`
-| *CL_SHORT_MIN*
+| *CL_SHRT_MIN*
   | Minimum value of a type `cl_short`
-| *CL_USHORT_MAX*
+| *CL_USHRT_MAX*
   | Maximum value of a type `cl_ushort`
 | *CL_INT_MAX*
   | Maximum value of a type `cl_int`


### PR DESCRIPTION
This change renames the `CL_SHORT_MIN`, `CL_SHORT_MAX`, and `CL_USHORT_MAX` constants in the spec to `CL_SHRT_MIN`, `CL_SHRT_MAX`, and `CL_USHRT_MAX`.

This matches the name of these constants in the OpenCL headers and is consistent with <limits.h>.

See #58.