### PR TITLE
fix comment for two subgroup info queries to cl_kernel_sub_group_info

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4172,11 +4172,9 @@ server's OpenCL/api-docs repository.
         <require comment="cl_program_info">
             <enum name="CL_PROGRAM_IL"/>
         </require>
-        <require comment="cl_kernel_info">
+        <require comment="cl_kernel_sub_group_info">
             <enum name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
             <enum name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
-        </require>
-        <require comment="cl_kernel_sub_group_info">
             <enum name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE"/>
             <enum name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE"/>
             <enum name="CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT"/>


### PR DESCRIPTION
See: https://github.com/KhronosGroup/OpenCL-Headers/pull/68