### PR TITLE
add provisional async copy extensions

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -38,8 +38,6 @@ include::copyrights.txt[]
 
 include::ext/introduction.asciidoc[]
 
-// These are OpenCL 1.0 extensions:
-
 include::ext/cl_khr_icd.asciidoc[]
 include::ext/cl_khr_byte_addressable_store.asciidoc[]
 include::ext/cl_khr_3d_image_writes.asciidoc[]
@@ -51,12 +49,8 @@ include::ext/cl_khr_select_fprounding_mode.asciidoc[]
 include::ext/cl_khr_gl_sharing__context.asciidoc[]
 include::ext/cl_khr_gl_sharing__memobjs.asciidoc[]
 
-// These are OpenCL 1.1 extensions:
-
 include::ext/cl_khr_gl_event.asciidoc[]
 include::ext/cl_khr_d3d10_sharing.asciidoc[]
-
-// These are OpenCL 1.2 extensions:
 
 include::ext/cl_khr_d3d11_sharing.asciidoc[]
 include::ext/cl_khr_dx9_media_sharing.asciidoc[]
@@ -72,21 +66,18 @@ include::ext/cl_khr_spir.asciidoc[]
 include::ext/cl_khr_il_program.asciidoc[]
 include::ext/cl_khr_create_command_queue.asciidoc[]
 
-// These are OpenCL 2.0 extensions:
-
 include::ext/cl_khr_device_enqueue_local_arg_types.asciidoc[]
 include::ext/cl_khr_subgroups.asciidoc[]
 include::ext/cl_khr_mipmap_image.asciidoc[]
 include::ext/cl_khr_srgb_image_writes.asciidoc[]
 
-// These are OpenCL 2.1 extensions:
-
 include::ext/cl_khr_priority_hints.asciidoc[]
 include::ext/cl_khr_throttle_hints.asciidoc[]
 
-// These are OpenCL 2.2 extensions:
-
 include::ext/cl_khr_subgroup_named_barrier.asciidoc[]
+
+include::ext/cl_khr_extended_async_copies.asciidoc[]
+include::ext/cl_khr_async_work_group_copy_fence.asciidoc[]
 
 // NOTE: To keep meaningful section numbers, new
 // extension documents should be added above here!

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -1,0 +1,48 @@
+// Copyright 2017-2020 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_khr_async_work_group_copy_fence]]
+== Async Work Group Copy Fence (Provisional)
+
+This section describes the *cl_khr_async_work_group_copy_fence* provisional extension.
+The extension adds a new built-in function in OpenCL C supporting
+fence semantics allowing ordering of async-copy's.
+
+[[cl_khr_async_work_group_copy_fence-additions-to-chapter-6-of-the-opencl-specification]]
+=== Additions to Chapter 6 of the OpenCL C Specification
+
+The following new built-in function is added to the _Async Copies from Global to
+Local Memory, Local to Global Memory, and Prefetch_ described in _section 6.12.10_
+and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 "C" specification documents accordingaly.
+
+[cols="5a,4",options="header",]
+|=======================================================================
+|*Function* |*Description*
+|[source,c]
+----
+void async_work_group_copy_fence(cl_mem_fence_flags flags)
+----
+| Orders async copies produced by the work-items of a work-group executing
+a kernel. Async copies preceding the async_work_group_copy_fence must
+complete their access to the designated memory/memories,
+including both reads-from and writes-to it, before async copies
+following the fence are allowed to start accessing these memories.
+In other words, every async copy preceding the async_work_group_copy_fence
+must happen-before every async copy following the fence, with respect to
+the designated memory/memories.
+
+The _flags_ argument specifies the memory address space and can be set to a
+combination of the following literal values:
+
+    CLK_LOCAL_MEM_FENCE
+    CLK_GLOBAL_MEM_FENCE
+
+The async fence is performed by all work-items in a work-group and this
+built-in function must therefore be encountered by all work-items in a
+work-group executing the kernel with the same argument values;
+otherwise the results are undefined. This rule applies to ND-ranges
+implemented with uniform and non-uniform work-groups.
+|=======================================================================
+
+NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -6,37 +6,37 @@
 == Async Work Group Copy Fence (Provisional)
 
 This section describes the *cl_khr_async_work_group_copy_fence* provisional extension.
