### PR TITLE
more API and enum link fixes

### DIFF
--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -266,90 +266,91 @@ definitions are also available.
 
 [width="100%",cols="<50%,<50%"]
 |====
-| {CL_CHAR_BIT} | Bit width of a character
-| {CL_SCHAR_MAX}
+| {CL_CHAR_BIT_anchor}
+  | Bit width of a character
+| {CL_SCHAR_MAX_anchor}
   | Maximum value of a type `cl_char`
-| {CL_SCHAR_MIN}
+| {CL_SCHAR_MIN_anchor}
   | Minimum value of a type `cl_char`
-| {CL_CHAR_MAX}
+| {CL_CHAR_MAX_anchor}
   | Maximum value of a type `cl_char`
-| {CL_CHAR_MIN}
+| {CL_CHAR_MIN_anchor}
   | Minimum value of a type `cl_char`
-| {CL_UCHAR_MAX}
+| {CL_UCHAR_MAX_anchor}
   | Maximum value of a type `cl_uchar`
-| {CL_SHRT_MAX}
+| {CL_SHRT_MAX_anchor}
   | Maximum value of a type `cl_short`
-| {CL_SHRT_MIN}
+| {CL_SHRT_MIN_anchor}
   | Minimum value of a type `cl_short`
-| {CL_USHRT_MAX}
+| {CL_USHRT_MAX_anchor}
   | Maximum value of a type `cl_ushort`
-| {CL_INT_MAX}
+| {CL_INT_MAX_anchor}
   | Maximum value of a type `cl_int`
-| {CL_INT_MIN}
+| {CL_INT_MIN_anchor}
   | Minimum value of a type `cl_int`
-| {CL_UINT_MAX}
+| {CL_UINT_MAX_anchor}
   | Maximum value of a type `cl_uint`
-| {CL_LONG_MAX}
+| {CL_LONG_MAX_anchor}
   | Maximum value of a type `cl_long`
-| {CL_LONG_MIN}
+| {CL_LONG_MIN_anchor}
   | Minimum value of a type `cl_long`
-| {CL_ULONG_MAX}
+| {CL_ULONG_MAX_anchor}
   | Maximum value of a type `cl_ulong`
-| {CL_FLT_DIG}
+| {CL_FLT_DIG_anchor}
   | Number of decimal digits of precision for the type `cl_float`
-| {CL_FLT_MANT_DIG}
+| {CL_FLT_MANT_DIG_anchor}
   | Number of digits in the mantissa of type `cl_float`
-| {CL_FLT_MAX_10_EXP}
+| {CL_FLT_MAX_10_EXP_anchor}
   | Maximum positive integer such that 10 raised to this power minus one can
     be represented as a normalized floating-point number of type `cl_float`
-| {CL_FLT_MAX_EXP}
+| {CL_FLT_MAX_EXP_anchor}
   | Maximum exponent value of type `cl_float`
-| {CL_FLT_MIN_10_EXP}
+| {CL_FLT_MIN_10_EXP_anchor}
   | Minimum negative integer such that 10 raised to this power minus one can
     be represented as a normalized floating-point number of type `cl_float`
-| {CL_FLT_MIN_EXP}
+| {CL_FLT_MIN_EXP_anchor}
   | Minimum exponent value of type `cl_float`
-| {CL_FLT_RADIX}
+| {CL_FLT_RADIX_anchor}
   | Base value of type `cl_float`
-| {CL_FLT_MAX}
+| {CL_FLT_MAX_anchor}
   | Maximum value of type `cl_float`
-| {CL_FLT_MIN}
+| {CL_FLT_MIN_anchor}
   | Minimum value of type `cl_float`
-| {CL_FLT_EPSILON}
+| {CL_FLT_EPSILON_anchor}
   | Minimum positive floating-point number of type `cl_float` such that `1.0
     {plus} {CL_FLT_EPSILON} != 1` is true.
-| {CL_DBL_DIG}
+| {CL_DBL_DIG_anchor}
   | Number of decimal digits of precision for the type `cl_double`
-| {CL_DBL_MANT_DIG}
+| {CL_DBL_MANT_DIG_anchor}
   | Number of digits in the mantissa of type `cl_double`
-| {CL_DBL_MAX_10_EXP}
+| {CL_DBL_MAX_10_EXP_anchor}
   | Maximum positive integer such that 10 raised to this power minus one can
     be represented as a normalized floating-point number of type `cl_double`
-| {CL_DBL_MAX_EXP}
+| {CL_DBL_MAX_EXP_anchor}
   | Maximum exponent value of type `cl_double`
