### PR TITLE
Remove Duplicated cl_sampler_properties

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1290,8 +1290,11 @@ server's OpenCL/api-docs repository.
         <enum value="0x1153"        name="CL_SAMPLER_ADDRESSING_MODE"/>
         <enum value="0x1154"        name="CL_SAMPLER_FILTER_MODE"/>
         <enum value="0x1155"        name="CL_SAMPLER_MIP_FILTER_MODE"/>
+        <enum value="0x1155"        name="CL_SAMPLER_MIP_FILTER_MODE_KHR"/>
         <enum value="0x1156"        name="CL_SAMPLER_LOD_MIN"/>
+        <enum value="0x1156"        name="CL_SAMPLER_LOD_MIN_KHR"/>
         <enum value="0x1157"        name="CL_SAMPLER_LOD_MAX"/>
+        <enum value="0x1157"        name="CL_SAMPLER_LOD_MAX_KHR"/>
         <enum value="0x1158"        name="CL_SAMPLER_PROPERTIES"/>
             <unused start="0x1159" end="0x115F" comment="Reserved for cl_sampler_info"/>
         <enum value="0x1160"        name="CL_PROGRAM_REFERENCE_COUNT"/>
@@ -4839,9 +4842,9 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
             </require>
             <require comment="cl_sampler_properties">
-                <enum name="CL_SAMPLER_MIP_FILTER_MODE"/>
-                <enum name="CL_SAMPLER_LOD_MIN"/>
-                <enum name="CL_SAMPLER_LOD_MAX"/>
+                <enum name="CL_SAMPLER_MIP_FILTER_MODE_KHR"/>
+                <enum name="CL_SAMPLER_LOD_MIN_KHR"/>
+                <enum name="CL_SAMPLER_LOD_MAX_KHR"/>
             </require>
         </extension>
         <extension name="cl_img_use_gralloc_ptr" supported="opencl">


### PR DESCRIPTION
Remove the `cl_sampler_properties` `CL_SAMPLER_MIP_FILTER_MODE`,
`CL_SAMPLER_LOD_MIN` and `CL_SAMPLER_LOD_MAX` which are duplicated
under `CL_VERSION_2_0` when they should only be required under
the `ck_khr_mipmap_image` extension.