### PR TITLE
allow parent devices to be passed to clRetainDevice and clReleaseDevice

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1002,7 +1002,7 @@ device except for the following queries:
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_DEVICE} if _device_ is not valid.
+  * {CL_INVALID_DEVICE} if _device_ is not a valid device.
   * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values or
     if size in bytes specified by _param_value_size_ is < size of return
     type as specified in the <<device-queries-table, Device Queries>> table
@@ -1051,7 +1051,7 @@ the same timebase.
 _host_timestamp_ if provided.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_DEVICE} if _device_ is not a valid OpenCL device.
+  * {CL_INVALID_DEVICE} if _device_ is not a valid device.
   * {CL_INVALID_VALUE} if _host_timestamp_ or _device_timestamp_ is `NULL`.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
@@ -1089,7 +1089,7 @@ the same timebase.
 _host_timestamp_ if provided.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_DEVICE} if _device_ is not a valid OpenCL device.
+  * {CL_INVALID_DEVICE} if _device_ is not a valid device.
   * {CL_INVALID_VALUE} if _host_timestamp_ is `NULL`.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
@@ -1206,7 +1206,7 @@ successfully.
 Otherwise, it returns a `NULL` value with the following error values
 returned in _errcode_ret_:
 
-  * {CL_INVALID_DEVICE} if _in_device_ is not valid.
+  * {CL_INVALID_DEVICE} if _in_device_ is not a valid device.
   * {CL_INVALID_VALUE} if values specified in _properties_ are not valid or if
     values specified in _properties_ are valid but not supported by the
     device.
@@ -1278,8 +1278,7 @@ If _device_ is a root level device i.e. a cl_device_id returned by
 or the device is a root-level device.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_DEVICE} if _device_ is not a valid sub-device created by a
-    call to {clCreateSubDevices}.
+  * {CL_INVALID_DEVICE} if _device_ is not a valid device.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -1305,8 +1304,7 @@ If _device_ is a root level device i.e. a cl_device_id returned by
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_DEVICE} if _device_ is not a valid sub-device created by a
-    call to {clCreateSubDevices}.
+  * {CL_INVALID_DEVICE} if _device_ is not a valid device.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -1415,7 +1413,7 @@ returned in _errcode_ret_:
   * {CL_INVALID_VALUE} if _num_devices_ is equal to zero.
   * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
     `NULL`.
-  * {CL_INVALID_DEVICE} if _devices_ contains an invalid device.
+  * {CL_INVALID_DEVICE} if any device in _devices_ is not a valid device.
   * {CL_DEVICE_NOT_AVAILABLE} if a device in _devices_ is currently not
     available even though the device was returned by {clGetDeviceIDs}.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4883,7 +4883,7 @@ returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
   * {CL_INVALID_VALUE} if _device_list_ is `NULL` or _num_devices_ is zero.
-  * {CL_INVALID_DEVICE} if OpenCL devices listed in _device_list_ are not in
+  * {CL_INVALID_DEVICE} if any device in _device_list_ is not in
     the list of devices associated with _context_.
   * {CL_INVALID_VALUE} if _lengths_ or _binaries_ are `NULL` or if any entry
     in _lengths_[i] is zero or _binaries_[i] is `NULL`.
@@ -4928,7 +4928,7 @@ returned in _errcode_ret_:
   * {CL_INVALID_VALUE} if _kernel_names_ is `NULL` or _kernel_names_ contains
     a kernel name that is not supported by any of the devices in
     _device_list_.
-  * {CL_INVALID_DEVICE} if devices listed in _device_list_ are not in the list
+  * {CL_INVALID_DEVICE} if any device in _device_list_ is not in the list
     of devices associated with _context_.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
@@ -5173,8 +5173,8 @@ Otherwise, it returns one of the following errors:
     than zero, or if _device_list_ is not `NULL` and _num_devices_ is zero.
   * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
     `NULL`.
-  * {CL_INVALID_DEVICE} if OpenCL devices listed in _device_list_ are not in
-    the list of devices associated with _program_
+  * {CL_INVALID_DEVICE} if any device in _device_list_ is not in
+    the list of devices associated with _program_.
   * {CL_INVALID_BINARY} if _program_ is created with
     {clCreateProgramWithBinary} and devices listed in _device_list_ do not
     have a valid program binary loaded.
@@ -5341,8 +5341,8 @@ Otherwise, it returns one of the following errors:
     _input_headers_ are `NULL`.
   * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
     `NULL`.
-  * {CL_INVALID_DEVICE} if OpenCL devices listed in _device_list_ are not in
-    the list of devices associated with _program_
+  * {CL_INVALID_DEVICE} if device in _device_list_ is not in
+    the list of devices associated with _program_.
   * {CL_INVALID_COMPILER_OPTIONS} if the compiler options specified by
     _options_ are invalid.
   * {CL_INVALID_OPERATION} if the compilation or build of a program executable
@@ -5472,8 +5472,8 @@ The list of errors that can be returned are:
     valid program objects.
   * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
     `NULL`.
-  * {CL_INVALID_DEVICE} if OpenCL devices listed in _device_list_ are not in
-    the list of devices associated with _context_
+  * {CL_INVALID_DEVICE} if any device in _device_list_ is not in
+    the list of devices associated with _context_.
   * {CL_INVALID_LINKER_OPTIONS} if the linker options specified by _options_
     are invalid.
   * {CL_INVALID_OPERATION} if the compilation or build of a program executable


### PR DESCRIPTION
This removes the contradiction between the description of these APIs and the error condition for `CL_INVALID_DEVICE`.

I've also reworded a few other error conditions for `CL_INVALID_DEVICE` for consistency.

Fixes #68.

