### PR TITLE
fix a few asciidoctor formatting issues in the shuffle built-in

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6363,16 +6363,16 @@ integer data types.
       type as the input and length that is the same as the shuffle mask.
       The size of each element in the _mask_ must match the size of each
       element in the result.
-      For *shuffle*, only the *ilogb*(2_m_-1) least significant bits of each
+      For *shuffle*, only the *ilogb*(2__m__-1) least significant bits of each
       _mask_ element are considered.
-      For *shuffle2*, only the *ilogb*(2_m_-1)+1 least significant bits of
+      For *shuffle2*, only the *ilogb*(2__m__-1)+1 least significant bits of
       each _mask_ element are considered.
       Other bits in the mask shall be ignored.
 
 The elements of the input vectors are numbered from left to right across one
 or both of the vectors.
 For this purpose, the number of elements in a vector is given by
-*vec_step*(gentype_m_).
+*vec_step*(gentype__m__).
 The shuffle _mask_ operand specifies, for each element of the result vector,
 which element of the one or two input vectors the result element gets.
 


### PR DESCRIPTION
This is a very simple PR that fixes a few asciidoctor formatting issues in the description of the "shuffle" built-in functions.