### PR TITLE
Adjust an include to fix build

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -10993,4 +10993,4 @@ one of the integers 0, 1, ... h~t~ - 1.
 
 <<<
 
-include::api/acknowledgements.txt[]
+include::api/acknowledgements.asciidoc[]


### PR DESCRIPTION
A file got renamed so an include from a seperate folder needs updated.