### PR TITLE
#66 Allow operations on C11 atomic types.

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6207,11 +6207,6 @@ Memory is affected according to the value of order.
 
 [open,refpage='atomicRestrictions',desc='Restrictions on Atomic Operations',type='freeform',spec='clang',anchor='atomic-restrictions',xrefs='atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-  * All operations on atomic types must be performed using the built-in
-    atomic functions.
-    C11 and C++11 support operators on atomic types.
-    OpenCL C does not support operators with atomic types.
-    Using atomic types with operators should result in a compilation error.
   * The `atomic_bool`, `atomic_char`, `atomic_uchar`, `atomic_short`,
     `atomic_ushort`, `atomic_intmax_t` and `atomic_uintmax_t` types are not
     supported by OpenCL C.


### PR DESCRIPTION
This is the frontend only feature. Removing the restriction
won't result in incorrect use of atomic types. There is a
convenience feature since using regular operations
is more concise than builtin functions.