### PR TITLE
use type markup consistently in the XML file

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4475,8 +4475,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="Interop tokens">
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
+            </require>
+            <require comment="cl_context_properties">
                 <enum name="CL_CONTEXT_TERMINATE_KHR"/>
             </require>
             <require>
@@ -4487,8 +4489,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_SPIR_VERSIONS"/>
+            </require>
+            <require comment="cl_program_binary_type">
                 <enum name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE"/>
             </require>
         </extension>
@@ -4507,7 +4511,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV"/>
                 <enum name="CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV"/>
                 <enum name="CL_DEVICE_REGISTERS_PER_BLOCK_NV"/>
@@ -4521,7 +4525,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_PROFILING_TIMER_OFFSET_AMD"/>
             </require>
         </extension>
@@ -4529,7 +4533,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_context_properties">
                 <enum name="CL_PRINTF_CALLBACK_ARM"/>
                 <enum name="CL_PRINTF_BUFFERSIZE_ARM"/>
             </require>
@@ -4549,7 +4553,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require comment="cl_device_partition_property_ext">
                 <enum name="CL_DEVICE_PARTITION_EQUALLY_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_BY_COUNTS_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_BY_NAMES_EXT"/>
@@ -4590,6 +4594,8 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_mem_migration_flags_ext">
                 <enum name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
+            </require>
+            <require comment="cl_command_type">
                 <enum name="CL_COMMAND_MIGRATE_MEM_OBJECT_EXT"/>
             </require>
             <require>
@@ -4645,7 +4651,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_channel_order">
                 <enum name="CL_NV21_IMG"/>
                 <enum name="CL_YV12_IMG"/>
             </require>
@@ -4654,7 +4660,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_mem_flags">
                 <enum name="CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG"/>
                 <enum name="CL_MEM_USE_CACHED_CPU_MEMORY_IMG"/>
             </require>
@@ -4682,6 +4688,8 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="Error codes">
                 <enum name="CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG"/>
+            <require>
+            </require>
                 <command name="clEnqueueAcquireGrallocObjectsIMG"/>
                 <command name="clEnqueueReleaseGrallocObjectsIMG"/>
             </require>
@@ -4696,6 +4704,8 @@ server's OpenCL/api-docs repository.
             <require comment="cl_kernel_sub_group_info">
                 <enum name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR"/>
                 <enum name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
+            </require>
+            <require>
                 <command name="clGetKernelSubGroupInfoKHR"/>
             </require>
         </extension>
@@ -4706,7 +4716,7 @@ server's OpenCL/api-docs repository.
             <require comment="To be used by clGetEventInfo">
                 <type name="cl_queue_priority_khr"/>
             </require>
-            <require comment="cl_command_queue_properties">
+            <require comment="cl_queue_properties">
                 <enum name="CL_QUEUE_PRIORITY_KHR"/>
             </require>
             <require comment="cl_queue_priority_khr">
@@ -4722,7 +4732,7 @@ server's OpenCL/api-docs repository.
             <require comment="To be used by clGetEventInfo">
                 <type name="cl_queue_throttle_khr"/>
             </require>
-            <require comment="cl_command_queue_properties">
+            <require comment="cl_queue_properties">
                 <enum name="CL_QUEUE_THROTTLE_KHR"/>
             </require>
             <require comment="cl_queue_throttle_khr">
@@ -4833,7 +4843,7 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
                 <type name="CL/cl_platform.h"/>
             </require>
-            <require>
+            <require comment="cl_command_queue_properties - bitfield">
                 <enum name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
             </require>
         </extension>
@@ -4855,7 +4865,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_ACCELERATOR_CONTEXT_INTEL"/>
                 <enum name="CL_ACCELERATOR_TYPE_INTEL"/>
             </require>
-            <require comment="error codes">
+            <require comment="Error codes">
                 <enum name="CL_INVALID_ACCELERATOR_INTEL"/>
                 <enum name="CL_INVALID_ACCELERATOR_TYPE_INTEL"/>
                 <enum name="CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL"/>
@@ -4939,18 +4949,18 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_simultaneous_sharing" supported="opencl">
-            <require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"/>
                 <enum name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_egl_image_yuv" supported="opencl">
-            <require>
+            <require comment="cl_egl_image_properties_khr">
                 <enum name="CL_EGL_YUV_PLANE_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_packed_yuv" supported="opencl">
-            <require>
+            <require comment="cl_channel_order">
                 <enum name="CL_YUYV_INTEL"/>
                 <enum name="CL_UYVY_INTEL"/>
                 <enum name="CL_YVYU_INTEL"/>
@@ -4958,9 +4968,13 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_required_subgroup_size" supported="opencl">
-            <require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"/>
+            </require>
+            <require comment="cl_kernel_work_group_info">
                 <enum name="CL_KERNEL_SPILL_MEM_SIZE_INTEL"/>
+            </require>
+            <require comment="cl_kernel_sub_group_info">
                 <enum name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"/>
             </require>
         </extension>
