### PR TITLE
Adds a table of "other miscellaneous enums" to the appendix

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -56,6 +56,7 @@ include::api/appendix_c.asciidoc[]
 include::api/appendix_d.asciidoc[]
 include::api/appendix_e.asciidoc[]
 include::api/appendix_f.asciidoc[]
+include::api/appendix_g.asciidoc[]
 
 <<<
 

--- a/api/appendix_g.asciidoc
+++ b/api/appendix_g.asciidoc
@@ -1,0 +1,31 @@
+// Copyright 2019 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[appendix]
+[[error_other_misc_enums]]
+= Other Miscellaneous Enums
+
+This section lists other miscellaneous OpenCL enumerants and their meanings.
+
+[cols="2,3",options="header",]
+|====
+| *Enumerant*
+| *Brief Description*
+
+| {CL_TRUE_anchor}
+
+include::{generated}/api/version-notes/CL_TRUE.asciidoc[]
+| Indicates a boolean "true" value.
+
+| {CL_FALSE_anchor}
+
+include::{generated}/api/version-notes/CL_FALSE.asciidoc[]
+| Indicates a boolean "false" value.
+
+| {CL_NONE_anchor}
+
+include::{generated}/api/version-notes/CL_NONE.asciidoc[]
+| Indicates that none of the other enumerations or conditions are applicable.
+
+|====


### PR DESCRIPTION
Adds a table of "other miscellaneous enums" to the appendix.  This table contains enums that are not described elsewhere.  This should be a small set of enums - it is currently CL_TRUE, CL_FALSE, and CL_NONE.

After this change there are no missing enum links.

Fixes #92.