### PR TITLE
Fix typo that was preventing some refpage redirects from being generated

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5240,7 +5240,7 @@ interpretations of the bit pattern of _c_.
 [[vector-data-load-and-store-functions]]
 === Vector Data Load and Store Functions
 
-[open,refpage='vectorDataLoadandStoreFunctions',desc='Vector Data Load and Store Functions',type='freeform',spec='clang',anchor='vector-data-load-and-store-functions',xrefs='',alias='vloan,vload_half,vload_halfn,vloada_halfn,vstoren,vstore_half,vstore_halfn,vstorea_halfn']
+[open,refpage='vectorDataLoadandStoreFunctions',desc='Vector Data Load and Store Functions',type='freeform',spec='clang',anchor='vector-data-load-and-store-functions',xrefs='',alias='vloadn vload_half vload_halfn vloada_halfn vstoren vstore_half vstore_halfn vstorea_halfn']
 --
 
 The following table describes the list of supported functions that allow you


### PR DESCRIPTION
Addresses additional cases in #246 (which didn't need any "fixing"
beyond generating an updated refpage set in OpenCL-Registry, AFAICT).

This is purely a markup change to enable refpage generation. @bashbaug please accept ASAP. Also, there should probably be a process step added somewhere to ensure that the OpenCL-Registry refpage section, which is generated from this repo, gets updated when substantive changes to the C or API specs are made.