### PR TITLE
update extension template

### DIFF
--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -24,14 +24,6 @@ This template is implemented as Asciidoctor markup and contains UTF-8
 text,  For portability, use of non-ASCII characters is discouraged
 except where essential, for example, for contributor names.
 
-TODO: Add a link to a published extension that follows this template.
-
-TODO: Link to a public github repo with published extension
-specifications.
-
-TODO: Add a link to a process document that describes how to publish
-an OpenCL extension.  Is the README.md sufficient?
-
 The first line of an extension document is the document title.  This
 is almost always the same as the name of the extension name string,
 but if an extension has multiple name strings, it may be a higher
@@ -78,8 +70,8 @@ increasing level of review.
 
 == Contact
 
-Please see the *Issues* list in the Khronos *TODO* repository: +
-https://github.com/KhronosGroup/TODO
+Please see the *Issues* list in the Khronos *OpenCL-Docs* repository: +
+https://github.com/KhronosGroup/OpenCL-Docs
 
 ****
 The 'Contact' section describes a way for users of the extension to
@@ -133,7 +125,7 @@ Promoters, or any other relevant status information.
 == Version
 
 Built On: {docdate} +
-Revision: 1
+Revision: 3
 
 ****
 The 'Version' section should indicate the document revision number and
@@ -157,8 +149,9 @@ the _base_ specification.  Additionally, any dependencies on API
 versions, other required extensions, or other required features should
 be described in this section.
 
-TODO: At some point it would be nice to describe the dependencies with
-links to the corresponding core and extension specifications.
+The _base_ specification will usually be a version of a specification
+from the
+https://github.com/KhronosGroup/OpenCL-Registry[specification registry].
 ****
 
 == Overview
@@ -229,8 +222,9 @@ CL_ANOTHER_ENUM_KHR   0xYYYY
 ****
 The 'New API Enums' section should list any new enumerants added by
 this extension along with the value of the new enumerant.  Until
-values are assigned by the Khronos Registry from the enumerant
-registry (TODO: link?), use a placeholder value, e.g. "0x????".
+values are assigned by the Khronos Registry from the
+https://github.com/KhronosGroup/OpenCL-Docs/blob/master/xml/cl.xml[enumerant
+registry], use a placeholder value, e.g. `0x????`.
 
 Typically, new enumerants have a short description indicating which
 API functions use them and for what purpose, but be brief, since
@@ -378,10 +372,6 @@ The text above demonstrates how to add a new built-in function.
 Two methods are described: One that describes the new built-in function
 in a table, similar to the OpenCL C spec, and another that describes the
 built-in function as its own item, similar to the OpenCL C++ spec.
-
-TODO: Which do we prefer?  Slight preference for the OpenCL C++ method,
-since it's the future and it supports syntax highlighting.  I'm also not
-sure how to indent lines in table cells.
 ****
 
 
@@ -403,7 +393,7 @@ to the other extension specs, then this section may be omitted.
 things?
 +
 --
-+RESOLVED+: Only interesting things.  Non-interesting things should
+*RESOLVED*: Only interesting things.  Non-interesting things should
 be exposed by a separate extension. (Teleconference 2016/11/11)
 --
 
@@ -432,7 +422,8 @@ best not to renumber issues, either.
 |====
 | Rev | Date       | Author       | Changes
 | 1   | 2016-11-14 | Ben Ashbaugh | *Initial revision*
-| 2   | 2019-10-03 | Kévin Petit  | *Minor tweaks, new API types section*
+| 2   | 2019-10-03 | Kévin Petit  | Minor tweaks, new API types section.
+| 3   | 2019-10-07 | Ben Ashbaugh | Minor updates, including asciidoctor syntax.
 |====
 
 ****


### PR DESCRIPTION
* Adds a link to the OpenCL-Docs repo.
* Adds a link to the OpenCL specification registry.
* Adds a link to the OpenCL enumerant registry.
* Minor updates for the asciidoctor toolchain.