### PR TITLE
fix a minor asciidoctor formatting error image_desc->mem_object

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1601,9 +1601,9 @@ include::{generated}/api/version-notes/clCreateImage.asciidoc[]
   * _image_format_ is a pointer to a structure that describes format properties
     of the image to be allocated.
     A 1D image buffer or 2D image can be created from a buffer by specifying a
-    buffer object in the _image_desc->mem_object_.
+    buffer object in the __image_desc__->__mem_object__.
     A 2D image can be created from another 2D image object by specifying an
-    image object in the _image_desc_->_mem_object_.
+    image object in the __image_desc__->__mem_object__.
     Refer to the <<image-format-descriptor, Image Format Descriptor>> section
     for a detailed description of the image format descriptor.
   * _image_desc_ is a pointer to a structure that describes type and dimensions


### PR DESCRIPTION
Very minor fix for an asciidoctor formatting error that caused extra underscores to be visible in the rendered document.  I didn't find any other instances of this pattern in the spec (`->_some_field_`).