@@ -4975,16 +4989,20 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_planar_yuv" supported="opencl">
-            <require>
+            <require comment="cl_channel_order">
                 <enum name="CL_NV12_INTEL"/>
+            </require>
+            <require comment="cl_mem_flags">
                 <enum name="CL_MEM_NO_ACCESS_INTEL"/>
                 <enum name="CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL"/>
+            </require>
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL"/>
                 <enum name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_device_side_avc_motion_estimation" supported="opencl">
-            <require comment="cl_intel_device_side_avc_motion_estimation.??">
+            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_AVC_ME_VERSION_INTEL"/>
                 <enum name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL"/>
                 <enum name="CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL"/>
@@ -5138,7 +5156,7 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl_gl.h"/>
                 <type name="cl_GLsync"/>
             </require>
-            <require>
+            <require comment="cl_command_type">
                 <enum name="CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR"/>
             </require>
             <require>
@@ -5239,8 +5257,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_channel_order">
                 <enum name="CL_DEPTH_STENCIL"/>
+            </require>
+            <require comment="cl_channel_type">
                 <enum name="CL_UNORM_INT24"/>
                 <enum name="CL_FLOAT"/>
             </require>
@@ -5249,7 +5269,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require>
+            <require comment="cl_gl_texture_info">
                 <!-- <enum name="GL_TEXTURE_2D_MULTISAMPLE"/> -->
                 <!-- <enum name="GL_TEXTURE_2D_MULTISAMPLE_ARRAY"/> -->
                 <enum name="CL_GL_NUM_SAMPLES"/>
@@ -5293,7 +5313,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_GL_OBJECT_TEXTURE3D"/>
                 <enum name="CL_GL_OBJECT_RENDERBUFFER"/>
             </require>
-            <require feature="CL_VERSION_1_2">
+            <require feature="CL_VERSION_1_2" comment="cl_gl_object_type">
                 <enum name="CL_GL_OBJECT_TEXTURE2D_ARRAY"/>
                 <enum name="CL_GL_OBJECT_TEXTURE1D"/>
                 <enum name="CL_GL_OBJECT_TEXTURE1D_ARRAY"/>
@@ -5303,10 +5323,10 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_GL_TEXTURE_TARGET"/>
                 <enum name="CL_GL_MIPMAP_LEVEL"/>
             </require>
-            <require feature="CL_VERSION_1_2">
+            <require feature="CL_VERSION_1_2" comment="cl_gl_texture_info">
                 <enum name="CL_GL_NUM_SAMPLES"/>
             </require>
-            <require>
+            <require comment="Error codes">
                 <enum name="CL_INVALID_GL_OBJECT"/>
                 <enum name="CL_INVALID_MIP_LEVEL"/>
             </require>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2138,7 +2138,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_EXT_SUFFIX__VERSION_1_1">
             <proto><type>cl_event</type>                   <name>clCreateEventFromGLsyncKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
-            <param><type>cl_GLsync</type>                  <name>cl_GLsync</name></param>
+            <param><type>cl_GLsync</type>                  <name>sync</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -194,7 +194,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_info_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_unified_shared_memory_type_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_migration_flags_intel</name>;</type>
-        <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_advice_intel></name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_advice_intel</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -85,19 +85,19 @@ server's OpenCL/api-docs repository.
         <type category="basetype" requires="CL/cl_platform.h" name="size_t"/>
 
             <comment>Scalar types</comment>
-        <type category="define" requires="stdint">typedef double      <name>cl_double</name> __attribute__((aligned(8)));</type>
-        <type category="define" requires="stdint">typedef float       <name>cl_float</name> __attribute__((aligned(4)));</type>
-        <type category="define" requires="stdint">typedef int16_t     <name>cl_short</name> __attribute__((aligned(2)));</type>
-        <type category="define" requires="stdint">typedef int32_t     <name>cl_int</name> __attribute__((aligned(4)));</type>
-        <type category="define" requires="stdint">typedef int64_t     <name>cl_long</name> __attribute__((aligned(8)));</type>
-        <type category="define" requires="stdint">typedef int8_t      <name>cl_char</name>;</type>
-        <type category="define" requires="stdint">typedef uint16_t    <name>cl_half</name> __attribute__((aligned(2)));</type>
-        <type category="define" requires="stdint">typedef uint16_t    <name>cl_ushort</name> __attribute__((aligned(2)));</type>
-        <type category="define" requires="stdint">typedef uint32_t    <name>cl_uint</name> __attribute__((aligned(4)));</type>
-        <type category="define" requires="stdint">typedef uint64_t    <name>cl_ulong</name> __attribute__((aligned(8)));</type>
-        <type category="define">typedef int                           <name>cl_GLint</name>;</type>
-        <type category="define">typedef unsigned int                  <name>cl_GLenum</name>;</type>
-        <type category="define">typedef unsigned int                  <name>cl_GLuint</name>;</type>
+        <type category="define" requires="stdint">typedef <type>double</type>   <name>cl_double</name> __attribute__((aligned(8)));</type>
+        <type category="define" requires="stdint">typedef <type>float</type>    <name>cl_float</name> __attribute__((aligned(4)));</type>
+        <type category="define" requires="stdint">typedef <type>int16_t</type>  <name>cl_short</name> __attribute__((aligned(2)));</type>
+        <type category="define" requires="stdint">typedef <type>int32_t</type>  <name>cl_int</name> __attribute__((aligned(4)));</type>
+        <type category="define" requires="stdint">typedef <type>int64_t</type>  <name>cl_long</name> __attribute__((aligned(8)));</type>
+        <type category="define" requires="stdint">typedef <type>int8_t</type>   <name>cl_char</name>;</type>
+        <type category="define" requires="stdint">typedef <type>uint16_t</type> <name>cl_half</name> __attribute__((aligned(2)));</type>
+        <type category="define" requires="stdint">typedef <type>uint16_t</type> <name>cl_ushort</name> __attribute__((aligned(2)));</type>
+        <type category="define" requires="stdint">typedef <type>uint32_t</type> <name>cl_uint</name> __attribute__((aligned(4)));</type>
+        <type category="define" requires="stdint">typedef <type>uint64_t</type> <name>cl_ulong</name> __attribute__((aligned(8)));</type>
+        <type category="define">typedef <type>int</type>              <name>cl_GLint</name>;</type>
+        <type category="define">typedef <type>unsigned int</type>     <name>cl_GLenum</name>;</type>
+        <type category="define">typedef <type>unsigned int</type>     <name>cl_GLuint</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_d3d11_device_source_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_d3d11_device_set_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_dx9_media_adapter_type_khr</name>;</type>
@@ -1916,21 +1916,21 @@ server's OpenCL/api-docs repository.
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
             <proto><type>void</type>                       <name>clLogMessagesToSystemLogAPPLE</name></proto>
