### PR TITLE
fix typo for 101010 image format

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -8905,7 +8905,7 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       `CLK_UNORM_INT16` +
       `CLK_UNORM_SHORT_565` +
       `CLK_UNORM_SHORT_555` +
-      `CLK_UNORM_SHORT_101010` +
+      `CLK_UNORM_INT_101010` +
       `CLK_SIGNED_INT8` +
       `CLK_SIGNED_INT16` +
       `CLK_SIGNED_INT32` +


### PR DESCRIPTION
The spec for `get_image_channel_data_type()` incorrectly lists `CLK_UNORM_SHORT_101010` as a possible return value.  The correct name is `CLK_UNORM_INT_101010`.

Fixes #287