### PR TITLE
Simplify Geometric builtin ULP definitions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9509,10 +9509,20 @@ currently undefined.
 | *cos*                 | {leq} 4 ulp
 | *cosh*                | {leq} 4 ulp
 | *cospi*               | {leq} 4 ulp
-| *cross*               | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+// 3 operations from the 2 multiplications and 1 subtraction per component
+| *cross*               | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | *degrees*             | {leq} 2 ulp
-| *distance*            | {leq} 3 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| *dot*                 | absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+// 3           ULP error in sqrt
+// 1.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 3 + (1.5 * n) + (0.5 * (n - 1))
+// = 3 + 1.5n + (0.5n - 0.5)
+// = 2.5 + 2n
+| *distance*            | {leq} 2.5 + 2n ulp, for gentype with vector width _n_
+// n + n-1  Number of operations from n multiples and (n-1) additions
+// 2n - 1
+| *dot*                 | absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | *erfc*                | {leq} 16 ulp
 | *erf*                 | {leq} 16 ulp
 | *exp*                 | {leq} 3 ulp
@@ -9530,7 +9540,15 @@ currently undefined.
 | *frexp*               | 0 ulp
 | *hypot*               | {leq} 4 ulp
 | *ilogb*               | 0 ulp
-| *length*              | {leq} 3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))) ulp, for gentype with vector width n
+// 3           ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 3 + 0.5 * (n - 0.5)
+// = 2.75 + 0.5n
+| *length*              | {leq} 2.75 + 0.5n ulp, for gentype with vector width _n_
 | *ldexp*               | Correctly rounded
 | *log*                 | {leq} 3 ulp
 | *log2*                | {leq} 3 ulp
@@ -9548,7 +9566,14 @@ currently undefined.
 | *modf*                | 0 ulp
 | *nan*                 | 0 ulp
 | *nextafter*           | 0 ulp
-| *normalize*           | {leq} 2.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+// 2.5         error in rsqrt + error in multiply
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 2.5 + (0.5 * n) + (0.5 * (n - 1))
+// = 2.5 + 0.5n + (0.5n - 0.5)
+// = 2.0 + n
+| *normalize*           | {leq} 2 + n ulp, for gentype with vector width _n_
 | *pow*(_x_, _y_)       | {leq} 16 ulp
 | *pown*(_x_, _y_)      | {leq} 16 ulp
 | *powr*(_x_, _y_)      | {leq} 16 ulp
@@ -9588,9 +9613,33 @@ currently undefined.
 | *half_sqrt*           | {leq} 8192 ulp
 | *half_tan*            | {leq} 8192 ulp
 | |
-| *fast_distance*       | {leq} 8192 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| *fast_length*         | {leq} 8192 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| *fast_normalize*      | {leq} 8192.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+
+// 8192        ULP error in half_sqrt
+// 1.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 8192 + (1.5 * n) + (0.5 * (n - 1))
+// = 8192 + 1.5n + (0.5n - 0.5)
+// = 8191.5 + 2n
+| *fast_distance*       | {leq} 8191.5 + 2n ulp, for gentype with vector width _n_
+
+// 8192        ULP error in half_sqrt
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 8192 + (0.5 * n) + (0.5 * (n - 1))
+// = 8192 + 0.5n + (0.5n - 0.5)
+// = 8191.5 + n
+| *fast_length*         | {leq} 8191.5 + n ulp, for gentype with vector width _n_
+
+// 8192.5      error in half_rsqrt + error in multiply
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 8192.5 + (0.5 * n) + (0.5 * (n - 1))
+// = 8192.5 + 0.5n + (0.5n - 0.5)
+// = 8192 + n
+| *fast_normalize*      | {leq} 8192 + n ulp, for gentype with vector width _n_
 | |
 | *native_cos*          | Implementation-defined
 | *native_divide*       | Implementation-defined
@@ -9621,11 +9670,11 @@ is the infinitely precise result.
 [cols=",",]
 |====
 | *Function*        | *Min Accuracy - ULP values*^70^
-| _x_ + _y_             | Correctly rounded
-| _x_ - _y_             | Correctly rounded
-| _x_ * _y_             | Correctly rounded
+| _x_ + _y_         | Correctly rounded
+| _x_ - _y_         | Correctly rounded
+| _x_ * _y_         | Correctly rounded
 | *1.0 / _x_*       | {leq} 3 ulp