-| {CL_DBL_MIN_10_EXP}
+| {CL_DBL_MIN_10_EXP_anchor}
   | Minimum negative integer such that 10 raised to this power minus one can
     be represented as a normalized floating-point number of type `cl_double`
-| {CL_DBL_MIN_EXP}
+| {CL_DBL_MIN_EXP_anchor}
   | Minimum exponent value of type `cl_double`
-| {CL_DBL_RADIX}
+| {CL_DBL_RADIX_anchor}
   | Base value of type `cl_double`
-| {CL_DBL_MAX}
+| {CL_DBL_MAX_anchor}
   | Maximum value of type `cl_double`
-| {CL_DBL_MIN}
+| {CL_DBL_MIN_anchor}
   | Minimum value of type `cl_double`
-| {CL_DBL_EPSILON}
+| {CL_DBL_EPSILON_anchor}
   | Minimum positive floating-point number of type `cl_double` such that
     `1.0 {plus} {CL_DBL_EPSILON} != 1` is true.
-| {CL_NAN}
+| {CL_NAN_anchor}
   | Macro expanding to a value representing NaN
-| {CL_HUGE_VALF}
+| {CL_HUGE_VALF_anchor}
   | Largest representative value of type `cl_float`
-| {CL_HUGE_VAL}
+| {CL_HUGE_VAL_anchor}
   | Largest representative value of type `cl_double`
-| {CL_MAXFLOAT}
+| {CL_MAXFLOAT_anchor}
   | Maximum value of type `cl_float`
-| {CL_INFINITY}
+| {CL_INFINITY_anchor}
   | Macro expanding to a value representing infinity
 |====
 

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -159,7 +159,7 @@ The following APIs in OpenCL 1.1 are deprecated (see glossary) in OpenCL
 
 The following queries are deprecated (see glossary) in OpenCL 1.2:
 
-  * {CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE} in _table 4.3_ queried using
+  * {CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE_anchor} in _table 4.3_ queried using
     {clGetDeviceInfo}.
 
 
@@ -198,10 +198,10 @@ The following APIs are deprecated (see glossary) in OpenCL 2.0:
 
 The following queries are deprecated (see glossary) in OpenCL 2.0:
 
-  * {CL_DEVICE_HOST_UNIFIED_MEMORY} in _table 4.3_ queried using
+  * {CL_DEVICE_HOST_UNIFIED_MEMORY_anchor} in _table 4.3_ queried using
     {clGetDeviceInfo}.
-  * {CL_IMAGE_BUFFER} in _table 5.10_ is deprecated.
-  * {CL_DEVICE_QUEUE_PROPERTIES} is replaced by
+  * {CL_IMAGE_BUFFER_anchor} in _table 5.10_ is deprecated.
+  * {CL_DEVICE_QUEUE_PROPERTIES_anchor} is replaced by
     {CL_DEVICE_QUEUE_ON_HOST_PROPERTIES}.
   * The explicit memory fence functions defined in section 6.12.9 of the
     OpenCL 1.2 specification.

--- a/api/appendix_f.asciidoc
+++ b/api/appendix_f.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017_anchor} The Khronos Group. This work is licensed under a
+// Copyright 2017 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -205,6 +205,6 @@ This section lists OpenCL error codes and their meanings.
 | Returned when the size of the specified kernel argument value exceeds the maximum size defined for the kernel argument.
 
 | {CL_PROFILING_INFO_NOT_AVAILABLE_anchor}
-| Returned by {clGetEventProfilingInfo} when the command associated with the specified event was not enqueued into a command queue with {CL_QUEUE_PROFILING_ENABLED}.
+| Returned by {clGetEventProfilingInfo} when the command associated with the specified event was not enqueued into a command queue with {CL_QUEUE_PROFILING_ENABLE}.
 
 |====

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -857,12 +857,12 @@ device except for the following queries:
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_DEVICE_AFFINITY_DOMAIN_NUMA} +
-        {CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE} +
-        {CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE} +
-        {CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE} +
-        {CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE} +
-        {CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE}
+        {CL_DEVICE_AFFINITY_DOMAIN_NUMA_anchor} +
+        {CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE_anchor} +
+        {CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE_anchor} +
+        {CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE_anchor} +
+        {CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE_anchor} +
+        {CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE_anchor}
 
         If the device does not support any affinity domains, a value of 0
         will be returned.
@@ -1152,12 +1152,10 @@ on the queue are executed only on the sub-device.
         units are not used.
 | {CL_DEVICE_PARTITION_BY_COUNTS_anchor}
   | cl_uint