-            <param>const char*                             <name>errstr</name></param>
+            <param>const <type>char</type>*                <name>errstr</name></param>
             <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
             <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
             <proto><type>void</type>                       <name>clLogMessagesToStdoutAPPLE</name></proto>
-            <param>const char*                             <name>errstr</name></param>
+            <param>const <type>char</type>*                <name>errstr</name></param>
             <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
             <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
             <proto><type>void</type>                       <name>clLogMessagesToStderrAPPLE</name></proto>
-            <param>const char*                             <name>errstr</name></param>
+            <param>const <type>char</type>*                <name>errstr</name></param>
             <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
             <param><type>void</type>*                      <name>user_data</name></param>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2051,7 +2051,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_svm_pointers</name></param>
             <param><type>void</type>*                      <name>svm_pointers</name>[]</param>
-            <param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue, cl_uint, void *[], void *)</param>
+            <param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue queue, cl_uint num_svm_pointers, void * svm_pointers[], void *user_data)</param>
             <param><type>void</type>*                      <name>user_data</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
@@ -2424,7 +2424,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_context_properties</type>*            <name>properties</name></param>
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
             <param>const <type>cl_device_id</type>*                     <name>devices</name></param>
-            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char*, const void*, size_t, void*)</param>
+            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char* errinfo, const void* private_info, size_t cb, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
@@ -2432,7 +2432,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_context</type>                              <name>clCreateContextFromType</name></proto>
             <param>const <type>cl_context_properties</type>*            <name>properties</name></param>
             <param><type>cl_device_type</type>                          <name>device_type</name></param>
-            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char*, const void*, size_t, void*)</param>
+            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char* errinfo, const void* private_info, size_t cb, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
@@ -2822,7 +2822,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clSetEventCallback</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_int</type>                                  <name>command_exec_callback_type</name></param>
-            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_event event, cl_int type, void *user_data)</param>
+            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_event event, cl_int event_command_status, void *user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -113,9 +113,9 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_va_api_device_source_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_va_api_device_set_intel</name>;</type>
         <type category="define">typedef struct __GLsync *             <name>cl_GLsync</name>;</type>
-        <type category="define">typedef void *                        <name>CLeglImageKHR</name>;</type>
-        <type category="define">typedef void *                        <name>CLeglDisplayKHR</name>;</type>
-        <type category="define">typedef void *                        <name>CLeglSyncKHR</name>;</type>
+        <type category="define">typedef <type>void</type>*            <name>CLeglImageKHR</name>;</type>
+        <type category="define">typedef <type>void</type>*            <name>CLeglDisplayKHR</name>;</type>
+        <type category="define">typedef <type>void</type>*            <name>CLeglSyncKHR</name>;</type>
         <type category="define">typedef <type>intptr_t</type>         <name>cl_egl_image_properties_khr</name>;</type>
         <type category="define">typedef <type>cl_ulong</type>         <name>cl_device_partition_property_ext</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_migration_flags_ext</name>;</type>
@@ -1707,7 +1707,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D10KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d10_device_source_khr</type> <name>d3d_device_source</name></param>
-            <param>void*                                   <name>d3d_object</name></param>
+            <param><type>void</type>*                      <name>d3d_object</name></param>
             <param><type>cl_d3d10_device_set_khr</type>    <name>d3d_device_set</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_device_id</type>*              <name>devices</name></param>
