### PR TITLE
clarify behavior of any() and all() for scalar inputs

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5467,11 +5467,11 @@ not a number (NaN) and the argument type is a vector.
      float is set else returns 0.
 | |
 | int *any*(igentype _x_)
-    | Returns 1 if the most significant bit in any component of _x_ is set;
-      otherwise returns 0.
+    | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
+      any component of _x_ (for vector inputs) is set; otherwise returns 0.
 | int *all*(igentype _x_)
-    | Returns 1 if the most significant bit in all components of _x_ is set;
-      otherwise returns 0.
+    | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
+      all components of _x_ (for vector inputs) is set; otherwise returns 0.
 | |
 | gentype *bitselect*(gentype _a_, gentype _b_, gentype _c_)
    | Each bit of the result is the corresponding bit of _a_ if the


### PR DESCRIPTION
See #178.

This PR clarifies the behavior of the `any()` and `all()` built-in functions for scalar inputs, documenting what is done in the SPIR-V LLVM Translator and clspv and many other implementations today.

This change does **not** deprecate scalar inputs for these built-in functions - if desired, this can be done with a subsequent PR.