### PR TITLE
Initial draft of C++ for OpenCL documentation

### DIFF
--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -1,0 +1,42 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+= The C++ for OpenCL Programming Language Documentation
+:R: pass:q,r[^(R)^]
+Khronos{R} OpenCL Working Group
+:data-uri:
+:icons: font
+:toc2:
+:toclevels: 2
+:max-width: 100
+:numbered:
+:imagewidth: 800
+:fullimagewidth: width="800"
+:source-highlighter: coderay
+:title-logo-image: image:images/OpenCL.png[Logo,200,200]
+
+:blank: pass:[ +]
+:cpp: pass:[C++]
+:cpp14: pass:[C++17]
+
+// Various special / math symbols. This is easier to edit with than Unicode.
+include::config/attribs.txt[]
+
+// type of the source code in the document
+:language: {basebackend@docbook:c++:cpp}
+
+include::cxx4opencl/intro.txt[]
+
+<<<
+
+include::cxx4opencl/restrictions.txt[]
+
+<<<
+
+include::cxx4opencl/address_spaces.txt[]
+
+<<<
+
+include::cxx4opencl/acknowledgements.txt[]
+

--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -32,11 +32,7 @@ include::copyrights-ccby.txt[]
 
 include::cxx4opencl/intro.txt[]
 
-<<<
-
 include::cxx4opencl/restrictions.txt[]
-
-<<<
 
 include::cxx4opencl/address_spaces.txt[]
 

--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The C++ for OpenCL Programming Language Documentation
+= The C++ for OpenCL Programming Language Documentation (Draft)
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:

--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -23,6 +23,10 @@ Khronos{R} OpenCL Working Group
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
 
+<<<<
+
+include::copyrights-ccby.txt[]
+
 // type of the source code in the document
 :language: {basebackend@docbook:c++:cpp}
 

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,30 @@ else
 	$(QUIET)mv $(PDFDIR)/$(CSPEC)-optimized.pdf $@
 endif
 
+# C++ for OpenCL doc
+CXX4OPENCLDOC = CXX_for_OpenCL
+CXX4OPENCLDOCSRC = $(CXX4OPENCLDOC).txt $(GENDEPENDS) \
+    $(shell grep ^include:: $(CXX4OPENCLDOC).txt | sed -e 's/^include:://' -e 's/\[\]/ /' | xargs echo)
+
+cxx4openclhtml: $(HTMLDIR)/$(CXX4OPENCLDOC).html $(CXX4OPENCLDOCSRC)
+
+$(HTMLDIR)/$(CXX4OPENCLDOC).html: $(CXX4OPENCLDOCSRC) katexinst
+	$(QUIET)$(ASCIIDOCTOR) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(CXX4OPENCLDOC).txt
+
+cxx4openclpdf: $(PDFDIR)/$(CXX4OPENCLDOC).pdf $(CXX4OPENCLDOCSRC)
+
+$(PDFDIR)/$(CXX4OPENCLDOC).pdf: $(CXX4OPENCLDOCSRC)
+	$(QUIET)$(MKDIR) $(PDFDIR)
+	$(QUIET)$(MKDIR) $(PDFMATHDIR)
+	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CXX4OPENCLDOC).txt
+ifndef GS_EXISTS
+	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
+else
+	$(QUIET)$(CURDIR)/config/optimize-pdf $@
+	$(QUIET)rm $@
+	$(QUIET)mv $(PDFDIR)/$(CXX4OPENCLDOC)-optimized.pdf $@
+endif
+
 # ICD installation guidelines
 ICDINSTSPEC = OpenCL_ICD_Installation
 ICDINSTSPECSRC = $(ICDINSTSPEC).txt \

--- a/copyrights-ccby.txt
+++ b/copyrights-ccby.txt
@@ -17,3 +17,8 @@ the terms of the Creative Commons Attribution 4.0 International (CC BY 4.0)
 License (the "License"), available at https://creativecommons.org/licenses/by/4.0/. 
 All use of such material is governed by the term of the License. Khronos bears 
 no responsibility whatsoever for additions or modifications to its material.
+
+Khronos is a registered trademark, and OpenCL is a trademark of Apple Inc.
+and used under license by Khronos. All other product names, trademarks, and/or
+company names are used solely for identification and belong to their respective
+owners.

