### PR TITLE
fix minor asciidoc formatting error in clSetKernelArgSVMPointer

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6466,10 +6466,10 @@ include::{generated}/api/protos/clSetKernelArgSVMPointer.txt[]
     The SVM pointer can only be used for arguments that are declared to be a
     pointer to `global` or `constant` memory.
     The SVM pointer value must be aligned according to the arguments type.
-    For example, if the argument is declared to be ``global float4 *p``, the SVM
+    For example, if the argument is declared to be `+global float4 *p+`, the SVM
     pointer value passed for `p` must be at a minimum aligned to a `float4`.
     The SVM pointer value specified as the argument value can be the pointer
-    returned by *{clSVMAlloc}* or can be a pointer offset into the SVM region.
+    returned by {clSVMAlloc} or can be a pointer offset into the SVM region.
 
 // refError
 


### PR DESCRIPTION
Fixes a minor asciidoc formatting error in the description of clSetKernelArgSVMPointer.