### PR TITLE
rename parameter name for event callback for consistency

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8834,21 +8834,21 @@ include::{generated}/api/version-notes/clSetEventCallback.asciidoc[]
     is thread-safe.
     The parameters to this callback function are:
   ** _event_ is the event object for which the callback function is invoked.
-  ** _event_command_exec_status_ is equal to the _command_exec_callback_type_
+  ** _event_command_status_ is equal to the _command_exec_callback_type_
      used while registering the callback.
-     Refer to the <<kernel-argument-info-table,Kernel Argument Queries>>
+     Refer to the <<event-info-table,Event Object Queries>>
      table for the command execution status values.
      If the callback is called as the result of the command associated with
      event being abnormally terminated, an appropriate error code for the
      error that caused the termination will be passed to
-     _event_command_exec_status_ instead.
+     _event_command_status_ instead.
   ** _user_data_ is a pointer to user supplied data.
   * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
     called.
     _user_data_ can be `NULL`.
 
 21::
-    The callback function registered for a command_exec_callback_type value
+    The callback function registered for a _command_exec_callback_type_ value
     of {CL_COMPLETE} will be called when the command has completed
     successfully or is abnormally terminated.
 

--- a/ext/cl_khr_terminate_context.asciidoc
+++ b/ext/cl_khr_terminate_context.asciidoc
@@ -96,7 +96,7 @@ When a context is terminated:
   * The execution status of enqueued commands will be CL_TERMINATED_KHR.
     Event objects can be queried using *clGetEventInfo*.
     Event callbacks can be registered and registered event callbacks will be
-    called with _event_command_exec_status_ set to CL_TERMINATED_KHR.
+    called with _event_command_status_ set to CL_TERMINATED_KHR.
     *clWaitForEvents* will return as immediately for commands associated
     with event objects specified in event_list.
     The status of user events can be set.

--- a/man/static/clTerminateContextKHR.txt
+++ b/man/static/clTerminateContextKHR.txt
@@ -30,7 +30,7 @@ When a context is terminated:
     Event objects can be queried using
     flink:clGetEventInfo. Event callbacks can be
     registered and registered event callbacks will be called with
-    `event_command_exec_status` set to `CL_TERMINATED_KHR`.
+    `event_command_status` set to `CL_TERMINATED_KHR`.
     flink:clWaitForEvents will return as immediately
     for commands associated with event objects specified in `event_list`.
     The status of user events can be set. Event objects can be retained and
@@ -75,7 +75,7 @@ successfully. Otherwise, it returns one of the following errors:
   * `CL_INVALID_CONTEXT` if _context_ is not a valid OpenCL context.
   * `CL_CONTEXT_TERMINATED_KHR` if _context_ has already been terminated.
   * `CL_INVALID_OPERATION` if _context_ was not created with
-    `CL_CONTEXT_TERMNATE_KHR` set to `CL_TRUE`.
+    `CL_CONTEXT_TERMINATE_KHR` set to `CL_TRUE`.
   * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources
     required by the OpenCL implementation on the device.
   * `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources


### PR DESCRIPTION
Fixes #198 

This change renames the `event_command_exec_status` argument to the event callback to be `event_command_status` to be consistent with the headers and the XML file.

These are bare minimum changes.  Additional changes we could consider making on top of this one:

1. The name `event_command_status` still doesn't seem great to me, especially in relation to `command_exec_callback_type`.  At the very least I'd prefer to use `status` or `type` consistently.

2. Even with the shortened name `event_command_status` the callback prototype wraps undesirably in both the PDF and HTML specs.  If we end up with a shorter name this problem might fix itself, otherwise we'll need to tweak the scripts slightly to generate the prototypes a little differently.