@@ -1758,7 +1758,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D11KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d11_device_source_khr</type> <name>d3d_device_source</name></param>
-            <param>void*                                   <name>d3d_object</name></param>
+            <param><type>void</type>*                      <name>d3d_object</name></param>
             <param><type>cl_d3d11_device_set_khr</type>    <name>d3d_device_set</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_device_id</type>*              <name>devices</name></param>
@@ -1810,7 +1810,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_uint</type>                    <name>num_media_adapters</name></param>
             <param><type>cl_dx9_media_adapter_type_khr</type>*  <name>media_adapter_type</name></param>
-            <param>void*                                   <name>media_adapters</name></param>
+            <param><type>void</type>*                      <name>media_adapters</name></param>
             <param><type>cl_dx9_media_adapter_set_khr</type> <name>media_adapter_set</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_device_id</type>*              <name>devices</name></param>
@@ -1821,7 +1821,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>cl_dx9_media_adapter_type_khr</type> <name>adapter_type</name></param>
-            <param>void*                                   <name>surface_info</name></param>
+            <param><type>void</type>*                      <name>surface_info</name></param>
             <param><type>cl_uint</type>                    <name>plane</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
@@ -1847,7 +1847,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromDX9INTEL</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_dx9_device_source_intel</type> <name>dx9_device_source</name></param>
-            <param>void*                                   <name>dx9_object</name></param>
+            <param><type>void</type>*                      <name>dx9_object</name></param>
             <param><type>cl_dx9_device_set_intel</type>    <name>dx9_device_set</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_device_id</type>*              <name>devices</name></param>
@@ -1915,25 +1915,25 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
-            <proto>void                                    <name>clLogMessagesToSystemLogAPPLE</name></proto>
+            <proto><type>void</type>                       <name>clLogMessagesToSystemLogAPPLE</name></proto>
             <param>const char*                             <name>errstr</name></param>
-            <param>const void*                             <name>private_info</name></param>
+            <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
-            <param>void*                                   <name>user_data</name></param>
+            <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
-            <proto>void                                    <name>clLogMessagesToStdoutAPPLE</name></proto>
+            <proto><type>void</type>                       <name>clLogMessagesToStdoutAPPLE</name></proto>
             <param>const char*                             <name>errstr</name></param>
-            <param>const void*                             <name>private_info</name></param>
+            <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
-            <param>void*                                   <name>user_data</name></param>
+            <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
-            <proto>void                                    <name>clLogMessagesToStderrAPPLE</name></proto>
+            <proto><type>void</type>                       <name>clLogMessagesToStderrAPPLE</name></proto>
             <param>const char*                             <name>errstr</name></param>
-            <param>const void*                             <name>private_info</name></param>
+            <param>const <type>void</type>*                <name>private_info</name></param>
             <param><type>size_t</type>                     <name>cb</name></param>
-            <param>void*                                   <name>user_data</name></param>
+            <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command>
             <proto><type>cl_int</type>                     <name>clIcdGetPlatformIDsKHR</name></proto>
@@ -1944,7 +1944,7 @@ server's OpenCL/api-docs repository.
         <command>
             <proto><type>cl_program</type>                 <name>clCreateProgramWithILKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
-            <param>const void*                             <name>il</name></param>
+            <param>const <type>void</type>*                <name>il</name></param>
             <param><type>size_t</type>                     <name>length</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
@@ -1993,7 +1993,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_image_format</type>*     <name>image_format</name></param>
             <param><type>cl_image_pitch_info_qcom</type>   <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>void*                                   <name>param_value</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
@@ -2020,9 +2020,9 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>               <name>in_device</name></param>
             <param><type>cl_kernel_sub_group_info</type>   <name>param_name</name></param>
             <param><type>size_t</type>                     <name>input_value_size</name></param>
-            <param>const void*                             <name>input_value</name></param>
+            <param>const <type>void</type>*                <name>input_value</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>void*                                   <name>param_value</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
@@ -2030,29 +2030,29 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param>const <type>cl_import_properties_arm</type>* <name>properties</name></param>
-            <param>void*                                   <name>memory</name></param>
+            <param><type>void</type>*                      <name>memory</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
-            <proto>void*                                   <name>clSVMAllocARM</name></proto>
+            <proto><type>void</type>*                      <name>clSVMAllocARM</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_svm_mem_flags_arm</type>       <name>flags</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_uint</type>                    <name>alignment</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
-            <proto>void                                    <name>clSVMFreeARM</name></proto>
+            <proto><type>void</type>                       <name>clSVMFreeARM</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
-            <param>void*                                   <name>svm_pointer</name></param>
+            <param><type>void</type>*                      <name>svm_pointer</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                     <name>clEnqueueSVMFreeARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_svm_pointers</name></param>
-            <param>void*                                   <name>svm_pointers</name>[]</param>
+            <param><type>void</type>*                      <name>svm_pointers</name>[]</param>
             <param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue, cl_uint, void *[], void *)</param>
