### PR TITLE
fix minor asciidoc formatting error in conversion built-ins

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -977,15 +977,19 @@ The full form of the scalar convert function is:
 
 [source,c]
 ----------
-destType *convert_destType<_sat><_roundingMode>*(sourceType)
+destType convert_destType<_sat><_roundingMode>(sourceType)
 ----------
+
+where `dstType` is the destination scalar type and `sourceType` is the source scalar type.
 
 The full form of the vector convert function is:
 
 [source,c]
 ----------
-destType__n__ *convert_destType__n__<_sat><_roundingMode>*(sourceType__n__)
+destTypen convert_destTypen<_sat><_roundingMode>(sourceTypen)
 ----------
+
+where `destTypen` is the n-element destination vector type and `sourceTypen` is the n-element source vector type.
 
 
 [[data-types]]


### PR DESCRIPTION
Removes some asciidoctor formatting that slipped into a source block for the conversion built-in functions.