### PR TITLE
rename argument index parameter name for clGetKernelArgInfo

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7897,7 +7897,7 @@ include::{generated}/api/protos/clGetKernelArgInfo.txt[]
 include::{generated}/api/version-notes/clGetKernelArgInfo.asciidoc[]
 
   * _kernel_ specifies the kernel object being queried.
-  * _arg_indx_ is the argument index.
+  * _arg_index_ is the argument index.
     Arguments to the kernel are referred by indices that go from 0 for the
     leftmost argument to _n_ - 1, where _n_ is the total number of arguments
     declared by a kernel.
@@ -7931,7 +7931,7 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[]
   | cl_kernel_arg_address_qualifier
       | Returns the address qualifier specified for the argument given by
-        _arg_indx_.
+        _arg_index_.
         This can be one of the following values:
 
         {CL_KERNEL_ARG_ADDRESS_GLOBAL_anchor} +
@@ -7946,7 +7946,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
   | cl_kernel_arg_access_qualifier
       | Returns the access qualifier specified for the argument given by
-        _arg_indx_.
+        _arg_index_.
         This can be one of the following values:
 
         {CL_KERNEL_ARG_ACCESS_READ_ONLY_anchor} +
@@ -7963,7 +7963,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
   | char[]
       | Returns the type name specified for the argument given by
-        _arg_indx_.
+        _arg_index_.
         The type name returned will be the argument type name as it was
         declared with any whitespace removed.
         If argument type name is an unsigned scalar type (i.e. unsigned
@@ -7976,7 +7976,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
   | cl_kernel_arg_type_qualifier
       | Returns a bitfield describing one or more type qualifiers specified
-        for the argument given by _arg_indx_.
+        for the argument given by _arg_index_.
         The returned values can be:
         
         {CL_KERNEL_ARG_TYPE_CONST_anchor}^17^ +
@@ -7991,7 +7991,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
   | char[]
-      | Returns the name specified for the argument given by _arg_indx_.
+      | Returns the name specified for the argument given by _arg_index_.
 |====
 
 17::
@@ -8021,7 +8021,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_ARG_INDEX} if _arg_indx_ is not a valid argument index.
+  * {CL_INVALID_ARG_INDEX} if _arg_index_ is not a valid argument index.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_ size is < size of return type as described in
     the <<kernel-argument-info-table,Kernel Argument Queries>> table and

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2866,7 +2866,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_int</type>                                  <name>clGetKernelArgInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
-            <param><type>cl_uint</type>                                 <name>arg_indx</name></param>
+            <param><type>cl_uint</type>                                 <name>arg_index</name></param>
             <param><type>cl_kernel_arg_info</type>                      <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param><type>void</type>*                                   <name>param_value</name></param>


### PR DESCRIPTION
Fixes #222.

This is a very simple change that renames one of the arguments to `clGetKernelArgInfo` in both the specs and the XML file for consistency.  Instead of calling the argument `arg_indx`, it is renamed `arg_index`, similar to other related APIs.

(Edit: corrected the issue that this change fixes.)