### PR TITLE
OpenCL XML Fixes

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2778,8 +2778,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
-            <param>const <type>size_t</type>*                           <name>origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>row_pitch</name></param>
             <param><type>size_t</type>                                  <name>slice_pitch</name></param>
             <param>void*                                                <name>ptr</name></param>
@@ -2792,8 +2792,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
-            <param>const <type>size_t</type>*                           <name>origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>input_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>input_slice_pitch</name></param>
             <param>const void*                                          <name>ptr</name></param>
@@ -2806,8 +2806,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param>const void*                                          <name>fill_color</name></param>
-            <param>const <type>size_t</type>*                           <name>origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2817,9 +2817,9 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_image</name></param>
             <param><type>cl_mem</type>                                  <name>dst_image</name></param>
-            <param>const <type>size_t</type>*                           <name>src_origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>dst_origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>src_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>dst_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2829,8 +2829,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_image</name></param>
             <param><type>cl_mem</type>                                  <name>dst_buffer</name></param>
-            <param>const <type>size_t</type>*                           <name>src_origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>src_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>dst_offset</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
@@ -2842,8 +2842,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>src_buffer</name></param>
             <param><type>cl_mem</type>                                  <name>dst_image</name></param>
             <param><type>size_t</type>                                  <name>src_offset</name></param>
-            <param>const <type>size_t</type>*                           <name>dst_origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>dst_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2867,8 +2867,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_map</name></param>
             <param><type>cl_map_flags</type>                            <name>map_flags</name></param>
-            <param>const <type>size_t</type>*                           <name>origin[3]</name></param>
-            <param>const <type>size_t</type>*                           <name>region[3]</name></param>
+            <param>const <type>size_t</type>*                           <name>origin</name></param>
+            <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>*                                 <name>image_row_pitch</name></param>
             <param><type>size_t</type>*                                 <name>image_slice_pitch</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -3050,6 +3050,7 @@ server's OpenCL/api-docs repository.
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>cl_int</type> <name>clUnloadCompiler</name></proto>
+            <param>void                                                 </param>
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto>void* <name>clGetExtensionFunctionAddress</name></proto>
@@ -3519,7 +3520,7 @@ server's OpenCL/api-docs repository.
             <command name="clEnqueueNDRangeKernel"/>
             <command name="clEnqueueNativeKernel"/>
         </require>
-        <require comment="Deprecated APIs">
+        <require comment="OpenCL 1.0 APIs that were deprecated in OpenCL 1.1">
             <comment>
             #ifdef CL_USE_DEPRECATED_OPENCL_1_0_APIS
                 /*
@@ -3535,6 +3536,20 @@ server's OpenCL/api-docs repository.
             #endif /* CL_USE_DEPRECATED_OPENCL_1_0_APIS */
             </comment>
             <command name="clSetCommandQueueProperty"/>
+        </require>
+        <require comment="OpenCL 1.0 APIs that were deprecated in OpenCL 1.2">
+            <command name="clCreateImage2D"/>
+            <command name="clCreateImage3D"/>
+            <command name="clEnqueueMarker"/>
+            <command name="clEnqueueWaitForEvents"/>
+            <command name="clEnqueueBarrier"/>
+            <command name="clUnloadCompiler"/>
+            <command name="clGetExtensionFunctionAddress"/>
+        </require>
+        <require comment="OpenCL 1.0 APIs that were deprecated in OpenCL 2.0">
+            <command name="clCreateCommandQueue"/>
+            <command name="clCreateSampler"/>
+            <command name="clEnqueueTask"/>
         </require>
     </feature>
 
@@ -3602,15 +3617,6 @@ server's OpenCL/api-docs repository.
             <command name="clEnqueueReadBufferRect"/>
             <command name="clEnqueueWriteBufferRect"/>
             <command name="clEnqueueCopyBufferRect"/>
-        </require>
-        <require comment="Deprecated OpenCL 1.1 APIs">
-            <command name="clCreateImage2D"/>
-            <command name="clCreateImage3D"/>
-            <command name="clEnqueueMarker"/>
-            <command name="clEnqueueWaitForEvents"/>
-            <command name="clEnqueueBarrier"/>
-            <command name="clUnloadCompiler"/>
-            <command name="clGetExtensionFunctionAddress"/>
         </require>
     </feature>
 
@@ -3910,11 +3916,6 @@ server's OpenCL/api-docs repository.
             <command name="clEnqueueSVMMemFill"/>
             <command name="clEnqueueSVMMap"/>
             <command name="clEnqueueSVMUnmap"/>
-        </require>
-        <require comment="Deprecated OpenCL 2.0 APIs">
-            <command name="clCreateCommandQueue"/>
-            <command name="clCreateSampler"/>
-            <command name="clEnqueueTask"/>
         </require>
     </feature>
 
@@ -5083,7 +5084,7 @@ server's OpenCL/api-docs repository.
             <require feature="CL_VERSION_1_2">
                 <command name="clCreateFromGLTexture"/>
             </require>
-            <require comment="Deprecated OpenCL 1.1 APIs">
+            <require comment="OpenCL 1.0 APIs that were deprecated in OpenCL 1.2">
                 <command name="clCreateFromGLTexture2D"/>
                 <command name="clCreateFromGLTexture3D"/>
             </require>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1618,7 +1618,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x4190" end="0x41AF"/>
     </enums>
 
-    <enums start="0x41B0" end="0x4FFF" name="enums.4180" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+    <enums start="0x41B0" end="0x4FFF" name="enums.41B0" comment="Reserved for vendor extensions. Allocate in groups of 16.">
             <unused start="0x41B0" end="0x4FFF"/>
     </enums>
 


### PR DESCRIPTION
This PR fixes a few issues I've found generating code from the OpenCL XML file:

* For several APIs, the "origin" and "region" arguments are of pointer type and include an array size in square brackets, which is redundant/incorrect.  I've removed the square brackets, which is consistent with the OpenCL headers.

* For clUnloadCompiler, I've added an explicit unnamed parameter of type "void", vs. no parameters.  This eliminates a special-case of no paramters, and is also consistent with the OpenCL headers and the OpenCL 1.0 specification.

* Several deprecated APIs were included in section for the API they were deprecated in rather than the section for the API that added them.  I've fixed a few of these, but there may be others.

* I fixed a small typo in my recent PR where the name of the unused enum block was not updated correctly.

I've built the specs and online man pages with these changes with no issues.