-      | This property is followed by a
-        {CL_DEVICE_PARTITION_BY_COUNTS_LIST_END} terminated list of compute
-        unit counts.
+      | This property is followed by a list of compute unit counts
+        terminated with 0 or {CL_DEVICE_PARTITION_BY_COUNTS_LIST_END_anchor}.
         For each non-zero count _m_ in the list, a sub-device is created
         with _m_ compute units in it.
-        {CL_DEVICE_PARTITION_BY_COUNTS_LIST_END} is defined to be 0.
 
         The number of non-zero count entries in the list may not exceed
         {CL_DEVICE_PARTITION_MAX_SUB_DEVICES}.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6032,7 +6032,7 @@ include::{generated}/api/protos/clGetProgramBuildInfo.txt[]
 
         {CL_BUILD_NONE_anchor} - The build status returned if no {clBuildProgram},
         {clCompileProgram} or {clLinkProgram} has been performed on the
-        specified _program_ object for _device).
+        specified _program_ object for _device_).
 
         {CL_BUILD_ERROR_anchor} - The build status returned if {clBuildProgram},
         {clCompileProgram} or {clLinkProgram} - whichever was performed last

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -75,7 +75,7 @@ include::{generated}/api/protos/clCreateCommandQueueWithProperties.txt[]
         If {CL_QUEUE_ON_DEVICE} is set,
         {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE}^1^ must also be set.
 
-        {CL_QUEUE_ON_DEVICE_DEFAULT}^2^ - indicates that this is the default
+        {CL_QUEUE_ON_DEVICE_DEFAULT_anchor}^2^ - indicates that this is the default
         device queue.
         This can only be used with {CL_QUEUE_ON_DEVICE}.
 
@@ -145,7 +145,7 @@ include::{generated}/api/protos/clSetDefaultDeviceCommandQueue.txt[]
 
 {clSetDefaultDeviceCommandQueue} may be used to replace a default device
 command queue created with {clCreateCommandQueueWithProperties} and the
-CL_QUEUE_ON_DEVICE_DEFAULT flag.
+{CL_QUEUE_ON_DEVICE_DEFAULT} flag.
 
 // refError
 
@@ -428,6 +428,12 @@ include::{generated}/api/protos/clCreateBuffer.txt[]
 
     {CL_MEM_HOST_WRITE_ONLY} or {CL_MEM_HOST_READ_ONLY} and
     {CL_MEM_HOST_NO_ACCESS} are mutually exclusive.
+| {CL_MEM_KERNEL_READ_AND_WRITE_anchor}
+  | This flag is only used by {clGetSupportedImageFormats} to query image
+    formats that may be both read from and written to by the same kernel
+    instance.
+    To create a memory object that may be read from and written to use
+    {CL_MEM_READ_WRITE}.
 |====
 
 The user is responsible for ensuring that data passed into and out of OpenCL
@@ -1576,18 +1582,41 @@ include::{generated}/api/structs/cl_image_format.txt[]
 
 [[image-channel-order-table]]
 .List of supported Image Channel Order Values
-[width="100%",cols="<100%",options="header"]
+[width="100%",cols="<50%,<50%",options="header"]
 |====
-| Enum values that can be specified in channel_order
-| {CL_R}, {CL_Rx} or {CL_A}
-| {CL_INTENSITY}
-| {CL_LUMINANCE}
-| {CL_DEPTH}
-| {CL_RG}, {CL_RGx} or {CL_RA}
-| {CL_RGB} or {CL_RGBx}
-| {CL_RGBA}
-| {CL_sRGB}, {CL_sRGBx}, {CL_sRGBA}, or {CL_sBGRA}
-| {CL_ARGB}, {CL_BGRA}, or {CL_ABGR}
+| Image Channel Order | Description
+| {CL_R_anchor}, {CL_A_anchor},
+  | Single channel image formats where the single channel represents a `RED` or `ALPHA` component.
+| {CL_DEPTH_anchor}
+  | A single channel image format where the single channel represents a `DEPTH` component.
+| {CL_LUMINANCE_anchor}
+  | A single channel image format where the single channel represents a `LUMINANCE` value.
+    The `LUMINANCE` value is replicated into the `RED`, `GREEN`, and `BLUE` components.
+| {CL_INTENSITY_anchor},
+  | A single channel image format where the single channel represents an `INTENSITY` value.
+    The `INTENSITY` value is replicated into the `RED`, `GREEN`, `BLUE`, and `ALPHA` components.
+| {CL_RG_anchor}, {CL_RA_anchor}
+  | Two channel image formats.
+    The first channel always represents a `RED` component.
+    The second channel represents a `GREEN` component or an `ALPHA` component.
+| {CL_Rx_anchor}
+  | A two channel image format, where the first channel represents a `RED` component and the second channel is ignored.
+| {CL_RGB_anchor}
+  | A three channel image format, where the three channels represent `RED`, `GREEN`, and `BLUE` components.
+| {CL_RGx_anchor}
+  | A three channel image format, where the first two channels represent `RED` and `GREEN` components and the third channel is ignored.
+| {CL_RGBA_anchor}, {CL_ARGB_anchor}, {CL_BGRA_anchor}, {CL_ABGR_anchor}
+  | Four channel image formats, where the four channels represent `RED`, `GREEN`, `BLUE`, and `ALPHA` components.
+| {CL_RGBx_anchor}
+  | A four channel image format, where the first three channels represent `RED`, `GREEN`, and `BLUE` components and the fourth channel is ignored.
+| {CL_sRGB_anchor}
+  | A three channel image format, where the three channels represent `RED`, `GREEN`, and `BLUE` components in the sRGB color space.
+| {CL_sRGBA_anchor}, {CL_sBGRA_anchor}
+  | Four channel image formats, where the first three channels represent `RED`, `GREEN`, and `BLUE` components in the sRGB color space.
+    The fourth channel represents an `ALPHA` component.
+| {CL_sRGBx_anchor}
+  | A four channel image format, where the three channels represent `RED`, `GREEN`, and `BLUE` components in the sRGB color space.
+    The fourth channel is ignored.
 |====
 
 [[image-channel-data-types-table]]
