### PR TITLE
Clarify 1.2 validation rules for Memory Semantics

### DIFF
--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -64,12 +64,12 @@ For all other instructions, _Scope_ for _Execution_ must be one of:
 
 In an OpenCL 1.2 environment,
 for the *Barrier Instructions* *OpControlBarrier* and *OpMemoryBarrier*, the
-_Scope_ for _Memory_ must be *Workgroup*, and the _Memory Semantics_ must be
-*SequentiallyConsistent*.
+_Scope_ for _Memory_ must be *Workgroup*, and the memory-order constraint in
+_Memory Semantics_ must be *SequentiallyConsistent*.
 
 In an OpenCL 1.2 environment,
 for the *Atomic Instructions*, the _Scope_ for _Memory_ must be *Device*,
-and the _Memory Semantics_ must be *Relaxed*.
+and the memory-order constraint in _Memory Semantics_ must be *Relaxed*.
 
 Otherwise, _Scope_ for _Memory_ must be one of:
 


### PR DESCRIPTION
Memory Semantics is used to specify both memory-order
constraints and the storage classes they apply to.

Make it explicit that only the memory-order constraint
bits are restricted. The storage class can vary
(WorkgroupMemory or CrossWorkgroupMemory).

Signed-off-by: Kevin Petit <kevin.petit@arm.com>