-The extension adds a new built-in function in OpenCL C supporting
-fence semantics allowing ordering of async-copy's.
+The extension adds a new built-in function to OpenCL C to establish a memory synchronization ordering of asynchronous copies.
 
 [[cl_khr_async_work_group_copy_fence-additions-to-chapter-6-of-the-opencl-specification]]
 === Additions to Chapter 6 of the OpenCL C Specification
 
 The following new built-in function is added to the _Async Copies from Global to
-Local Memory, Local to Global Memory, and Prefetch_ described in _section 6.12.10_
-and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 "C" specification documents accordingaly.
+Local Memory, Local to Global Memory, and Prefetch_ functions described in _section 6.12.10_
+and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 C specifications:
 
-[cols="5a,4",options="header",]
+[cols="1a,1",options="header",]
 |=======================================================================
 |*Function* |*Description*
 |[source,c]
 ----
-void async_work_group_copy_fence(cl_mem_fence_flags flags)
+void async_work_group_copy_fence(
+    cl_mem_fence_flags flags)
 ----
 | Orders async copies produced by the work-items of a work-group executing
-a kernel. Async copies preceding the async_work_group_copy_fence must
-complete their access to the designated memory/memories,
+a kernel. Async copies preceding the *async_work_group_copy_fence* must
+complete their access to the designated memory or memories,
 including both reads-from and writes-to it, before async copies
 following the fence are allowed to start accessing these memories.
-In other words, every async copy preceding the async_work_group_copy_fence
+In other words, every async copy preceding the *async_work_group_copy_fence*
 must happen-before every async copy following the fence, with respect to
-the designated memory/memories.
+the designated memory or memories.
 
 The _flags_ argument specifies the memory address space and can be set to a
 combination of the following literal values:
 
