### PR TITLE
Intel extension updates

### DIFF
--- a/extensions/cl_intel_required_subgroup_size.asciidoc
+++ b/extensions/cl_intel_required_subgroup_size.asciidoc
@@ -19,6 +19,10 @@
 // C++ unless it is required.
 //:language: {basebackend@docbook:c++:cpp}
 
+:CL_DEVICE_SUB_GROUP_SIZES_INTEL: pass:q[`CL_&#8203;DEVICE_&#8203;SUB_&#8203;GROUP_&#8203;SIZES_&#8203;INTEL`]
+:CL_KERNEL_SPILL_MEM_SIZE_INTEL: pass:q[`CL_&#8203;KERNEL_&#8203;SPILL_&#8203;MEM_&#8203;SIZE_&#8203;INTEL`]
+:CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL: pass:q[`CL_&#8203;KERNEL_&#8203;COMPILE_&#8203;SUB_&#8203;GROUP_&#8203;SIZE_&#8203;INTEL`]
+
 == Name Strings
 
 `cl_intel_required_subgroup_size`
@@ -35,7 +39,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -44,11 +48,11 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 2
+Revision: 3
 
 == Dependencies
 
-Support for OpenCL 2.1, `cl_khr_subgroups, or `cl_intel_subgroups` is required.
+Support for OpenCL 2.1, `cl_khr_subgroups`, or `cl_intel_subgroups` is required.
 This extension is written against revision 23 of the OpenCL 2.1 API specification, against revision 30 of the OpenCL 2.0 OpenCL C specification, against version 31 of the OpenCL 2.0 Extensions specification, and against version 3 of the `cl_intel_subgroups` specification.
 
 == Overview
@@ -86,7 +90,7 @@ CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL          0x410A
 
 == New OpenCL C Optional Attribute Qualifiers
 
-Optional __kernel qualifier:
+Optional `+__kernel+` qualifier:
 
 [source]
 ----
@@ -97,11 +101,11 @@ __attribute__((intel_reqd_sub_group_size(<int>)))
 
 === Additions to Table 4.3 - "OpenCL Device Queries"
 
-[width="100%",cols="<30%,<20%,<50%",options="header"]
+[width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
 | *cl_device_info* | Return Type | Description
 
-| *CL_DEVICE_SUB_GROUP_SIZES_INTEL*
+| {CL_DEVICE_SUB_GROUP_SIZES_INTEL}
 | `size_t[]`
 | Returns the set of subgroup sizes supported by the device.
 
@@ -113,7 +117,7 @@ __attribute__((intel_reqd_sub_group_size(<int>)))
 |====
 | *cl_kernel_work_group_info* | Return Type | Info. returned in _param_value_
 
-| *CL_KERNEL_SPILL_MEM_SIZE_INTEL*
+| {CL_KERNEL_SPILL_MEM_SIZE_INTEL}
 | `cl_ulong`
 | Returns the amount of spill memory used by a kernel.
 The meaning of this value will vary from implementation-to-implementation, however a return value of 0 will always indicate that compiler was able to compile the kernel to fit into the device's register file without spilling registers to memory.
@@ -127,11 +131,10 @@ This is Table 5.22 - "*clGetKernelSubGroupInfo* parameter queries" in the OpenCL
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
 | *cl_kernel_sub_group_info* | Input Type | Return Type | Info. returned in _param_value_
-| *CL_KERNEL_COMPILE_ +
-SUB_GROUP_SIZE_INTEL*
+| {CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL}
 | `ignored`
 | `size_t`
-| Returns the subgroup size specified by the `__attribute__(( intel_reqd_sub_group_size(<int>) ))` qualifier.
+| Returns the subgroup size specified by the `+__attribute__((intel_reqd_sub_group_size(<int>)))+` qualifier.
 Refer to section 6.7.2.
 
 If the subgroup size is not specified using the above attribute qualifier then 0 is returned.
@@ -142,7 +145,7 @@ If the subgroup size is not specified using the above attribute qualifier then 0
 
 === Additions to Section 6.7.2 - "Optional Attribute Qualifiers"
 
-The optional `__attribute__((intel_reqd_sub_group_size(<int>)))` can be used to indicate that the kernel must be compiled and executed with the specified subgroup size.
+The optional `+__attribute__((intel_reqd_sub_group_size(<int>)))+` can be used to indicate that the kernel must be compiled and executed with the specified subgroup size.
 When this attribute is present, *get_max_sub_group_size*() is guaranteed to return the specified integer value.
 This is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.
 
@@ -172,6 +175,7 @@ None.
 |Rev|Date|Author|Changes
 |1|2016-07-14|Ben Ashbaugh|*First public revision.*
 |2|2018-11-15|Ben Ashbaugh|Conversion to asciidoc.
+|3|2019-09-17|Ben Ashbaugh|Minor formatting fixes for asciidoctor.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
@@ -16,7 +16,7 @@
 
 == Name Strings
 
-+cl_intel_spirv_device_side_avc_motion_estimation+
+`cl_intel_spirv_device_side_avc_motion_estimation`
 
 == Contact
 
@@ -29,7 +29,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -38,19 +38,19 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 1
+Revision: 2
 
 == Dependencies
 
 This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.
 
-This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the +cl_khr_il_program+ extension, and support for the +cl_intel_device_side_avc_motion_estimation+ extension.
+This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension, and support for the `cl_intel_device_side_avc_motion_estimation` extension.
 
 == Overview
 
-This extension defines how modules using the SPIR-V extension +SPV_INTEL_device_side_avc_motion_estimation+ may behave in an OpenCL environment.
+This extension defines how modules using the SPIR-V extension `SPV_INTEL_device_side_avc_motion_estimation` may behave in an OpenCL environment.
 
-This extension is a companion to the +cl_intel_device_side_avc_motion_estimation+ OpenCL extension, and the functionality described in this extension and +SPV_INTEL_device_side_avc_motion_estimation+ is sufficient to implement the built-in functions defined in the +cl_intel_device_side_avc_motion_estimation+ extension.
+This extension is a companion to the `cl_intel_device_side_avc_motion_estimation` OpenCL extension, and the functionality described in this extension and `SPV_INTEL_device_side_avc_motion_estimation` is sufficient to implement the built-in functions defined in the `cl_intel_device_side_avc_motion_estimation` extension.
 
 == New API Functions
 
@@ -62,11 +62,11 @@ None.
 
 == Modifications to the OpenCL SPIR-V Environment Specification
 
-=== Add a new Section 7.1.X - +cl_intel_spirv_device_side_avc_motion_estimation+
+=== Add a new Section 7.1.X - `cl_intel_spirv_device_side_avc_motion_estimation`
 
-If the OpenCL environment supports the extension +cl_intel_spirv_device_side_avc_motion_estimation+, then the environment must accept SPIR-V modules that declare use of the +SPV_INTEL_device_side_avc_motion_estimation+ extension via *OpExtension*.
+If the OpenCL environment supports the extension `cl_intel_spirv_device_side_avc_motion_estimation`, then the environment must accept SPIR-V modules that declare use of the `SPV_INTEL_device_side_avc_motion_estimation` extension via *OpExtension*.
 
-If the OpenCL environment supports the extension +cl_intel_spirv_device_side_avc_motion_estimation+ and use of the +SPV_INTEL_device_side_avc_motion_estimation+ extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
+If the OpenCL environment supports the extension `cl_intel_spirv_device_side_avc_motion_estimation` and use of the `SPV_INTEL_device_side_avc_motion_estimation` extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
 
 * *SubgroupAvcMotionEstimationINTEL*
 * *SubgroupAvcMotionEstimationIntraINTEL*
@@ -90,13 +90,14 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2018-10-29|Ben Ashbaugh|*Initial revision*
+|2|2019-09-17|Ben Ashbaugh|Minor formatting fixes for asciidoctor.
 |========================================
 
 //************************************************************************
 //Other formatting suggestions:
 //
 //* Use *bold* text for host APIs, or [source] syntax highlighting.
-//* Use +mono+ text for device APIs, or [source] syntax highlighting.
-//* Use +mono+ text for extension names, types, or enum values.
+//* Use `mono` text for device APIs, or [source] syntax highlighting.
+//* Use `mono` text for extension names, types, or enum values.
 //* Use _italics_ for parameters.
 //************************************************************************

--- a/extensions/cl_intel_spirv_media_block_io.asciidoc
+++ b/extensions/cl_intel_spirv_media_block_io.asciidoc
@@ -16,7 +16,7 @@
 
 == Name Strings
 
-+cl_intel_spirv_media_block_io+
+`cl_intel_spirv_media_block_io`
 
 == Contact
 
@@ -30,7 +30,7 @@ Pawel Jurek, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -39,23 +39,23 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 1
+Revision: 2
 
 == Dependencies
 
 This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.
 
-This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the +cl_khr_il_program+ extension, and support for the +cl_intel_media_block_io+ extension.
+This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension, and support for the `cl_intel_media_block_io` extension.
 
-This extension interacts with the +cl_intel_packed_yuv+ extension.
+This extension interacts with the `cl_intel_packed_yuv` extension.
 
-This extension interacts with the +cl_intel_planar_yuv+ extension.
+This extension interacts with the `cl_intel_planar_yuv` extension.
 
 == Overview
 
-This extension defines how modules using the SPIR-V extension +SPV_INTEL_media_block_io+ may behave in an OpenCL environment.
+This extension defines how modules using the SPIR-V extension `SPV_INTEL_media_block_io` may behave in an OpenCL environment.
 
-This extension is a companion to the +cl_intel_media_block_io+ OpenCL extension, and the functionality described in this extension and +SPV_INTEL_media_block_io+ is sufficient to implement the built-in functions defined in the +cl_intel_media_block_io+ extension.
+This extension is a companion to the `cl_intel_media_block_io` OpenCL extension, and the functionality described in this extension and `SPV_INTEL_media_block_io` is sufficient to implement the built-in functions defined in the `cl_intel_media_block_io` extension.
 
 == New API Functions
 
@@ -67,20 +67,20 @@ None.
 
 == Modifications to the OpenCL SPIR-V Environment Specification
 
-=== Add a new Section 7.1.X - +cl_intel_spirv_media_block_io+
+=== Add a new Section 7.1.X - `cl_intel_spirv_media_block_io`
 
-If the OpenCL environment supports the extension +cl_intel_spirv_media_block_io+, then the environment must accept SPIR-V modules that declare use of the +SPV_INTEL_media_block_io+ extension via *OpExtension*.
+If the OpenCL environment supports the extension `cl_intel_spirv_media_block_io`, then the environment must accept SPIR-V modules that declare use of the `SPV_INTEL_media_block_io` extension via *OpExtension*.
 
-If the OpenCL environment supports the extension +cl_intel_spirv_media_block_io+ and use of the +SPV_INTEL_media_block_io+ extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
+If the OpenCL environment supports the extension `cl_intel_spirv_media_block_io` and use of the `SPV_INTEL_media_block_io` extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
 
 * *SubgroupImageMediaBlockIOINTEL*
 
 Additionally, the environment must accept the following types for 'Result Type' for *OpSubgroupImageMediaBlockReadINTEL*, and for the type of 'Data' for *OpSubgroupImageMediaBlockWriteINTEL*:
 
 * Scalars and *OpTypeVectors* with 2, 4, 8, or 16 _Component Count_ components of the following _Component Type_ types:
-** *OpTypeInt* with a _Width_ of 8 bits and _Signedness_ of 0 (equivalent to +char+ and +uchar+)
-** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to +short+ and +ushort+)
-** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to +int+ and +uint+)
+** *OpTypeInt* with a _Width_ of 8 bits and _Signedness_ of 0 (equivalent to `char` and `uchar`)
+** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to `short` and `ushort`)
+** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to `int` and `uint`)
 
 For _Image_:
 
@@ -88,15 +88,15 @@ For _Image_:
 * _Depth_ must be 0 (not a depth image)
 * _Arrayed_ must be 0 (non-arrayed content)
 * _MS_ must be 0 (single-sampled content)
-* (equivalent to +image2d_t+)
+* (equivalent to `image2d_t`)
 
 For 'Coordinate', the following types are supported:
 
-* *OpTypeVectors* with 2 _Component Count_ components of _Component Type_ *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to +int2+)
+* *OpTypeVectors* with 2 _Component Count_ components of _Component Type_ *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to `int2`)
 
 For 'Width' and 'Height', the following type is supported:
 
-* Scalars of *OpTypeInt* with a _Width_ of 32 bits and a _Signedness_ of 0 (equivalent to +int+)
+* Scalars of *OpTypeInt* with a _Width_ of 32 bits and a _Signedness_ of 0 (equivalent to `int`)
 
 === Add a new Section 7.1.X.1 - Notes and Restrictions
 
@@ -131,23 +131,23 @@ The 'Image' operand must be created such that the image byte width, defined as t
 
 For *OpSubgroupImageMediaBlockReadINTEL*, if the 'Image Format' size is smaller than the block read 'Component Type', then an out-of-bounds read will return data replicated from the nearest edge element, otherwise out-of-bound read behavior is undefined.  For example:
 
-* For an image with 'Image Format' size equal to a single byte (for example *R8*), and a 32-bit boundary value +B0B1B2B3+, replicating off the left edge may result in the 32-bit value +B0B0B0B0+, and replicating off the right edge may result in the 32-bit value +B3B3B3B3+.
-* For an image with an 'Image Format' size equal to two bytes (for example *R16*), replicating off the left edge may result in the 32-bit value +B0B1B0B1+, and replicating off the right edge may result in the 32-bit value +B2B3B2B3+.
+* For an image with 'Image Format' size equal to a single byte (for example *R8*), and a 32-bit boundary value `B0B1B2B3`, replicating off the left edge may result in the 32-bit value `B0B0B0B0`, and replicating off the right edge may result in the 32-bit value `B3B3B3B3`.
+* For an image with an 'Image Format' size equal to two bytes (for example *R16*), replicating off the left edge may result in the 32-bit value `B0B1B0B1`, and replicating off the right edge may result in the 32-bit value `B2B3B2B3`.
 * For an image with an 'Image Format' size equal to four bytes (for example *Rgba8*), the entire boundary value is replicated, for both the left or right edges.
 * Because the maximum 'Component Type' is a four byte component type, there is no defined out-of-bounds behavior for images with an 'Image Format' size greater than four bytes.
 * As a special case, an image with a packed YUV 'Image Format' (and hence an 'Image Format' size equal to two bytes) behaves as follows:
-** Replicating off of the left edge replicates the UV components and the first Y component, so, for example, replicating the 32-bit boundary value +Y0U0Y1V0+ will result in the 32-bit value +Y0U0Y0V0+.
-** Replicating off the right edge replicates the UV components and the second Y component, so, for example, replicating the 32-bit boundary value +Y0U0Y1V0+ will result in the 32-bit value +Y1U0Y1V0+.
+** Replicating off of the left edge replicates the UV components and the first Y component, so, for example, replicating the 32-bit boundary value `Y0U0Y1V0` will result in the 32-bit value `Y0U0Y0V0`.
+** Replicating off the right edge replicates the UV components and the second Y component, so, for example, replicating the 32-bit boundary value `Y0U0Y1V0` will result in the 32-bit value `Y1U0Y1V0`.
 
 For *OpSubgroupImageMediaBlockWriteINTEL*, if the 'Image Format' size is smaller than the block write 'Component Type', then out-of-bounds writes will be dropped, otherwise out-of-bounds write behavior is undefined.
 
 When reading or writing a 2D 'Image' created from a buffer:
 
-* The 'image row pitch' is required to be a multiple of 64-bytes, in addition to the +CL_DEVICE_IMAGE_PITCH_ALIGNMENT+ requirements.
+* The 'image row pitch' is required to be a multiple of 64-bytes, in addition to the `CL_DEVICE_IMAGE_PITCH_ALIGNMENT` requirements.
 
-* If the buffer is a +cl_mem+ that was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ must be 256-bit (32-byte) aligned.
+* If the buffer is a `cl_mem` that was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ must be 256-bit (32-byte) aligned.
 
-* If the buffer is a +cl_mem+ that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.  Additionally, if the _buffer_ that the sub-buffer is created from was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
+* If the buffer is a `cl_mem` that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.  Additionally, if the _buffer_ that the sub-buffer is created from was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
 
 * The maximum 'Height' is further restricted to 16 rows or less.
 
@@ -171,13 +171,14 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2018-10-29|Ben Ashbaugh|*Initial revision*
+|2|2019-09-17|Ben Ashbaugh|Minor formatting fixes for asciidoctor.
 |========================================
 
 //************************************************************************
 //Other formatting suggestions:
 //
 //* Use *bold* text for host APIs, or [source] syntax highlighting.
-//* Use +mono+ text for device APIs, or [source] syntax highlighting.
-//* Use +mono+ text for extension names, types, or enum values.
+//* Use `mono` text for device APIs, or [source] syntax highlighting.
+//* Use `mono` text for extension names, types, or enum values.
 //* Use _italics_ for parameters.
 //************************************************************************

--- a/extensions/cl_intel_spirv_subgroups.asciidoc
+++ b/extensions/cl_intel_spirv_subgroups.asciidoc
@@ -16,7 +16,7 @@
 
 == Name Strings
 
-+cl_intel_spirv_subgroups+
+`cl_intel_spirv_subgroups`
 
 == Contact
 
@@ -31,7 +31,7 @@ Mariusz Merecki, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -40,21 +40,21 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 1
+Revision: 2
 
 == Dependencies
 
 This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.
 
-This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the +cl_khr_il_program+ extension, and support for the +cl_intel_subgroups+ extension.
+This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension, and support for the `cl_intel_subgroups` extension.
 
-This extension interacts with the +cl_intel_subgroups_short+ extension.
+This extension interacts with the `cl_intel_subgroups_short` extension.
 
 == Overview
 
-This extension defines how modules using the SPIR-V extension +SPV_INTEL_subgroups+ may behave in an OpenCL environment.
+This extension defines how modules using the SPIR-V extension `SPV_INTEL_subgroups` may behave in an OpenCL environment.
 
-This extension is a companion to the +cl_intel_subgroups+ and +cl_intel_subgroups_short+ OpenCL extensions, and the functionality described in this extension and +SPV_INTEL_subgroups+ is sufficient to implement the built-in functions defined in the +cl_intel_subgroups+ and +cl_intel_subgroups_short+ extensions.
+This extension is a companion to the `cl_intel_subgroups` and `cl_intel_subgroups_short` OpenCL extensions, and the functionality described in this extension and `SPV_INTEL_subgroups` is sufficient to implement the built-in functions defined in the `cl_intel_subgroups` and `cl_intel_subgroups_short` extensions.
 
 == New API Functions
 
@@ -66,11 +66,11 @@ None.
 
 == Modifications to the OpenCL SPIR-V Environment Specification
 
-=== Add a new Section 7.1.X - +cl_intel_spirv_subgroups+
+=== Add a new Section 7.1.X - `cl_intel_spirv_subgroups`
 
-If the OpenCL environment supports the extension +cl_intel_spirv_subgroups+, then the environment must accept SPIR-V modules that declare use of the +SPV_INTEL_subgroups+ extension via *OpExtension*.
+If the OpenCL environment supports the extension `cl_intel_spirv_subgroups`, then the environment must accept SPIR-V modules that declare use of the `SPV_INTEL_subgroups` extension via *OpExtension*.
 
-If the OpenCL environment supports the extension +cl_intel_spirv_subgroups+ and use of the +SPV_INTEL_subgroups+ extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
+If the OpenCL environment supports the extension `cl_intel_spirv_subgroups` and use of the `SPV_INTEL_subgroups` extension is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
 
 * *SubgroupShuffleINTEL*
 * *SubgroupBufferBlockIOINTEL*
@@ -125,41 +125,41 @@ For the _Group Instructions_:
 
 === Add a new Section 7.1.X.1 - Shuffle Instructions
 
-Because support for +cl_intel_subgroups+ is required for +cl_intel_spirv_subgroups+, if the OpenCL environment supports the extension +cl_intel_spirv_subgroups+ and use of the +SPV_INTEL_subgroups+ extension is declared in the module via *OpExtension*, then the environment must accept the following types for 'Data' for the *SubgroupShuffleINTEL* instructions:
+Because support for `cl_intel_subgroups` is required for `cl_intel_spirv_subgroups`, if the OpenCL environment supports the extension `cl_intel_spirv_subgroups` and use of the `SPV_INTEL_subgroups` extension is declared in the module via *OpExtension*, then the environment must accept the following types for 'Data' for the *SubgroupShuffleINTEL* instructions:
 
-* Scalars and *OpTypeVectors* with 2, 4, 8, or 16 _Component Count_ components of the following _Component Type_ types:
-** *OpTypeFloat* with a _Width_ of 32 bits (equivalent to +float+)
-** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to +int+ and +uint+)
-* Scalars of *OpTypeInt* with a _Width_ of 64 bits and _Signedness_ of 0 (equivalent to +long+ and +ulong+)
+* Scalars and *OpTypeVectors* with 2, 3, 4, 8, or 16 _Component Count_ components of the following _Component Type_ types:
+** *OpTypeFloat* with a _Width_ of 32 bits (equivalent to `float`)
+** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to `int` and `uint`)
+* Scalars of *OpTypeInt* with a _Width_ of 64 bits and _Signedness_ of 0 (equivalent to `long` and `ulong`)
 
 Additionally, if the *Float16* capability is declared and supported:
 
-* Scalars of *OpTypeFloat* with a _Width_ of 16 bits (equivalent to +half+)
+* Scalars of *OpTypeFloat* with a _Width_ of 16 bits (equivalent to `half`)
 
 Additionally, if the *Float64* capability is declared and supported:
 
-* Scalars of *OpTypeFloat* with a _Width_ of 64 bits (equivalent to +double+)
+* Scalars of *OpTypeFloat* with a _Width_ of 64 bits (equivalent to `double`)
 
-Additionally, if the OpenCL environment supports the extension +cl_intel_subgroups_short+:
+Additionally, if the OpenCL environment supports the extension `cl_intel_subgroups_short`:
 
-* Scalars and *OpTypeVectors* with 2, 4, 8, or 16 _Component Count_ components of the following _Component Type_ types:
-** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to +short+ and +ushort+)
+* Scalars and *OpTypeVectors* with 2, 3, 4, 8, or 16 _Component Count_ components of the following _Component Type_ types:
+** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to `short` and `ushort`)
 
 === Add a new Section 7.1.X.2 - Block IO Instructions
 
-Because support for +cl_intel_subgroups+ is required for +cl_intel_spirv_subgroups+, if the OpenCL environment supports the extension +cl_intel_spirv_subgroups+ and use of the +SPV_INTEL_subgroups+ extension is declared in the module via *OpExtension*, then the environment must accept the following types for _Result_ and _Data_ for the *SubgroupBufferBlockIOINTEL* and *SubgroupImageBlockIOINTEL* instructions:
+Because support for `cl_intel_subgroups` is required for `cl_intel_spirv_subgroups`, if the OpenCL environment supports the extension `cl_intel_spirv_subgroups` and use of the `SPV_INTEL_subgroups` extension is declared in the module via *OpExtension*, then the environment must accept the following types for _Result_ and _Data_ for the *SubgroupBufferBlockIOINTEL* and *SubgroupImageBlockIOINTEL* instructions:
 
 * Scalars and *OpTypeVectors* with 2, 4, or 8 _Component Count_ components of the following _Component Type_ types:
-** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to +int+ and +uint+)
+** *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to `int` and `uint`)
 
-Additionally, if the OpenCL environment supports the extension +cl_intel_subgroups_short+:
+Additionally, if the OpenCL environment supports the extension `cl_intel_subgroups_short`:
 
 * Scalars and *OpTypeVectors* with 2, 4, or 8 _Component Count_ components of the following _Component Type_ types:
-** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to +short+ and +ushort+)
+** *OpTypeInt* with a _Width_ of 16 bits and _Signedness_ of 0 (equivalent to `short` and `ushort`)
 
 For _Ptr_, valid _Storage Classes_ are:
 
-* *CrossWorkGroup* (equivalent to the +global+ address space)
+* *CrossWorkGroup* (equivalent to the `global` address space)
 
 For _Image_:
 
@@ -167,11 +167,11 @@ For _Image_:
 * _Depth_ must be 0 (not a depth image)
 * _Arrayed_ must be 0 (non-arrayed content)
 * _MS_ must be 0 (single-sampled content)
-* (equivalent to +image2d_t+)
+* (equivalent to `image2d_t`)
 
 For _Coordinate_, the following types are supported:
 
-* *OpTypeVectors* with 2 _Component Count_ components of _Component Type_ *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to +int2+)
+* *OpTypeVectors* with 2 _Component Count_ components of _Component Type_ *OpTypeInt* with a _Width_ of 32 bits and _Signedness_ of 0 (equivalent to `int2`)
 
 === Add a new Section 7.1.X.3 - Notes and Restrictions
 
@@ -183,31 +183,35 @@ The *SubgroupBufferBlockIOINTEL* and *SubgroupImageBlockIOINTEL* instructions ar
 
 There is no defined out-of-range behavior for the *SubgroupBufferBlockIOINTEL* instructions.
 
-The *SubgroupImageBlockIOINTEL* instructions do support bounds checking, however they bounds-check to the image width in units of +uints+, not in units of image elements.  This means:
+The *SubgroupImageBlockIOINTEL* instructions do support bounds checking, however they bounds-check to the image width in units of `uints`, not in units of image elements.  This means:
 
-* If the image has an _Image Format_ size equal to the size of a +uint+ (four bytes, for example *Rgba8*), the image will be correctly bounds-checked.  In this case, out-of-bounds reads will return the edge image element (the equivalent of *ClampToEdge*), and out-of-bounds writes will be ignored.
+* If the image has an _Image Format_ size equal to the size of a `uint` (four bytes, for example *Rgba8*), the image will be correctly bounds-checked.  In this case, out-of-bounds reads will return the edge image element (the equivalent of *ClampToEdge*), and out-of-bounds writes will be ignored.
 
-* If the image has an _Image Format_ size less than the size of a +uint+ (such as *R8*), the entire image is addressable, however bounds checking will occur too late.  For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.
+* If the image has an _Image Format_ size less than the size of a `uint` (such as *R8*), the entire image is addressable, however bounds checking will occur too late.  For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.
 
 The following restrictions apply to the *SubgroupBufferBlockIOINTEL* instructions:
 
 * The pointer _Ptr_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
-* If the pointer _Ptr_ is computed from a kernel argument that is a +cl_mem+ that was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
+* If the pointer _Ptr_ is computed from a kernel argument that is a `cl_mem` that was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
-* If the pointer _Ptr_ is computed from a kernel argument that is a +cl_mem+ that is a sub-buffer, then the _origin_ defining the sub-buffer offset into the _buffer_ must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the +CL_DEVICE_MEM_BASE_ADDR_ALIGN+ requirements.  Additionally, if the _buffer_ that the sub-buffer is created from was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ for the _buffer_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
+* If the pointer _Ptr_ is computed from a kernel argument that is a `cl_mem` that is a sub-buffer, then the _origin_ defining the sub-buffer offset into the _buffer_ must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the `CL_DEVICE_MEM_BASE_ADDR_ALIGN` requirements.  Additionally, if the _buffer_ that the sub-buffer is created from was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ for the _buffer_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
 * If the pointer _Ptr_ is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
+
+* Behavior is undefined if the *SubgroupSize* is smaller than *SubgruopMaxSize*; in other words, if this is a partial subgroup.
 
 The following restrictions apply to the *SubgroupImageBlockIOINTEL* instructions:
 
 * The behavior of the *SubgroupImageBlockIOINTEL* instructions is undefined for images with an element size greater than four bytes (such as *Rgba32f*).
 
-* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, the image row pitch is required to be a multiple of 64-bytes, in addition to the +CL_DEVICE_IMAGE_PITCH_ALIGNMENT+ requirements.
+* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, the image row pitch is required to be a multiple of 64-bytes, in addition to the `CL_DEVICE_IMAGE_PITCH_ALIGNMENT` requirements.
 
-* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, if the buffer is a +cl_mem+ that was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ must be 256-bit (32-byte) aligned.
+* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, if the buffer is a `cl_mem` that was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ must be 256-bit (32-byte) aligned.
 
-* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, if the buffer is a +cl_mem+ that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.  Additionally, if the _buffer_ that the sub-buffer is created from was created with +CL_MEM_USE_HOST_PTR+, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
+* When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, if the buffer is a `cl_mem` that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.  Additionally, if the _buffer_ that the sub-buffer is created from was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
+
+* Behavior is undefined if the *SubgroupSize* is smaller than *SubgruopMaxSize*; in other words, if this is a partial subgroup.
 
 The following restrictions apply to the *OpSubgroupImageBlockWriteINTEL* instruction:
 
@@ -231,13 +235,14 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2018-10-29|Ben Ashbaugh|*Initial revision*
+|2|2019-09-17|Ben Ashbaugh|Added 3-component vector support for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.
 |========================================
 
 //************************************************************************
 //Other formatting suggestions:
 //
 //* Use *bold* text for host APIs, or [source] syntax highlighting.
-//* Use +mono+ text for device APIs, or [source] syntax highlighting.
-//* Use +mono+ text for extension names, types, or enum values.
+//* Use `mono` text for device APIs, or [source] syntax highlighting.
+//* Use `mono` text for extension names, types, or enum values.
 //* Use _italics_ for parameters.
 //************************************************************************

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -19,6 +19,9 @@
 // C++ unless it is required.
 //:language: {basebackend@docbook:c++:cpp}
 
+:CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR: pass:q[`CL_&#8203;KERNEL_&#8203;MAX_&#8203;SUB_&#8203;GROUP_&#8203;SIZE_&#8203;FOR_&#8203;NDRANGE_&#8203;KHR`]
+:CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR: pass:q[`CL_&#8203;KERNEL_&#8203;SUB_&#8203;GROUP_&#8203;COUNT_&#8203;FOR_&#8203;NDRANGE_&#8203;KHR`]
+
 == Name Strings
 
 `cl_intel_subgroups`
