### PR TITLE
Increase the number of levels in the API spec table of contents

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -8,7 +8,7 @@ Khronos{R} OpenCL Working Group
 :data-uri:
 :icons: font
 :toc2:
-:toclevels: 2
+:toclevels: 3
 :max-width: 100
 :numbered:
 :imagewidth: 800


### PR DESCRIPTION
3 levels is what we had prior to the move to asciidoc. This makes
the spec quite a bit more navigable.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>