@@ -1877,18 +1906,16 @@ include::{generated}/api/protos/clGetSupportedImageFormats.txt[]
 
   * _context_ is a valid OpenCL context on which the image object(s) will be
     created.
-  * _flags_ is a bit-field that is used to specify allocation and usage
-    information about the image memory object being queried and is described in
+  * _flags_ is a bit-field that is used to specify usage
+    information about the image formats being queried and is described in
     the <<memory-flags-table,Memory Flags>> table.
-    To get a list of supported image formats that can be read from or written to
-    by a kernel, _flags_ must be set to {CL_MEM_READ_WRITE} (get a list of images
-    that can be read from and written to by different kernel instances when
-    correctly ordered by event dependencies), {CL_MEM_READ_ONLY} (list of images
-    that can be read from by a kernel) or {CL_MEM_WRITE_ONLY} (list of images that
-    can be written to by a kernel).
-    To get a list of supported image formats that can be both read from and
-    written to by the same kernel instance, _flags_ must be set to
-    {CL_MEM_KERNEL_READ_AND_WRITE}.
+    _flags_ may be {CL_MEM_READ_WRITE} to query image formats that may be read
+    from and written to by different kernel instances when correctly ordered by
+    event dependencies, or {CL_MEM_READ_ONLY} to query image formats that may
+    be read from by a kernel, or {CL_MEM_WRITE_ONLY} to query image formats that
+    may be written to by a kernel, or {CL_MEM_KERNEL_READ_AND_WRITE} to query
+    image formats that may be both read from and written to by the same kernel
+    instance.
     Please see <<image-format-mapping, Image Format Mapping>> for clarification.
   * _image_type_ describes the image type and must be either
     {CL_MEM_OBJECT_IMAGE1D}, {CL_MEM_OBJECT_IMAGE1D_BUFFER}, {CL_MEM_OBJECT_IMAGE2D},
@@ -2056,7 +2083,6 @@ _Minimum list of required image formats: kernel read and write
         {CL_FLOAT}
 |====
 --
-
 
 [[image-format-mapping]]
 ==== Image format mapping to OpenCL kernel language image access qualifiers
@@ -3589,13 +3615,13 @@ include::{generated}/api/protos/clGetMemObjectInfo.txt[]
   | cl_mem_object_type
       | Returns one of the following values:
 
-        {CL_MEM_OBJECT_BUFFER} if _memobj_ is created with {clCreateBuffer} or
+        {CL_MEM_OBJECT_BUFFER_anchor} if _memobj_ is created with {clCreateBuffer} or
         {clCreateSubBuffer}.
 
         cl_image_desc.image_type argument value if _memobj_ is created with
         {clCreateImage}.
 
-        {CL_MEM_OBJECT_PIPE} if _memobj_ is created with {clCreatePipe}.
+        {CL_MEM_OBJECT_PIPE_anchor} if _memobj_ is created with {clCreatePipe}.
 | {CL_MEM_FLAGS_anchor}
   | cl_mem_flags
       | Return the flags argument value specified when _memobj_ is created
@@ -4482,7 +4508,7 @@ include::{generated}/api/protos/clCreateSamplerWithProperties.txt[]
 
 [[sampler-properties-table]]
 .List of supported sampler creation properties by <<clCreateSamplerWithProperties>>
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+[width="100%",cols="2,1,3",options="header"]
 |====
 | *cl_sampler_properties* enum | Property Value | Description
 | {CL_SAMPLER_NORMALIZED_COORDS_anchor}
