### PR TITLE
fix a few more asciidoc formatting errors

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1386,11 +1386,11 @@ endif::refpageOnly[]
 
 [open,refpage='arithmeticOperators',desc='Arithmetic Operators',type='freeform',spec='clang',anchor='operators-arithmetic',xrefs='operators']
 --
-The arithmetic operators add (*+*), subtract (*-*), multiply (***) and
+The arithmetic operators add (*+++*), subtract (*-*), multiply (*+*+*) and
 divide (*/*) operate on built-in integer and floating-point scalar, and
 vector data types.
-The remainder (*%*) operates on built-in integer scalar and integer vector
-data types.
+The arithmetic operator remainder (*%*) operates on built-in integer scalar
+and integer vector data types.
 All arithmetic operators return result of the same built-in type (integer or
 floating-point) as the type of the operands, after operand type conversion.
 After conversion, the following cases are valid:
@@ -1769,19 +1769,19 @@ All expressions are evaluated, in order, from left to right.
 
 [open,refpage='indirectionOperator',desc='Indirection Operator',type='freeform',spec='clang',anchor='operators-indirection',xrefs='operators']
 --
-The unary (**+*+**) operator denotes indirection.
+The unary (*+*+*) operator denotes indirection.
 If the operand points to an object, the result is an l-value designating the
 object.
-If the operand has type "`pointer to __type__`", the result has type
-"`__type__`".
+If the operand has type "pointer to __type__", the result has type
+"__type__".
 If an invalid value has been assigned to the pointer, the behavior of the
-unary *** operator is undefined^22^.
+unary *+*+* operator is undefined^22^.
 
-[22] Among the invalid values for dereferencing a pointer by the unary **+*+**
+[22] Among the invalid values for dereferencing a pointer by the unary *+*+*
 operator are a null pointer, an address inappropriately aligned for the type
 of object pointed to, and the address of an object after the end of its
 lifetime.
-If *P* is an l-value and *T* is the name of an object pointer type, *(T)P*
+If *+*P+* is an l-value and *T* is the name of an object pointer type, *+*(T)P+*
 is an l-value that has a type compatible with that to which *T* points.
 --
 
@@ -1792,23 +1792,23 @@ is an l-value that has a type compatible with that to which *T* points.
 [open,refpage='addressOperator',desc='Address Operator',type='freeform',spec='clang',anchor='operators-address',xrefs='operators']
 --
 The unary (*&*) operator returns the address of its operand.
-If the operand has type "`__type__`", the result has type "`pointer to
-__type__`".
-If the operand is the result of a unary **+*+** operator, neither that operator
-nor the **&** operator is evaluated and the result is as if both were omitted,
+If the operand has type "__type__", the result has type "pointer to
+__type__".
+If the operand is the result of a unary *+*+* operator, neither that operator
+nor the *&* operator is evaluated and the result is as if both were omitted,
 except that the constraints on the operators still apply and the result is
 not an l-value.
 Similarly, if the operand is the result of a *[]* operator, neither the *&*
-operator nor the unary *** that is implied by the *[]* is evaluated and the
+operator nor the unary *+*+* that is implied by the *[]* is evaluated and the
 result is as if the *&* operator were removed and the *[]* operator were
 changed to a *+* operator.
 Otherwise, the result is a pointer to the object designated by its
 operand^23^.
 
 [23] Thus, *&*E* is equivalent to *E* (even if *E* is a null pointer), and
-*&(E1[E2])* to **\((E1){plus}(E2))**.
+*&(E1[E2])* is equivalent to *\((E1) {plus} (E2))*.
 It is always true that if *E* is an l-value that is a valid operand of the
-unary *&* operator, *&E* is an l-value equal to *E*.
+unary *&* operator, *+*&E+* is an l-value equal to *E*.
 --
 
 
@@ -3823,7 +3823,7 @@ to function pointers.
   ** A block cannot be a return value or a parameter of a function.
   ** Blocks cannot be used as expressions of the ternary selection operator
      (*?:*).
-  * The unary operators (*** and *&*) cannot be used with a Block.
+  * The unary operators (*+*+*) and (*&*) cannot be used with a Block.
   * Pointers to Blocks are not allowed.
   * A Block cannot capture another Block variable declared in the outer
     scope (Example 4).

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -261,7 +261,7 @@ Device Queries>> table.
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS}
   | cl_uint
-      | Max number of arguments declared with the `__constant` qualifier
+      | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 4 for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -367,7 +367,7 @@ Intermediate Language ::
 Kernel ::
     A _kernel_ is a function declared in a _program_ and executed on an
     OpenCL _device_.
-    A _kernel_ is identified by the kernel or kernel qualifier applied to
+    A _kernel_ is identified by the `+__kernel+` or `kernel` qualifier applied to
     any function defined in a _program_.
 
 Kernel-instance ::
@@ -378,9 +378,9 @@ Kernel-instance ::
     _NDRange_ index space.
 
 Kernel Object ::
-    A _kernel object_ encapsulates a specific `__kernel` function declared
+    A _kernel object_ encapsulates a specific _kernel_ function declared
     in a _program_ and the argument values to be used when executing this
-    `__kernel` function.
+    _kernel_ function.
 
 Kernel Language ::
     A language that is used to create source code for kernel.
@@ -510,7 +510,7 @@ Processing Element ::
 Program ::
     An OpenCL _program_ consists of a set of _kernels_.
     _Programs_ may also contain auxiliary functions called by the
-    `__kernel` functions and constant data.
+    _kernel_ functions and constant data.
 
 Program Object ::
     A _program object_ encapsulates the following information:

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -580,7 +580,7 @@ device except for the following queries:
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS_anchor}
   | cl_uint
-      | Max number of arguments declared with the `__constant` qualifier
+      | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 8 for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4706,9 +4706,9 @@ Otherwise, it returns one of the following errors:
 == Program Objects
 
 An OpenCL program consists of a set of kernels that are identified as
-functions declared with the `__kernel` qualifier in the program source.
+functions declared with the `+__kernel+` qualifier in the program source.
 OpenCL programs may also contain auxiliary functions and constant data that
-can be used by `__kernel` functions.
+can be used by kernel functions.
 The program executable can be generated _online_ or _offline_ by the OpenCL
 compiler for the appropriate target device(s).
 

--- a/cxx/lang/kernel_functions.txt
+++ b/cxx/lang/kernel_functions.txt
@@ -8,13 +8,13 @@
 [[function-qualifiers]]
 ==== Function Qualifiers
 
-The `kernel` (or `__kernel`) qualifier declares a function to be a kernel that can be executed by an application on an OpenCL device(s).
+The `kernel` (or `+__kernel+`) qualifier declares a function to be a kernel that can be executed by an application on an OpenCL device(s).
 The following rules apply to functions that are declared with this qualifier:
 
   * It can be executed on the device only.
   * It can be enqueued by the host or on the device.
 
-The `kernel` and `__kernel` names are reserved for use as functions qualifiers and shall not be used otherwise.
+The `kernel` and `+__kernel+` names are reserved for use as function qualifiers and shall not be used otherwise.
 
 [[restrictions]]
 ==== Restrictions

--- a/cxx/lang/keywords.txt
+++ b/cxx/lang/keywords.txt
@@ -8,5 +8,5 @@ The following names are reserved for use as keywords in OpenCL {cpp} and shall n
 
   * Names reserved as keywords by {cpp14}.
   * OpenCL {cpp} data types defined in <<device_builtin_scalar_data_types,Device built-in scalar data types>> and <<device_builtin_vector_data_types,Device built-in vector data types>> tables.
-  * Function qualifiers: `__kernel` and `kernel`.
-  * Access qualifiers: `\__read_only`, `read_only`, `\__write_only`, `write_only`, `__read_write` and `read_write`.
+  * Function qualifiers: `+__kernel+` and `kernel`.
+  * Access qualifiers: `+__read_only+`, `read_only`, `+__write_only+`, `write_only`, `+__read_write+` and `read_write`.

--- a/cxx/stdlib/address_spaces.txt
+++ b/cxx/stdlib/address_spaces.txt
@@ -1443,7 +1443,7 @@ kernel void foo() {
 
     if(get_local_id(0) == 0) {
         // example of variable in local address space
-        // but not declared at __kernel function scope.
+        // but not declared at kernel function scope.
         local<int> c{2}; // not allowed
   }
 }


### PR DESCRIPTION
This change fixes a few more asciidoc formatting errors:

* A few instances of `__kernel` and other underscore-prefixed terms were not being rendered correctly.  To avoid confusion, I changed all of these cases to use the form `+__symbol+`, and I believe they are all rendering correctly now.

* In many cases the unary `*` operator was not rendering correctly or was omitted entirely.  I believe these cases are all correct now, and match the pre-asciidoc text.

Note, I've checked both PDF and HTML outputs.