### PR TITLE
clarifies that image_desc is only for creating images with properties

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -2154,35 +2154,28 @@ typedef cl_uint cl_version;
 #define CL_VERSION_PATCH_MASK ((1 << CL_VERSION_PATCH_BITS) - 1)
 
 #define CL_VERSION_MAJOR(version) \
-        ((version) >> (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS))
+  ((version) >> (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS))
 
 #define CL_VERSION_MINOR(version) \
-        (((version) >> CL_VERSION_PATCH_BITS) & CL_VERSION_MINOR_MASK)
+  (((version) >> CL_VERSION_PATCH_BITS) & CL_VERSION_MINOR_MASK)
 
 #define CL_VERSION_PATCH(version) ((version) & CL_VERSION_PATCH_MASK)
 
 #define CL_MAKE_VERSION(major, minor, patch) \
-    ((((major) & CL_VERSION_MAJOR_MASK) << (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS)) | \
-     (((minor) & CL_VERSION_MINOR_MASK) << CL_VERSION_PATCH_BITS) | \
-     ((patch) & CL_VERSION_PATCH_MASK))
+  ((((major)& CL_VERSION_MAJOR_MASK) << \
+        (CL_VERSION_MINOR_BITS + CL_VERSION_PATCH_BITS)) | \
+   (((minor)& CL_VERSION_MINOR_MASK) << \
+         CL_VERSION_PATCH_BITS) | \
+    ((patch) & CL_VERSION_PATCH_MASK))
 ----
 
 ==== Version name pairing
 
 It is sometimes necessary to associate a version to an entity it applies to
 (e.g. extension or built-in kernel). This is done using a dedicated
-`cl_name_version` structure, defined as follows:
+{cl_name_version} structure, defined as follows:
 
-[source,c]
-----
-
-#define CL_NAME_VERSION_MAX_NAME_SIZE 64
-
-typedef struct _cl_name_version {
-    cl_version version;
-    char name[CL_NAME_VERSION_MAX_NAME_SIZE];
-} cl_name_version;
-----
+include::{generated}/api/structs/cl_name_version.txt[]
 
 The `name` field is an array of `CL_NAME_VERSION_MAX_NAME_SIZE` bytes used as
 storage for a NUL-terminated string whose maximum length is therefore

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -701,7 +701,7 @@ include::{generated}/api/version-notes/clCreateSubBuffer.asciidoc[]
 include::{generated}/api/version-notes/CL_BUFFER_CREATE_TYPE_REGION.asciidoc[]
   | Create a buffer object that represents a specific region in _buffer_.
 
-    _buffer_create_info_ is a pointer to a `<<cl_buffer_region>>` structure
+    _buffer_create_info_ is a pointer to a {cl_buffer_region} structure
     specifying a region of the buffer.
 
     If _buffer_ is created with {CL_MEM_USE_HOST_PTR}, the _host_ptr_
@@ -742,13 +742,13 @@ Otherwise, it returns one of the following errors in _errcode_ret_:
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 // These errors are specific to the {CL_BUFFER_CREATE_TYPE_REGION} parameter
-  * {CL_INVALID_VALUE} if the region specified by the *<<cl_buffer_region>>*
+  * {CL_INVALID_VALUE} if the region specified by the {cl_buffer_region}
     structure passed in _buffer_create_info_ is out of bounds in _buffer_.
-  * {CL_INVALID_BUFFER_SIZE} if the _size_ field of the *<<cl_buffer_region>>*
+  * {CL_INVALID_BUFFER_SIZE} if the _size_ field of the {cl_buffer_region}
     structure passed in _buffer_create_info_ is 0.
   * {CL_MISALIGNED_SUB_BUFFER_OFFSET} if there are no devices in _context_
     associated with _buffer_ for which the _origin_ field of the
-    `<<cl_buffer_region>>` structure passed in _buffer_create_info_ is
+    {cl_buffer_region} structure passed in _buffer_create_info_ is
     aligned to the {CL_DEVICE_MEM_BASE_ADDR_ALIGN} value.
 
 [NOTE]
@@ -764,7 +764,7 @@ from multiple overlapping sub-buffer objects is defined.
 
 [open,refpage='cl_buffer_region',desc='',type='structs',xrefs='clCreateSubBuffer']
 --
-The `<<cl_buffer_region>>` structure specifies a region of a buffer object:
+The {cl_buffer_region} structure specifies a region of a buffer object:
 
 include::{generated}/api/structs/cl_buffer_region.txt[]
 
@@ -1956,7 +1956,7 @@ returned in _errcode_ret_:
 
 [open,refpage='cl_image_format',desc='The image format descriptor structure is defined as:',type='structs',xrefs='clCreateImage']
 --
