### PR TITLE
Added language extension doc and variadic macros ext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,30 @@ else
 	$(QUIET)mv $(PDFDIR)/$(EXTENSIONSSPEC)-optimized.pdf $@
 endif
 
+# Language Extensions spec
+EXTSPEC = OpenCL_LangExt
+EXTSPECSRC = $(EXTSPEC).txt $(GENDEPENDS) \
+    $(shell grep ^include:: $(EXTSPEC).txt | sed -e 's/^include:://' -e 's/\[\]/ /' | xargs echo)
+
+exthtml: $(HTMLDIR)/$(EXTSPEC).html $(EXTSPECSRC)
+
+$(HTMLDIR)/$(EXTSPEC).html: $(EXTSPECSRC) katexinst
+	$(QUIET)$(ASCIIDOCTOR) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(EXTSPEC).txt
+
+extpdf: $(PDFDIR)/$(EXTSPEC).pdf $(EXTSPECSRC)
+
+$(PDFDIR)/$(EXTSPEC).pdf: $(EXTSPECSRC)
+	$(QUIET)$(MKDIR) $(PDFDIR)
+	$(QUIET)$(MKDIR) $(PDFMATHDIR)
+	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(EXTSPEC).txt
+ifndef GS_EXISTS
+	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
+else
+	$(QUIET)$(CURDIR)/config/optimize-pdf $@
+	$(QUIET)rm $@
+	$(QUIET)mv $(PDFDIR)/$(EXTSPEC)-optimized.pdf $@
+endif
+
 # C++ (cxx) spec
 CXXSPEC = OpenCL_Cxx
 CXXSPECSRC = $(CXXSPEC).txt $(GENDEPENDS) \

--- a/Makefile
+++ b/Makefile
@@ -261,27 +261,27 @@ else
 endif
 
 # Language Extensions spec
-EXTSPEC = OpenCL_LangExt
-EXTSPECSRC = $(EXTSPEC).txt $(GENDEPENDS) \
-    $(shell grep ^include:: $(EXTSPEC).txt | sed -e 's/^include:://' -e 's/\[\]/ /' | xargs echo)
+CEXTDOC = OpenCL_LangExt
+CEXTDOCSRC = $(CEXTDOC).txt $(GENDEPENDS) \
+    $(shell grep ^include:: $(CEXTDOC).txt | sed -e 's/^include:://' -e 's/\[\]/ /' | xargs echo)
 
-exthtml: $(HTMLDIR)/$(EXTSPEC).html $(EXTSPECSRC)
+cexthtml: $(HTMLDIR)/$(CEXTDOC).html $(CEXTDOCSRC)
 
-$(HTMLDIR)/$(EXTSPEC).html: $(EXTSPECSRC) katexinst
-	$(QUIET)$(ASCIIDOCTOR) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(EXTSPEC).txt
+$(HTMLDIR)/$(CEXTDOC).html: $(CEXTDOCSRC) katexinst
+	$(QUIET)$(ASCIIDOCTOR) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(CEXTDOC).txt
 
-extpdf: $(PDFDIR)/$(EXTSPEC).pdf $(EXTSPECSRC)
+cextpdf: $(PDFDIR)/$(CEXTDOC).pdf $(CEXTDOCSRC)
 
-$(PDFDIR)/$(EXTSPEC).pdf: $(EXTSPECSRC)
+$(PDFDIR)/$(CEXTDOC).pdf: $(CEXTDOCSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
-	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(EXTSPEC).txt
+	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CEXTDOC).txt
 ifndef GS_EXISTS
 	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
 else
 	$(QUIET)$(CURDIR)/config/optimize-pdf $@
 	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(EXTSPEC)-optimized.pdf $@
+	$(QUIET)mv $(PDFDIR)/$(CEXTDOC)-optimized.pdf $@
 endif
 
 # C++ (cxx) spec

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -32,8 +32,6 @@ include::copyrights-ccby.txt[]
 
 include::langext/intro.txt[]
 
-<<<
-
 include::langext/variadic_macro.txt[]
 
 <<<

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The OpenCL^(TM)^ Language Extensions Documentation
+= The OpenCL Language Extensions Documentation
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:
@@ -22,6 +22,10 @@ Khronos{R} OpenCL Working Group
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+<<<<
+
+include::copyrights.txt[]
 
 // type of the source code in the document
 :language: {basebackend@docbook:c++:cpp}

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The OpenCL Language Extensions Documentation
+= The OpenCL C Language Extensions Documentation
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:
@@ -25,7 +25,7 @@ include::config/attribs.txt[]
 
 <<<<
 
-include::copyrights.txt[]
+include::copyrights-ccby.txt[]
 
 // type of the source code in the document
 :language: {basebackend@docbook:c++:cpp}

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The OpenCL^(TM)^ Language Extensions Specification
+= The OpenCL^(TM)^ Language Extensions Documentation
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:
@@ -26,12 +26,12 @@ include::config/attribs.txt[]
 // type of the source code in the document
 :language: {basebackend@docbook:c++:cpp}
 
-include::copyrights.txt[]
-
-<<<
-
 include::langext/intro.txt[]
 
 <<<
 
 include::langext/variadic_macro.txt[]
