### PR TITLE
require support for OpenCL.std extended instruction set

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -24,6 +24,17 @@ OpenCL environments that support the `cl_khr_il_program` extension or
 OpenCL 2.1 must support SPIR-V 1.0 modules.  OpenCL environments that support
 OpenCL 2.2 must support SPIR-V 1.0, 1.1, and 1.2 modules.
 
+=== Extended Instruction Sets
+
+OpenCL environments supporting SPIR-V must support SPIR-V modules that import
+the *OpenCL.std*
+<<opencl-extended-instruction-set, extended instruction set for OpenCL>>
+using *OpExtInstImport*. For example:
+
+----
+... = OpExtInstImport "OpenCL.std"
+----
+
 === Source Language Encoding
 
 If a SPIR-V module represents a program written in OpenCL C, then the
@@ -324,12 +335,12 @@ An *OpFunction* in a SPIR-V module that is identified with *OpEntryPoint*
 defines an OpenCL kernel that may be invoked using the OpenCL host API
 enqueue kernel interfaces.
 
-=== Kernel Return Types
+==== Kernel Return Types
 
 The _Result Type_ for an *OpFunction* identified with *OpEntryPoint* must be
 *OpTypeVoid*.
 
-=== Kernel Arguments
+==== Kernel Arguments
 
 An *OpFunctionParameter* for an *OpFunction* that is identified with
 *OpEntryPoint* defines an OpenCL kernel argument.

--- a/env/references.asciidoc
+++ b/env/references.asciidoc
@@ -38,6 +38,8 @@
 //    other versions exists.
   . [[spirv-spec]] "`SPIR-V Specification, Version 1.2, Unified`",
     https://www.khronos.org/registry/spir-v/ .
+  . [[opencl-extended-instruction-set]] "`OpenCL Extended Instruction Set
+    Specification`", https://www.khronos.org/registry/spir-v/ .
   . [[ulp-definition]] Jean-Michel Muller. _On the definition of ulp(x)_.
     RR-5504, INRIA. 2005, pp.16. <inria-00070503>
     Currently hosted at


### PR DESCRIPTION
This change adds a section to the OpenCL SPIR-V Environment Spec to indicate that all OpenCL environments most support the OpenCL.std extended instruction set.