### PR TITLE
reworded NaN behavior in Additional Requirements Beyond C99 TC2

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -10010,15 +10010,7 @@ except <<additional-requirements-beyond-c99-tc2,where noted below>>.
 [[additional-requirements-beyond-c99-tc2]]
 === Additional Requirements Beyond C99 TC2
 
-Functions that return a NaN with more than one NaN operand shall return one
-of the NaN operands.
-Functions that return a NaN operand may silence the NaN if it is a signaling
-NaN.
-A non-signaling NaN shall be converted to a non-signaling NaN.
-A signaling NaN shall be converted to a NaN, and should be converted to a
-non-signaling NaN.
-How the rest of the NaN payload bits or the sign of NaN is converted is
-undefined.
+All functions that return a NaN should return a quiet NaN.
 
 *half_<funcname>* functions behave identically to the function of the same
 name without the *half_* prefix.

--- a/cxx/numerical_compliance/edge_case_behavior.txt
+++ b/cxx/numerical_compliance/edge_case_behavior.txt
@@ -10,11 +10,7 @@ The edge case behavior of the math functions (see the <<math-functions, _Math Fu
 [[additional-requirements-beyond-isoiec-9899tc2]]
 ==== Additional Requirements Beyond ISO/IEC 9899:TC2
 
-Functions that return a NaN with more than one NaN operand shall return one of the NaN operands.
-Functions that return a NaN operand may silence the NaN if it is a signaling NaN.
-A non-signaling NaN shall be converted to a non-signaling NaN.
-A signaling NaN shall be converted to a NaN, and should be converted to a non-signaling NaN.
-How the rest of the NaN payload bits or the sign of NaN is converted is undefined.
+All functions that return a NaN should return a quiet NaN.
 
 The usual allowances for rounding error (see the <<relative-error-as-ulps, _Relative Error as ULPs_>> section) or flushing behavior (see the <<edge-case-behavior-in-flush-to-zero-mode, _Edge Case Behavior in Flush To Zero Mode_>> section) shall not apply for those values for which _section F.9_ of ISO/IEC 9899:,TC2, or the <<additional-requirements-beyond-isoiec-9899tc2, _Additional Requirements Beyond ISO/IEC 9899:TC2_>> and the <<edge-case-behavior-in-flush-to-zero-mode, _Edge Case Behavior in Flush To Zero Mode_>> sections below (and similar sections for other floating-point precisions) prescribe a result (e.g. ceil( -1 < x < 0 ) returns -0).
 Those values shall produce exactly the prescribed answers, and no other.

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1541,15 +1541,7 @@ Beyond ISO/IEC 9899:TC2>> section__.
 [[additional-requirements-beyond-isoiec-9899tc2]]
 ==== Additional Requirements Beyond ISO/IEC 9899:TC2
 
-Functions that return a NaN with more than one NaN operand shall return one
-of the NaN operands.
-Functions that return a NaN operand may silence the NaN if it is a signaling
-NaN.
-A non-signaling NaN shall be converted to a non-signaling NaN.
-A signaling NaN shall be converted to a NaN, and should be converted to a
-non-signaling NaN.
-How the rest of the NaN payload bits or the sign of NaN is converted is
-undefined.
+All functions that return a NaN should return a quiet NaN.
 
 The usual allowances for rounding error (__<<relative-error-as-ulps,Relative
 Error as ULPs>> section__) or flushing behavior


### PR DESCRIPTION
Possible fix for #74.

Changes the NaN description in "Additional Requirements Beyond C99 TC2" from:

> Functions that return a NaN with more than one NaN operand shall return one of the NaN operands. Functions that return a NaN operand may silence the NaN if it is a signaling NaN. A non-signaling NaN shall be converted to a non-signaling NaN. A signaling NaN shall be converted to a NaN, and should be converted to a non-signaling NaN. How the rest of the NaN payload bits or the sign of NaN is converted is undefined.

to:

> For functions returning NaN, a signaling NaN should be converted to a non-signaling NaN, but must remain a NaN. A non-signaling NaN may be converted to a different NaN, but must remain a non-signaling NaN. When one NaN is converted to a different NaN, the conversion may assign any value to the NaN sign bit and NaN payload bits.

Changes were made to the OpenCL C, OpenCL C++, and OpenCL SPIR-V Environment specs.