@@ -4496,24 +4522,37 @@ include::{generated}/api/protos/clCreateSamplerWithProperties.txt[]
   | cl_addressing_mode
       | Specifies how out-of-range image coordinates are handled when
         reading from an image.
-
         Valid values are:
 
-        {CL_ADDRESS_MIRRORED_REPEAT} +
-        {CL_ADDRESS_REPEAT} +
-        {CL_ADDRESS_CLAMP_TO_EDGE} +
-        {CL_ADDRESS_CLAMP} +
-        {CL_ADDRESS_NONE}
+        {CL_ADDRESS_NONE_anchor} - Behavior is undefined for out-of-range
+        image coordinates.
+
+        {CL_ADDRESS_CLAMP_TO_EDGE_anchor} - Out-of-range image coordinates
+        are clamped to the edge of the image.
+
+        {CL_ADDRESS_CLAMP_anchor} - Out-of-range image coordinates are
+        assigned a border color value.
+
+        {CL_ADDRESS_REPEAT_anchor} - Out-of-range image coordinates read
+        from the image as-if the image data were replicated in all dimensions.
+
+        {CL_ADDRESS_MIRRORED_REPEAT_anchor} - Out-of-range image coordinates
+        read from the image as-if the image data were replicated in all
+        dimensions, mirroring the image contents at the edge of each
+        replication.
 
         The default is {CL_ADDRESS_CLAMP}.
 | {CL_SAMPLER_FILTER_MODE_anchor}
   | cl_filter_mode
-      | Specifies the type of filter that must be applied when reading an
+      | Specifies the type of filter that is applied when reading an
         image.
         Valid values are:
 
-        {CL_FILTER_NEAREST} +
-        {CL_FILTER_LINEAR}
+        {CL_FILTER_NEAREST_anchor} - Returns the image element nearest
+        to the image coordinate.
+
+        {CL_FILTER_LINEAR_anchor} - Returns a weighted average of the
+        four image elements nearest to the image coordinate.
 
         The default value is {CL_FILTER_NEAREST}.
 |====
@@ -5987,68 +6026,68 @@ include::{generated}/api/protos/clGetProgramBuildInfo.txt[]
 | {CL_PROGRAM_BUILD_STATUS_anchor}
   | cl_build_status
       | Returns the build, compile or link status, whichever was performed
-        last on program for device.
+        last on the specified _program_ object for _device_.
 
         This can be one of the following:
 
         {CL_BUILD_NONE_anchor} - The build status returned if no {clBuildProgram},
         {clCompileProgram} or {clLinkProgram} has been performed on the
-        specified program object for device.
+        specified _program_ object for _device).
 
         {CL_BUILD_ERROR_anchor} - The build status returned if {clBuildProgram},
-        {clCompileProgram} or {clLinkProgram} whichever was performed last
-        on the specified program object for device generated an error.
+        {clCompileProgram} or {clLinkProgram} - whichever was performed last
+        on the specified _program_ object for _device_ - generated an error.
 
         {CL_BUILD_SUCCESS_anchor} - The build status returned if {clBuildProgram},
-        {clCompileProgram} or {clLinkProgram} whichever was performed last
-        on the specified program object for device was successful.
+        {clCompileProgram} or {clLinkProgram} - whichever was performed last
+        on the specified _program_ object for _device_ - was successful.
 
         {CL_BUILD_IN_PROGRESS_anchor} - The build status returned if
-        {clBuildProgram}, {clCompileProgram} or {clLinkProgram} whichever
-        was performed last on the specified program object for device has
+        {clBuildProgram}, {clCompileProgram} or {clLinkProgram} - whichever
+        was performed last on the specified _program_ object for _device_ - has
         not finished.
 | {CL_PROGRAM_BUILD_OPTIONS_anchor}
   | char[]
       | Return the build, compile or link options specified by the options
         argument in {clBuildProgram}, {clCompileProgram} or {clLinkProgram},
-        whichever was performed last on program for device.
+        whichever was performed last on the specified _program_ object for
+        _device_.
 
-        If build status of program for device is {CL_BUILD_NONE}, an empty
-        string is returned.
+        If build status of the specified _program_ for _device_ is
+        {CL_BUILD_NONE}, an empty string is returned.
 | {CL_PROGRAM_BUILD_LOG_anchor}
   | char[]
       | Return the build, compile or link log for {clBuildProgram},
         {clCompileProgram} or {clLinkProgram}, whichever was performed last
         on program for device.
 
