### PR TITLE
move acknowledgements to the end the API, C, and C++ specs

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -25,10 +25,6 @@ include::copyrights.txt[]
 
 <<<
 
-include::api/acknowledgements.txt[]
-
-<<<
-
 // :numbered:
 
 :leveloffset: 1
@@ -59,5 +55,6 @@ include::api/d_appendix.txt[]
 
 include::api/e_appendix.txt[]
 
+<<<
 
-
+include::api/acknowledgements.txt[]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -38,10 +38,6 @@ include::copyrights.txt[]
 
 <<<
 
-include::api/acknowledgements.txt[]
-
-<<<
-
 // :numbered:
 
 :leveloffset: 1
@@ -10647,3 +10643,6 @@ one of the integers 0, 1, ... h~t~ - 1.
     Default RGB colour space - sRGB`",
     https://webstore.iec.ch/publication/6169 .
 
+<<<
+
+include::api/acknowledgements.txt[]

--- a/OpenCL_Cxx.txt
+++ b/OpenCL_Cxx.txt
@@ -31,10 +31,6 @@ include::copyrights.txt[]
 
 <<<
 
-include::cxx/acknowledgements.txt[]
-
-<<<
-
 :numbered:
 
 // Generic Type Notation chapter
@@ -155,3 +151,7 @@ include::cxx/compiler_options.txt[]
 :numbered!:
 
 include::cxx/annotation.txt[]
+
+<<<
+
+include::cxx/acknowledgements.txt[]

--- a/api/acknowledgements.txt
+++ b/api/acknowledgements.txt
@@ -2,7 +2,8 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-*Acknowledgements*
+[float]
+= Acknowledgements
 
 The OpenCL specification is the result of the contributions of many people,
 representing a cross section of the desktop, hand-held, and embedded

--- a/api/acknowledgements.txt
+++ b/api/acknowledgements.txt
@@ -2,7 +2,6 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-[float]
 = Acknowledgements
 
 The OpenCL specification is the result of the contributions of many people,


### PR DESCRIPTION
I think we should consider moving the "Acknowledgements" section of the specs to the end vs. the beginning.  This avoids needing to scroll through a few pages before getting to the content, especially for the HTML versions of the specs.