### PR TITLE
[C++ for OpenCL] Document further deviation from OpenCL C

### DIFF
--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -16,7 +16,7 @@ but simply provide extra functionality.
 {cpp} for OpenCL is a different language derived from {cpp} and
 therefore it inherits {cpp}'s fundamental design principles. Hence
 {cpp} for OpenCL deviates from OpenCL C in the same areas where
-{cpp} deviates from C. The main reasons for that is to provide a
+{cpp} deviates from C. This results in a
 more helpful language to the developers or compilation tools.
 
 ====== Implicit Conversions

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -7,7 +7,7 @@
 {cpp} for OpenCL provides backwards compatibility with OpenCL C
 for the majority of features. However, there are a number of
 exceptions that are described in this section. Some of them come
-from the nature of C++ but others are due to improvements in OpenCL
+from the nature of {cpp} but others are due to improvements in OpenCL
 features. Most of such improvements do not invalidate old code,
 but simply provide extra functionality.
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -16,9 +16,9 @@ but simply provide extra functionality.
 {cpp} for OpenCL is a different language derived from {cpp} and
 therefore it inherits {cpp}'s fundamental design principles. Hence
 {cpp} for OpenCL deviates from OpenCL C in the same areas where
-{cpp} deviates from C. This results in a
-more helpful language for developers and avoids substantially
-increasing complexity of compilation tools.
+{cpp} deviates from C. This results in a more helpful language for
+developers and facilitates improvements in compilation tools without
+substantially increasing their complexity.
 
 ====== Implicit Conversions
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -132,7 +132,8 @@ in OpenCL specific behavior.
 
 ===== Variadic macros
 
-{cpp} for OpenCL eliminates restriction on variadic macros from `OpenCL C v2.0 s6.9.e`.
+{cpp} for OpenCL eliminates the restriction on variadic macros from
+`OpenCL C v2.0 s6.9.e`.
 Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -20,7 +20,7 @@ from {cpp} inheriting {cpp}'s fundamental design principles. Hence
 developers and facilitates improvements in compilation tools without
 substantially increasing their complexity.
 
-====== Implicit Conversions
+====== Implicit conversions
 
 {cpp} is much stricter about conversions between types,
 especially those that are performed implicitly by the compiler.