-        If build status of program for device is {CL_BUILD_NONE}, an empty
-        string is returned.
+        If build status of the specified _program_ for _device_ is
+        {CL_BUILD_NONE}, an empty string is returned.
 | {CL_PROGRAM_BINARY_TYPE_anchor}
   | cl_program_binary_type
       | Return the program binary type for device.
         This can be one of the following values:
 
-        {CL_PROGRAM_BINARY_TYPE_NONE} - There is no binary associated with
-        device.
+        {CL_PROGRAM_BINARY_TYPE_NONE_anchor} - There is no binary associated
+        with the specified _program_ object for _device_.
 
-        {CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT} - A compiled binary is
-        associated with device.
-        This is the case if program was created using
-        {clCreateProgramWithSource} and compiled using {clCompileProgram} or
-        a compiled binary is loaded using {clCreateProgramWithBinary}.
+        {CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT_anchor} - A compiled binary is
+        associated with _device_.
+        This is the case when the specified _program_ object was created using
+        {clCreateProgramWithSource} and compiled using {clCompileProgram}, or
+        when a compiled binary was loaded using {clCreateProgramWithBinary}.
 
-        {CL_PROGRAM_BINARY_TYPE_LIBRARY} - A library binary is associated with
-        device.
-        This is the case if program was created by {clLinkProgram} which is
-        called with the `-create-library` link option or if a library binary
-        is loaded using {clCreateProgramWithBinary}.
+        {CL_PROGRAM_BINARY_TYPE_LIBRARY_anchor} - A library binary is
+        associated with _device_.
+        This is the case when the specified _program_ object was linked by
+        {clLinkProgram} using the `-create-library` link option, or when a
+        compiled library binary was loaded using {clCreateProgramWithBinary}.
 
-        {CL_PROGRAM_BINARY_TYPE_EXECUTABLE} - An executable binary is
-        associated with device.
-        This is the case if program was created by {clLinkProgram} without
-        the `-create-library link` option or program was created by
-        {clBuildProgram} or an executable binary is loaded using
-        {clCreateProgramWithBinary}.
+        {CL_PROGRAM_BINARY_TYPE_EXECUTABLE_anchor} - An executable binary is
+        associated with _device_.
+        This is the case when the specified _program_ object was linked by
+        {clLinkProgram} without the `-create-library` link option, or when an
+        executable binary was built using {clBuildProgram}.
 | {CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE_anchor}
   | size_t
       | The total amount of storage, in bytes, used by program variables in
@@ -6984,7 +7023,7 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
 
 [[kernel-argument-info-table]]
 .List of supported param_names by <<clGetKernelArgInfo>>
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+[width="100%",cols="2,1,3",options="header"]
 |====
 | *cl_kernel_arg_info* | Return Type | Info. returned in _param_value_
 | {CL_KERNEL_ARG_ADDRESS_QUALIFIER_anchor}
@@ -6993,10 +7032,10 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
         _arg_indx_.
         This can be one of the following values:
 
-        {CL_KERNEL_ARG_ADDRESS_GLOBAL} +
-        {CL_KERNEL_ARG_ADDRESS_LOCAL} +
-        {CL_KERNEL_ARG_ADDRESS_CONSTANT} +
-        {CL_KERNEL_ARG_ADDRESS_PRIVATE}
+        {CL_KERNEL_ARG_ADDRESS_GLOBAL_anchor} +
+        {CL_KERNEL_ARG_ADDRESS_LOCAL_anchor} +
+        {CL_KERNEL_ARG_ADDRESS_CONSTANT_anchor} +
+        {CL_KERNEL_ARG_ADDRESS_PRIVATE_anchor}
 
         If no address qualifier is specified, the default address qualifier
         which is {CL_KERNEL_ARG_ADDRESS_PRIVATE} is returned.
@@ -7006,10 +7045,10 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
         _arg_indx_.
         This can be one of the following values:
 
-        {CL_KERNEL_ARG_ACCESS_READ_ONLY} +
-        {CL_KERNEL_ARG_ACCESS_WRITE_ONLY} +
-        {CL_KERNEL_ARG_ACCESS_READ_WRITE} +
-        {CL_KERNEL_ARG_ACCESS_NONE}
+        {CL_KERNEL_ARG_ACCESS_READ_ONLY_anchor} +
+        {CL_KERNEL_ARG_ACCESS_WRITE_ONLY_anchor} +
+        {CL_KERNEL_ARG_ACCESS_READ_WRITE_anchor} +
+        {CL_KERNEL_ARG_ACCESS_NONE_anchor}
 
         If argument is not an image type and is not declared with the pipe
         qualifier, {CL_KERNEL_ARG_ACCESS_NONE} is returned.
