### PR TITLE
add missing new line to environment spec to fix asciidoctor formatting

### DIFF
--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -22,6 +22,7 @@ For all *OpTypeInt* integer type-declaration instructions:
   * _Signedness_ must be 0, indicating no signedness semantics.
   
 For all *OpTypeImage* type-declaration instructions:
+
   * _Sampled Type_ must be *OpTypeVoid*.
   * _Sampled_ must be 0, indicating that the image usage will be known at
      run time, not at compile time.


### PR DESCRIPTION
This is a trivial fix to add a missing newline.  Without the newline, a bulleted list was not displayed correctly.