### PR TITLE
Document required formats for {read,write}_only images in embedded profile

### DIFF
--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -305,3 +305,30 @@ Device Queries>> table is {CL_TRUE}, the values assigned to
 must be greater than or equal to the minimum values specified in the
 <<embedded-device-queries-table, OpenCL Embedded Device Queries>> table.
 
+For 1D, 1D image from buffer, 2D, 3D image objects, 1D and 2D image array
+objects, when supported, the mandated minimum list of image formats that can
+be read from and written to by different kernel instances when correctly ordered
+by event dependencies and that must be supported by all devices that support
+images is described in the <<embedded-required-image-read-or-write-formats-table>> table.
+
+[[embedded-required-image-read-or-write-formats-table]]
+.Minimum list of required image formats (embedded profile): kernel read or write
+[width="100%",cols="<34%,<33%,<33%",options="header"]
+|====
+| num_channels | channel_order | channel_data_type
+| 4
+  | {CL_RGBA}
+      | {CL_UNORM_INT8} +
+        {CL_UNORM_INT16} +
+        {CL_SIGNED_INT8} +
+        {CL_SIGNED_INT16} +
+        {CL_SIGNED_INT32} +
+        {CL_UNSIGNED_INT8} +
+        {CL_UNSIGNED_INT16} +
+        {CL_UNSIGNED_INT32} +
+        {CL_HALF_FLOAT}^1^ +
+        {CL_FLOAT}
+|====
+
+1:: If the *cl_khr_fp16* extension is supported.
+

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -326,9 +326,7 @@ images is described in the <<embedded-required-image-read-or-write-formats-table
         {CL_UNSIGNED_INT8} +
         {CL_UNSIGNED_INT16} +
         {CL_UNSIGNED_INT32} +
-        {CL_HALF_FLOAT}^1^ +
+        {CL_HALF_FLOAT} +
         {CL_FLOAT}
 |====
-
-1:: If the *cl_khr_fp16* extension is supported.
 


### PR DESCRIPTION
Adapt the wording from the unified spec to allow for optionality.

Required formats for read_write images aren't covered by this change.

Contributes to #201.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>