### PR TITLE
Fix typo + copyright year in XML header

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright (c) 2013-2018 The Khronos Group Inc.
+Copyright (c) 2013-2019 The Khronos Group Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ machine-readable definition of the API, parameter and member validation
 language incorporated into the Specification and reference pages, and other
 material which is registered by Khronos.
 
-The authoritative public version of ck.xml is maintained in the master
+The authoritative public version of cl.xml is maintained in the master
 branch of the Khronos OpenCL-API GitHub repository. The authoritative
 private version is maintained in the master branch of the member gitlab
 server's OpenCL/api-docs repository.


### PR DESCRIPTION
Does what it says on the tin.