-            <param>void*                                   <name>user_data</name></param>
+            <param><type>void</type>*                      <name>user_data</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                  <name>event</name></param>
@@ -2061,8 +2061,8 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clEnqueueSVMMemcpyARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_bool</type>                    <name>blocking_copy</name></param>
-            <param>void*                                   <name>dst_ptr</name></param>
-            <param>const void*                             <name>src_ptr</name></param>
+            <param><type>void</type>*                      <name>dst_ptr</name></param>
+            <param>const <type>void</type>*                <name>src_ptr</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
@@ -2071,8 +2071,8 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                     <name>clEnqueueSVMMemFillARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
-            <param>void*                                   <name>svm_ptr</name></param>
-            <param>const void*                             <name>pattern</name></param>
+            <param><type>void</type>*                      <name>svm_ptr</name></param>
+            <param>const <type>void</type>*                <name>pattern</name></param>
             <param><type>size_t</type>                     <name>pattern_size</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
@@ -2084,7 +2084,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_bool</type>                    <name>blocking_map</name></param>
             <param><type>cl_map_flags</type>               <name>flags</name></param>
-            <param>void*                                   <name>svm_ptr</name></param>
+            <param><type>void</type>*                      <name>svm_ptr</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
@@ -2093,7 +2093,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                     <name>clEnqueueSVMUnmapARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
-            <param>void*                                   <name>svm_ptr</name></param>
+            <param><type>void</type>*                      <name>svm_ptr</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                  <name>event</name></param>
@@ -2102,21 +2102,21 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clSetKernelArgSVMPointerARM</name></proto>
             <param><type>cl_kernel</type>                  <name>kernel</name></param>
             <param><type>cl_uint</type>                    <name>arg_index</name></param>
-            <param>const void*                             <name>arg_value</name></param>
+            <param>const <type>void</type>*                <name>arg_value</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                     <name>clSetKernelExecInfoARM</name></proto>
             <param><type>cl_kernel</type>                  <name>kernel</name></param>
             <param><type>cl_kernel_exec_info_arm</type>    <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>const void*                             <name>param_value</name></param>
+            <param>const <type>void</type>*                <name>param_value</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
             <proto><type>cl_accelerator_intel</type>       <name>clCreateAcceleratorINTEL</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_accelerator_type_intel</type>  <name>accelerator_type</name></param>
             <param><type>size_t</type>                     <name>descriptor_size</name></param>
-            <param>const void*                             <name>descriptor</name></param>
+            <param>const <type>void</type>*                <name>descriptor</name></param>
             <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
@@ -2124,7 +2124,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_accelerator_intel</type>       <name>accelerator</name></param>
             <param><type>cl_accelerator_info_intel</type>  <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>void*                                   <name>param_value</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_2">
@@ -2146,7 +2146,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_context_properties</type>*  <name>properties</name></param>
             <param><type>cl_gl_context_info</type>         <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>void*                                   <name>param_value</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2183,7 +2183,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                     <name>memobj</name></param>
             <param><type>cl_gl_texture_info</type>         <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
-            <param>void*                                   <name>param_value</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2226,7 +2226,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromVA_APIMediaAdapterINTEL</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_va_api_device_source_intel</type> <name>media_adapter_type</name></param>
-            <param>void*                                   <name>media_adapter</name></param>
+            <param><type>void</type>*                      <name>media_adapter</name></param>
             <param><type>cl_va_api_device_set_intel</type> <name>media_adapter_set</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_device_id</type>*              <name>devices</name></param>
@@ -2259,7 +2259,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command>
-            <proto>void*                                        <name>clHostMemAllocINTEL</name></proto>
+            <proto><type>void</type>*                           <name>clHostMemAllocINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
@@ -2267,7 +2267,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
         </command>
         <command>
-            <proto>void*                                        <name>clDeviceMemAllocINTEL</name></proto>
+            <proto><type>void</type>*                           <name>clDeviceMemAllocINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param><type>cl_device_id</type>                    <name>device</name></param>
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
@@ -2276,7 +2276,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
         </command>
         <command>
-            <proto>void*                                        <name>clSharedMemAllocINTEL</name></proto>
+            <proto><type>void</type>*                           <name>clSharedMemAllocINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param><type>cl_device_id</type>                    <name>device</name></param>
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
@@ -2287,27 +2287,27 @@ server's OpenCL/api-docs repository.
         <command>
             <proto><type>cl_int</type>                          <name>clMemFreeINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
-            <param>void*                                        <name>ptr</name></param>
+            <param><type>void</type>*                           <name>ptr</name></param>
         </command>
         <command>
             <proto><type>cl_int</type>                          <name>clGetMemAllocInfoINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
-            <param>const void*                                  <name>ptr</name></param>
+            <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>cl_mem_info_intel</type>               <name>param_name</name></param>
             <param><type>size_t</type>                          <name>param_value_size</name></param>
-            <param>void*                                        <name>param_value</name></param>
+            <param><type>void</type>*                           <name>param_value</name></param>
             <param><type>size_t</type>*                         <name>param_value_size_ret</name></param>
         </command>
         <command>
             <proto><type>cl_int</type>                          <name>clSetKernelArgMemPointerINTEL</name></proto>
             <param><type>cl_kernel</type>                       <name>kernel</name></param>
             <param><type>cl_uint</type>                         <name>arg_index</name></param>
