### PR TITLE
documentation for cl_khr_srgb_image_writes

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7022,15 +7022,8 @@ of the following values:
 
 The built-in image read functions will perform sRGB to linear RGB
 conversions if the image is an sRGB image.
-Writing to sRGB images from a kernel is an optional extension.
-The *cl_khr_srgb_image_writes* extension will be reported in the
-`CL_DEVICE_EXTENSIONS` string if a device supports writing to sRGB images
-using *write_imagef*.
-*clGetSupportedImageFormats* will return the supported sRGB images if
-`CL_MEM_READ_WRITE` or `CL_MEM_WRITE_ONLY` is specified in _flags_ argument
-and the device supports writing to an sRGB image.
-If *cl_khr_srgb_image_writes* is supported, the built-in image write
-functions will perform the linear to sRGB conversion.
+Likewise, the built-in image write functions perform the linear to
+sRGB conversion if the image is an sRGB image.
 
 Only the R, G and B components are converted from linear to sRGB and
 vice-versa.
@@ -7793,9 +7786,6 @@ For samplerless read functions this may be `read_only` or `read_write`.
 --
 
 The following built-in function calls to write images are supported.
-Note that image writes to sRGB images are only supported if the
-*cl_khr_srgb_image_writes* extension is supported; otherwise the behavior of
-writing to a sRGB image is undefined.
 
 _aQual_ in the following table refers to one of the access qualifiers.
 For write functions this may be `write_only` or `read_write`.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -782,26 +782,10 @@ device except for the following queries:
   | char[]
       | Returns a space separated list of extension names (the extension
         names themselves do not contain any spaces) supported by the device.
-        The list of extension names returned can be vendor supported
-        extension names and one or more of the following Khronos approved
-        extension names:
+        The list of extension names may include Khronos approved extension
+        names and vendor specified extension names.
 
-        *cl_khr_int64_base_atomics* +
-        *cl_khr_int64_extended_atomics* +
-        *cl_khr_fp16* +
-        *cl_khr_gl_sharing* +
-        *cl_khr_gl_event* +
-        *cl_khr_d3d10_sharing* +
-        *cl_khr_dx9_media_sharing* +
-        *cl_khr_d3d11_sharing* +
-        *cl_khr_gl_depth_images* +
-        *cl_khr_gl_msaa_sharing* +
-        *cl_khr_initialize_memory* +
-        *cl_khr_terminate_context* +
-        *cl_khr_spir* +
-        *cl_khr_srgb_image_writes*
-
-        The following approved Khronos extension names must be returned by
+        The following Khronos extension names must be returned by
         all devices that support OpenCL C 2.0:
 
         *cl_khr_byte_addressable_store* +
@@ -811,8 +795,8 @@ device except for the following queries:
         *cl_khr_image2d_from_buffer* +
         *cl_khr_depth_images*
 
-        Please refer to the OpenCL Extension Specification for a
-        detailed description of these extensions.
+        Please refer to the OpenCL Extension Specification or vendor
+        provided documentation for a detailed description of these extensions.
 | {CL_DEVICE_PRINTF_BUFFER_SIZE_anchor}
   | size_t
       | Maximum size in bytes of the internal buffer that holds the output

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2043,9 +2043,8 @@ Kernel Read Or Write>> table.
     objects.
 
 10::
-    sRGB channel order support is not required for 1D image buffers.
-    Writes to images with sRGB channel orders requires device support of the
-    *cl_khr_srgb_image_writes* extension.
+    Read sRGB channel order support is optional for 1D image buffers.
+    Write sRGB channel order support is optional for all image types.
 
 For 1D, 1D image from buffer, 2D, 3D image objects, 1D and 2D image array
 objects, the mandated minimum list of image formats that can be read from

--- a/cxx/stdlib/images_and_samplers.txt
+++ b/cxx/stdlib/images_and_samplers.txt
@@ -934,7 +934,7 @@ If `<addressing mode>` in sampler is clamp, then out-of-range image coordinates 
 [[srgb-images]]
 ==== sRGB Images
 
-The built-in image read functions perform sRGB to linear RGB conversions if the image is an sRGB image. Writes to sRGB images from a kernel is an optional extension. The *cl_khr_srgb_image_writes* extension will be reported in the `CL_DEVICE_EXTENSIONS` string if a device supports writing to sRGB images using `image::write`. `clGetSupportedImageFormats` will return the supported sRGB images if `CL_MEM_READ_WRITE` or `CL_MEM_WRITE_ONLY` is specified in `flags` argument and the device supports writing to an sRGB image. If the *cl_khr_srgb_image_writes* extension is supported and has been enabled, the built-in image write functions perform the linear to sRGB conversion.
+The built-in image read functions perform sRGB to linear RGB conversions if the image is an sRGB image. Likewise, the built-in image write functions perform the linear to sRGB conversion if the image is an sRGB image.
 
 Only the R, G and B components are converted from linear to sRGB and vice-versa. The alpha component is returned as is.
 

--- a/ext/cl_khr_srgb_image_writes.txt
+++ b/ext/cl_khr_srgb_image_writes.txt
@@ -8,7 +8,7 @@
 This section describes the *cl_khr_srgb_image_writes* extension.
 
 This extension enables kernels to write to sRGB images using the *write_imagef* built-in function.
-The sRGB image formats that may be written to will be returned by *clGetSupportedImageFormats* when `CL_MEM_WRITE_ONLY` is specified in the _flags_ argument.
+The sRGB image formats that may be written to will be returned by *clGetSupportedImageFormats*.
 
 When the image is an sRGB image, the *write_imagef* built-in function will perform the linear to sRGB conversion.
 Only the R, G, and B components are converted from linear to sRGB; the A component is written as-is.

--- a/man/static/cl_khr_srgb_image_writes.txt
+++ b/man/static/cl_khr_srgb_image_writes.txt
@@ -12,13 +12,6 @@ include::../config/attribs.txt[]
 
 cl_khr_srgb_image_writes - Extension allowing writes to sRGB images from a kernel.
 
-== C Specification
-
-[source,c]
-----
-#pragma OPENCL EXTENSION cl_khr_srgb_image_writes : enable
-----
-
 == Description
 
 This extensions adds changes to the following:
@@ -38,8 +31,7 @@ flink:clCompileProgram,
 This extension enables kernels to write to sRGB images using the
 reflink:imageFunctions[write_imagef] built-in function.
 The sRGB image formats that may be written to will be returned by
-flink:clGetSupportedImageFormats when `CL_MEM_WRITE_ONLY` is specified in
-the _flags_ argument.
+flink:clGetSupportedImageFormats.
 
 When the image is an sRGB image, the reflink:imageFunctions[write_imagef]
 built-in function will perform the linear to sRGB conversion. Only the R, G,


### PR DESCRIPTION
Fixes #20.

Removes description of cl_khr_srgb_image_writes from the language specs (OpenCL C and OpenCL C++), for consistency.  Instead, the behavior of this extension is described in the extensions spec, similar to all other extensions.

Also includes a few minor edits to the API spec that also refer to this extension.