### PR TITLE
Define ULP overflow leniency

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11022,6 +11022,11 @@ The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
 0 ulp is used for math functions that do not require rounding.
 
+Result overflow within the specified ULP error is permitted. Math functions are
+allowed to return infinity for a finite reference value when the next
+floating-point number that would be representable after the finite maximum, if
+there was sufficient range, meets ULP error tolerance.
+
 [[table-ulp-float-math]]
 .ULP values for single precision built-in math functions
 [cols=",",]

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -158,6 +158,11 @@ On the definition of ulp(x)>>.
 The reference value used to compute the ULP value is the infinitely precise
 result.
 
+Result overflow within the specified ULP error is permitted. Math functions are
+allowed to return infinity for a finite reference value when the next
+floating-point number that would be representable after the finite maximum, if
+there was sufficient range, meets ULP error tolerance.
+
 ==== ULP Values for Math Instructions - Full Profile
 
 The ULP Values for Math Instructions table below describes the minimum

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -158,8 +158,8 @@ On the definition of ulp(x)>>.
 The reference value used to compute the ULP value is the infinitely precise
 result.
 
-Result overflow within the specified ULP error is permitted. Math functions are
-allowed to return infinity for a finite reference value when the next
+Result overflow within the specified ULP error is permitted. Math instructions
+are allowed to return infinity for a finite reference value when the next
 floating-point number that would be representable after the finite maximum, if
 there was sufficient range, meets ULP error tolerance.
 


### PR DESCRIPTION
Add wording clarifying the current CTS behaviour permitting arithmetic operations
to overflow to infinity within ULP threshold error of a finite reference.

Motivated by CTS PR https://github.com/KhronosGroup/OpenCL-CTS/pull/600