@@ -66,7 +66,7 @@ void foo(){
 ----------
 
 [[null_literal]]
-===== Null Literal
+===== Null literal
 
 In C and OpenCL C the null literal is defined using other
 language features as it is not represented explicitly i.e.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -17,7 +17,8 @@ but simply provide extra functionality.
 therefore it inherits {cpp}'s fundamental design principles. Hence
 {cpp} for OpenCL deviates from OpenCL C in the same areas where
 {cpp} deviates from C. This results in a
-more helpful language to the developers or compilation tools.
+more helpful language for developers and avoids substantially
+increasing complexity of compilation tools.
 
 ====== Implicit Conversions
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -65,6 +65,7 @@ void foo(){
 }
 ----------
 
+[[null_literal]]
 ===== Null Literal
 
 In C and OpenCL C the null literal is defined using other
@@ -138,8 +139,9 @@ Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
 
-The predefined macros `__OPENCL_C_VERSION__` and `NULL`,
-described in `OpenCL C v2.0 s6.10`, are not supported.
+The predefined macros `__OPENCL_C_VERSION__` and `NULL` (see also
+<<null_literal, _Null literal_>>), described in `OpenCL C v2.0 s6.10`,
+are not supported.
 
 The following new predefined macros are added in {cpp} for OpenCL:
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -7,15 +7,16 @@
 {cpp} for OpenCL provides backwards compatibility with OpenCL C
 for the majority of features. However, there are a number of
 exceptions that are described in this section. Some of them come
-from the nature of C++ but others are due to improved behaviour
-of a kernel language.
+from the nature of C++ but others are due to improvements in OpenCL
+features. Most of such improvements do not invalidate old code,
+but simply provide extra functionality.
 
 ==== C++ related differences
 
 {cpp} for OpenCL is a different language derived from {cpp} and
-therefore it inherits its fundamental design principles. Hence
+therefore it inherits {cpp}'s fundamental design principles. Hence
 {cpp} for OpenCL deviates from OpenCL C in the same areas where
-{cpp} deviates from C. The main reasons for that is to provide
+{cpp} deviates from C. The main reasons for that is to provide a
 more helpful language to the developers or compilation tools.
 
 ====== Implicit Conversions
@@ -23,8 +24,7 @@ more helpful language to the developers or compilation tools.
 {cpp} is much stricter about conversions between types,
 especially those that are performed implicitly by the compiler.
 For example it is not possible to convert a `const` object
-to non-`const` implicitly. For details please refer to {cpp}17
-(`ISO/IEC 14882:2017`) `[conv]`.
+to non-`const` implicitly. For details please refer to {cpp}17 `[conv]`.
 
 [source,c]
 ----------
@@ -126,33 +126,34 @@ label:  // invalid: jumping forward over declaration of n
 
 ==== OpenCL specific difference
 
-This section described where {cpp} for OpenCL differs from OpenCL C
+This section describes where {cpp} for OpenCL differs from OpenCL C
 in OpenCL specific behavior.
 
 ===== Variadic macros
 
-{cpp} for OpenCL eliminates restriction on variadic macro from
-section 6.9.e of OpenCL C. Variadic macros can be used regularly
-as per {cpp}17 [cpp.replace].
+{cpp} for OpenCL eliminates restriction on variadic macros from `OpenCL C v2.0 s6.9.e`.
+Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
 
-Predefined version macro `__OPENCL_C_VERSION__` and `NULL` described
-in OpenCL C 2.0 section 6.10 are not supported.
+Predefined version macro `__OPENCL_C_VERSION__` and macro `NULL`,
+described in `OpenCL C v2.0 s6.10`, are not supported.
 
-There is a macro `__OPENCL_CPP_VERSION__` available that is set to
-value `100`. For convenience there is also `__CL_CPP_VERSION_1_0__`
-that is defined to the same value `100` and can be used instead of a
-literal.
+The following new predefined macros are added in {cpp} for OpenCL:
+
+ * `__OPENCL_CPP_VERSION__` set to value `100`.
+ * `__CL_CPP_VERSION_1_0__` also set to `100` and can be used for
+   convenience instead of a literal.
 
 ===== Atomic operations
 
-{cpp} for OpenCL relaxes restriction from OpenCL C 2.0 section 6.13.11 to
-atomic types by allowing to modify variables of such types using builtin
-operators, and not only using builtin function.
+{cpp} for OpenCL relaxes restriction from `OpenCL C v2.0 s6.13.11` to
+atomic types allowing them to be used by builtin operators, and not
+only by builtin functions.
 
 The behavior of operators on atomic types follows the logic from {cpp}17
-sections [atomics.types.int][atomics.types.pointer][atomics.types.float].
+sections `[atomics.types.int]` `[atomics.types.pointer]`
+`[atomics.types.float]`.
 
 [source,c]
 ----------
@@ -165,5 +166,5 @@ acnt++; // equivalent to atomic_fetch_add_explicit(&acnt, 1);
 Clang Blocks that are defined by the Objective-C language are not supported
 and their use can be replaced by lambdas ({cpp}17 `[expr.prim.lambda]`).
 
-This also implies that builtin functions using blocks, such as `enqueue_kernel`,
+The above implies that builtin functions using blocks, such as `enqueue_kernel`,
 are not supported in {cpp} for OpenCL.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -13,8 +13,8 @@ but simply provide extra functionality.
 
 ==== C++ related differences
 
-{cpp} for OpenCL is a different language derived from {cpp} and
-therefore it inherits {cpp}'s fundamental design principles. Hence
+{cpp} for OpenCL is a different language to OpenCL C and it is derived
+from {cpp} inheriting {cpp}'s fundamental design principles. Hence
 {cpp} for OpenCL deviates from OpenCL C in the same areas where
 {cpp} deviates from C. This results in a more helpful language for
 developers and facilitates improvements in compilation tools without

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -138,7 +138,7 @@ Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
 
-Predefined version macro `__OPENCL_C_VERSION__` and macro `NULL`,
+The predefined macros `__OPENCL_C_VERSION__` and `NULL`,
 described in `OpenCL C v2.0 s6.10`, are not supported.
 
 The following new predefined macros are added in {cpp} for OpenCL:

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -4,17 +4,21 @@
 
 === Difference to OpenCL C
 
-{cpp} for OpenCL aims to achieve backwards compatibility with OpenCL C
-for the majority of features. However, it is a different
-language that is derived from {cpp} and therefore it inherits
-its fundamental design principles. Hence {cpp} for OpenCL
-deviates from OpenCL C in the same areas where {cpp} deviates
-from C.
+{cpp} for OpenCL provides backwards compatibility with OpenCL C
+for the majority of features. However, there are a number of
+exceptions that are described in this section. Some of them come
+from the nature of C++ but others are due to improved behaviour
+of a kernel language.
 
-This section describes the main differences between {cpp} for
-OpenCL and OpenCL C.
+==== C++ related differences
 
-==== Implicit Conversions
+{cpp} for OpenCL is a different language derived from {cpp} and
+therefore it inherits its fundamental design principles. Hence
+{cpp} for OpenCL deviates from OpenCL C in the same areas where
+{cpp} deviates from C. The main reasons for that is to provide
+more helpful language to the developers or compilation tools.
+
+====== Implicit Conversions
 
 {cpp} is much stricter about conversions between types,
 especially those that are performed implicitly by the compiler.
@@ -60,7 +64,7 @@ void foo(){
 }
 ----------
 
-==== Null Literal
+===== Null Literal
 
 In C and OpenCL C the null literal is defined using other
 language features as it is not represented explicitly i.e.
@@ -89,7 +93,7 @@ void foo(){
 }
 ----------
 
-==== Use of restrict
+===== Use of restrict
 
 {cpp}17 does not support `restrict` and therefore {cpp} for OpenCL
 can not support it either. Some compilers might provide extensions
@@ -104,7 +108,7 @@ macro or mapping it to another similar compiler features, e.g.
 `__restrict` in Clang. This can be done in headers or using `-D`
 compilation flag.
 
-==== Limitations of goto statements
+===== Limitations of goto statements
 
 {cpp} is more restrictive with respect to entering the scope of
 variables than C. It is not possible to jump forward over a variable
@@ -120,10 +124,46 @@ label:  // invalid: jumping forward over declaration of n
    // ...
 ----------
 
-==== Use of Clang Blocks
+==== OpenCL specific difference
+
+This section described where {cpp} for OpenCL differs from OpenCL C
+in OpenCL specific behavior.
+
+===== Variadic macros
+
+{cpp} for OpenCL eliminates restriction on variadic macro from
+section 6.9.e of OpenCL C. Variadic macros can be used regularly
+as per {cpp}17 [cpp.replace].
+
+===== Predefined macros
+
+Predefined version macro `__OPENCL_C_VERSION__` and `NULL` described
+in OpenCL C 2.0 section 6.10 are not supported.
+
+There is a macro `__OPENCL_CPP_VERSION__` available that is set to
+value `100`. For convenience there is also `__CL_CPP_VERSION_1_0__`
+that is defined to the same value `100` and can be used instead of a
+literal.
+
+===== Atomic operations
+
+{cpp} for OpenCL relaxes restriction from OpenCL C 2.0 section 6.13.11 to
+atomic types by allowing to modify variables of such types using builtin
+operators, and not only using builtin function.
+
+The behavior of operators on atomic types follows the logic from {cpp}17
+sections [atomics.types.int][atomics.types.pointer][atomics.types.float].
+
+[source,c]
+----------
+atomic_int acnt;
+acnt++; // equivalent to atomic_fetch_add_explicit(&acnt, 1);
+----------
+
+===== Use of Clang Blocks
 
 Clang Blocks that are defined by the Objective-C language are not supported
 and their use can be replaced by lambdas ({cpp}17 `[expr.prim.lambda]`).
 
-This means that builtin functions using blocks, such as `enqueue_kernel`,
+This also implies that builtin functions using blocks, such as `enqueue_kernel`,
 are not supported in {cpp} for OpenCL.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -153,7 +153,7 @@ The following new predefined macros are added in {cpp} for OpenCL:
 atomic types allowing them to be used by builtin operators, and not
 only by builtin functions.
 
-The behavior of operators on atomic types follows the logic from {cpp}17
+Operators on atomic types behave as described in {cpp}17
 sections `[atomics.types.int]` `[atomics.types.pointer]`
 `[atomics.types.float]`.
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -160,7 +160,7 @@ sections `[atomics.types.int]` `[atomics.types.pointer]`
 [source,c]
 ----------
 atomic_int acnt;
-acnt++; // equivalent to atomic_fetch_add_explicit(&acnt, 1);
+acnt++; // equivalent to atomic_fetch_add(&acnt, 1);
 ----------
 
 ===== Use of Clang Blocks


### PR DESCRIPTION
Document difference in predefined macros, atomics and variadic macro.