### PR TITLE
Separate out 2.1 additions to device-side enqueue (#246)

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -368,7 +368,7 @@ device:
   * {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} to
     determine whether a device supports the generic address space.
   * {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} to determine the device-side enqueue
-    capabilities of a device
+    capabilities of a device.
   * {CL_DEVICE_PIPE_SUPPORT} to determine whether a device supports
     pipe memory objects.
   * {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE} to determine the

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -367,8 +367,8 @@ device:
     collective functions, such as broadcasts, scans, and reductions.
   * {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} to
     determine whether a device supports the generic address space.
-  * {CL_DEVICE_DEVICE_ENQUEUE_SUPPORT} to determine whether a device
-    supports device queues and device-side enqueue.
+  * {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} to determine the device-side enqueue
+    capabilities of a device
   * {CL_DEVICE_PIPE_SUPPORT} to determine whether a device supports
     pipe memory objects.
   * {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE} to determine the

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -165,7 +165,7 @@ When Device-Side Enqueue is not supported:
 
 |====
 
-When Device-Side Enqueue is supported but a replaceable On-Device Queue is not supported:
+When Device-Side Enqueue is supported but a replaceable default On-Device Queue is not supported:
 
 [cols="2,3",options="header",]
 |====

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -174,7 +174,7 @@ When Device-Side Enqueue is supported but a replaceable On-Device Queue is not s
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES}
-| May not set {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} , indicating that _device_ does not support a replaceable default On-Device Queue.
+| May omit {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT}, indicating that _device_ does not support a replaceable default On-Device Queue.
 
 | {clSetDefaultDeviceCommandQueue}
 | Returns {CL_INVALID_OPERATION} if _device_ does not support a replaceable default On-Device Queue.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -137,8 +137,8 @@ When Device-Side Enqueue is not supported:
 |*Behavior*
 
 | {clGetDeviceInfo}, passing +
-{CL_DEVICE_DEVICE_ENQUEUE_SUPPORT}
-| May return {CL_FALSE}, indicating that _device_ does not support Device-Side Enqueue and On-Device Queues.
+{CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES}
+| May return `0`, indicating that _device_ does not support Device-Side Enqueue and On-Device Queues.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES}
@@ -162,6 +162,22 @@ When Device-Side Enqueue is not supported:
 
 | {clSetDefaultDeviceCommandQueue}
 | Returns {CL_INVALID_OPERATION} if _device_ does not support On-Device Queues.