-| _x_ / _y_             | {leq} 3 ulp
+| _x_ / _y_         | {leq} 3 ulp
 | |
 | *acos*            | {leq} 4 ulp
 | *acospi*          | {leq} 5 ulp
@@ -9683,9 +9732,9 @@ is the infinitely precise result.
 | *nan*             | 0 ulp
 | *normalize*       | Implementation-defined
 | *nextafter*       | 0 ulp
-| *pow*(_x_, _y_)       | {leq} 16 ulp
-| *pown*(_x_, _y_)      | {leq} 16 ulp
-| *powr*(_x_, _y_)      | {leq} 16 ulp
+| *pow*(_x_, _y_)   | {leq} 16 ulp
+| *pown*(_x_, _y_)  | {leq} 16 ulp
+| *powr*(_x_, _y_)  | {leq} 16 ulp
 | *radians*         | {leq} 2 ulp
 | *remainder*       | 0 ulp
 | *remquo*          | 0 ulp
@@ -9936,10 +9985,26 @@ is the infinitely precise result.
 | *cos*             | {leq} 4 ulp
 | *cosh*            | {leq} 4 ulp
 | *cospi*           | {leq} 4 ulp
-| *cross*           | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+// 3 operations from the 2 multiplications and 1 subtraction per component
+| *cross*           | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | *degrees*         | {leq} 2 ulp
-| *distance*        | {leq} 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1)))) For vector width n
-| *dot*             | absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+// 3           ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 1.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1))))
+// = 2 * (3 + 0.5 * (1.5n + (0.5n - 0.5)))
+// = 2 * (3 + 0.5 * (2n - 0.5))
+// = 2 * (3 + n - 0.25)
+// = 2 * (2.75 + n)
+// = 5.5 + 2n
+| *distance*        | {leq} 5.5 + 2n ulp, for gentype with vector width _n_
+// n + n-1  Number of operations from n multiples and (n-1) additions
+// 2n - 1
+| *dot*             | absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | *erfc*            | {leq} 16 ulp
 | *erf*             | {leq} 16 ulp
 | *exp*             | {leq} 3 ulp
@@ -9957,7 +10022,18 @@ is the infinitely precise result.
 | *frexp*           | 0 ulp
 | *hypot*           | {leq} 4 ulp
 | *ilogb*           | 0 ulp
-| *length*          | {leq} 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) For vector width n
+// 3           ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 2 * (3 + 0.5 * (n - 0.5))
+// = 2 * (2.75 + 0.5n)
+// = 5.5 + n
+| *length*          | {leq} 5.5 + n ulp, for gentype with vector width _n_
 | *ldexp*           | Correctly rounded
 | *log*             | {leq} 3 ulp
 | *log2*            | {leq} 3 ulp
@@ -9973,7 +10049,20 @@ is the infinitely precise result.
 | *modf*            | 0 ulp
 | *nan*             | 0 ulp
 | *nextafter*       | 0 ulp
-| *normalize*       | {leq} 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1)))) For vector width n
+// 2.5         error in rsqrt + error in multiply
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 2 * (2.5 + 0.5 * (0.5n + (0.5n - 0.5)))
+// = 2 * (2.5 + 0.5 * (n - 0.5))
+// = 2 * (2.5 + 0.5n - 0.25)
+// = 2 * (2.25 + 0.5n)
+// = 4.5 + n
+| *normalize*       | {leq} 4.5 + n ulp, for gentype with vector width _n_
 | *pow*(_x_, _y_)   | {leq} 16 ulp
 | *pown*(_x_, _y_)  | {leq} 16 ulp
 | *powr*(_x_, _y_)  | {leq} 16 ulp

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -5,7 +5,7 @@
 [[numerical_compliance]]
 == OpenCL Numerical Compliance
 
-This section describes features of the <<cpp14-spec, {cpp14}>> and 
+This section describes features of the <<cpp14-spec, {cpp14}>> and
 <<ieee-754-spec, IEEE-754>> standards that must be supported by all OpenCL
 compliant devices.
 
@@ -278,10 +278,11 @@ devices given as ULP values.
 | \<= 4 ulp
 | \<= 2 ulp
 
+// 3 operations from the 2 multiplications and 1 subtraction per component
 | *OpExtInst* *cross*
-| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)', where max is the maximum input operand value
-| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
-| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 
 | *OpExtInst* *degrees*
 | \<= 2 ulp