-            <param>const void*                                  <name>arg_value</name></param>
+            <param>const <type>void</type>*                     <name>arg_value</name></param>
         </command>
         <command comment="Deprecated">
             <proto><type>cl_int</type>                          <name>clEnqueueMemsetINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
-            <param>void*                                        <name>dst_ptr</name></param>
+            <param><type>void</type>*                           <name>dst_ptr</name></param>
             <param><type>cl_int</type>                          <name>value</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
@@ -2317,8 +2317,8 @@ server's OpenCL/api-docs repository.
         <command>
             <proto><type>cl_int</type>                          <name>clEnqueueMemFillINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
-            <param>void*                                        <name>dst_ptr</name></param>
-            <param>const void*                                  <name>pattern</name></param>
+            <param><type>void</type>*                           <name>dst_ptr</name></param>
+            <param>const <type>void</type>*                     <name>pattern</name></param>
             <param><type>size_t</type>                          <name>pattern_size</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
@@ -2329,8 +2329,8 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                          <name>clEnqueueMemcpyINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param><type>cl_bool</type>                         <name>blocking</name></param>
-            <param>void*                                        <name>dst_ptr</name></param>
-            <param>const void*                                  <name>src_ptr</name></param>
+            <param><type>void</type>*                           <name>dst_ptr</name></param>
+            <param>const <type>void</type>*                     <name>src_ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                 <name>event_wait_list</name></param>
@@ -2339,7 +2339,7 @@ server's OpenCL/api-docs repository.
         <command>
             <proto><type>cl_int</type>                          <name>clEnqueueMigrateMemINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
-            <param>const void*                                  <name>ptr</name></param>
+            <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_mem_migration_flags_intel</type>    <name>flags</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
@@ -2349,7 +2349,7 @@ server's OpenCL/api-docs repository.
         <command>
             <proto><type>cl_int</type>                          <name>clEnqueueMemAdviseINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
-            <param>const void*                                  <name>ptr</name></param>
+            <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_mem_advice_intel</type>             <name>advice</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
@@ -2367,7 +2367,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_platform_id</type>                          <name>platform</name></param>
             <param><type>cl_platform_info</type>                        <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2383,7 +2383,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_device_info</type>                          <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
@@ -2425,7 +2425,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
             <param>const <type>cl_device_id</type>*                     <name>devices</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char*, const void*, size_t, void*)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2433,7 +2433,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_context_properties</type>*            <name>properties</name></param>
             <param><type>cl_device_type</type>                          <name>device_type</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char*, const void*, size_t, void*)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2449,7 +2449,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_context_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
@@ -2472,7 +2472,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_command_queue_info</type>                   <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2480,7 +2480,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
-            <param>void*                                                <name>host_ptr</name></param>
+            <param><type>void</type>*                                   <name>host_ptr</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
@@ -2488,7 +2488,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>cl_buffer_create_type</type>                   <name>buffer_create_type</name></param>
-            <param>const void*                                          <name>buffer_create_info</name></param>
+            <param>const <type>void</type>*                             <name>buffer_create_info</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
@@ -2497,7 +2497,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param>const <type>cl_image_format</type>*                  <name>image_format</name></param>
             <param>const <type>cl_image_desc</type>*                    <name>image_desc</name></param>
-            <param>void*                                                <name>host_ptr</name></param>
+            <param><type>void</type>*                                   <name>host_ptr</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
@@ -2531,7 +2531,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param><type>cl_mem_info</type>                             <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2539,7 +2539,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_image_info</type>                           <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
@@ -2547,32 +2547,32 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem</type>                                  <name>pipe</name></param>
             <param><type>cl_pipe_info</type>                            <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
             <proto><type>cl_int</type>                                  <name>clSetMemObjectDestructorCallback</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_mem memobj, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_EXT_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                                  <name>clSetMemObjectDestructorAPPLE</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_mem memobj, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto>void*                                                <name>clSVMAlloc</name></proto>
+            <proto><type>void</type>*                                   <name>clSVMAlloc</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_svm_mem_flags</type>                        <name>flags</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>cl_uint</type>                                 <name>alignment</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto>void                                                 <name>clSVMFree</name></proto>
+            <proto><type>void</type>                                    <name>clSVMFree</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
-            <param>void*                                                <name>svm_pointer</name></param>
+            <param><type>void</type>*                                   <name>svm_pointer</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_sampler</type>                              <name>clCreateSamplerWithProperties</name></proto>
@@ -2593,7 +2593,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_sampler</type>                              <name>sampler</name></param>
             <param><type>cl_sampler_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2625,7 +2625,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
             <proto><type>cl_program</type>                              <name>clCreateProgramWithIL</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
-            <param>const void*                                          <name>il</name></param>
+            <param>const <type>void</type>*                             <name>il</name></param>
             <param><type>size_t</type>                                  <name>length</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
