### PR TITLE
Fix refpage links not opening

### DIFF
--- a/man/copyright-ccby.txt
+++ b/man/copyright-ccby.txt
@@ -2,5 +2,5 @@
 
 Copyright (c) 2014-2019 Khronos Group. This work is licensed under a
 http://creativecommons.org/licenses/by/4.0/[Creative Commons
-Attribution 4.0 International License].
+Attribution 4.0 International License^].
 

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -224,9 +224,8 @@ def refPageTail(pageName,
         seeAlso = 'No cross-references are available\n'
 
     notes = [
-        'For more information, see the ' + specName + ' Specification at URL',
-        '',
-        '{}#{}'.format(specURL, specAnchor),
+        'For more information, see the {}#{}[{} Specification^]'.format(
+            specURL, specAnchor, specName),
         '',
         ]
 
@@ -316,7 +315,7 @@ def emitPage(baseDir, specDir, pi, file):
 
     # Substitute xrefs to point at the main spec
     specLinksPattern = re.compile(r'<<([^>,]+)[,]?[ \t\n]*([^>,]*)>>')
-    specLinksSubstitute = r'link:{}#\1[\2]'.format(specURL)
+    specLinksSubstitute = r'link:{}#\1[\2^]'.format(specURL)
     if specText is not None:
         specText, _ = specLinksPattern.subn(specLinksSubstitute, specText)
     if fieldText is not None:


### PR DESCRIPTION
This adds '^' to generated asciidoctor link: text, causing the resulting
HTML to open external hyperlinks in a new page (see https://github.com/asciidoctor/asciidoctor/issues/2071). While that works, there
are some related issues I'm exploring with landing on the wrong anchor
in the opened document when it's a CL specification, so marking this WIP
for the moment.

Closes #93 (once it's deWIPed).