### PR TITLE
fix fp16 vload/vstore description

### DIFF
--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -702,7 +702,7 @@ vector types.
 
 The vector data load (*vload__n__*) and store (*vstore__n__*) functions
 described in _table 6.13_ (also listed below) are extended to include
-versions that read from or write to half scalar or vector values.
+versions that read or write half vector values.
 The generic type `gentype` is extended to include `half`.
 The generic type `gentypen` is extended to include `half2`, `half3`,
 `half4`, `half8`, and `half16`.


### PR DESCRIPTION
These functions can only read or write vector values, and cannot read or write scalar value.

Fixes #210.