@@ -2644,7 +2644,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_device_id</type>*                     <name>device_list</name></param>
             <param>const <type>char</type>*                             <name>options</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                                  <name>clCompileProgram</name></proto>
@@ -2656,7 +2656,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_program</type>*                       <name>input_headers</name></param>
             <param>const <type>char</type>**                            <name>header_include_names</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_program</type>                              <name>clLinkProgram</name></proto>
@@ -2667,21 +2667,21 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_input_programs</name></param>
             <param>const <type>cl_program</type>*                       <name>input_programs</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_2">
             <proto><type>cl_int</type>                                  <name>clSetProgramReleaseCallback</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_2">
             <proto><type>cl_int</type>                                  <name>clSetProgramSpecializationConstant</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_uint</type>                                 <name>spec_id</name></param>
             <param><type>size_t</type>                                  <name>spec_size</name></param>
-            <param>const void*                                          <name>spec_value</name></param>
+            <param>const <type>void</type>*                             <name>spec_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                                  <name>clUnloadPlatformCompiler</name></proto>
@@ -2692,7 +2692,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_program_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2701,7 +2701,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_program_build_info</type>                   <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2735,27 +2735,27 @@ server's OpenCL/api-docs repository.
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>arg_index</name></param>
             <param><type>size_t</type>                                  <name>arg_size</name></param>
-            <param>const void*                                          <name>arg_value</name></param>
+            <param>const <type>void</type>*                             <name>arg_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_int</type>                                  <name>clSetKernelArgSVMPointer</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>arg_index</name></param>
-            <param>const void*                                          <name>arg_value</name></param>
+            <param>const <type>void</type>*                             <name>arg_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_int</type>                                  <name>clSetKernelExecInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_kernel_exec_info</type>                     <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>const void*                                          <name>param_value</name></param>
+            <param>const <type>void</type>*                             <name>param_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                                  <name>clGetKernelInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_kernel_info</type>                          <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
@@ -2764,7 +2764,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>arg_indx</name></param>
             <param><type>cl_kernel_arg_info</type>                      <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2773,7 +2773,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_kernel_work_group_info</type>               <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
@@ -2782,9 +2782,9 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_kernel_sub_group_info</type>                <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>input_value_size</name></param>
-            <param>const void*                                          <name>input_value</name></param>
+            <param>const <type>void</type>*                             <name>input_value</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2797,7 +2797,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_event_info</type>                           <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
@@ -2823,14 +2823,14 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_int</type>                                  <name>command_exec_callback_type</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_event event, cl_int type, void *user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                                  <name>clGetEventProfilingInfo</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_profiling_info</type>                       <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
-            <param>void*                                                <name>param_value</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
@@ -2848,7 +2848,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
             <param><type>size_t</type>                                  <name>offset</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
-            <param>void*                                                <name>ptr</name></param>
+            <param><type>void</type>*                                   <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2865,7 +2865,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>buffer_slice_pitch</name></param>
             <param><type>size_t</type>                                  <name>host_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>host_slice_pitch</name></param>
-            <param>void*                                                <name>ptr</name></param>
+            <param><type>void</type>*                                   <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2877,7 +2877,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
             <param><type>size_t</type>                                  <name>offset</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
-            <param>const void*                                          <name>ptr</name></param>
+            <param>const <type>void</type>*                             <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2894,7 +2894,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>buffer_slice_pitch</name></param>
             <param><type>size_t</type>                                  <name>host_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>host_slice_pitch</name></param>
-            <param>const void*                                          <name>ptr</name></param>
+            <param>const <type>void</type>*                             <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2903,7 +2903,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueFillBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
-            <param>const void*                                          <name>pattern</name></param>
+            <param>const <type>void</type>*                             <name>pattern</name></param>
             <param><type>size_t</type>                                  <name>pattern_size</name></param>
             <param><type>size_t</type>                                  <name>offset</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
@@ -2948,7 +2948,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>row_pitch</name></param>
             <param><type>size_t</type>                                  <name>slice_pitch</name></param>
-            <param>void*                                                <name>ptr</name></param>
+            <param><type>void</type>*                                   <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2962,7 +2962,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>input_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>input_slice_pitch</name></param>
-            <param>const void*                                          <name>ptr</name></param>
+            <param>const <type>void</type>*                             <name>ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -2971,7 +2971,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueFillImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
-            <param>const void*                                          <name>fill_color</name></param>
+            <param>const <type>void</type>*                             <name>fill_color</name></param>
             <param>const <type>size_t</type>*                           <name>origin</name></param>
             <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -3015,7 +3015,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto>void*                                                <name>clEnqueueMapBuffer</name></proto>
