### PR TITLE
Reserve 5 bits in cl_mem_flags for Arm

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -650,6 +650,12 @@ server's OpenCL/api-docs repository.
         <enum bitpos="29"           name="CL_MEM_EXT_HOST_PTR_QCOM"/>
         <!-- unused <enum bitpos="30"   name="CL_MEM_BUS_ADDRESSABLE_AMD"/> -->
         <!-- unused <enum bitpos="31"   name="CL_MEM_EXTERNAL_MEMORY_AMD"/> -->
+        <enum bitpos="32"           name="CL_MEM_RESERVED0_ARM"/>
+        <enum bitpos="33"           name="CL_MEM_RESERVED1_ARM"/>
+        <enum bitpos="34"           name="CL_MEM_RESERVED2_ARM"/>
+        <enum bitpos="35"           name="CL_MEM_RESERVED3_ARM"/>
+        <enum bitpos="36"           name="CL_MEM_RESERVED4_ARM"/>
+            <unused start="37" end="63"/>
     </enums>
 
     <enums name="cl_map_flags" vendor="Khronos" type="bitmask">


### PR DESCRIPTION
Also mark the remaining bits in the upper 32-bit region as unused
(cl_mem_flags is defined as a cl_bitfield which is a cl_ulong,
guaranteed to be 64-bit).

Signed-off-by: Kevin Petit <kevin.petit@arm.com>