### PR TITLE
Correct the rendering of the phrase `C++`

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -16,6 +16,8 @@ Khronos{R} OpenCL Working Group
 :source-highlighter: coderay
 :title-logo-image: image:images/OpenCL.png[Logo,200,200]
 
+:cpp: pass:[C++]
+
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -20,6 +20,8 @@ Khronos{R} OpenCL Working Group
 // Needed for expressing C math in unary ops section
 :pp: ++
 
+:cpp: pass:[C++]
+:cpp11: pass:[C++11]
 :private: pass:[__private]
 :global: pass:[__global]
 :local: pass:[__local]
@@ -5719,7 +5721,7 @@ memory that is shared with one or more OpenCL devices, it must use atomic
 and fence operations that are compatible with the C11 atomic operations.
 
 We can't require <<C11-spec,C11 atomics>> since host programs can be
-implemented in other programming languages and versions of C or C++, but we
+implemented in other programming languages and versions of C or {cpp}, but we
 do require that the host programs use atomics and that those atomics be
 compatible with those in C11.
 ====
@@ -6268,7 +6270,7 @@ Memory is affected according to the value of order.
 --
   * All operations on atomic types must be performed using the built-in
     atomic functions.
-    C11 and C++11 support operators on atomic types.
+    C11 and {cpp11} support operators on atomic types.
     OpenCL C does not support operators with atomic types.
     Using atomic types with operators should result in a compilation error.
   * The `atomic_bool`, `atomic_char`, `atomic_uchar`, `atomic_short`,

--- a/api/glossary.txt
+++ b/api/glossary.txt
@@ -384,7 +384,7 @@ Kernel Object ::
 
 Kernel Language ::
     A language that is used to create source code for kernel.
-    Supported kernel languages include OpenCL C, OpenCL C++, and OpenCL
+    Supported kernel languages include OpenCL C, OpenCL {cpp}, and OpenCL
     dialect of SPIR-V.
 
 Launch ::
@@ -701,7 +701,7 @@ Specialization constants ::
     Application might provide values for the specialization constants that
     will be used when program is built from the intermediate format.
     Specialization constants that do not receive a value from an application
-    shall use default values as defined in OpenCL C++ or SPIR-V specification.
+    shall use default values as defined in OpenCL {cpp} or SPIR-V specification.
 
 SPMD ::
     Single Program Multiple Data.

--- a/api/opencl_architecture.txt
+++ b/api/opencl_architecture.txt
@@ -66,7 +66,7 @@ implemented with OpenCL.
 image::images/platform_model.png[align="center", title="Platform Model ... one host plus one or more compute devices each with one or more compute units composed of one or more processing elements."]
 
 Programmers provide programs in the form of SPIR-V source binaries, OpenCL C
-or OpenCL C++ source strings or implementation-defined binary objects.
+or OpenCL {cpp} source strings or implementation-defined binary objects.
 The OpenCL platform provides a compiler to translate program input of either
 form into executable program objects.
 The device code compiler may be _online_ or _offline_.
@@ -209,9 +209,9 @@ These prerequisites have three sources:
     commands and coordinate execution between the host and one or more
     devices.
   * The third source of prerequisites can be the presence of non-trivial C
-    initializers or C++ constructors for program scope global variables.
-    In this case, OpenCL C/C++ compiler shall generate program
-    initialization kernels that perform C initialization or C++
+    initializers or {cpp} constructors for program scope global variables.
+    In this case, OpenCL C/{cpp} compiler shall generate program
+    initialization kernels that perform C initialization or {cpp}
     construction.
     These kernels must be executed by OpenCL runtime on a device before any
     kernel from the same program can be executed on the same device.
@@ -222,13 +222,13 @@ These prerequisites have three sources:
 
 Program clean up may result in the execution of one or more program clean up
 kernels by the OpenCL runtime.
-This is due to the presence of non-trivial pass:[C++] destructors for
+This is due to the presence of non-trivial {cpp} destructors for
 program scope variables.
 The ND-range for executing any program clean up kernel is (1,1,1).
 The order of execution of clean up kernels from different programs (that are
 linked together) is undefined.
 
-Note that C initializers, C++ constructors, or C++ destructors for program
+Note that C initializers, {cpp} constructors, or {cpp} destructors for program
 scope variables cannot use pointers to coarse grain and fine grain SVM
 allocations.
 
@@ -1573,7 +1573,7 @@ read-modify-write operation.
 are computed that circularly depend on their own computation.#
 
 Note: Under the rules described above, and independent to the previously