-The *cl_image_format* image format descriptor structure describes an image
+The {cl_image_format} image format descriptor structure describes an image
 format, and is defined as:
 
 include::{generated}/api/structs/cl_image_format.txt[]
@@ -2182,7 +2182,7 @@ then the call to {clCreateImage}, {clCreateImageWithProperties},
 
 [open,refpage='cl_image_desc',desc='The image descriptor structure describes the type and dimensions of the image or image array and is defined as:',type='structs',xrefs='clCreateImage']
 --
-The `<<cl_image_desc>>` image descriptor structure describes the image type
+The {cl_image_desc} image descriptor structure describes the image type
 and dimensions of an image or image array when creating an image using
 {clCreateImage} or {clCreateImageWithProperties}, and is defined as:
 
@@ -2381,7 +2381,7 @@ include::{generated}/api/version-notes/clGetSupportedImageFormats.asciidoc[]
     memory location given by _image_formats_.
   * _image_formats_ is a pointer to a memory location where the list of
     supported image formats are returned.
-    Each entry describes a _cl_image_format_ structure supported by the OpenCL
+    Each entry describes a {cl_image_format} structure supported by the OpenCL
     implementation.
     If _image_formats_ is `NULL`, it is ignored.
   * _num_image_formats_ is the actual number of supported image formats for a
@@ -2873,7 +2873,7 @@ include::{generated}/api/version-notes/clEnqueueCopyImage.asciidoc[]
 
 It is currently a requirement that the _src_image_ and _dst_image_ image
 memory objects for {clEnqueueCopyImage} must have the exact same image