@@ -7028,12 +7067,15 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
         qualifiers.
 | {CL_KERNEL_ARG_TYPE_QUALIFIER_anchor}
   | cl_kernel_arg_type_qualifier
-      | Returns the type qualifier specified for the argument given by
-        _arg_indx_.
-        The returned value can be: {CL_KERNEL_ARG_TYPE_CONST}^17^,
-        {CL_KERNEL_ARG_TYPE_RESTRICT}, {CL_KERNEL_ARG_TYPE_VOLATILE}^18^, a
-        combination of the above enums, {CL_KERNEL_ARG_TYPE_PIPE}, or
-        {CL_KERNEL_ARG_TYPE_NONE}.
+      | Returns a bitfield describing one or more type qualifiers specified
+        for the argument given by _arg_indx_.
+        The returned values can be:
+        
+        {CL_KERNEL_ARG_TYPE_CONST_anchor}^17^ +
+        {CL_KERNEL_ARG_TYPE_RESTRICT_anchor} +
+        {CL_KERNEL_ARG_TYPE_VOLATILE_anchor}^18^ +
+        {CL_KERNEL_ARG_TYPE_PIPE_anchor}, or +
+        {CL_KERNEL_ARG_TYPE_NONE_anchor}
 
         {CL_KERNEL_ARG_TYPE_NONE} is returned for all parameters passed by
         value.
@@ -7041,7 +7083,6 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
   | char[]
       | Returns the name specified for the argument given by _arg_indx_.
 |====
-
 
 17::
     {CL_KERNEL_ARG_TYPE_CONST} is returned for
@@ -7623,35 +7664,35 @@ include::{generated}/api/protos/clGetEventInfo.txt[]
       | Return the command associated with event.
         Can be one of the following values:
 
-        {CL_COMMAND_NDRANGE_KERNEL} +
-        {CL_COMMAND_NATIVE_KERNEL} +
-        {CL_COMMAND_READ_BUFFER} +
-        {CL_COMMAND_WRITE_BUFFER} +
-        {CL_COMMAND_COPY_BUFFER} +
-        {CL_COMMAND_READ_IMAGE} +
-        {CL_COMMAND_WRITE_IMAGE} +
-        {CL_COMMAND_COPY_IMAGE} +
-        {CL_COMMAND_COPY_BUFFER_TO_IMAGE} +
-        {CL_COMMAND_COPY_IMAGE_TO_BUFFER} +
-        {CL_COMMAND_MAP_BUFFER} +
-        {CL_COMMAND_MAP_IMAGE} +
-        {CL_COMMAND_UNMAP_MEM_OBJECT} +
-        {CL_COMMAND_MARKER} +
-        {CL_COMMAND_ACQUIRE_GL_OBJECTS} +
-        {CL_COMMAND_RELEASE_GL_OBJECTS} +
-        {CL_COMMAND_READ_BUFFER_RECT} +
-        {CL_COMMAND_WRITE_BUFFER_RECT} +
-        {CL_COMMAND_COPY_BUFFER_RECT} +
-        {CL_COMMAND_USER} +
-        {CL_COMMAND_BARRIER} +
-        {CL_COMMAND_MIGRATE_MEM_OBJECTS} +
-        {CL_COMMAND_FILL_BUFFER} +
-        {CL_COMMAND_FILL_IMAGE} +
-        {CL_COMMAND_SVM_FREE} +
-        {CL_COMMAND_SVM_MEMCPY} +
-        {CL_COMMAND_SVM_MEMFILL} +
-        {CL_COMMAND_SVM_MAP} +
-        {CL_COMMAND_SVM_UNMAP}
+        {CL_COMMAND_NDRANGE_KERNEL_anchor} +
+        {CL_COMMAND_NATIVE_KERNEL_anchor} +
+        {CL_COMMAND_READ_BUFFER_anchor} +
+        {CL_COMMAND_WRITE_BUFFER_anchor} +
+        {CL_COMMAND_COPY_BUFFER_anchor} +
+        {CL_COMMAND_READ_IMAGE_anchor} +
+        {CL_COMMAND_WRITE_IMAGE_anchor} +
+        {CL_COMMAND_COPY_IMAGE_anchor} +
+        {CL_COMMAND_COPY_BUFFER_TO_IMAGE_anchor} +
+        {CL_COMMAND_COPY_IMAGE_TO_BUFFER_anchor} +
+        {CL_COMMAND_MAP_BUFFER_anchor} +
+        {CL_COMMAND_MAP_IMAGE_anchor} +
+        {CL_COMMAND_UNMAP_MEM_OBJECT_anchor} +
+        {CL_COMMAND_MARKER_anchor} +
+        {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor} +
+        {CL_COMMAND_RELEASE_GL_OBJECTS_anchor} +
+        {CL_COMMAND_READ_BUFFER_RECT_anchor} +
+        {CL_COMMAND_WRITE_BUFFER_RECT_anchor} +
+        {CL_COMMAND_COPY_BUFFER_RECT_anchor} +
+        {CL_COMMAND_USER_anchor} +
+        {CL_COMMAND_BARRIER_anchor} +
+        {CL_COMMAND_MIGRATE_MEM_OBJECTS_anchor} +
+        {CL_COMMAND_FILL_BUFFER_anchor} +
+        {CL_COMMAND_FILL_IMAGE_anchor} +
+        {CL_COMMAND_SVM_FREE_anchor} +
+        {CL_COMMAND_SVM_MEMCPY_anchor} +
+        {CL_COMMAND_SVM_MEMFILL_anchor} +
+        {CL_COMMAND_SVM_MAP_anchor} +
+        {CL_COMMAND_SVM_UNMAP_anchor}
 | {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor}^19^
   | cl_int
       | Return the execution status of the command identified by event.

