### PR TITLE
Experimental enum for Khronos vendor ID

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4269,6 +4269,10 @@ server's OpenCL/api-docs repository.
     </feature>
 
     <feature api="opencl" name="CL_EXPERIMENTAL" number="2.2" comment="OpenCL experimental API interface definitions">
+        <require>
+            <type name="cl_device_atomic_capabilities"/>
+            <type name="cl_khronos_vendor_id"/>
+        </require>
         <require comment="cl_device_atomic_capabilities - bitfield">
             <enum name="CL_DEVICE_ATOMIC_ORDER_RELAXED"/>
             <enum name="CL_DEVICE_ATOMIC_ORDER_ACQ_REL"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -206,6 +206,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_migration_flags_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_advice_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_atomic_capabilities</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_khronos_vendor_id</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">


### PR DESCRIPTION
Represents a non-PCIe address `CL_DEVICE_VENDOR_ID` with the Khronos vendor IDs