-format (i.e. the cl_image_format descriptor specified when _src_image_ and
+format (i.e. the {cl_image_format} descriptor specified when _src_image_ and
 _dst_image_ are created must match).
 
 // refError
@@ -3481,7 +3481,7 @@ include::{generated}/api/version-notes/clGetImageInfo.asciidoc[]
 | {CL_IMAGE_FORMAT_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_FORMAT.asciidoc[]
-  | cl_image_format
+  | {cl_image_format}
       | Return the image format descriptor specified when _image_ is created
         with {clCreateImage}, {clCreateImageWithProperties},
         {clCreateImage2D} or {clCreateImage3D}.
@@ -3491,8 +3491,6 @@ include::{generated}/api/version-notes/CL_IMAGE_ELEMENT_SIZE.asciidoc[]
   | size_t
       | Return size of each element of the image memory object given by
         _image_ in bytes.
-        An element is made up of _n_ channels.
-        The value of _n_ is given in _cl_image_format_ descriptor.
 | {CL_IMAGE_ROW_PITCH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ROW_PITCH.asciidoc[]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -701,7 +701,7 @@ include::{generated}/api/version-notes/clCreateSubBuffer.asciidoc[]
 include::{generated}/api/version-notes/CL_BUFFER_CREATE_TYPE_REGION.asciidoc[]
   | Create a buffer object that represents a specific region in _buffer_.
 
-    _buffer_create_info_ is a pointer to a *<<cl_buffer_region>>* structure
+    _buffer_create_info_ is a pointer to a `<<cl_buffer_region>>` structure
     specifying a region of the buffer.
 
     If _buffer_ is created with {CL_MEM_USE_HOST_PTR}, the _host_ptr_
@@ -748,7 +748,7 @@ Otherwise, it returns one of the following errors in _errcode_ret_:
     structure passed in _buffer_create_info_ is 0.
   * {CL_MISALIGNED_SUB_BUFFER_OFFSET} if there are no devices in _context_
     associated with _buffer_ for which the _origin_ field of the
-    *<<cl_buffer_region>>* structure passed in _buffer_create_info_ is
+    `<<cl_buffer_region>>` structure passed in _buffer_create_info_ is
     aligned to the {CL_DEVICE_MEM_BASE_ADDR_ALIGN} value.
 
 [NOTE]
@@ -764,7 +764,7 @@ from multiple overlapping sub-buffer objects is defined.
 
 [open,refpage='cl_buffer_region',desc='',type='structs',xrefs='clCreateSubBuffer']
 --
-The *cl_buffer_region* structure specifies a region of a buffer object:
+The `<<cl_buffer_region>>` structure specifies a region of a buffer object:
 
 include::{generated}/api/structs/cl_buffer_region.txt[]
 
@@ -1885,8 +1885,8 @@ include::{generated}/api/version-notes/clCreateImage3D.asciidoc[]
   * _image_width_ and _image_height_ are the width and height of the image in
     pixels.
     These must be values greater than or equal to 1.
-  * _image_depth_ is the depth of the image in pixels.  This must be a value
-    {gt} 1.
+  * _image_depth_ is the depth of the image in pixels.  For {clCreateImage3D},
+    this must be a value {gt} 1.
   * _image_row_pitch_ is the  scan-line pitch in bytes.
     This must be 0 if _host_ptr_ is `NULL` and can be either 0 or {geq}
     _image_width_ {times} size of element in bytes if _host_ptr_ is not `NULL`.
@@ -1930,9 +1930,9 @@ returned in _errcode_ret_:
   * {CL_INVALID_IMAGE_FORMAT_DESCRIPTOR} if values specified in _image_format_
     are not valid or if _image_format_ is `NULL`.
   * {CL_INVALID_IMAGE_SIZE} if _image_width_ or _image_height_ are 0 or if
-    _image_depth_ {leq} 1 or if they exceed the maximum values specified in
+    _image_depth_ {leq} 1, or if they exceed the maximum values specified in
     {CL_DEVICE_IMAGE3D_MAX_WIDTH}, {CL_DEVICE_IMAGE3D_MAX_HEIGHT} or
-    {CL_DEVICE_IMAGE3D_MAX_DEPTH} respectively for all devices in _context_ or
+    {CL_DEVICE_IMAGE3D_MAX_DEPTH} respectively for all devices in _context_, or
     if values specified by _image_row_pitch_ and _image_slice_pitch_ do not
     follow rules described in the argument description above.
   * {CL_INVALID_HOST_PTR} if _host_ptr_ is `NULL` and {CL_MEM_USE_HOST_PTR} or
@@ -2182,8 +2182,9 @@ then the call to {clCreateImage}, {clCreateImageWithProperties},
 
 [open,refpage='cl_image_desc',desc='The image descriptor structure describes the type and dimensions of the image or image array and is defined as:',type='structs',xrefs='clCreateImage']
 --
-The *cl_image_desc* image descriptor structure describes the type and
-dimensions of an image or image array, and is defined as:
+The `<<cl_image_desc>>` image descriptor structure describes the image type
+and dimensions of an image or image array when creating an image using
+{clCreateImage} or {clCreateImageWithProperties}, and is defined as:
 
 include::{generated}/api/structs/cl_image_desc.txt[]
 
@@ -2194,11 +2195,11 @@ include::{generated}/api/structs/cl_image_desc.txt[]
   * `image_width` is the width of the image in pixels.
     For a 2D image and image array, the image width must be a value {geq} 1 and
     {leq} {CL_DEVICE_IMAGE2D_MAX_WIDTH}.
-    For a 3D image, the image width must be a value {geq}1 and {leq}
+    For a 3D image, the image width must be a value {geq} 1 and {leq}
     {CL_DEVICE_IMAGE3D_MAX_WIDTH}.
-    For a 1D image buffer, the image width must be a value {geq}1 and {leq}
+    For a 1D image buffer, the image width must be a value {geq} 1 and {leq}
     {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE}.
-    For a 1D image and 1D image array, the image width must be a value {geq}1
+    For a 1D image and 1D image array, the image width must be a value {geq} 1
     and {leq} {CL_DEVICE_IMAGE2D_MAX_WIDTH}.
   * `image_height` is the height of the image in pixels.
     This is only used if the image is a 2D or 3D image, or a 2D image array.
@@ -2285,28 +2286,26 @@ If the buffer object specified by `mem_object` was created with
 context associated with the buffer specified by `mem_object` that
 support images.
 
-Creating a 2D image object from another 2D image object allows users to
-create a new image object that shares the image data store with `mem_object`
-but views the pixels in the image with a different channel order.
-The restrictions are:
+Creating a 2D image object from another 2D image object creates a new
+2D image object that shares the image data store with `mem_object` but views
+the pixels in the image with a different image channel order.
+Restrictions are:
 
-  * all the values specified in `image_desc` except for `mem_object` must match
-    the image descriptor information associated with `mem_object`.
+  * All of the values specified in _image_desc_ must match the image descriptor
+    information associated with `mem_object`, except for `mem_object`.
 
-  * The `image_desc` used for creation of `mem_object` may not be
-    equivalent to image descriptor information associated with `mem_object`.
-    To ensure the values in _`image_desc_ will match one can query
-    `mem_object` for associated information using {clGetImageInfo} function
-    described in <<image-object-queries, Image Object Queries>>.
+  * The image channel data type specified in _image_format_ must match the
+    image channel data type associated with `mem_object`.
 
-  * the channel data type specified in `image_format` must match the channel
-    data type associated with `mem_object`.
-    The channel order values^8^ supported are:
+  * The image channel order specified in _image_format_ must be compatible
+    with the image channel order associated with `mem_object`.
+    Compatible image channel orders ^8^ are:
 +
 --
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| `image_channel_order` specified in `image_format` | image channel order of `mem_object`
+| Image Channel Order in _image_format_:
+  | Image Channel Order associated with `mem_object`:
 | {CL_sBGRA}
   | {CL_BGRA}
 | {CL_BGRA}
@@ -2327,11 +2326,9 @@ The restrictions are:
   | {CL_R}
 |====
 --
-  * the channel order specified must have the same number of channels as the
-    channel order of `mem_object`.
 
 8::
-    This allows developers to create a sRGB view of the image from a linear
+    This allows creation of a sRGB view of the image from a linear
     RGB view or vice-versa i.e. the pixels stored in the image can be
     accessed as linear RGB or sRGB values.
 
@@ -4193,9 +4190,12 @@ include::{generated}/api/version-notes/CL_MEM_TYPE.asciidoc[]
         {CL_MEM_OBJECT_BUFFER_anchor} if _memobj_ is created with {clCreateBuffer},
         {clCreateBufferWithProperties}, or {clCreateSubBuffer}.
 
-        cl_image_desc.image_type argument value if _memobj_ is created with
-        {clCreateImage}, {clCreateImageWithProperties}, {clCreateImage2D}, or
-        {clCreateImage3D}.
+        {CL_MEM_OBJECT_IMAGE2D} if _memobj_ is created with {clCreateImage2D}.
+
+        {CL_MEM_OBJECT_IMAGE3D} if _memobj_ is created with {clCreateImage3D}.
+
+        The value of __image_desc__->__image_type__ if _memobj_ is created with
+        {clCreateImage} or {clCreateImageWithProperties}.
 
         {CL_MEM_OBJECT_PIPE_anchor} if _memobj_ is created with {clCreatePipe}.
 | {CL_MEM_FLAGS_anchor}
@@ -4236,7 +4236,7 @@ include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
         the origin value specified in buffer_create_info when _memobj_ is
         created.
 
-        Otherwise, return `NULL`.
+        Otherwise, returns `NULL`.
 | {CL_MEM_MAP_COUNT_anchor}^11^
 
 include::{generated}/api/version-notes/CL_MEM_MAP_COUNT.asciidoc[]
@@ -4260,14 +4260,16 @@ include::{generated}/api/version-notes/CL_MEM_CONTEXT.asciidoc[]
 include::{generated}/api/version-notes/CL_MEM_ASSOCIATED_MEMOBJECT.asciidoc[]
   | cl_mem
       | Return memory object from which _memobj_ is created.
+
         This returns the memory object specified as buffer argument to
         {clCreateSubBuffer} if _memobj_ is a subbuffer object created using
         {clCreateSubBuffer}.
 
-        This returns the mem_object specified in cl_image_desc if _memobj_
-        is an image object.
+        This returns __image_desc__->__mem_object__ if _memobj_
+        is an image object created using {clCreateImage} or
+        {clCreateImageWithProperties}.
 
-        Otherwise a `NULL` value is returned.
+        Otherwise, returns `NULL`.
 | {CL_MEM_OFFSET_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_OFFSET.asciidoc[]

--- a/ext/cl_khr_mipmap_image.asciidoc
+++ b/ext/cl_khr_mipmap_image.asciidoc
@@ -35,7 +35,7 @@ device, the *cl_khr_mipmap_image* extension must also be supported.
 
 A mip-mapped 1D image, 1D image array, 2D image, 2D image array or 3D image
 is created by specifying _num_mip_levels_ to be a value greater than one in
-the _cl_image_desc_ passed to *clCreateImage*.
+the _image_desc_ passed to *clCreateImage*.
 The dimensions of a mip-mapped image can be a power of two or a non-power of
 two.
 Each successively smaller mipmap level is half the size of the previous

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -3407,7 +3407,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_image_format"/>
             <type name="cl_buffer_region"/>
         </require>
-	<require comment="Constants">
+        <require comment="Constants">
             <enum name="CL_CHAR_BIT"/>
             <enum name="CL_CHAR_MAX"/>
             <enum name="CL_CHAR_MIN"/>


### PR DESCRIPTION
This change adds a number of clarifications around the `image_desc` structure argument and specifically documents the differences between the newer "create image with properties" APIs and the legacy "create image 2D" and "create image 3D" APIs.

I also added the structure types to the spec dictionaries to ensure consistent formatting and to add linking to the specs.

Fixes #289.