### PR TITLE
Fix vendor enumerant reservations

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1614,12 +1614,24 @@ server's OpenCL/api-docs repository.
             <unused start="0x4180" end="0x418F"/>
     </enums>
 
-    <enums start="0x4190" end="0x41AF" name="enums.4190" vendor="Intel">
-            <unused start="0x4190" end="0x41AF"/>
+    <enums start="0x4190" end="0x419F" name="enums.4190" vendor="Intel">
+            <unused start="0x4190" end="0x419F"/>
     </enums>
 
-    <enums start="0x41B0" end="0x4FFF" name="enums.41B0" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x41B0" end="0x4FFF"/>
+    <enums start="0x41A0" end="0x41DF" name="enums.41A0" vendor="Qualcomm">
+            <unused start="0x41A0" end="0x41DF"/>
+    </enums>
+
+    <enums start="0x41E0" end="0x41FF" name="enums.41E0" vendor="Arm">
+            <unused start="0x41E0" end="0x41FF"/>
+    </enums>
+
+    <enums start="0x4200" end="0x420F" name="enums.4200" vendor="Intel">
+            <unused start="0x4200" end="0x420F"/>
+    </enums>
+
+    <enums start="0x420F" end="0x4FFF" name="enums.420F" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x420F" end="0x4FFF"/>
     </enums>
 
     <enums start="0x10000" end="0x10FFF" name="enums.10000" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">


### PR DESCRIPTION
Some reservations were undone when moving from OpenCL-Registry
to OpenCL-Docs. This change restores the state from OpenCL-Registry.

The Qualcomm block was reserved in https://github.com/KhronosGroup/OpenCL-Registry/pull/42
The Arm block was reserved in https://github.com/KhronosGroup/OpenCL-Registry/pull/48

The overlapping Intel reservation was made in https://github.com/KhronosGroup/OpenCL-Docs/pull/94

Signed-off-by: Kevin Petit <kevin.petit@arm.com>