### PR TITLE
add travis continuous integration for spec builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,29 +18,4 @@ before_install:
 
 script:
   - git describe --tags --dirty
-  # This produces an error because travis-ci works with a "detached head".
-  #- git symbolic-ref --short HEAD
   - make api c env ext
-
-#after_success:
-#  - cd out
-#  - git init
-#  - git config user.name "${GH_USER_NAME}"
-#  - git config user.email "${GH_USER_EMAIL}"
-#  - git add html pdf ; git commit -m "Deploy to Github Pages"
-#  - git push -f "https://${GH_TOKEN}@${GH_REF}" master:gh-pages
-
-after_success:
-  - mkdir deploy
-  - cp -R out/html out/pdf deploy
-
-deploy:
-  verbose: true
-  provider: pages
-  local_dir: deploy
-  skip_cleanup: true
-  github_token: $GH_TOKEN
-  #keep_history: true
-  on:
-    #branch: master
-    branch: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 before_install:
   - sudo apt-get install -y libpango1.0-dev ghostscript
   - gem install asciidoctor -v 1.5.8
-  - gem install coderay json-schema
+  - gem install coderay -v 1.1.1
   - gem install ttfunk -v 1.5.1
   - gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
   - MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+dist: xenial
+
+language: ruby
+
+git:
+  depth: 200
+
+rvm:
+  - 2.3.3
+
+before_install:
+  - sudo apt-get install -y libpango1.0-dev ghostscript
+  - gem install asciidoctor -v 1.5.8
+  - gem install coderay json-schema
+  - gem install ttfunk -v 1.5.1
+  - gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+  - MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
+
+script:
+  - git describe --tags --dirty
+  # This produces an error because travis-ci works with a "detached head".
+  #- git symbolic-ref --short HEAD
+  - make api c env ext
+
+#after_success:
+#  - cd out
+#  - git init
+#  - git config user.name "${GH_USER_NAME}"
+#  - git config user.email "${GH_USER_EMAIL}"
+#  - git add html pdf ; git commit -m "Deploy to Github Pages"
+#  - git push -f "https://${GH_TOKEN}@${GH_REF}" master:gh-pages
+
+after_success:
+  - mkdir deploy
+  - cp -R out/html out/pdf deploy
+
+deploy:
+  verbose: true
+  provider: pages
+  local_dir: deploy
+  skip_cleanup: true
+  github_token: $GH_TOKEN
+  #keep_history: true
+  on:
+    #branch: master
+    branch: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - gem install asciidoctor -v 1.5.8
   - gem install coderay -v 1.1.1
   - gem install ttfunk -v 1.5.1
-  - gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+  - gem install asciidoctor-pdf -v 1.5.0
   - MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
 
 script:

--- a/README.adoc
+++ b/README.adoc
@@ -256,7 +256,7 @@ parts you don't use) completely before trying to install.
   * Asciidoctor (asciidoctor, version: 1.5.8)
   * Coderay (coderay, version: 1.1.1)
   * ttfunk (ttfunk, version: 1.5.1)
-  * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0.beta.8)
+  * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0)
   * Asciidoctor Mathematical (asciidoctor-mathematical, version 0.2.2)
   * https://github.com/asciidoctor/asciidoctor-mathematical#dependencies[Dependencies
     for asciidoctor-mathematical] (There are a lot of these!)
@@ -422,7 +422,7 @@ echo "2.3.3" > ~/.rbenv/version
 gem install asciidoctor -v 1.5.8
 gem install coderay -v 1.1.1
 gem install ttfunk -v 1.5.1
-gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+gem install asciidoctor-pdf -v 1.5.0
 MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
 ----
 
@@ -634,7 +634,7 @@ gem install coderay -v 1.1.1
 gem install ttfunk -v 1.5.1
 
 # Required only for pdf builds
-gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+gem install asciidoctor-pdf -v 1.5.0
 MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
 ----
 
@@ -661,7 +661,7 @@ by Khronos.
 [[history]]
 == Revision History
 
-  * 2020-02-28 - Updated package versions to match Travis build.
+  * 2020-03-13 - Updated package versions to match Travis build.
   * 2019-06-20 - Add directions for publishing OpenCL 2.2 reference pages,
     generated from the spec sources in this repository, in the
     OpenCL-Registry repository.

--- a/README.adoc
+++ b/README.adoc
@@ -420,7 +420,7 @@ echo "2.3.3" > ~/.rbenv/version
 # The same RUBY_CONFIGURE_OPTS advice above may apply here as well.
 
 gem install asciidoctor -v 1.5.8
-gem install coderay json-schema
+gem install coderay -v 1.1.1
 gem install ttfunk -v 1.5.1
 gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
 MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
@@ -630,7 +630,7 @@ command, once the platform is set up:
 
 ----
 gem install asciidoctor -v 1.5.8
-gem install coderay json-schema
+gem install coderay -v 1.1.1
 gem install ttfunk -v 1.5.1
 
 # Required only for pdf builds

--- a/README.adoc
+++ b/README.adoc
@@ -253,14 +253,15 @@ environment managers below.
 Please read the remainder of this document (other than platform-specific
 parts you don't use) completely before trying to install.
 
-  * Asciidoctor (asciidoctor, version: 1.5.5)
-  * Coderay (coderay, version 1.1.1)
-  * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0.alpha15)
+  * Asciidoctor (asciidoctor, version: 1.5.8)
+  * Coderay (coderay, version: 1.1.1)
+  * ttfunk (ttfunk, version: 1.5.1)
+  * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0.beta.8)
   * Asciidoctor Mathematical (asciidoctor-mathematical, version 0.2.2)
   * https://github.com/asciidoctor/asciidoctor-mathematical#dependencies[Dependencies
     for asciidoctor-mathematical] (There are a lot of these!)
   * KaTeX distribution (version 0.7.0 from https://github.com/Khan/KaTeX .
-    This is cached under `doc/specs/vulkan/katex/`, and need not be
+    This is cached under `katex/`, and need not be
     installed from github.
 
 Only the `asciidoctor` and `coderay` gems are needed if you don't intend to
@@ -418,9 +419,11 @@ echo "2.3.3" > ~/.rbenv/version
 # asciidoctor-mathematical also takes in excess of 20 min. to build!
 # The same RUBY_CONFIGURE_OPTS advice above may apply here as well.
 
-gem install asciidoctor coderay json-schema
-gem install --pre asciidoctor-pdf
-MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical
+gem install asciidoctor -v 1.5.8
+gem install coderay json-schema
+gem install ttfunk -v 1.5.1
+gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
 ----
 
 
@@ -626,11 +629,13 @@ The following ruby gems can be installed directly via the `gem install`
 command, once the platform is set up:
 
 ----
-gem install rake asciidoctor coderay json-schema
+gem install asciidoctor -v 1.5.8
+gem install coderay json-schema
+gem install ttfunk -v 1.5.1
 
 # Required only for pdf builds
-MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical
-gem install --pre asciidoctor-pdf
+gem install asciidoctor-pdf -v 1.5.0.beta.8 --pre
+MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
 ----
 
 
@@ -656,6 +661,7 @@ by Khronos.
 [[history]]
 == Revision History
 
+  * 2020-02-28 - Updated package versions to match Travis build.
   * 2019-06-20 - Add directions for publishing OpenCL 2.2 reference pages,
     generated from the spec sources in this repository, in the
     OpenCL-Registry repository.


### PR DESCRIPTION
This change adds Travis continuous integration to verify that the specs build correctly and updates the README to reflect the package versions used by the Travis build.  This change does NOT add automatic deployment of the built specs, but this could be added at a later date.