### PR TITLE
remove Initializer and Finalizer from list of required capabilities

### DIFF
--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -48,8 +48,10 @@ SPIR-V 1.1 modules that declare the following capabilities:
 
   * *SubgroupDispatch* (OpenCL 2.2 and Newer)
   * *PipeStorage* (OpenCL 2.2 and Newer)
-  * *Initializer* (OpenCL 2.2 and Newer)
-  * *Finalizer* (OpenCL 2.2 and Newer)
+
+// TODO: Initializer and Finalizer are execution modes, not capabilities.
+//  * *Initializer* (OpenCL 2.2 and Newer)
+//  * *Finalizer* (OpenCL 2.2 and Newer)
 
 [[required-capabilities-1.2]]
 === SPIR-V 1.2


### PR DESCRIPTION
Initializer and Finalizer are execution modes, not capabilities.  So, they should not be included in the list of required capabilities.

Still TBD: does use of Initializer and Finalizer exeuction modes in a pre-OpenCL 2.2 environment make a module invalid?

This is a partial fix for issue #190.