-    CLK_LOCAL_MEM_FENCE
-    CLK_GLOBAL_MEM_FENCE
+`CLK_LOCAL_MEM_FENCE` +
+`CLK_GLOBAL_MEM_FENCE`
 
 The async fence is performed by all work-items in a work-group and this
 built-in function must therefore be encountered by all work-items in a

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -1,0 +1,153 @@
+// Copyright 2017-2020 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_khr_extended_async_copies]]
+== Extended Async Copies (Provisional)
+
+This section describes the *cl_khr_extended_async_copies* provisional extension.
+This extension augments existing built-in async copy functions in OpenCL C
+    language with four new functions to cover more patterns:
+    1. for async copy between 2D source and 2D destination.
+    2. for async copy between 3D source and 3D destination.
+
+[[cl_khr_extended_async_copies-additions-to-chapter-6-of-the-opencl-specification]]
+=== Additions to Chapter 6 of the OpenCL C Specification
+
+The following new built-in functions are added to the _Async Copies from Global to
+Local Memory, Local to Global Memory, and Prefetch_ described in _section 6.12.10_
+and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 "C" specification documents accordingaly.
+
+[cols="5a,4",options="header",]
+|=======================================================================
+|*Function* |*Description*
+|[source,c]
+----
+event_t async_work_group_copy_2D2D(
+                 __local gentype *dst,
+          const __global gentype *src,
+        size_t  num_elements_per_line,
+                    size_t  num_lines,
+                   size_t  src_stride,
+                   size_t  dst_stride,
+                       event_t  event)
+
+event_t async_work_group_copy_2D2D(
+                __global gentype *dst,
+           const __local gentype *src,
+        size_t  num_elements_per_line,
+                    size_t  num_lines,
+                   size_t  src_stride,
+                   size_t  dst_stride,
+                       event_t  event)
+----
+| Perform an async copy of _num_lines_ lines from _src_ to _dst_.  Each line
+      contains _num_elements_per_line_ gentype elements.  After each line of
+      transfer, _src_ address is incremented by
+      (_src_stride_ + _num_elements_per_line_) gentype elements,
+      _dst_ address is incremented by
+      (_dst_stride_ + _num_elements_per_line_) gentype elements
+      for the next line of transfer.
+
+    For these functions, the stride describes the number of elements between
+    the *end* of the current line and the *beginning* of the next line, i.e.,
+    without overlap.
+    Note that async_work_group_strided_copy() is a special case of
+    async_work_group_copy_2D2D – namely, one which copies a single column to a
+    single line or vice versa:
+      async_work_group_strided_copy(dst, src, num_gentypes, src_stride) ==
+    async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1) or
+    async_work_group_copy_2D2D(dst, src, 1, num_gentypes, 1, dst_stride-1)
+    if src is global or dst is global, respectively.
+
+      gentype is defined the same as the one in the
+      *Async Copies from Global to Local Memory, Local to Global Memory,
+            and Prefetch* section, in OpenCL 1.2 and OpenCL 2.0 C Specifications.
+
+      The async copy is performed by all work-items in a work-group and this
+      built-in function must therefore be encountered by all work-items in a
+      work-group executing the kernel with the same argument values;
+      otherwise the results are undefined.
+
+      Returns an event object that can be used by wait_group_events to wait
+      for the async copy to finish.  The event argument can also be used to
+      associate the _async_work_group_copy_2D2D_ with a previous async copy
+      allowing an event to be shared by multiple async copies;
+      otherwise event should be zero.
+
+      If event argument is non-zero, the event object supplied in event
+      argument will be returned.
+
+      This function does not perform any implicit synchronization of source
+      data such as using a barrier before performing the copy.
+
+      The behavior of _async_work_group_copy_2D2D_ is undefined if the
+      _num_elements_per_line_ or _src_stride_ or _dst_stride_ values cause
+      the _src_ or _dst_ addresses to exceed the upper bounds of the address
+      space during the copy.
+
+|[source,c]
+----
+event_t async_work_group_copy_3D3D(
+                   __local gentype *dst,
+            const __global gentype *src,
+          size_t  num_elements_per_line,
+                      size_t  num_lines,
+                size_t  src_line_stride,
+                size_t  dst_line_stride,
+                     size_t  num_planes,
+               size_t  src_plane_stride,
+               size_t  dst_plane_stride,
+                         event_t  event)
+
+event_t async_work_group_copy_3D3D(
+                  __global gentype *dst,
+             const __local gentype *src,
+          size_t  num_elements_per_line,
+                      size_t  num_lines,
+                size_t  src_line_stride,
+                size_t  dst_line_stride,
+                     size_t  num_planes,
+               size_t  src_plane_stride,
+               size_t  dst_plane_stride,
+                         event_t  event)
+----
+| Perform an async copy of _num_planes_ X _num_lines_ lines from _src_ to
+      _dst_ arranged in _num_planes_ planes.  Each plane contains _num_lines_
+      lines.  Each line contains _num_elements_per_line_ gentype elements.
+      After each line of transfer, _src_ address is incremented by
+      (_src_line_stride_ + _num_elements_per_line_) gentype elements, _dst_
+      address is incremented by (_dst_line_stride_ + _num_elements_per_line_)
+      gentype elements for the next line of transfer.  For the last line of a
+      plane, an additional _src_plane_stride_ gentype elements is added to
+      _src_ address, and an additional _dst_plane_stride_ gentype elements is
+      added to _dst_ address.
+
+      gentype is defined the same as the one in the
+      *Async Copies from Global to Local Memory, Local to Global Memory,
+            and Prefetch* section, in OpenCL 1.2 and OpenCL 2.0 C Specifications.
+
+      The async copy is performed by all work-items in a work-group and this
+      built-in function must therefore be encountered by all work-items in a
+      work-group executing the kernel with the same argument values;
+      otherwise the results are undefined.
+
+      Returns an event object that can be used by wait_group_events to wait
+      for the async copy to finish.  The event argument can also be used to
+      associate the _async_work_group_copy_3D3D_ with a previous async copy
+      allowing an event to be shared by multiple async copies;
+      otherwise event should be zero.
+
+      If event argument is non-zero, the event object supplied in event
+      argument will be returned.
+
+      This function does not perform any implicit synchronization of source
+      data such as using a barrier before performing the copy.
+
+      The behavior of _async_work_group_copy_3D3D_ is undefined if any of
+      _num_elements_per_line_, _src_line_stride_, _dst_line_stride_,
+      _src_plane_stride_ or _dst_plane_stride_ values cause the _src_ or _dst_
+      addresses to exceed the upper bounds of the address space during the copy.
+|=======================================================================
+
+NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -21,11 +21,10 @@ and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 C specifications.
 
 Note that *async_work_group_strided_copy* is a special case of
 *async_work_group_copy_2D2D*, namely one which copies a single column to a
