### PR TITLE
eliminate double parens, which asciidoctor treats as index terms

### DIFF
--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -291,7 +291,7 @@ devices given as ULP values.
 | *OpExtInst* *distance*
 | \<= 0.5 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 | \<= 3 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * (1.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *OpExtInst* *dot*
 | absolute error tolerance of 'max * max * (2 * (n - 1)) * HLF_EPSILON', For vector width n and maximum input operand value 'max'
@@ -404,9 +404,9 @@ devices given as ULP values.
 | Correctly rounded
 
 | *OpExtInst* *length*
-| \<= 0.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
-| \<= 3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
-| \<= 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 0.5 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 3 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *OpExtInst* *lgamma*
 | Implementation-defined
@@ -484,7 +484,7 @@ devices given as ULP values.
 | *OpExtInst* *normalize*
 | \<= 1.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
 | \<= 2.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 2 * (2.5 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *OpExtInst* *pow*
 | \<= 16 ulp

--- a/ext/cl_khr_fp16.txt
+++ b/ext/cl_khr_fp16.txt
@@ -1580,7 +1580,7 @@ is the infinitely precise result.
 | Correctly rounded
 
 | *length*
-| \<= 0.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 0.5 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
 | Implementation-defined
 
 | *log*

--- a/ext/cl_khr_fp64.txt
+++ b/ext/cl_khr_fp64.txt
@@ -1078,7 +1078,7 @@ is the infinitely precise result.
 | \<= 2 ulp
 
 | *distance*
-| \<= 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * (1.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *dot*
 | absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
@@ -1138,7 +1138,7 @@ is the infinitely precise result.
 | Correctly rounded
 
 | *length*
-| \<= 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 2 * (3 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *log*
 | \<= 3 ulp
@@ -1183,7 +1183,7 @@ is the infinitely precise result.
 | 0 ulp
 
 | *normalize*
-| \<= 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) ulp, for gentype with vector width n
+| \<= 2 * (2.5 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
 
 | *pow(x, y)*
 | \<= 16 ulp


### PR DESCRIPTION
Asciidoctor treats text in double parentheses as index terms.  See:

https://asciidoctor.org/docs/user-manual/#index-terms

Asciidoctor additionally removes the double parentheses from the index term, which is obviously a problem when the double parentheses is actually intended to represent an algebraic formula.

This change eliminates double parentheses in several problematic cases, which cleans up the index in the OpenCL extensions doc PDF, and corrects how these cases appear in both the HTML and PDF specs.