### PR TITLE
Fix vector literal example rendering

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -562,12 +562,11 @@ replicated across all lanes of the vector.
 Examples:
 
 [source,c]
-[subs="verbatim,quotes,macros"]
+[subs="verbatim,quotes"]
 ----------
 float4 f = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
 uint4 u = (uint4)(1); //  u will be (1, 1, 1, 1).
-float4 f = (float4)((float2)(1.0f, 2.0f),
-(float2)(3.0f, 4.0f));
+float4 f = (float4)((float2)(1.0f, 2.0f), (float2)(3.0f, 4.0f));
 float4 f = (float4)(1.0f, (float2)(2.0f, 3.0f), 4.0f);
 float4 f = (float4)(1.0f, 2.0f); //  error
 ----------


### PR DESCRIPTION
Disable AsciiDoc's macro expansion.  It is not needed for this
example, and actually causes a problem due to `((` and `))` being
interpreted.