-single line or vice versa:
-
+single line or vice versa.
+For example: +
 `async_work_group_strided_copy(dst, src, num_gentypes, src_stride)` is equal to +
-`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1)` or +
-`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, 1, dst_stride-1)`
+`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1)`
 
 These new built-in functions support the same `gentype` generic type names as
 the standard asynchronous copy functions unless otherwise stated.

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -6,148 +6,146 @@
 == Extended Async Copies (Provisional)
 
 This section describes the *cl_khr_extended_async_copies* provisional extension.
-This extension augments existing built-in async copy functions in OpenCL C
-    language with four new functions to cover more patterns:
-    1. for async copy between 2D source and 2D destination.
-    2. for async copy between 3D source and 3D destination.
+This extension augments built-in asynchronous copy functions to OpenCL C
+to support more patterns:
+
+1. for async copy between 2D source and 2D destination.
+2. for async copy between 3D source and 3D destination.
 
 [[cl_khr_extended_async_copies-additions-to-chapter-6-of-the-opencl-specification]]
 === Additions to Chapter 6 of the OpenCL C Specification
 
 The following new built-in functions are added to the _Async Copies from Global to
-Local Memory, Local to Global Memory, and Prefetch_ described in _section 6.12.10_
-and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 "C" specification documents accordingaly.
+Local Memory, Local to Global Memory, and Prefetch_ functions described in _section 6.12.10_
+and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 C specifications.
 
-[cols="5a,4",options="header",]
+Note that *async_work_group_strided_copy* is a special case of
+*async_work_group_copy_2D2D*, namely one which copies a single column to a
+single line or vice versa:
+
+`async_work_group_strided_copy(dst, src, num_gentypes, src_stride)` is equal to +
+`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1)` or +
+`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, 1, dst_stride-1)`
+
+These new built-in functions support the same `gentype` generic type names as
+the standard asynchronous copy functions unless otherwise stated.
+
+[cols="1a,1",options="header",]
 |=======================================================================
 |*Function* |*Description*
 |[source,c]
 ----
 event_t async_work_group_copy_2D2D(
-                 __local gentype *dst,
-          const __global gentype *src,
-        size_t  num_elements_per_line,
-                    size_t  num_lines,
-                   size_t  src_stride,
-                   size_t  dst_stride,
-                       event_t  event)
+    __local gentype *dst,
+    const __global gentype *src,
+    size_t num_elements_per_line,
+    size_t num_lines,
+    size_t src_stride,
+    size_t dst_stride,
+    event_t event)
 
 event_t async_work_group_copy_2D2D(
-                __global gentype *dst,
-           const __local gentype *src,
-        size_t  num_elements_per_line,
-                    size_t  num_lines,
-                   size_t  src_stride,
-                   size_t  dst_stride,
-                       event_t  event)
+    __global gentype *dst,
+    const __local gentype *src,
+    size_t num_elements_per_line,
+    size_t num_lines,
+    size_t src_stride,
+    size_t dst_stride,
+    event_t event)
 ----
-| Perform an async copy of _num_lines_ lines from _src_ to _dst_.  Each line
-      contains _num_elements_per_line_ gentype elements.  After each line of
-      transfer, _src_ address is incremented by
-      (_src_stride_ + _num_elements_per_line_) gentype elements,
-      _dst_ address is incremented by
-      (_dst_stride_ + _num_elements_per_line_) gentype elements
-      for the next line of transfer.
+| Perform an asynchronous copy of _num_lines_ lines from _src_ to _dst_.  Each line
+contains _num_elements_per_line_ `gentype` elements.  After each line of
+transfer, _src_ address is incremented by
+(_src_stride_ + _num_elements_per_line_) `gentype` elements,
+_dst_ address is incremented by
+(_dst_stride_ + _num_elements_per_line_) `gentype` elements
+for the next line of transfer.
 
-    For these functions, the stride describes the number of elements between
-    the *end* of the current line and the *beginning* of the next line, i.e.,
-    without overlap.
-    Note that async_work_group_strided_copy() is a special case of
-    async_work_group_copy_2D2D – namely, one which copies a single column to a
-    single line or vice versa:
-      async_work_group_strided_copy(dst, src, num_gentypes, src_stride) ==
-    async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1) or
-    async_work_group_copy_2D2D(dst, src, 1, num_gentypes, 1, dst_stride-1)
-    if src is global or dst is global, respectively.
+For these functions, the stride describes the number of elements between
+the *end* of the current line and the *beginning* of the next line, i.e.,
+without overlap.
 
