### PR TITLE
fix minor env formatting issue

### DIFF
--- a/env/image_addressing_and_filtering.txt
+++ b/env/image_addressing_and_filtering.txt
@@ -838,8 +838,8 @@ The conversions described in this section must be correctly saturated.
 ==== Conversion Rules for sRGBA and sBGRA Images
 
 Standard RGB data, which roughly displays colors in a linear ramp of luminosity levels such that an average observer, under average viewing conditions, can view them as perceptually equal steps on an average display.
-All 0`s maps to 0.0f, and all 1`s maps to 1.0f.
-The sequence of unsigned integer encodings between all 0`s and all 1`s represent a nonlinear progression in the floating-point interpretation of the numbers between 0.0f to 1.0f.
+All 0s maps to 0.0f, and all 1s maps to 1.0f.
+The sequence of unsigned integer encodings between all 0s and all 1s represent a nonlinear progression in the floating-point interpretation of the numbers between 0.0f to 1.0f.
 For more detail, see the <<sRGB-spec, SRGB color standard>>.
 
 Conversion from sRGB space is automatically done the image read instruction if the image channel order is one of the sRGB values described above.


### PR DESCRIPTION
This is a very small change to fix a minor formatting issue in the SPIR-V environment spec.

The apostrophes were causing some formatting issues in the HTML doc.  The PDF didn't seem to be affected.  After this change, both docs look OK.