### PR TITLE
Deduplicate some sub-section titles

### DIFF
--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -300,8 +300,7 @@ Happens before ::
     in particular, any value written by A will be visible to B.
     We define two separate happens before relations: _global-happens-before_
     and _local-happens-before_.
-    These are defined in <<memory-ordering-rules, Memory Model: Memory
-    Ordering Rules>>.
+    These are defined in <<memory-ordering-rules, Memory Ordering Rules>>.
 
 Host ::
     The _host_ interacts with the _context_ using the OpenCL API.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1136,7 +1136,7 @@ enumeration constants:
 NOTE: In general, no acquire must _always_ synchronise with any particular
 release.
 However, synchronisation can be forced by certain executions.
-See <<memory-ordering-fence, Memory Order Rules: Fence Operations>> for
+See the description of <<memory-ordering-fence, Fence Operations>> for
 detailed rules for when synchronisation must occur.
 
   * *memory_order_acq_rel*: A synchronization operation with acquire-release

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -270,8 +270,8 @@ If such synchronization points are established between commands in multiple
 command-queues, an implementation must assure that the command-queues
 progress concurrently and correctly account for the dependencies established
 by the synchronization points.
-For a detailed explanation of synchronization points, see
-<<execution-model-sync, Execution Model: Synchronization>>.
+For a detailed explanation of synchronization points, see the execution model
+<<execution-model-sync, Synchronization>> section.
 
 The core of the OpenCL execution model is defined by how the kernels
 execute.
@@ -295,7 +295,7 @@ within a work-group.
 The details of this mapping are described in the following section.
 
 
-=== Execution Model: Mapping work-items onto an NDRange
+=== Mapping work-items onto an NDRange
 
 The index space supported by OpenCL is called an NDRange.
 An NDRange is an N-dimensional index space, where N is one, two or three.
@@ -397,7 +397,7 @@ In this situation all sub-group scope functions are equivalent to their
 work-group level equivalents.
 
 
-=== Execution Model: Execution of kernel-instances
+=== Execution of kernel-instances
 
 The work carried out by an OpenCL program occurs through the execution of
 kernel-instances on compute devices.
@@ -499,7 +499,7 @@ work-group synchronization functions.
 
 
 [[device-side-enqueue]]
-=== Execution Model: Device-side enqueue
+=== Device-side enqueue
 
 Algorithms may need to generate additional work as they execute.
 In many cases, this additional work cannot be determined statically; so the
@@ -544,7 +544,7 @@ implementation-defined.
 
 
 [[execution-model-sync]]
-=== Execution Model: Synchronization
+=== Synchronization
 
 Synchronization refers to mechanisms that constrain the order of execution
 between two or more units of execution.
@@ -652,7 +652,7 @@ These rules are described in detail in <<memory-ordering-rules, Memory
 Ordering Rules>>.
 
 
-=== Execution Model: Categories of Kernels
+=== Categories of Kernels
 
 The OpenCL execution model supports three types of kernels:
 
@@ -726,7 +726,7 @@ We define the memory model in four parts.
     synchronization relationships.
 
 
-=== Memory Model: Fundamental Memory Regions
+=== Fundamental Memory Regions
 
 Memory in OpenCL is divided into two parts.
 
@@ -827,7 +827,7 @@ model may also be used to ensure that host threads safely access memory
 locations in the shared memory region.
 
 
-=== Memory Model: Memory Objects
+=== Memory Objects
 
 The contents of global memory are _memory objects_.
 A memory object is a handle to a reference counted region of global memory.
@@ -976,7 +976,7 @@ improve performance.
 
 
 [[shared-virtual-memory]]
-=== Memory Model: Shared Virtual Memory
+=== Shared Virtual Memory
 
 IMPORTANT: Shared virtual memory is <<unified-spec, missing before>>
 version 2.0.
@@ -1041,7 +1041,7 @@ The various SVM mechanisms to access host memory from the work-items
 associated with a kernel instance are <<svm-summary-table, summarized
 above>>.
 
-=== Memory Model: Memory Consistency Model for OpenCL 1.x
+=== Memory Consistency Model for OpenCL 1.x
 
 IMPORTANT: This memory consistency model is <<unified-spec, deprecated
 by>> version 2.0.
@@ -1061,7 +1061,7 @@ Memory consistency for memory objects shared between enqueued commands is
 enforced at a synchronization point.
 
 [[memory-consistency-model]]
-=== Memory Model: Memory Consistency Model for OpenCL 2.x
+=== Memory Consistency Model for OpenCL 2.x
 
 IMPORTANT: This memory consistency model is <<unified-spec, missing
 before>> version 2.0.
@@ -1220,7 +1220,7 @@ If these guidelines are followed in your OpenCL programs, you can skip the
 detailed rules behind the relaxed memory models and go directly to
 <<opencl-framework, OpenCL Framework>>.
 
-=== Memory Model: Overview of atomic and fence operations
+=== Overview of atomic and fence operations
 
 OpenCL 2.x has a number of _synchronization operations_ that are used to define
 memory order constraints in a program.
@@ -1324,7 +1324,7 @@ the same scope *P* such that:
 
 
 [[memory-ordering-rules]]
-=== Memory Model: Memory Ordering Rules
+=== Memory Ordering Rules
 
 Fundamentally, the issue in a memory model is to understand the orderings in
 time of modifications to objects in memory.
@@ -1502,7 +1502,7 @@ computation *B* of *M*, then the evaluation *B* shall take its value from
 This requirement is known as write-read coherence.
 
 
-==== Memory Ordering Rules: Atomic Operations
+==== Atomic Operations
 
 This and following sections describe how different program actions in kernel
 C code and the host program contribute to the local- and
@@ -1660,7 +1660,7 @@ all_svm_devices scope.
 
 
 [[memory-ordering-fence]]
-==== Memory Ordering Rules: Fence Operations
+==== Fence Operations
 
 This section describes how the OpenCL 2.x fence operations contribute to the
 local- and global-happens-before relations.
@@ -1730,7 +1730,7 @@ conditions required for *X* to local-synchronize-with *Y* are met, or both
 sets of conditions are met.
 
 
-==== Memory Ordering Rules: Work-group Functions
+==== Work-group Functions
 
 The OpenCL kernel execution model includes collective operations across the
 work-items within a single work-group.
@@ -1785,7 +1785,7 @@ must execute the same work-group function call site, or dynamic work-group
 function instance.
 
 
-==== Memory Ordering Rules: Sub-group Functions
+==== Sub-group Functions
 
 The OpenCL kernel execution model includes collective operations across the
 work-items within a single sub-group.
@@ -1840,7 +1840,7 @@ must execute the same sub-group function call site, or dynamic sub-group
 function instance.
 
 
-==== Memory Ordering Rules: Host-side and Device-side Commands
+==== Host-side and Device-side Commands
 
 This section describes how the OpenCL API functions associated with
 command-queues contribute to happens-before relations.
@@ -2028,7 +2028,7 @@ The framework contains the following components:
     Other input languages may be supported by some implementations.
 
 
-=== OpenCL Framework: Mixed Version Support
+=== Mixed Version Support
 
 OpenCL supports devices with different capabilities under a single platform.
 This includes devices which conform to different versions of the OpenCL


### PR DESCRIPTION
I deduplicated section titles of the form "Section: Detail" to "Detail".  I decided to leave chapter 5 as the possible duplication there are nouns in the section title, so would require a full section rename to eliminate.

Closes #184