--- a/copyrights-ccby.txt
+++ b/copyrights-ccby.txt
@@ -1,0 +1,19 @@
+Copyright 2019 The Khronos Group.
+
+Khronos licenses this file to you under the Creative Commons Attribution 4.0 
+International (CC BY 4.0) License (the "License"); you may not use this file 
+except in compliance with the License.  You may obtain a copy of the License 
+at https://creativecommons.org/licenses/by/4.0/
+
+Unless required by applicable law or agreed to in writing, material distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+CONDITIONS OF ANY KIND, either express or implied. If all or a portion of this 
+material is re-used, notice substantially similar to the following must be included:
+
+This documentation includes material developed at The Khronos Group 
+(http://www.khronos.org/). Khronos supplied such material on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, under 
+the terms of the Creative Commons Attribution 4.0 International (CC BY 4.0) 
+License (the "License"), available at https://creativecommons.org/licenses/by/4.0/. 
+All use of such material is governed by the term of the License. Khronos bears 
+no responsibility whatsoever for additions or modifications to its material.

--- a/cxx4opencl/acknowledgements.txt
+++ b/cxx4opencl/acknowledgements.txt
@@ -1,0 +1,17 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[acknowledgements]]
+[float]
+== Acknowledgements
+
+The C++ for OpenCL documentation is the result of the contributions of
+many people. Following is a partial list of the contributors, including 
+the company that they represented at the time of their contribution:
+
+  * Anastasia Stulova, Arm
+  * Neil Hickey, Arm
+  * Sven van Haastregt, Arm
+  * Marco Antognini, Arm
+  * Kevin Petit, Arm

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -51,8 +51,8 @@ void foo() {
 
 template <int N>
 struct S {
-  int i; // i has no address space
-  static int ii; // ii is in global address space
+  int i; // i has no address space.
+  static int ii; // ii is in global address space.
   int * ptr; // ptr points to generic address space int.
   int & ref = ...; // ref references int in generic address space.
 };
@@ -60,7 +60,7 @@ struct S {
 template <int N>
 void bar()
 {
-  S<N> s; // s is in __private address space
+  S<N> s; // s is in __private address space.
 }
 ----------
 
@@ -72,7 +72,7 @@ Reference types can be qualified with an address space.
 
 [source,c]
 ----------
-__private int & ref = ...; // references int in __private address space
+__private int & ref = ...; // references int in __private address space.
 ----------
 
 By default references will refer to generic address space objects, except
@@ -87,10 +87,10 @@ All non-static member functions take an implicit object parameter `this`
 that is a pointer type. By default the `this` pointer parameter is in the
 generic address space. All concrete objects passed as an argument to the
 implicit `this` parameter will be converted to the generic address
-parameter will be converted to the generic address space first if such
-conversion is valid. Therefore programs using objects in the `__constant`
-address space will not be compiled unless the address space is explicitly
-specified using address space qualifiers on member functions (see
+generic address space first if such conversion is valid. Therefore
+programs using objects in the `__constant` address space will not be
+compiled unless the address space is explicitly specified using address
+space qualifiers on member functions (see
 <<addrspace-member-function-qualifiers, _Member function qualifier_>>)
 as the conversion between `__constant` and generic is disallowed.
 Member function qualifiers can also be used in case conversion to the
@@ -114,18 +114,18 @@ diagnostic.
 [source,c]
 ----------
 struct C {
-   void foo() __local;
-   void foo();
+  void foo() __local;
+  void foo();
 };
 
 __kernel void bar() {
   __local C c1;
   C c2;
   __constant C c3;
-  c1.foo(); // will resolve to the first foo
-  c2.foo(); // will resolve to the second foo
+  c1.foo(); // will resolve to the first foo.
+  c2.foo(); // will resolve to the second foo.
   c3.foo(); // error due to mismatching address spaces - can't convert to
-            // __local or generic
+            // __local or generic.
 }
 ----------
 
@@ -142,8 +142,8 @@ class C {
   // void C() /*__generic*/;
   // void C(const /*__generic*/ C &) /*__generic*/;
   // void C(/*__generic*/ C &&) /*__generic*/;
-  // operator= '/*__generic*/ C &(/*__generic*/ C &&)'
-  // operator= '/*__generic*/ C &(const /*__generic*/ C &) /*__generic*/
+  // operator= '/*__generic*/ C &(/*__generic*/ C &&)';
+  // operator= '/*__generic*/ C &(const /*__generic*/ C &) /*__generic*/;
 }
 ----------
 
@@ -170,7 +170,7 @@ instantiation.
  6 __global int g;
  7 void bar(){
  8   foo(&g); // error: template instantiation failed as function scope variable
- 9            // appears to be declared in __global address space (see line 3)
+ 9            // appears to be declared in __global address space (see line 3).
 10 }
 ----------
 
@@ -188,7 +188,7 @@ void foo() {
 
 void bar() {
   foo<__global int>(); // error: conflicting address space qualifiers are provided
-                       // __global and __private
+                       // __global and __private.
 }
 ----------
 
@@ -204,7 +204,7 @@ void foo(){
 
 void bar(){
   foo<__global int>(); // error: function scope variable cannot be declared in
-                       // __global address space
+                       // __global address space.
 }
 ----------
 
@@ -220,13 +220,13 @@ int bar(const unsigned int &i);
 
 void foo() {
   bar(1); // temporary is created in __private address space but converted
-          // to generic address space of parameter reference
+          // to generic address space of parameter reference.
 }
 
 __global const int& f(__global float &ref) {
   return ref; // error: address space mismatch between temporary object
               // created to hold value converted float->int and return
-              // value type (can't convert from __private to __global)
+              // value type (can't convert from __private to __global).
 }
 ----------
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -87,17 +87,16 @@ All non-static member functions take an implicit object parameter `this`
 that is a pointer type. By default the `this` pointer parameter is in the
 generic address space. All concrete objects passed as an argument to the
 implicit `this` parameter will be converted to the generic address
-generic address space first if such conversion is valid. Therefore
-programs using objects in the `__constant` address space will not be
-compiled unless the address space is explicitly specified using address
-space qualifiers on member functions (see
-<<addrspace-member-function-qualifiers, _Member function qualifier_>>)
-as the conversion between `__constant` and generic is disallowed.
-Member function qualifiers can also be used in case conversion to the
-generic address space is undesirable (even if it is legal). For example,
-a method can be implemented to exploit memory access coalescing for
-segments with memory bank. This not only applies to regular member
-functions but to constructors and destructors too.
+space first if such conversion is valid. Therefore programs using objects
+in the `__constant` address space will not be compiled unless the address
+space is explicitly specified using address space qualifiers on member
+functions (see <<addrspace-member-function-qualifiers,
+_Member function qualifier_>>) as the conversion between `__constant` 
+and generic is disallowed. Member function qualifiers can also be used
+in case conversion to the generic address space is undesirable (even if
+it is legal). For example, a method can be implemented to exploit memory
+access coalescing for segments with memory bank. This not only applies
+to regular member functions but to constructors and destructors too.
 
 [[addrspace-member-function-qualifiers]]
 ==== Member function qualifier

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -1,0 +1,235 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[opencl_c_variadic_macro]]
+=== Address spaces
+
+{cpp} for OpenCL inherits address space behavior from `OpenCL C v2.0 s6.5`.
+
+This section only documents behavior related to {cpp} features. For example
+conversion rules are extended from the qualification conversion but the
+compatibility is determined using notation of sets and overlapping of address
+spaces from Embedded C (`ISO/IEC JTC1 SC22 WG14 N1021 s3.1.3`). For OpenCL
+it means that implicit conversions are allowed from a named address space
+(except for `__constant`) to generic (`OpenCL C v2.0 6.5.5`). Reverse
+conversion is only allowed explicitly. The `__constant` address space does
+not overlap with any other and therefore no valid conversion between
+`__constant` and other address spaces exists. Most of the rules follow this
+logic.
+
+==== Casts
+
+C-style casts follow `OpenCL C v2.0 rules (s6.5.5)`. All cast operators
+permit conversion to generic address space implicitly. However converting
+from generic to named address spaces can only be done using
+`addrspace_cast`. Note that conversions between `__constant` and any other
+other address space are disallowed.
+
+TODO: Example with `addrspace_cast`.
+
+[[addrspace-deduction]]
+==== Deduction
+
+Address spaces are not deduced for:
+
+  * non-pointer/non-reference template parameters or any dependent types
+    except for template specializations.
+  * non-pointer/non-reference class members except for static data members
+    that are deduced to `__global` address space.
+  * non-pointer/non-reference alias declarations.
+  * decltype expressions.
+
+[source,c]
+----------
+template <typename T>
+void foo() {
+  T m; // address space of m will be known at template instantiation time.
+  T * ptr; // ptr points to generic address space object.
+  T & ref = ...; // ref references an object in generic address space.
+};
+
+template <int N>
+struct S {
+  int i; // i has no address space
+  static int ii; // ii is in global address space
+  int * ptr; // ptr points to generic address space int.
+  int & ref = ...; // ref references int in generic address space.
+};
+
+template <int N>
+void bar()
+{
+  S<N> s; // s is in __private address space
+}
+----------
+
+TODO: Example for type alias and decltype!
+
+==== References
+
+Reference types can be qualified with an address space.
+
+[source,c]
+----------
+__private int & ref = ...; // references int in __private address space
+----------
+
+By default references will refer to generic address space objects, except
+for dependent types that are not template specializations (see
+<<addrspace-deduction, _Deduction_>>). Address space compatibility checks
+are performed when references are bound to values. The logic follows the
+rules from address space pointer conversion (`OpenCL v2.0 s6.5.5`).
+
+==== Default address space
+
+All non-static member functions take an implicit object parameter this
+that is a pointer type. By default this pointer parameter is in the
+generic address space. All concrete objects passed as an argument to the
+implicit `this` parameter will be converted to the generic address
+parameter will be converted to the generic address space first if such
+conversion is valid. Therefore programs using objects in the `__constant`
+address space will not be compiled unless the address space is explicitly
+specified using address space qualifiers on member functions (see
+<<addrspace-member-function-qualifiers, _Member function qualifier_>>)
+as the conversion between `__constant` and generic is disallowed.
+Member function qualifiers can also be used in case conversion to the
+generic address space is undesirable (even if it is legal). For example,
+a method can be implemented to exploit memory access coalescing for
+segments with memory bank. This not only applies to regular member
+functions but to constructors and destructors too.
+
+[[addrspace-member-function-qualifiers]]
+==== Member function qualifier
+
+{cpp} for OpenCL allows specifying an address space qualifier on member
+functions to signal that they are to be used with objects constructed
+in some specific address space. This works just the same as qualifying
+member functions with `const` or any other qualifiers. The overloading
+resolution will select the candidate with the most specific address
+space if multiple candidates are provided. If there is no conversion
+to an address space among candidates, compilation will fail with a
+diagnostic.
+
+[source,c]
+----------
+struct C {
+   void foo() __local;
+   void foo();
+};
+
+__kernel void bar() {
+  __local C c1;
+  C c2;
+  __constant C c3;
+  c1.foo(); // will resolve to the first foo
+  c2.foo(); // will resolve to the second foo
+  c3.foo(); // error due to mismatching address spaces - can't convert to
+            // __local or generic
+}
+----------
+
+==== Implicit special members
+
+All implicit special members (default, copy or move constructor, copy or
+move assignment, destructor) will be generated with the generic address
+space.
+
+[source,c]
+----------
+class C {
+  // Has the following implicitly defined member functions
+  // void C() /*__generic*/;
+  // void C(const /*__generic*/ C &) /*__generic*/;
+  // void C(/*__generic*/ C &&) /*__generic*/;
+  // operator= '/*__generic*/ C &(/*__generic*/ C &&)'
+  // operator= '/*__generic*/ C &(const /*__generic*/ C &) /*__generic*/
+}
+----------
+
+==== Builtin operators
+
+All builtin operators are available in the specific address spaces, thus
+no conversion to generic address space is performed.
+
+==== Templates
+
+There is no deduction of address spaces in non-pointer/non-reference
+template parameters and dependent types (see <<addrspace-deduction,
+_Deduction_>>). The address space of a template parameter is deduced
+during type deduction if it is not explicitly provided in the
+instantiation.
+
+[source,c]
+----------
+ 1 template<typename T>
+ 2 void foo(T* i){
+ 3   T var;
+ 4 }
+ 5
+ 6 __global int g;
+ 7 void bar(){
+ 8   foo(&g); // error: template instantiation failed as function scope variable
+ 9            // appears to be declared in __global address space (see line 3)
+10 }
+----------
+
+It is not legal to specify multiple different address spaces between
+template definition and instantiation. If multiple different address
+spaces are specified in a template definition and instantiation,
+compilation of such a program will fail with a diagnostic.
+
+[source,c]
+----------
+template <typename T>
+void foo() {
+  __private T var;
+}
+
+void bar() {
+  foo<__global int>(); // error: conflicting address space qualifiers are provided
+                       // __global and __private
+}
+----------
+
+Once a template has been instantiated, regular restrictions for
+address spaces will apply.
+
+[source,c]
+----------
+template<typename T>
+void foo(){
+  T var;
+}
+
+void bar(){
+  foo<__global int>(); // error: function scope variable cannot be declared in
+                       // __global address space
+}
+----------
+
+==== Temporary materialization
+
+All temporaries are materialized in the __private address space. If a reference
+with another address space is bound to them, a conversion will be generated
+in case it is valid, otherwise compilation will fail with a diagnostic.
+
+[source,c]
+----------
+int bar(const unsigned int &i);
+
+void foo() {
+  bar(1); // temporary is created in __private address space but converted
+          // to generic address space of parameter reference
+}
+
+__global const int& f(__global float &ref) {
+  return ref; // error: address space mismatch between temporary object
+              // created to hold value converted float->int and return
+              // value type (can't convert from __private to __global)
+}
+----------
+
+==== Initialization of local and constant address space objects
+
+TODO

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -12,10 +12,10 @@ conversion rules are extended from the qualification conversion but the
 compatibility is determined using notation of sets and overlapping of address
 spaces from Embedded C (`ISO/IEC JTC1 SC22 WG14 N1021 s3.1.3`). For OpenCL
 it means that implicit conversions are allowed from a named address space
-(except for `__constant`) to generic (`OpenCL C v2.0 6.5.5`). Reverse
+(except for `__constant`) to generic (`OpenCL C v2.0 6.5.5`). The reverse
 conversion is only allowed explicitly. The `__constant` address space does
 not overlap with any other and therefore no valid conversion between
-`__constant` and other address spaces exists. Most of the rules follow this
+`__constant` and any other address space exists. Most of the rules follow this
 logic.
 
 ==== Casts
@@ -83,8 +83,8 @@ rules from address space pointer conversion (`OpenCL v2.0 s6.5.5`).
 
 ==== Default address space
 
-All non-static member functions take an implicit object parameter this
-that is a pointer type. By default this pointer parameter is in the
+All non-static member functions take an implicit object parameter `this`
+that is a pointer type. By default the `this` pointer parameter is in the
 generic address space. All concrete objects passed as an argument to the
 implicit `this` parameter will be converted to the generic address
 parameter will be converted to the generic address space first if such
@@ -104,7 +104,7 @@ functions but to constructors and destructors too.
 
 {cpp} for OpenCL allows specifying an address space qualifier on member
 functions to signal that they are to be used with objects constructed
-in some specific address space. This works just the same as qualifying
+in a specific address space. This works just the same as qualifying
 member functions with `const` or any other qualifiers. The overloading
 resolution will select the candidate with the most specific address
 space if multiple candidates are provided. If there is no conversion

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -1,0 +1,19 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[intro]]
+== Introduction
+
+This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
+most of regular {cpp} features in OpenCL kernel code. Most functionality
+from OpenCL C and {cpp} is inherited. List of restrictions is documented
+in <<restrictions, _Restrictions_>> sections.
+
+The main aim of this document is to describe behavior that is not
+documented in the OpenCL C and {cpp}17 specifications. This is mainly related
+to interactions between OpenCL and {cpp} language features.
+
+== The {cpp} for OpenCL Programming Language 
+ 
+This chapter documents various language features of {cpp} for OpenCL.

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -7,7 +7,7 @@
 
 This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
-from OpenCL C and {cpp} is inherited. List of restrictions is documented
+from OpenCL C and {cpp} is inherited. Restrictions are documented
 in <<restrictions, _Restrictions_>> sections.
 
 The main aim of this document is to describe behavior that is not

--- a/cxx4opencl/restrictions.txt
+++ b/cxx4opencl/restrictions.txt
@@ -1,0 +1,19 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[restrictions]]
+=== Restrictions
+
+This section describes various restrictions and limitations for
+language features from OpenCL v2.0 and {cpp}17.
+
+==== Restrictions to {cpp} features 
+
+The following {cpp} language features are not supported:
+
+  * Virtual functions
+  * Exceptions
+  * `dynamic_cast` operator
+  * Non-placement `new`/`delete` operators
+  * Standard C++ libraries


### PR DESCRIPTION
Added the main document and a subfolder to contain various chapters.

This change also adds basic description of address space behavior that is not documented elsewhere.