-      gentype is defined the same as the one in the
-      *Async Copies from Global to Local Memory, Local to Global Memory,
-            and Prefetch* section, in OpenCL 1.2 and OpenCL 2.0 C Specifications.
+Returns an event object that can be used by *wait_group_events* to wait
+for the async copy to finish.  The _event_ argument can also be used to
+associate the *async_work_group_copy_2D2D* with a previous async copy
+allowing an event to be shared by multiple async copies;
+otherwise _event_ should be zero.
 
-      The async copy is performed by all work-items in a work-group and this
-      built-in function must therefore be encountered by all work-items in a
-      work-group executing the kernel with the same argument values;
-      otherwise the results are undefined.
+If _event_ argument is non-zero, the event object supplied in _event_
+argument will be returned.
 
-      Returns an event object that can be used by wait_group_events to wait
-      for the async copy to finish.  The event argument can also be used to
-      associate the _async_work_group_copy_2D2D_ with a previous async copy
-      allowing an event to be shared by multiple async copies;
-      otherwise event should be zero.
+This function does not perform any implicit synchronization of source
+data such as using a *barrier* before performing the copy.
 
-      If event argument is non-zero, the event object supplied in event
-      argument will be returned.
+The behavior of *async_work_group_copy_2D2D* is undefined if the
+_num_elements_per_line_ or _src_stride_ or _dst_stride_ values cause
+the _src_ or _dst_ addresses to exceed the upper bounds of the address
+space during the copy.
 
-      This function does not perform any implicit synchronization of source
-      data such as using a barrier before performing the copy.
-
-      The behavior of _async_work_group_copy_2D2D_ is undefined if the
-      _num_elements_per_line_ or _src_stride_ or _dst_stride_ values cause
-      the _src_ or _dst_ addresses to exceed the upper bounds of the address
-      space during the copy.
+The async copy is performed by all work-items in a work-group and this
+built-in function must therefore be encountered by all work-items in a
+work-group executing the kernel with the same argument values;
+otherwise the results are undefined.
 
 |[source,c]
 ----
 event_t async_work_group_copy_3D3D(
-                   __local gentype *dst,
-            const __global gentype *src,
-          size_t  num_elements_per_line,
-                      size_t  num_lines,
-                size_t  src_line_stride,
-                size_t  dst_line_stride,
-                     size_t  num_planes,
-               size_t  src_plane_stride,
-               size_t  dst_plane_stride,
-                         event_t  event)
+    __local gentype *dst,
+    const __global gentype *src,
+    size_t num_elements_per_line,
+    size_t num_lines,
+    size_t src_line_stride,
+    size_t dst_line_stride,
+    size_t num_planes,
+    size_t src_plane_stride,
+    size_t dst_plane_stride,
+    event_t event)
 
 event_t async_work_group_copy_3D3D(
-                  __global gentype *dst,
-             const __local gentype *src,
-          size_t  num_elements_per_line,
-                      size_t  num_lines,
-                size_t  src_line_stride,
-                size_t  dst_line_stride,
-                     size_t  num_planes,
-               size_t  src_plane_stride,
-               size_t  dst_plane_stride,
-                         event_t  event)
+    __global gentype *dst,
+    const __local gentype *src,
+    size_t num_elements_per_line,
+    size_t num_lines,
+    size_t src_line_stride,
+    size_t dst_line_stride,
+    size_t num_planes,
+    size_t src_plane_stride,
+    size_t dst_plane_stride,
+    event_t event)
 ----
-| Perform an async copy of _num_planes_ X _num_lines_ lines from _src_ to
-      _dst_ arranged in _num_planes_ planes.  Each plane contains _num_lines_
-      lines.  Each line contains _num_elements_per_line_ gentype elements.
-      After each line of transfer, _src_ address is incremented by
-      (_src_line_stride_ + _num_elements_per_line_) gentype elements, _dst_
-      address is incremented by (_dst_line_stride_ + _num_elements_per_line_)
-      gentype elements for the next line of transfer.  For the last line of a
-      plane, an additional _src_plane_stride_ gentype elements is added to
-      _src_ address, and an additional _dst_plane_stride_ gentype elements is
-      added to _dst_ address.
+| Perform an async copy of _num_planes_ times _num_lines_ lines from _src_ to
+_dst_ arranged in _num_planes_ planes.  Each plane contains _num_lines_
+lines.  Each line contains _num_elements_per_line_ `gentype` elements.
+After each line of transfer, _src_ address is incremented by
+(_src_line_stride_ + _num_elements_per_line_) `gentype` elements, _dst_
+address is incremented by (_dst_line_stride_ + _num_elements_per_line_)
+`gentype` elements for the next line of transfer.  For the last line of a
+plane, an additional _src_plane_stride_ `gentype` elements is added to
+_src_ address, and an additional _dst_plane_stride_ `gentype` elements is
+added to _dst_ address.
 
