### PR TITLE
update README and travis config for latexmath fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.3.3
 
 before_install:
-  - sudo apt-get install -y libpango1.0-dev ghostscript
+  - sudo apt-get install -y libpango1.0-dev ghostscript fonts-lyx
   - gem install asciidoctor -v 1.5.8
   - gem install coderay -v 1.1.1
   - gem install ttfunk -v 1.5.1

--- a/README.adoc
+++ b/README.adoc
@@ -245,6 +245,9 @@ Before building the OpenCL specs, you must install the following tools:
     This is for the PDF build, and it can still progress without it.
     Ghostscript is used to optimize the size of the PDF, so will be a lot
     smaller if it is included.
+  * ttf Fonts.
+    These are needed the PDF build for latexmath rendering.
+    See https://github.com/asciidoctor/asciidoctor-mathematical/blob/master/README.md#dependencies[Font Dependencies for asciidoctor-mathematical].
 
 The following Ruby Gems and platform package dependencies must also be
 installed.
@@ -309,7 +312,7 @@ installed via apt-get:
 ----
 sudo apt-get -qq -y install build-essential python3 git cmake bison flex \
     libffi-dev libgmp-dev libxml2-dev libgdk-pixbuf2.0-dev libcairo2-dev \
-    libpango1.0-dev ttf-lyx gtk-doc-tools ghostscript
+    libpango1.0-dev fonts-lyx gtk-doc-tools ghostscript
 ----
 
 The default ruby packages on Ubuntu are fairly out of date.
@@ -612,6 +615,7 @@ The instructions for the <<depends-ubuntu,Ubuntu / Windows 10>> installation
 are generally applicable to native Linux environments using Debian packages,
 such as Debian and Ubuntu, although the exact list of packages to install
 may differ.
+
 Other distributions using different package managers, such as RPM (Fedora)
 and Yum (SuSE) will have different requirements.
 


### PR DESCRIPTION
Fixes #324.

Updates the README instructions to get fonts and an updated version of asciidoctor-mathmatical for proper latexmath rendering.

Also updates the travis spec build configuration file with these changes.