### PR TITLE
fix a few extension issues  in the XML file

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -95,9 +95,9 @@ server's OpenCL/api-docs repository.
         <type category="define" requires="stdint">typedef uint16_t    <name>cl_ushort</name> __attribute__((aligned(2)));</type>
         <type category="define" requires="stdint">typedef uint32_t    <name>cl_uint</name> __attribute__((aligned(4)));</type>
         <type category="define" requires="stdint">typedef uint64_t    <name>cl_ulong</name> __attribute__((aligned(8)));</type>
-        <type category="define" >typedef int                          <name>cl_GLint</name>;</type>
-        <type category="define" >typedef unsigned int                 <name>cl_GLenum</name>;</type>
-        <type category="define" >typedef unsigned int                 <name>cl_GLuint</name>;</type>
+        <type category="define">typedef int                           <name>cl_GLint</name>;</type>
+        <type category="define">typedef unsigned int                  <name>cl_GLenum</name>;</type>
+        <type category="define">typedef unsigned int                  <name>cl_GLuint</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_d3d11_device_source_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_d3d11_device_set_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_dx9_media_adapter_type_khr</name>;</type>
@@ -1664,7 +1664,7 @@ server's OpenCL/api-docs repository.
     <!-- SECTION: CL command definitions. (TBD) -->
     <commands>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>*                    <name>clGetDeviceIDsFromD3D10KHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D10KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d10_device_source_khr</type> <name>d3d_device_source</name></param>
             <param>void*                                   <name>d3d_object</name></param>
@@ -1674,14 +1674,14 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                   <name>num_devices</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D10BufferKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D10BufferKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Buffer</type>*              <name>resource</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D10Texture2DKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D10Texture2DKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Texture2D</type>*           <name>resource</name></param>
@@ -1689,7 +1689,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D10Texture3DKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D10Texture3DKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Texture3D</type>*           <name>resource</name></param>
@@ -1697,7 +1697,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>*                    <name>clEnqueueAcquireD3D10ObjectsKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueAcquireD3D10ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1706,7 +1706,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>*                    <name>clEnqueueReleaseD3D10ObjectsKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueReleaseD3D10ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1715,7 +1715,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clGetDeviceIDsFromD3D11KHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D11KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d11_device_source_khr</type> <name>d3d_device_source</name></param>
             <param>void*                                   <name>d3d_object</name></param>
@@ -1725,14 +1725,14 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                   <name>num_devices</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D11BufferKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D11BufferKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Buffer</type>*              <name>resource</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D11Texture2DKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D11Texture2DKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Texture2D</type>*           <name>resource</name></param>
@@ -1740,7 +1740,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromD3D11Texture3DKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromD3D11Texture3DKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Texture3D</type>*           <name>resource</name></param>
@@ -1748,7 +1748,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clEnqueueAcquireD3D11ObjectsKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueAcquireD3D11ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1757,7 +1757,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clEnqueueReleaseD3D11ObjectsKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueReleaseD3D11ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1766,7 +1766,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clGetDeviceIDsFromDX9MediaAdapterKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromDX9MediaAdapterKHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_uint</type>                    <name>num_media_adapters</name></param>
             <param><type>cl_dx9_media_adapter_type_khr</type>*  <name>media_adapter_type</name></param>
@@ -1777,7 +1777,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                   <name>num_devices</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromDX9MediaSurfaceKHR</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromDX9MediaSurfaceKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>cl_dx9_media_adapter_type_khr</type> <name>adapter_type</name></param>
@@ -1786,7 +1786,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clEnqueueAcquireDX9MediaSurfacesKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueAcquireDX9MediaSurfacesKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1795,7 +1795,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>*                    <name>clEnqueueReleaseDX9MediaSurfacesKHR</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueReleaseDX9MediaSurfacesKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1814,7 +1814,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                   <name>num_devices</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_1">
-            <proto><type>cl_mem</type>*                    <name>clCreateFromDX9MediaSurfaceINTEL</name></proto>
+            <proto><type>cl_mem</type>                     <name>clCreateFromDX9MediaSurfaceINTEL</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>IDirect3DSurface9</type>*         <name>resource</name></param>
@@ -1823,7 +1823,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>*                    <name>clEnqueueAcquireDX9ObjectsINTEL</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueAcquireDX9ObjectsINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -1832,7 +1832,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>*                    <name>clEnqueueReleaseDX9ObjectsINTEL</name></proto>
+            <proto><type>cl_int</type>                     <name>clEnqueueReleaseDX9ObjectsINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param><type>cl_mem</type>*                    <name>mem_objects</name></param>
@@ -1916,7 +1916,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_command_queue</type>           <name>clCreateCommandQueueWithPropertiesKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_device_id</type>               <name>device</name></param>
-            <param>const <type>cl_queue_properties_khr</type> <name>*properties</name></param>
+            <param>const <type>cl_queue_properties_khr</type>* <name>properties</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_1">
@@ -1950,7 +1950,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>               <name>device</name></param>
             <param><type>size_t</type>                     <name>image_width</name></param>
             <param><type>size_t</type>                     <name>image_height</name></param>
-            <param>const <type>cl_image_format</type>      <name>*image_format</name></param>
+            <param>const <type>cl_image_format</type>*     <name>image_format</name></param>
             <param><type>cl_image_pitch_info_qcom</type>   <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
             <param>void*                                   <name>param_value</name></param>
@@ -1989,7 +1989,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_mem</type>                     <name>clImportMemoryARM</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
-            <param>const <type>cl_import_properties_arm</type> <name>*properties</name></param>
+            <param>const <type>cl_import_properties_arm</type>* <name>properties</name></param>
             <param>void*                                   <name>memory</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>


### PR DESCRIPTION
I've found a few issues with the definitions of several extension functions in the cl.xml file.  The affected extensions are:

* Several of the DX interop extensions, e.g. `cl_khr_d3d10_sharing`.
* `cl_khr_create_command_queue`
* `cl_qcom_ext_host_ptr`
* `cl_arm_import_memory`