### PR TITLE
allocate two enum blocks for upcoming Intel extensions

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1610,8 +1610,16 @@ server's OpenCL/api-docs repository.
         <enum value="0x417F"        name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
     </enums>
 
-    <enums start="0x4180" end="0x4FFF" name="enums.4180" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x4180" end="0x4FFF"/>
+    <enums start="0x4180" end="0x418F" name="enums.4180" vendor="Intel" comment="Per OpenCL-Registry #22">
+            <unused start="0x4180" end="0x418F"/>
+    </enums>
+
+    <enums start="0x4190" end="0x41AF" name="enums.4190" vendor="Intel">
+            <unused start="0x4190" end="0x41AF"/>
+    </enums>
+
+    <enums start="0x41B0" end="0x4FFF" name="enums.4180" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x41B0" end="0x4FFF"/>
     </enums>
 
     <enums start="0x10000" end="0x10FFF" name="enums.10000" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">


### PR DESCRIPTION
Please allocate two enum blocks for upcoming Intel extensions (0x4190 to 0x41AF).

Note, this PR also re-adds the enum block that was previously allocated to Intel via https://github.com/KhronosGroup/OpenCL-Registry/pull/22, but that appears to have gone missing when the XML file moved to this repo (0x4180 to 0x418F)

Thanks!