### PR TITLE
fix formatting in "Specifying Attributes of Types"

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3226,21 +3226,22 @@ closing curly brace of the _definition_.
 The former syntax is preferred.
 
 `aligned (_alignment_)` ::
-
++
+--
 This attribute specifies a minimum alignment (in bytes) for variables of the
 specified type.
 For example, the declarations:
-+
+
 [source,c]
 ----------
 struct S { short f[3]; } __attribute__ ((aligned (8)));
 typedef int more_aligned_int __attribute__ ((aligned (8)));
 ----------
-+
+
 force the compiler to insure (as far as it can) that each variable whose
 type is `struct S` or `more_aligned_int` will be allocated and aligned _at
 least_ on a 8-byte boundary.
-+
+
 Note that the alignment of any given struct or union type is required by the
 ISO C standard to be at least a perfect multiple of the lowest common
 multiple of the alignments of all of the members of the struct or union in
@@ -3250,19 +3251,19 @@ union type by attaching an aligned attribute to any one of the members of
 such a type, but the notation illustrated in the example above is a more
 obvious, intuitive, and readable way to request the compiler to adjust the
 alignment of an entire struct or union type.
-+
+
 As in the preceding example, you can explicitly specify the alignment (in
 bytes) that you wish the compiler to use for a given struct or union type.
 Alternatively, you can leave out the alignment factor and just ask the
 compiler to align a type to the maximum useful alignment for the target
 machine you are compiling for.
 For example, you could write:
-+
+
 [source,c]
 ----------
 struct S { short f[3]; } __attribute__ ((aligned));
 ----------
-+
+
 Whenever you leave out the alignment factor in an aligned attribute
 specification, the compiler automatically sets the alignment for the type to
 the largest alignment which is ever used for any data type on the target
@@ -3271,7 +3272,7 @@ In the example above, the size of each `short` is 2 bytes, and therefore the
 size of the entire `struct S` type is 6 bytes.
 The smallest power of two which is greater than or equal to that is 8, so
 the compiler sets the alignment for the entire `struct S` type to 8 bytes.
-+
+
 Note that the effectiveness of aligned attributes may be limited by inherent
 limitations of the OpenCL device and compiler.
 For some devices, the OpenCL compiler may only be able to arrange for
@@ -3280,26 +3281,28 @@ If the OpenCL compiler is only able to align variables up to a maximum of 8
 byte alignment, then specifying `aligned(16)` in an `+__attribute__+` will
 still only provide you with 8 byte alignment.
 See your platform-specific documentation for further information.
-+
+
 The aligned attribute can only increase the alignment; but you can decrease
 it by specifying packed as well.
 See below.
+--
 
 `packed` ::
-
++
+--
 This attribute, attached to struct or union type definition, specifies that
 each member of the structure or union is placed to minimize the memory
 required.
 When attached to an enum definition, it indicates that the smallest integral
 type should be used.
-+
+
 Specifying this attribute for struct and union types is equivalent to
 specifying the packed attribute on each of the structure or union members.
-+
-In the following example struct `my_packed_struct`'s members are packed
+
+In the following example, the members of `my_packed_struct` are packed
 closely together, but the internal layout of its `s` member is not packed.
 To do that, struct `my_unpacked_struct` would need to be packed, too.
-+
+
 [source,c]
 ----------
 struct my_unpacked_struct
@@ -3315,12 +3318,12 @@ struct __attribute__ ((packed)) my_packed_struct
     struct my_unpacked_struct s;
 };
 ----------
-+
+
 You may only specify this attribute on the definition of a enum, struct or
 union, not on a `typedef` which does not also define the enumerated type,
 structure or union.
 --
-
+--
 
 [[specifying-attributes-of-functions]]
 === Specifying Attributes of Functions


### PR DESCRIPTION
Fixes asciidoctor formatting errors in the OpenCL C "Specifying Attributes of Types" section.