+            <proto><type>void</type>*                                   <name>clEnqueueMapBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_map</name></param>
@@ -3028,7 +3028,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto>void*                                                <name>clEnqueueMapImage</name></proto>
+            <proto><type>void</type>*                                   <name>clEnqueueMapImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_map</name></param>
@@ -3046,7 +3046,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueUnmapMemObject</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
-            <param>void*                                                <name>mapped_ptr</name></param>
+            <param><type>void</type>*                                   <name>mapped_ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -3077,11 +3077,11 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueNativeKernel</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param>void (CL_CALLBACK*                                   <name>user_func</name>)(void*)</param>
-            <param>void*                                                <name>args</name></param>
+            <param><type>void</type>*                                   <name>args</name></param>
             <param><type>size_t</type>                                  <name>cb_args</name></param>
             <param><type>cl_uint</type>                                 <name>num_mem_objects</name></param>
             <param>const <type>cl_mem</type>*                           <name>mem_list</name></param>
-            <param>const void**                                         <name>args_mem_loc</name></param>
+            <param>const <type>void</type>**                            <name>args_mem_loc</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -3104,9 +3104,9 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueSVMFree</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_svm_pointers</name></param>
-            <param>void*                                                <name>svm_pointers</name>[]</param>
+            <param><type>void</type>*                                   <name>svm_pointers</name>[]</param>
             <param>void (CL_CALLBACK*                                   <name>pfn_free_func</name>)(cl_command_queue queue, cl_uint num_svm_pointers, void* svm_pointers[], void* user_data)</param>
-            <param>void*                                                <name>user_data</name></param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -3115,8 +3115,8 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueSVMMemcpy</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_copy</name></param>
-            <param>void*                                                <name>dst_ptr</name></param>
-            <param>const void*                                          <name>src_ptr</name></param>
+            <param><type>void</type>*                                   <name>dst_ptr</name></param>
+            <param>const <type>void</type>*                             <name>src_ptr</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
@@ -3125,8 +3125,8 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_int</type>                                  <name>clEnqueueSVMMemFill</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
-            <param>void*                                                <name>svm_ptr</name></param>
-            <param>const void*                                          <name>pattern</name></param>
+            <param><type>void</type>*                                   <name>svm_ptr</name></param>
+            <param>const <type>void</type>*                             <name>pattern</name></param>
             <param><type>size_t</type>                                  <name>pattern_size</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -3138,7 +3138,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_map</name></param>
             <param><type>cl_map_flags</type>                            <name>flags</name></param>
-            <param>void*                                                <name>svm_ptr</name></param>
+            <param><type>void</type>*                                   <name>svm_ptr</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
@@ -3147,7 +3147,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_int</type>                                  <name>clEnqueueSVMUnmap</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
-            <param>void*                                                <name>svm_ptr</name></param>
+            <param><type>void</type>*                                   <name>svm_ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
@@ -3156,7 +3156,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                  <name>clEnqueueSVMMigrateMem</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_svm_pointers</name></param>
-            <param>const void**                                         <name>svm_pointers</name></param>
+            <param>const <type>void</type>**                            <name>svm_pointers</name></param>
             <param>const <type>size_t</type>*                           <name>sizes</name></param>
             <param><type>cl_mem_migration_flags</type>                  <name>flags</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -3164,7 +3164,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto>void*                                                <name>clGetExtensionFunctionAddressForPlatform</name></proto>
+            <proto><type>void</type>*                                   <name>clGetExtensionFunctionAddressForPlatform</name></proto>
             <param><type>cl_platform_id</type>                          <name>platform</name></param>
             <param>const <type>char</type>*                             <name>func_name</name></param>
         </command>
@@ -3183,7 +3183,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>image_width</name></param>
             <param><type>size_t</type>                                  <name>image_height</name></param>
             <param><type>size_t</type>                                  <name>image_row_pitch</name></param>
-            <param>void*                                                <name>host_ptr</name></param>
+            <param><type>void</type>*                                   <name>host_ptr</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
@@ -3196,7 +3196,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>image_depth</name></param>
             <param><type>size_t</type>                                  <name>image_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>image_slice_pitch</name></param>
-            <param>void*                                                <name>host_ptr</name></param>
+            <param><type>void</type>*                                   <name>host_ptr</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
@@ -3216,10 +3216,10 @@ server's OpenCL/api-docs repository.
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>cl_int</type> <name>clUnloadCompiler</name></proto>
-            <param>void                                                 </param>
+            <param><type>void</type>                                    </param>
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED">
-            <proto>void* <name>clGetExtensionFunctionAddress</name></proto>
+            <proto><type>void</type>*  <name>clGetExtensionFunctionAddress</name></proto>
             <param>const <type>char</type>*  <name>func_name</name></param>
         </command>
         <command prefix="CL_EXT_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED">


### PR DESCRIPTION
This PR contains a few more fixes to the XML file, and fixes #193.  There should be no functional changes.

* Use the `<type>` markup consistently in the XML file.
* One minor fix for the name of an argument for clCreateFromGLsyncKHR.
* Fixed, added, or edited a few enum block comments for consistency.

The one place where the `<type>` markup is not currently used is for function pointers, e.g.:

```
<param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue, cl_uint, void *[], void *)</param>
```

I think if we wanted to fix this we'd do so by creating a typedef for each function pointer type, then referencing the new type using the `<type>` markup.  If we decide to go this route I'd prefer to make this change as part of a separate PR.