-footnoted C++ issue, it is known that _x == y == 42_ is a valid final state
+footnoted {cpp} issue, it is known that _x == y == 42_ is a valid final state
 in the following problematic example:
 
 [source,c]
@@ -1987,7 +1987,7 @@ The framework contains the following components:
     contexts once they have been created.
   * *OpenCL Compiler*: The OpenCL compiler creates program executables that
     contain OpenCL kernels.
-    SPIR-V intermediate language, OpenCL C, OpenCL C++, and OpenCL C
+    SPIR-V intermediate language, OpenCL C, OpenCL {cpp}, and OpenCL C
     language versions from earlier OpenCL specifications are supported by
     the compiler.
     Other input languages may be supported by some implementations.

--- a/api/opencl_assoc_spec.txt
+++ b/api/opencl_assoc_spec.txt
@@ -36,7 +36,7 @@ versions of the extension specification document.
 == Support for earlier OpenCL C kernel languages
 
 The OpenCL C kernel language is not defined in the OpenCL 2.2 specification.
-New language features are described in the OpenCL C++ specification as well
+New language features are described in the OpenCL {cpp} specification as well
 as the SPIR-V 1.2 specification and in kernel languages that target it.
 A kernel language defined by any of the OpenCL 1.0, OpenCL 1.1, OpenCL 1.2
 and OpenCL 2.0 kernel language specifications as well as kernels language

--- a/api/opencl_runtime_layer.txt
+++ b/api/opencl_runtime_layer.txt
@@ -4715,7 +4715,7 @@ with _context_.
 The source code specified by _strings_ is either an OpenCL C program source,
 header or implementation-defined source for custom devices that support an
 online compiler.
-OpenCL C++ is not supported as an online-compiled kernel language through
+OpenCL {cpp} is not supported as an online-compiled kernel language through
 this interface.
 
 // refError
@@ -5463,14 +5463,14 @@ math intrinsics, options that control optimization and miscellaneous
 options.
 This specification defines a standard set of options that must be supported
 by the compiler when building program executables online or offline from
-OpenCL C/C++ or, where relevant, from an IL.
+OpenCL C/{cpp} or, where relevant, from an IL.
 These may be extended by a set of vendor- or platform-specific options.
 
 
 [[preprocessor-options]]
 ==== Preprocessor options
 
-These options control the OpenCL C/C++ preprocessor which is run on each
+These options control the OpenCL C/{cpp} preprocessor which is run on each
 program source before actual compilation.
 These options are ignored for programs created with IL.
 
@@ -6390,7 +6390,7 @@ Otherwise, it returns one of the following errors:
     _arg_size_ (if the argument was declared with local qualifier) exceed
     the maximum size restriction that was set with the optional language
     attribute.
-    The optional attribute can be `cl::max_size` defined in OpenCL 2.2 C++
+    The optional attribute can be `cl::max_size` defined in OpenCL 2.2 {cpp}
     Kernel Language specification or `SpvDecorationMaxByteOffset` defined
     in SPIR-V 1.2 Specification.
   * {CL_INVALID_ARG_VALUE} if the argument is an image declared with the
@@ -6669,7 +6669,7 @@ include::{generated}/api/protos/clGetKernelInfo.txt[]
 | {CL_KERNEL_ATTRIBUTES_anchor}
   | char[]
       | Returns any attributes specified using the `+__attribute__+`
-        OpenCL C qualifier (or using an OpenCL C++ qualifier syntax [[]] )
+        OpenCL C qualifier (or using an OpenCL {cpp} qualifier syntax [[]] )
         with the kernel function declaration in the program source.
         These attributes include attributes described in the earlier OpenCL
         C kernel language specifications and other attributes supported by
@@ -7301,7 +7301,7 @@ Otherwise, it returns one of the following errors:
 
 [open,refpage='clEnqueueNativeKernel',desc='Enqueues a command to execute a native C/C++ function not compiled using the OpenCL compiler.',type='protos']
 --
-To enqueue a command to execute a native C/C++ function not compiled using
+To enqueue a command to execute a native C/{cpp} function not compiled using
 the OpenCL compiler, call the function
 
 include::{generated}/api/protos/clEnqueueNativeKernel.txt[]


### PR DESCRIPTION
In some instances the phrase `C++` was rendered as `C`, due to the `++`
sometimes being considered as markup.  This change modifies all
instances to use a macro, whether they happen to currently render
incorrectly or not.