### PR TITLE
add cl_amd_device_attribute_query enums to XML file

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1532,7 +1532,6 @@ server's OpenCL/api-docs repository.
         <!-- <enum value="0x4030"      name="CL_DEVICE_PARENT_DEVICE_EXT"/> -->
         <!-- <enum value="0x4031"      name="CL_DEVICE_PARTITION_STYLE_EXT"/> -->
         <!-- <enum value="0x4032"      name="CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT"/> -->
-            <unused start="0x4033" end="0x4035"/>
         <enum value="0x4030"        name="CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD"/>
         <enum value="0x4031"        name="CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD"/>
             <unused start="0x4032" end="0x4032"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1533,28 +1533,34 @@ server's OpenCL/api-docs repository.
         <!-- <enum value="0x4031"      name="CL_DEVICE_PARTITION_STYLE_EXT"/> -->
         <!-- <enum value="0x4032"      name="CL_DEVICE_MAX_ATOMIC_COUNTERS_EXT"/> -->
             <unused start="0x4033" end="0x4035"/>
+        <enum value="0x4030"        name="CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD"/>
+        <enum value="0x4031"        name="CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD"/>
+            <unused start="0x4032" end="0x4032"/>
+        <enum value="0x4033"        name="CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD"/>
+        <enum value="0x4034"        name="CL_DEVICE_PCIE_ID_AMD"/>
+            <unused start="0x4035" end="0x4035"/>
         <enum value="0x4036"        name="CL_DEVICE_PROFILING_TIMER_OFFSET_AMD"/>
-        <!-- unused <enum value="0x4037"      name="CL_DEVICE_TOPOLOGY_AMD"/> -->
-        <!-- unused <enum value="0x4038"      name="CL_DEVICE_BOARD_NAME_AMD"/> -->
-        <!-- unused <enum value="0x4039"      name="CL_DEVICE_GLOBAL_FREE_MEMORY_AMD"/> -->
+        <enum value="0x4037"        name="CL_DEVICE_TOPOLOGY_AMD"/>
+        <enum value="0x4038"        name="CL_DEVICE_BOARD_NAME_AMD"/>
+        <enum value="0x4039"        name="CL_DEVICE_GLOBAL_FREE_MEMORY_AMD"/>
             <unused start="0x403A" end="0x403F"/>
     </enums>
 
     <enums start="0x4040" end="0x404F" name="enums.4040" vendor="AMD" comment="Per Bug 6261 (IBM), then Bug 13603 giving control to AMD">
         <enum value="0x4040"        name="CL_COMMAND_MIGRATE_MEM_OBJECT_EXT" comment="From cl_ext_migrate_memobject. Benign collision with the following enum."/>
-        <!-- unused <enum value="0x4040"      name="CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD"/> -->
-        <!-- unused <enum value="0x4041"      name="CL_DEVICE_SIMD_WIDTH_AMD"/> -->
-        <!-- unused <enum value="0x4042"      name="CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD"/> -->
-        <!-- unused <enum value="0x4043"      name="CL_DEVICE_WAVEFRONT_WIDTH_AMD"/> -->
-        <!-- unused <enum value="0x4044"      name="CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD"/> -->
-        <!-- unused <enum value="0x4045"      name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD"/> -->
-        <!-- unused <enum value="0x4046"      name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD"/> -->
-        <!-- unused <enum value="0x4047"      name="CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD"/> -->
-        <!-- unused <enum value="0x4048"      name="CL_DEVICE_LOCAL_MEM_BANKS_AMD"/> -->
-        <!-- unused <enum value="0x4049"      name="CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD"/> -->
-        <!-- unused <enum value="0x404A"      name="CL_DEVICE_GFXIP_MAJOR_AMD"/> -->
-        <!-- unused <enum value="0x404B"      name="CL_DEVICE_GFXIP_MINOR_AMD"/> -->
-        <!-- unused <enum value="0x404C"      name="CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD"/> -->
+        <enum value="0x4040"        name="CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD"/>
+        <enum value="0x4041"        name="CL_DEVICE_SIMD_WIDTH_AMD"/>
+        <enum value="0x4042"        name="CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD"/>
+        <enum value="0x4043"        name="CL_DEVICE_WAVEFRONT_WIDTH_AMD"/>
+        <enum value="0x4044"        name="CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD"/>
+        <enum value="0x4045"        name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD"/>
+        <enum value="0x4046"        name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD"/>
+        <enum value="0x4047"        name="CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD"/>
+        <enum value="0x4048"        name="CL_DEVICE_LOCAL_MEM_BANKS_AMD"/>
+        <enum value="0x4049"        name="CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD"/>
+        <enum value="0x404A"        name="CL_DEVICE_GFXIP_MAJOR_AMD"/>
+        <enum value="0x404B"        name="CL_DEVICE_GFXIP_MINOR_AMD"/>
+        <enum value="0x404C"        name="CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD"/>
             <unused start="0x404D" end="0x404F"/>
     </enums>
 
@@ -4699,6 +4705,26 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_PROFILING_TIMER_OFFSET_AMD"/>
+                <enum name="CL_DEVICE_TOPOLOGY_AMD"/>
+                <enum name="CL_DEVICE_BOARD_NAME_AMD"/>
+                <enum name="CL_DEVICE_GLOBAL_FREE_MEMORY_AMD"/>
+                <enum name="CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD"/>
+                <enum name="CL_DEVICE_SIMD_WIDTH_AMD"/>
+                <enum name="CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD"/>
+                <enum name="CL_DEVICE_WAVEFRONT_WIDTH_AMD"/>
+                <enum name="CL_DEVICE_GLOBAL_MEM_CHANNELS_AMD"/>
+                <enum name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANKS_AMD"/>
+                <enum name="CL_DEVICE_GLOBAL_MEM_CHANNEL_BANK_WIDTH_AMD"/>
+                <enum name="CL_DEVICE_LOCAL_MEM_SIZE_PER_COMPUTE_UNIT_AMD"/>
+                <enum name="CL_DEVICE_LOCAL_MEM_BANKS_AMD"/>
+                <enum name="CL_DEVICE_THREAD_TRACE_SUPPORTED_AMD"/>
+                <enum name="CL_DEVICE_GFXIP_MAJOR_AMD"/>
+                <enum name="CL_DEVICE_GFXIP_MINOR_AMD"/>
+                <enum name="CL_DEVICE_AVAILABLE_ASYNC_QUEUES_AMD"/>
+                <enum name="CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_AMD"/>
+                <enum name="CL_DEVICE_MAX_WORK_GROUP_SIZE_AMD"/>
+                <enum name="CL_DEVICE_PREFERRED_CONSTANT_BUFFER_SIZE_AMD"/>
+                <enum name="CL_DEVICE_PCIE_ID_AMD"/>
             </require>
         </extension>
         <extension name="cl_arm_printf" supported="opencl">


### PR DESCRIPTION
This adds enums for [cl_amd_device_attribute_query](https://www.khronos.org/registry/OpenCL/extensions/amd/cl_amd_device_attribute_query.txt) to the XML file, consistent with the header updates added by https://github.com/KhronosGroup/OpenCL-Headers/pull/90.