### PR TITLE
Tweak the generator script to allow anonymous <member> declarations

### DIFF
--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -626,11 +626,13 @@ class OutputGenerator:
             paramdecl = indent + ' '.join(paramdecl.split())
         return paramdecl
 
-    # getCParamTypeLength - return the length of the type field is an indented, formatted
-    # declaration for a <param> or <member> block (e.g. function parameter
-    # or structure/union member).
+    # getCParamTypeLength - return the length of the type field in an
+    # indented, formatted declaration for a <param> or <member> block (e.g.
+    # function parameter or structure/union member). This relies on the
+    # presence of the <name> tag; if not present, return zero.
     # param - Element (<param> or <member>) to identify
     def getCParamTypeLength(self, param):
+        newLen = 0
         paramdecl = '    ' + noneStr(param.text)
         for elem in param:
             text = noneStr(elem.text)

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -237,14 +237,13 @@ server's OpenCL/api-docs repository.
             <member><type>cl_uint</type>             <name>num_mip_levels</name></member>
             <member><type>cl_uint</type>             <name>num_samples</name></member>
             <!-- Can't properly express this in XML schema yet - use name/ tag to align? -->
-            <member>
-#ifdef __GNUC__
-            __extension__   /* Prevents warnings about anonymous union in -pedantic builds */
+            <member>#ifdef __GNUC__
+    __extension__   /* Prevents warnings about anonymous union in -pedantic builds */
 #endif
-            union {
-                cl_mem buffer;
-                cl_mem mem_object;
-            };<name/></member>
+    union {
+        cl_mem buffer;
+        cl_mem mem_object;
+    }</member>
         </type>
         <type category="struct" name="cl_buffer_region">
             <member><type>size_t</type>              <name>origin</name></member>


### PR DESCRIPTION
(e.g. no <name> field), and modify the cl_image_desc XML definition to format more cleanly (internal issue 177). This has no impact on spec language, just generated code formatting.