+
+<<<
+
+include::langext/acknowledgements.txt[]

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -1,0 +1,37 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+= The OpenCL^(TM)^ Language Extensions Specification
+:R: pass:q,r[^(R)^]
+Khronos{R} OpenCL Working Group
+:data-uri:
+:icons: font
+:toc2:
+:toclevels: 2
+:max-width: 100
+:numbered:
+:imagewidth: 800
+:fullimagewidth: width="800"
+:source-highlighter: coderay
+:title-logo-image: image:images/OpenCL.png[Logo,200,200]
+
+:blank: pass:[ +]
+:cpp: pass:[C++]
+:cpp14: pass:[C++14]
+
+// Various special / math symbols. This is easier to edit with than Unicode.
+include::config/attribs.txt[]
+
+// type of the source code in the document
+:language: {basebackend@docbook:c++:cpp}
+
+include::copyrights.txt[]
+
+<<<
+
+include::langext/intro.txt[]
+
+<<<
+
+include::langext/variadic_macro.txt[]

--- a/langext/acknowledgements.txt
+++ b/langext/acknowledgements.txt
@@ -6,8 +6,8 @@
 [float]
 == Acknowledgements
 
-The OpenCL Language Extensions documentation is the result of the
-contributions of many people. Following is a partial list of the
+The OpenCL C Language Extensions documentation is the result of
+the contributions of many people. Following is a partial list of
 contributors, including the company that they represented at the
 time of their contribution:
 

--- a/langext/acknowledgements.txt
+++ b/langext/acknowledgements.txt
@@ -1,0 +1,15 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[acknowledgements]]
+[float]
+== Acknowledgements
+
+The OpenCL Language Extensions documentation is the result of the
+contributions of many people. Following is a partial list of the
+contributors, including the company that they represented at the
+time of their contribution:
+
+  * Anastasia Stulova, Arm
+  * Ben Ashbaugh, Intel

--- a/langext/intro.txt
+++ b/langext/intro.txt
@@ -5,13 +5,13 @@
 [[intro]]
 == Introduction
 
-This document describes language extensions that can be supported optionally by the compiler in addition to the functionality from the existing standard language versions. To detect whether extension is supported by the compiler special feature macros can be used `\__opencl_c_<feature name>`. Each feature macro has a value corresponding to the publishing date. Some extensions are available in all versions and others only in the specific versions of OpenCL kernel language (see <<lang_ext_list,the full list of lanuage extension>>).
+This document describes The OpenCL C language extensions that can be supported optionally by the compiler in addition to the functionality from the existing standard language versions. To detect whether extension is supported by the compiler special feature macros can be used `\__opencl_c_<feature name>`. Each feature macro has a value corresponding to the publishing date. Some extensions are available in all versions and others only in the specific versions of OpenCL kernel language (see <<lang_ext_list,the full list of lanuage extension>>).
 
 
 [[lang_ext_list]]
 == Language Extension List
  
-The section contains all optional language extensions listed along with their feature macros as well as OpenCL version in which the extensions are available .
+The section contains all optional language extensions listed along with their feature macros as well as OpenCL C version in which the extensions are available .
 
 // Editors note: Please keep this table in alphabetical order!
 

--- a/langext/intro.txt
+++ b/langext/intro.txt
@@ -1,0 +1,33 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[intro]]
+== Introduction
+
+This document describes language extensions that can be supported optionally by the compiler in addition to the functionality from the existing standard language versions. To detect whether extension is supported by the compiler special feature macros can be used `\__opencl_c_<feature name>`. Each feature macro has a value corresponding to the publishing date. Some extensions are available in all versions and others only in the specific versions of OpenCL kernel language (see <<lang_ext_list,the full list of lanuage extension>>).
+
+
+[[lang_ext_list]]
+== Language Extension List
+ 
+The section contains all optional language extensions listed along with their feature macros as well as OpenCL version in which the extensions are available .
+
+// Editors note: Please keep this table in alphabetical order!
+
+[cols="5,4,2,4",options="header",]
+|====
+| *Extension Name*
+| *Feature macro*
+| *FM Value*
+| *OpenCL versions*
+
+| <<opencl_c_variadic_macro,Variadic Macros>>
+| __opencl_c_variadic_macro
+| TBD
+| OpenCL C v1.0 to v2.0
+
+|====
+
+== Language Extensions
+

--- a/langext/variadic_macro.txt
+++ b/langext/variadic_macro.txt
@@ -1,0 +1,28 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[opencl_c_variadic_macro]]
+=== Variadic Macros
+
+This extension allows the use of macros with a variable number of arguments in OpenCL C (as per C99 s6.10).
+
+*_Feature macro_*: `__opencl_c_variadic_macro`
+
+*_Macro value_*: `TBD`
+
+Example:
+
+[source,c]
+----------
+#if defined(__opencl_c_variadic_macro)
+#define DBGOUT(msg, ...)  printf ("%s(%u): " msg "\n", __FILE__, __LINE__, __VA_ARGS__)
+#endif
+----------
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds a new document to describe the language extensions and a folder for individual extensions (https://github.com/KhronosGroup/OpenCL-Docs/issues/65). 


There is also the first extension added to allow the variadic macros (https://github.com/KhronosGroup/OpenCL-Docs/issues/50).