--- a/scripts/checklinks.py
+++ b/scripts/checklinks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2013-2019 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import re
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-d', action='store', dest='directory',
+                        default='../api',
+                        help='Directory containing files to check')
+    parser.add_argument('--unlinked', action='store_true',
+                        help='Check for unlinked APIs and enums (may have false positives!)')
+
+    args = parser.parse_args()
+
+    links = set()
+    anchors = set()
+
+    for filename in os.listdir(args.directory):
+        filename = args.directory + '/' + filename
+        sourcefile = open(filename, 'r')
+        sourcetext = sourcefile.read()
+        sourcefile.close()
+
+        # We're not going to check API links.
+        #filelinks = re.findall(r"{((cl\w+)|(CL\w+))}", sourcetext)
+        filelinks = re.findall(r"{((CL\w+))}", sourcetext)
+        fileanchors = re.findall(r"{((cl\w+)|(CL\w+))_anchor}", sourcetext)
+
+        filelinks = [re.sub(r"_anchor\b", "", link[0]) for link in filelinks]
+        fileanchors = [anchor[0] for anchor in fileanchors]
+
+        links = links.union(set(filelinks) - set(fileanchors))
+        anchors = anchors.union(set(fileanchors))
+
+        #print("=== " + filename)
+        #print("links:")
+        #print(' '.join(filelinks))
+        #print("anchors:")
+        #print(' '.join(fileanchors))
+
+        if args.unlinked:
+            # Look for APIs and enums that do not begin with:
+            #   { = asciidoctor attribute link
+            #   character = middle of word
+            #   < = asciidoctor link
+            #   ' = refpage description
+            #   / = proto include
+            fileunlinkedapi = sorted(list(set(re.findall(r"[^{\w<'/](cl[A-Z]\w+)\b[^'](?!.')", sourcetext))))
+            fileunlinkedenums = sorted(list(set(re.findall("r[^{\w<](CL_\w+)", sourcetext))))
+
+            if len(fileunlinkedapi) != 0:
+                print("unlinked APIs in " + filename + ":\n\t" + '\n\t'.join(fileunlinkedapi))
+
+            if len(fileunlinkedenums) != 0:
+                print("unlinked enums in " + filename + ":\n\t" + '\n\t'.join(fileunlinkedenums))
+
+    linkswithoutanchors = sorted(list(links - anchors))
+    anchorswithoutlinks = sorted(list(anchors - links))
+
+    print("links without anchors:\n\t" + '\n\t'.join(linkswithoutanchors))
+    #print("anchors without links:\n\t" + '\n\t'.join(anchorswithoutlinks))


### PR DESCRIPTION
This is a follow-on change to #98 that adds anchors for all API and enum links except for `CL_TRUE`, `CL_FALSE`, and `CL_NONE`.  I'll probably add another table as an appendix for these enums for completeness, but I'd like to get these changes merged first.

Most of the missing anchors were easy to add, but a few could use a more detailed review:

* `CL_MEM_KERNEL_READ_AND_WRITE`: The description for this enum was missing, so I added it.  As best I can tell, it is only used when querying enum formats via `clGetSupportedImageFormats`, and it is never used when creating a new memory object.
* Image Channel Orders: These were listed in the spec, but also didn't have a description, so I updated the "List of supported Image Channel Order Values" table to describe them.
* Sampler Properties: These were missing descriptions too, so I updated the "List of supported sampler creation properties" table to describe them.