### PR TITLE
all built-in variables must be in the input storage class

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -384,3 +384,9 @@ API.
 
 Environments that support extensions or optional features may allow
 additional types in an entry point's parameter list.
+
+=== Built-in Variables
+
+An *OpVariable* in a SPIR-V module with the *BuiltIn* decoration represents
+a built-in variable.
+All built-in variables must be in the *Input* storage class.


### PR DESCRIPTION
Fixes #269.

This change documents in the OpenCL SPIR-V Environment Spec that all variables decorated with **BuiltIn** must be in the **Input** storage class.

There's probably a bit more we could say here - do specific built-in variables need to be specific types, for example? - but documenting that they must be in the input storage class is a good first step.