### PR TITLE
add bit definitions for mem migration aliases for USM

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -678,9 +678,11 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums name="cl_mem_migration_flags" vendor="Khronos" type="bitmask">
-        <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
         <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST"/>
+        <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
+        <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_INTEL"/>
         <enum bitpos="1"            name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED"/>
+        <enum bitpos="1"            name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED_INTEL"/>
             <unused start="2" end="31"/>
     </enums>
 


### PR DESCRIPTION
I'm still looking for a way to avoid requiring these aliases for USM, but at least this way the aliases are  defined and the XML file is consistent.

Fixes #205 .