-      gentype is defined the same as the one in the
-      *Async Copies from Global to Local Memory, Local to Global Memory,
-            and Prefetch* section, in OpenCL 1.2 and OpenCL 2.0 C Specifications.
+Returns an event object that can be used by *wait_group_events* to wait
+for the async copy to finish.  The _event_ argument can also be used to
+associate the *async_work_group_copy_3D3D* with a previous async copy
+allowing an event to be shared by multiple async copies;
+otherwise _event_ should be zero.
 
-      The async copy is performed by all work-items in a work-group and this
-      built-in function must therefore be encountered by all work-items in a
-      work-group executing the kernel with the same argument values;
-      otherwise the results are undefined.
+If _event_ argument is non-zero, the event object supplied in _event_
+argument will be returned.
 
-      Returns an event object that can be used by wait_group_events to wait
-      for the async copy to finish.  The event argument can also be used to
-      associate the _async_work_group_copy_3D3D_ with a previous async copy
-      allowing an event to be shared by multiple async copies;
-      otherwise event should be zero.
+This function does not perform any implicit synchronization of source
+data such as using a *barrier* before performing the copy.
 
-      If event argument is non-zero, the event object supplied in event
-      argument will be returned.
+The behavior of *async_work_group_copy_3D3D* is undefined if any of
+_num_elements_per_line_, _src_line_stride_, _dst_line_stride_,
+_src_plane_stride_ or _dst_plane_stride_ values cause the _src_ or _dst_
+addresses to exceed the upper bounds of the address space during the copy.
 
-      This function does not perform any implicit synchronization of source
-      data such as using a barrier before performing the copy.
+The async copy is performed by all work-items in a work-group and this
+built-in function must therefore be encountered by all work-items in a
+work-group executing the kernel with the same argument values;
+otherwise the results are undefined.
 
-      The behavior of _async_work_group_copy_3D3D_ is undefined if any of
-      _num_elements_per_line_, _src_line_stride_, _dst_line_stride_,
-      _src_plane_stride_ or _dst_plane_stride_ values cause the _src_ or _dst_
-      addresses to exceed the upper bounds of the address space during the copy.
 |=======================================================================
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -17,6 +17,10 @@
 | Write to 3D images
 | Core Feature in OpenCL 2.0
 
+| <<cl_khr_async_work_group_copy_fence,cl_khr_async_work_group_copy_fence>>
+| Asynchronous Copy Fences
+| Provisional Extension
+
 | <<cl_khr_byte_addressable_store,cl_khr_byte_addressable_store>>
 | Read and write from 8-bit and 16-bit pointers
 | Core Feature in OpenCL 1.1
@@ -52,6 +56,10 @@
 | <<cl_khr_egl_image,cl_khr_egl_image>>
 | Share EGL Images with OpenCL
 | Extension
+
+| <<cl_khr_extended_async_copies,cl_khr_extended_async_copies>>
+| 2D and 3D Async Copies
+| Provisional Extension
 
 | <<cl_khr_fp16,cl_khr_fp16>>
 | Operations on 16-bit Floating-Point Values


### PR DESCRIPTION
This pull request adds two provisional extensions that add functionality and may improve the performance of devices that support asynchronous copies in device kernels:

* `cl_khr_extended_async_copies` extends the existing async copy built-in functions by adding the ability to copy from one 2D region to another 2D region, or from one 3D volume to another 3D volume.

* `cl_khr_async_work_group_copy_fence` adds a new built-in function to order multiple async copies.

Both extensions are provisional extension specifications that have been Ratified under the Khronos Intellectual Property Framework.  They are being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback, please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/ (this repo).  Thanks!