### PR TITLE
Fix minor typos related to sub_group_barrier

### DIFF
--- a/ext/cl_khr_subgroups.txt
+++ b/ext/cl_khr_subgroups.txt
@@ -202,33 +202,33 @@ Otherwise, it returns one of the following errors:
   These rules apply to ND-ranges implemented with uniform and non-uniform
   work groups.
 
-  If *subgroup_barrier* is inside a conditional statement, then all work
+  If *sub_group_barrier* is inside a conditional statement, then all work
   items within the subgroup must enter the conditional if any work item in
   the subgroup enters the conditional statement and executes the
-  subgroup_barrier.
+  sub_group_barrier.
 
-  If *subgroup_barrier* is inside a loop, all work items within the subgroup
-  must execute the subgroup_barrier for each iteration of the loop before
-  any are allowed to continue execution beyond the subgroup_barrier.
+  If *sub_group_barrier* is inside a loop, all work items within the subgroup
+  must execute the sub_group_barrier for each iteration of the loop before
+  any are allowed to continue execution beyond the sub_group_barrier.
 
-  The *subgroup_barrier* function also queues a memory fence (reads and
+  The *sub_group_barrier* function also queues a memory fence (reads and
   writes) to ensure correct ordering of memory operations to local or global
   memory.
 
   The flags argument specifies the memory address space and can be set to a
   combination of the following values:
 
-  CLK_LOCAL_MEM_FENCE - The *subgroup_barrier* function will either flush
+  CLK_LOCAL_MEM_FENCE - The *sub_group_barrier* function will either flush
   any variables stored in local memory or queue a memory fence to ensure
   correct ordering of memory operations to local memory.
 
-  CLK_GLOBAL_MEM_FENCE -- The *subgroup_barrier* function will queue a
+  CLK_GLOBAL_MEM_FENCE -- The *sub_group_barrier* function will queue a
   memory fence to ensure correct ordering of memory operations to global
   memory.
   This can be useful when work items, for example, write to buffer objects
   and then want to read the updated data from these buffer objects.
 
-  CLK_IMAGE_MEM_FENCE -- The *subgroup_barrier* function will queue a memory
+  CLK_IMAGE_MEM_FENCE -- The *sub_group_barrier* function will queue a memory
   fence to ensure correct ordering of memory operations to image objects.
   This can be useful when work items, for example, write to image objects
   and then want to read the updated data from these image objects.


### PR DESCRIPTION
`subgroup_barrier` (with one underscore) was used instead of `sub_group_barrier` (with two underscores).