### PR TITLE
API: Update clEnqueueNDRange description for OpenCL 1.0

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8061,6 +8061,7 @@ include::{generated}/api/version-notes/clEnqueueNDRangeKernel.asciidoc[]
     values that describe the offset used to calculate the global ID of a
     work-item.
     If _global_work_offset_ is `NULL`, the global IDs start at offset (0, 0, 0).
+    _global_work_offset_ must be `NULL` <<unified-spec, before>> version 1.1.
   * _global_work_size_ points to an array of _work_dim_ unsigned values that
     describe the number of global work-items in _work_dim_ dimensions that will
     execute the kernel function.
@@ -8184,7 +8185,8 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_GLOBAL_OFFSET} if the value specified in _global_work_size_
     {plus} the corresponding values in _global_work_offset_ for any
     dimensions is greater than the maximum value representable by size t on
-    the device on which the kernel-instance will be enqueued.
+    the device on which the kernel-instance will be enqueued, or if
+    _global_work_offset_ is non-`NULL` <<unified-spec, before>> version 1.1.
   * {CL_INVALID_WORK_GROUP_SIZE} if _local_work_size_ is specified and does
     not match the required work-group size for _kernel_ in the program
     source.


### PR DESCRIPTION
In OpenCL 1.0, `clEnqueueNDRange`’s `global_work_offset` had to be `NULL`. This information was missing from the unified API specification.