### PR TITLE
Clarify default value of program-scope/static variables

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -2063,8 +2063,8 @@ program.
 These variables are not shared across devices.
 They have distinct storage.
 
-Program scope and `static` variables in the `global` address space may be
-initialized, but only with constant expressions.
+Program scope and `static` variables in the `global` address space are zero
+initialized by default. A constant expression may be given as an initializer.
 
 Examples:
 


### PR DESCRIPTION
This patch clarifies that OpenCL program-scope/static variables in the
global address space have an appropriate null value by default,
similar to objects with static storage duration in C99 6.7.8p10.

The previous wording was not clear regarding the default value (is the
variable uninitialized?) when no constant expression is given. This
clarifies the intent.