+
+|====
+
+When Device-Side Enqueue is supported but a replaceable On-Device Queue is not supported:
+
+[cols="2,3",options="header",]
+|====
+|*API*
+|*Behavior*
+
+| {clGetDeviceInfo}, passing +
+{CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES}
+| May not set {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} , indicating that _device_ does not support a replaceable default On-Device Queue.
+
+| {clSetDefaultDeviceCommandQueue}
+| Returns {CL_INVALID_OPERATION} if _device_ does not support a replaceable default On-Device Queue.
 
 |====
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1456,7 +1456,7 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
 
         {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue
 
-        If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} should also be set.
+        If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} must also be set.
 
         Devices that set {CL_DEVICE_QUEUE_SUPPORTED} for {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1452,13 +1452,13 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues
+        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues.
 
-        {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue
+        {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue.
 
         If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} must also be set.
 
-        Devices that set {CL_DEVICE_QUEUE_SUPPORTED} for {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}
+        Devices that set {CL_DEVICE_QUEUE_SUPPORTED} for {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}.
 
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for device-side enqueue and on-device queues is required for an OpenCL 2.0, 2.1, or 2.2 device.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1444,13 +1444,22 @@ include::{generated}/api/version-notes/CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.a
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for the generic address space is required for an OpenCL 2.0, 2.1, or 2.2 device.
 
-| {CL_DEVICE_DEVICE_ENQUEUE_SUPPORT_anchor}
+| {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES_anchor}
 
-include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_SUPPORT.asciidoc[]
-  | cl_bool
-      | Is {CL_TRUE} if the device supports device-side enqueue and on-device queues, and {CL_FALSE} otherwise.
+include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asciidoc[]
+  | cl_device_device_enqueue_capabilities
+      | Describes device-side enqueue capabilities of the device.
+        This is a bit-field that describes one or more of the following
+        values:
 
-      Devices that return {CL_TRUE} for {CL_DEVICE_DEVICE_ENQUEUE_SUPPORT} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}.
+        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues
+
+        {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue
+
+        If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} should also be set.
+
+        Devices that set {CL_DEVICE_QUEUE_SUPPORTED} for {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}
+
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for device-side enqueue and on-device queues is required for an OpenCL 2.0, 2.1, or 2.2 device.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -228,14 +228,13 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
   * {CL_INVALID_DEVICE} if _device_ is not a valid device or is not associated
     with _context_.
-  * {CL_INVALID_OPERATION} if _device_ does not support On-Device Queues.
+  * {CL_INVALID_OPERATION} if _device_ does not support a replaceable default On-Device Queue.
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid command-queue
     for _device_.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
-  * {CL_INVALID_OPERATION} if _device_ does not support a replacable default On-Device Queue.
 --
 
 [open,refpage='clRetainCommandQueue',desc='Increments the command_queue reference count.',type='protos']

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -235,6 +235,7 @@ Otherwise, it returns one of the following errors:
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
+  * {CL_INVALID_OPERATION} if _device_ does not support a replacable default On-Device Queue.
 --
 
 [open,refpage='clRetainCommandQueue',desc='Increments the command_queue reference count.',type='protos']

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -21,7 +21,7 @@ modules that declare the following capabilities:
   * *Linkage*
   * *Vector16*
   * *DeviceEnqueue*
-    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Device-Side Enqueue (where {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} is not `0`.
+    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Device-Side Enqueue (where {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} is not `0`).
   * *GenericPointer*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting the Generic Address Space (where {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} is {CL_TRUE}).
   * *Groups*
@@ -74,4 +74,3 @@ modules that declare the capabilities required for SPIR-V 1.1 modules,
 above.
 
 SPIR-V 1.2 does not add any new required capabilities.
-

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -21,7 +21,7 @@ modules that declare the following capabilities:
   * *Linkage*
   * *Vector16*
   * *DeviceEnqueue*
-    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Device-Side Enqueue (where {CL_DEVICE_DEVICE_ENQUEUE_SUPPORT} is {CL_TRUE}).
+    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Device-Side Enqueue (where {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES} is not `0`.
   * *GenericPointer*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting the Generic Address Space (where {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} is {CL_TRUE}).
   * *Groups*

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -208,6 +208,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_atomic_capabilities</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_khronos_vendor_id</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_version</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_device_enqueue_capabilities</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
@@ -655,6 +656,12 @@ server's OpenCL/api-docs repository.
         <enum bitpos="5"            name="CL_DEVICE_ATOMIC_SCOPE_DEVICE"/>
         <enum bitpos="6"            name="CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES"/>
             <unused start="7" end="31"/>
+    </enums>
+
+    <enums name="cl_device_device_enqueue_capabilities" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_DEVICE_QUEUE_SUPPORTED"/>
+        <enum bitpos="1"            name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
+            <unused start="2" end="31"/>
     </enums>
 
     <enums name="cl_command_queue_properties" vendor="Khronos" type="bitmask">
@@ -1172,7 +1179,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x1069"        name="CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT"/>
             <unused start="0x106A" end="0x106E" comment="Reserved for upcoming KHR extension"/>
         <enum value="0x106F"        name="CL_DEVICE_OPENCL_C_FEATURES"/>
-        <enum value="0x1070"        name="CL_DEVICE_DEVICE_ENQUEUE_SUPPORT"/>
+        <enum value="0x1070"        name="CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES"/>
         <enum value="0x1071"        name="CL_DEVICE_PIPE_SUPPORT"/>
             <unused start="0x1072" end="0x107F" comment="Reserved for cl_device_info"/>
         <enum value="0x1080"        name="CL_CONTEXT_REFERENCE_COUNT"/>
@@ -4329,6 +4336,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_mem_properties"/>
             <type name="cl_version"/>
             <type name="cl_name_version"/>
+            <type name="cl_device_device_enqueue_capabilities"/>
         </require>
         <require comment="cl_device_atomic_capabilities - bitfield">
             <enum name="CL_DEVICE_ATOMIC_ORDER_RELAXED"/>
@@ -4351,7 +4359,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT"/>
             <enum name="CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT"/>
             <enum name="CL_DEVICE_OPENCL_C_FEATURES"/>
-            <enum name="CL_DEVICE_DEVICE_ENQUEUE_SUPPORT"/>
+            <enum name="CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES"/>
             <enum name="CL_DEVICE_PIPE_SUPPORT"/>
             <enum name="CL_DEVICE_NUMERIC_VERSION"/>
             <enum name="CL_DEVICE_EXTENSIONS_WITH_VERSION"/>
@@ -4383,6 +4391,10 @@ server's OpenCL/api-docs repository.
         <require comment="Memory Object APIs">
             <command name="clCreateBufferWithProperties"/>
             <command name="clCreateImageWithProperties"/>
+        </require>
+        <require comment="cl_device_device_enqueue_capabilities - bitfield">
+            <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
+            <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
         </require>
     </feature>
 


### PR DESCRIPTION
Change the query to a bitfield to allow for querying support for
clSetDefaultDeviceCommandQueue separately from support
for the rest of the device-side enqueue feature