@@ -39,7 +42,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -48,7 +51,7 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 7
+Revision: 8
 
 == Dependencies
 
@@ -174,7 +177,7 @@ gentype sub_group_scan_inclusive_max( gentype x)
 These built-in functions are unique to the Intel subgroups extension and are not part of the Khronos subgroups extension: ::
 +
 --
-For the sub_group_shuffle, sub_group_shuffle_down, sub_group_shuffle_up, and sub_group_shuffle_xor functions, `gentype` is `float`, `float2`, `float4`, `float8`, `float16`, `int`, `int2`, `int4`, `int8`, `int16`, `uint`, `uint2`,`uint4`, `uint8`, `uint16`, `long`, or `ulong`.
+For the sub_group_shuffle, sub_group_shuffle_down, sub_group_shuffle_up, and sub_group_shuffle_xor functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If cl_khr_fp16 is supported, `gentype` also includes `half`.
 
@@ -370,7 +373,7 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
 | *cl_kernel_sub_group_info* | Input Type | Return Type | Info. returned in _param_value_
-| *CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR*
+| {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
           | Returns the maximum sub-group size for this kernel.
@@ -383,7 +386,7 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
             dispatch.
             The number of dimensions in the ND-range will be inferred from
             the value specified for _input_value_size_.
-| *CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR*
+| {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
           | Returns the number of sub-groups that will be present in each
@@ -410,7 +413,7 @@ Otherwise, it returns one of the following errors:
     specified by _param_value_size_ is less than the size of return type as described in
     the table above and _param_value_ is not `NULL`.
   * `CL_INVALID_VALUE` if _param_name_ is
-    `CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE` and the size in bytes specified by
+    {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR} and the size in bytes specified by
     _input_value_size_ is not valid or if _input_value_ is `NULL`.
   * `CL_INVALID_KERNEL` if _kernel_ is a not a valid kernel object.
   * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required
@@ -676,7 +679,7 @@ These are new functions: ::
 The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
 These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
 Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
-For these functions, `gentype` is `float`, `float2`, `float4`, `float8`, `float16`, `int`, `int2`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
+For these functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If `cl_khr_fp16` is supported, `gentype` also includes `half`.
 
@@ -907,6 +910,8 @@ Additionally, if the _buffer_ that the sub-buffer is created from was created wi
 
 * If the pointer _p_ is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
+* Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.
+
 The following restrictions apply to the subgroup image block read and write functions:
 
 * The behavior of the subgroup image block read and write built-ins is undefined for images with an element size greater than four bytes (such as `CL_RGBA` + `CL_FLOAT`).
@@ -917,6 +922,8 @@ The following restrictions apply to the subgroup image block read and write func
 
 * When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.
 Additionally, if the _buffer_ that the sub-buffer is created from was created with CL_MEM_USE_HOST_PTR, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
+
+* Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.
 --
 
 == Issues
@@ -943,6 +950,7 @@ None.
 |5|2018-11-15|Ben Ashbaugh|Converted to asciidoc.
 |6|2018-12-02|Ben Ashbaugh|Added back a section that was inadvertently removed during conversion to asciidoc.
 |7|2019-01-15|Ben Ashbaugh|Fixed a typo in the summary section of new built-in functions.
+|8|2019-09-17|Ben Ashbaugh|Added vec3 types for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -40,7 +40,7 @@ Insoo Woo, Intel
 
 == Notice
 
-Copyright (c) 2018 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -49,7 +49,7 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 2
+Revision: 3
 
 == Dependencies
 
@@ -110,7 +110,7 @@ ushort  intel_sub_group_scan_inclusive_max( ushort x )
 ----
 --
 
-Add `short`, `short2`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort4`, `ushort8`, and `ushort16` to the list of `gentype` data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
+Add `short`, `short2`, `short3`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort3`, `ushort4`, `ushort8`, and `ushort16` to the list of `gentype` data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
 +
 --
 [source]
@@ -264,13 +264,13 @@ The scan order is defined by increasing subgroup local ID within the subgroup.
 
 This section was added by the `cl_intel_subgroups` extension.
 
-Add `short`, `short2`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort4`, `ushort8`, and `ushort16` to the list of data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
+Add `short`, `short2`, `short3`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort3`, `ushort4`, `ushort8`, and `ushort16` to the list of data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
 +
 --
 The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
 These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
 Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
-For these functions, `gentype` is `float`, `float2`, `float4`, `float8`, `float16`, `short`, `short2`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort4`, `ushort8`, `ushort16`, `int`, `int2`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
+For these functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `short`, `short2`, `short3`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort3`, `ushort4`, `ushort8`, `ushort16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If `cl_khr_fp16` is supported, `gentype` also includes `half`.
 
@@ -536,6 +536,7 @@ None.
 |Rev|Date|Author|Changes
 |1|2016-10-20|Ben Ashbaugh|*First public revision.*
 |2|2018-11-15|Ben Ashbaugh|Conversion to asciidoc.
+|3|2019-09-17|Ben Ashbaugh|Added vec3 types for shuffles and asciidoctor formatting fixes.
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
This PR updates the asciidoc source for a few Intel extensions:

* Minor updates to switch to the Asciidoctor toolchain.
* Adds missing vec3 support for subgroup shuffles (spec bugfix).
* Adds restriction for subgroup block i/o and partial subgroups (spec bugfix).
