### PR TITLE
add definitions of stdint types to cl.xml

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -83,6 +83,16 @@ server's OpenCL/api-docs repository.
         <type category="basetype" requires="CL/cl_platform.h" name="unsigned char"/>
         <type category="basetype" requires="CL/cl_platform.h" name="intptr_t"/>
         <type category="basetype" requires="CL/cl_platform.h" name="size_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="float"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="double"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="int8_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="int16_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="int32_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="int64_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="uint8_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="uint16_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="uint32_t"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="uint64_t"/>
 
             <comment>Scalar types</comment>
         <type category="define" requires="stdint">typedef <type>double</type>   <name>cl_double</name> __attribute__((aligned(8)));</type>


### PR DESCRIPTION
This fixes some warnings produced when building the specs.