### PR TITLE
cl_khr_icd: reflect changes in definition of the dispatch table

### DIFF
--- a/ext/cl_khr_icd.asciidoc
+++ b/ext/cl_khr_icd.asciidoc
@@ -43,10 +43,9 @@ The structure `_cl_icd_dispatch` is a function pointer dispatch table which
 is used to direct calls to a particular vendor implementation.
 All objects created from ICD compatible objects must be ICD compatible.
 
-The order of the functions in `_cl_icd_dispatch` is determined by the ICD
-Loader's source.
-The ICD Loader's source's `_cl_icd_dispatch` table is to be appended to
-only.
+The definition for `_cl_icd_dispatch` is provided along with the OpenCL
+headers. Existing members can never be removed from that structure but new
+members can be appended.
 
 Functions which do not have an argument from which the vendor implementation
 may be inferred have been deprecated and may be ignored.
@@ -300,7 +299,7 @@ The official source for the ICD loader is available on github, at:
 https://github.com/KhronosGroup/OpenCL-ICD-Loader
 
 The complete `_cl_icd_dispatch` structure is defined in the header
-*icd_dispatch.h*, which is available as a part of the source code.
+*cl_icd.h*, which is available as a part of the OpenCL headers.
 
 [[cl_khr_icd-issues]]
 === Issues


### PR DESCRIPTION
The dispatch table declaration no longer is an implementation
detail of the Khronos ICD loader and is now provided with the
OpenCL headers.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>