@@ -289,14 +290,19 @@ devices given as ULP values.
 | \<= 2 ulp
 
 | *OpExtInst* *distance*
-| \<= 0.5 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 3 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2 * (3 + 0.5 * (1.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 2n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2.5 + 2n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp64.asciidoc for derivation
+| \<= 5.5 + 2n ulp, for gentype with vector width _n_
 
+// n + n-1  Number of operations from n multiples and (n-1) additions
+// 2n - 1
 | *OpExtInst* *dot*
-| absolute error tolerance of 'max * max * (2 * (n - 1)) * HLF_EPSILON', For vector width n and maximum input operand value 'max'
-| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
-| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value max
+| absolute error tolerance of 'max * max * (2n - 1) * HLF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
+| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
+| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 
 | *OpExtInst* *erfc*
 | \<= 16 ulp
@@ -404,9 +410,12 @@ devices given as ULP values.
 | Correctly rounded
 
 | *OpExtInst* *length*
-| \<= 0.5 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 3 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2 * (3 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 0.25 + 0.5n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2.75 + 0.5n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp64.asciidoc for derivation
+| \<= 5.5 + n ulp, for gentype with vector width _n_
 
 | *OpExtInst* *lgamma*
 | Implementation-defined
@@ -482,9 +491,12 @@ devices given as ULP values.
 | 0 ulp
 
 | *OpExtInst* *normalize*
-| \<= 1.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
-| \<= 2 * (2.5 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 1 + n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2 + n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp64.asciidoc for derivation
+| \<= 4.5 + n ulp, for gentype with vector width _n_
 
 | *OpExtInst* *pow*
 | \<= 16 ulp
@@ -671,19 +683,22 @@ devices given as ULP values.
 | \<= 8192 ulp
 |
 
+// See OpenCL_C.txt derivation
 | *OpExtInst* *fast_distance*
 |
-| \<= 8192 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 8191.5 + 2n ulp, for gentype with vector width _n_
 |
 
+// See OpenCL_C.txt derivation
 | *OpExtInst* *fast_length*
 |
-| \<= 8192 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 8191.5 + n ulp, for gentype with vector width _n_
 |
 
+// See OpenCL_C.txt derivation
 | *OpExtInst* *fast_normalize*
 |
-| \<= 8192.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 8192 + n ulp, for gentype with vector width _n_
 |
 
 | *OpExtInst* *native_cos*

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -1491,20 +1491,30 @@ is the infinitely precise result.
 | \<= 2 ulp
 | \<= 2 ulp
 
+// 3 operations from the 2 multiplications and 1 subtraction per component
 | *cross*
-| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)', where max is the maximum input operand value
+| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | Implementation-defined
 
 | *degrees*
 | \<= 2 ulp
 | \<= 2 ulp
 
+// 0.5         ULP error in sqrt
+// 1.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 0.5 + (1.5 * n) + (0.5 * (n - 1))
+// = 0.5 + 1.5n + (0.5n - 0.5)
+// = 2n
 | *distance*
-| \<= 0.5 + (1.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 2n ulp, for gentype with vector width _n_
 | Implementation-defined
 
+// n + n-1  Number of operations from n multiples and (n-1) additions
+// 2n - 1
 | *dot*
-| absolute error tolerance of 'max * max * (2 * (n - 1)) * HLF_EPSILON', For vector width n and maximum input operand value 'max'
+| absolute error tolerance of 'max * max * (2n - 1) * HLF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | Implementation-defined
 
 | *erfc*
@@ -1579,8 +1589,16 @@ is the infinitely precise result.
 | Correctly rounded
 | Correctly rounded
 
+// 0.5         ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = (0.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 0.5 + 0.5 * (n - 0.5)
+// = 0.25 + 0.5n
 | *length*
-| \<= 0.5 + 0.5 * (0.5 * n + 0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 0.25 + 0.5n ulp, for gentype with vector width _n_
 | Implementation-defined
 
 | *log*
@@ -1639,8 +1657,15 @@ is the infinitely precise result.
 | 0 ulp
 | 0 ulp
 
+// 1.5         error in rsqrt + error in multiply
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// = 1.5 + (0.5 * n) + (0.5 * (n - 1))
+// = 1.5 + 0.5n + (0.5n - 0.5)
+// = 1.0 + n
 | *normalize*
-| \<= 1.5 + (0.5 * n) + (0.5 * (n - 1)) ulp, for gentype with vector width n
+| \<= 1 + n ulp, for gentype with vector width _n_
 | Implementation-defined
 
 | *pow(x, y)*

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -5,7 +5,7 @@
 [[cl_khr_fp64]]
 == Double Precision Floating-Point
 
-This section describes the *cl_khr_fp64* extension. 
+This section describes the *cl_khr_fp64* extension.
 This extension became an optional core feature in OpenCL 1.2.
 
 [[cl_khr_fp64-additions-to-chapter-6]]
@@ -64,7 +64,7 @@ to take a `double` scalar data type and a `doublen` vector data type.
 
 The `as_typen()` function for re-interpreting types as described in _section
 6.2.4.2_ is extended to allow conversion-free casts between `longn`,
-`ulongn` and `doublen` scalar and vector data types. 
+`ulongn` and `doublen` scalar and vector data types.
 
 [[cl_khr_fp64-math-functions]]
 ==== Math Functions
@@ -1071,17 +1071,33 @@ is the infinitely precise result.
 | *cospi*
 | \<= 4 ulp
 
+// 3 operations from the 2 multiplications and 1 subtraction per component
 | *cross*
-| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)', where max is the maximum input operand value
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 
 | *degrees*
 | \<= 2 ulp
 
+// 3           ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 1.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (3 + 0.5 * ((1.5 * n) + (0.5 * (n - 1))))
+// = 2 * (3 + 0.5 * (1.5n + (0.5n - 0.5)))
+// = 2 * (3 + 0.5 * (2n - 0.5))
+// = 2 * (3 + n - 0.25)
+// = 2 * (2.75 + n)
+// = 5.5 + 2n
 | *distance*
-| \<= 2 * (3 + 0.5 * (1.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 5.5 + 2n ulp, for gentype with vector width _n_
 
+// n + n-1  Number of operations from n multiples and (n-1) additions
+// 2n - 1
 | *dot*
-| absolute error tolerance of 'max * max * (2 * (n - 1)) * FLT_EPSILON', For vector width n and maximum input operand value 'max'
+| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 
 | *erfc*
 | \<= 16 ulp
@@ -1137,8 +1153,19 @@ is the infinitely precise result.
 | *ldexp*
 | Correctly rounded
 
+// 3           ULP error in sqrt
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (3 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 2 * (3 + 0.5 * (n - 0.5))
+// = 2 * (2.75 + 0.5n)
+// = 5.5 + n
 | *length*
-| \<= 2 * (3 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 5.5 + n ulp, for gentype with vector width _n_
 
 | *log*
 | \<= 3 ulp
@@ -1182,8 +1209,21 @@ is the infinitely precise result.
 | *nextafter*
 | 0 ulp
 
+// 2.5         error in rsqrt + error in multiply
+// 0.5         effect on e of taking sqrt(x + e)
+// 0.5 * n     cumulative error for multiplications
+// 0.5 * (n-1) cumulative error for additions
+//
+// 2           accounts for error in reference code
+//
+// = 2 * (2.5 + 0.5 * ((0.5 * n) + (0.5 * (n - 1))))
+// = 2 * (2.5 + 0.5 * (0.5n + (0.5n - 0.5)))
+// = 2 * (2.5 + 0.5 * (n - 0.5))
+// = 2 * (2.5 + 0.5n - 0.25)
+// = 2 * (2.25 + 0.5n)
+// = 4.5 + n
 | *normalize*
-| \<= 2 * (2.5 + 0.5 * (0.5 * n + 0.5 * (n - 1))) ulp, for gentype with vector width n
+| \<= 4.5 + n ulp, for gentype with vector width _n_
 
 | *pow(x, y)*
 | \<= 16 ulp


### PR DESCRIPTION
Condensed the ULP formulas used to define the ULP bounds of geometric builtin functions, and included comments on the derivation taken from the CTS.

Also fixed a bug in the `dot()` error where I had misread the [CTS code](https://github.com/KhronosGroup/OpenCL-CTS/blob/master/test_conformance/geometrics/test_geometrics.cpp#L432) as `(2 * (n - 1))` when it should've been `2n - 1`.

Addresses [Github Issue 150](https://github.com/KhronosGroup/OpenCL-Docs/issues/150)

Used lines comments in table rather than block comments due to [Asciidoctor bug](https://github.com/asciidoctor/asciidoctor/issues/1681)