### PR TITLE
fix a few minor formatting issues in the image format tables

### DIFF
--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -313,7 +313,7 @@ images is described in the <<embedded-required-image-read-or-write-formats-table
 
 [[embedded-required-image-read-or-write-formats-table]]
 .Minimum list of required image formats (embedded profile): kernel read or write
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+[width="100%",cols="1,1,2",options="header"]
 |====
 | num_channels | channel_order | channel_data_type
 | 4

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2393,7 +2393,7 @@ Kernel Read Or Write>> table.
 
 [[min-supported-cross-kernel-table]]
 .Minimum list of required image formats: kernel read or write
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+[width="100%",cols="1,1,2",options="header"]
 |====
 | num_channels | channel_order | channel_data_type
 | 1
@@ -2466,8 +2466,8 @@ devices that support images is described in the
 Write>> table.
 
 [[min-supported-same-kernel-table]]
-_Minimum list of required image formats: kernel read and write
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+.Minimum list of required image formats: kernel read and write
+[width="100%",cols="1,1,2",options="header"]
 |====
 | num_channels | channel_order | channel_data_type
 | 1


### PR DESCRIPTION
* Fixes a typo affecting one of the table titles.
* Extends the column width of the rightmost column in the image format tables to avoid wrapping the image format enums in the HTML output.  It seems odd this is required given `width=100%`, and in the PDF output the table spans the entire page as expected, but I can't otherwise find a reliable way to affect the width of tables in the HTML output (@oddhack, any ideas?).

No functional changes.

