### PR TITLE
for now, remove aliases to cl_mem_migration_flags

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -204,7 +204,6 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_alloc_flags_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_info_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_unified_shared_memory_type_intel</name>;</type>
-        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_migration_flags_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_mem_advice_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_atomic_capabilities</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_khronos_vendor_id</name>;</type>
@@ -723,9 +722,7 @@ server's OpenCL/api-docs repository.
     <enums name="cl_mem_migration_flags" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST"/>
         <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
-        <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_INTEL"/>
         <enum bitpos="1"            name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED"/>
-        <enum bitpos="1"            name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED_INTEL"/>
             <unused start="2" end="31"/>
     </enums>
 
@@ -2427,7 +2424,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
-            <param><type>cl_mem_migration_flags_intel</type>    <name>flags</name></param>
+            <param><type>cl_mem_migration_flags</type>          <name>flags</name></param>
             <param><type>cl_uint</type>                         <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                 <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                       <name>event</name></param>
@@ -5527,7 +5524,6 @@ server's OpenCL/api-docs repository.
                 <type name="cl_mem_alloc_flags_intel"/>
                 <type name="cl_mem_info_intel"/>
                 <type name="cl_unified_shared_memory_type_intel"/>
-                <type name="cl_mem_migration_flags_intel"/>
                 <type name="cl_mem_advice_intel"/>
             </require>
             <require comment="cl_device_info">
@@ -5573,10 +5569,6 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_COMMAND_MIGRATEMEM_INTEL"/>
                 <enum name="CL_COMMAND_MEMADVISE_INTEL"/>
             </require>
-            <require comment="cl_mem_migration_flags_intel - bitfield">
-                <enum name="CL_MIGRATE_MEM_OBJECT_HOST_INTEL"/>
-                <enum name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED_INTEL"/>
-            </require>
             <require>
                 <command name="clHostMemAllocINTEL"/>
                 <command name="clDeviceMemAllocINTEL"/>
@@ -5587,7 +5579,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueMemsetINTEL"/>
                 <command name="clEnqueueMemFillINTEL"/>
                 <command name="clEnqueueMemcpyINTEL"/>
-                <command name="clEnqueueMigrateMemINTEL"/>
+                <command name="clEnqueueMigrateMemINTEL" requires="CL_VERSION_1_2"/>
                 <command name="clEnqueueMemAdviseINTEL"/>
             </require>
         </extension>


### PR DESCRIPTION
Instead of adding aliases to `cl_mem_migration_flags` and associated enums, restrict the `clEnqueueMigrateMemINTEL` API to OpenCL 1.2 or newer, which satisfies all current use-cases.

If needed, the aliases can be re-introduced at a later date, since adding them does not change the ABI.

See related header file PR: https://github.com/KhronosGroup/OpenCL-Headers/pull/65