### PR TITLE
switch to lists with no markers for indentation

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1915,7 +1915,8 @@ unary *&* operator, *+*&E+* is an l-value equal to *E*.
 Assignments of values to variable names are done with the assignment
 operator (*=*), like
 
-  :: _lvalue_ = _expression_
+[none]
+* _lvalue_ = _expression_
 
 The assignment operator stores the value of _expression_ into _lvalue_.
 The _expression_ and _lvalue_ must have the same type, or the expression
@@ -1950,11 +1951,13 @@ or into (*|=*), and exclusive or into (*^=*).
 
 The expression
 
-  :: _lvalue_ __op__*=* _expression_
+[none]
+* _lvalue_ __op__ *=* _expression_
 
 is equivalent to
 
-  :: _lvalue_ = _lvalue_ _op_ _expression_
+[none]
+* _lvalue_ = _lvalue_ _op_ _expression_
 
 and the _lvalue_ and _expression_ must satisfy the requirements for both
 operator _op_ and assignment (*=*).
@@ -2903,7 +2906,8 @@ void foo( __global float4 *p ) { ... }
 
 If for example, a `+__kernel+` function is declared with
 
- :: `+__attribute__(( vec_type_hint (float4)))+`
+[none]
+* `+__attribute__(( vec_type_hint (float4)))+`
 
 (meaning that most operations in the `+__kernel+` function are explicitly
 vectorized using `float4`) and the kernel is running using Intel^{reg}^
@@ -3150,7 +3154,8 @@ The preprocessing directives defined by the C99 specification are supported.
 
 The *#pragma* directive is described as:
 
-  :: *#pragma* _pp-tokens~opt~_ _new-line_
+[none]
+* *#pragma* _pp-tokens~opt~_ _new-line_
 
 A *#pragma* directive where the preprocessing token `OPENCL` (used instead
 of *`STDC`*) does not immediately follow *pragma* in the directive (prior to
@@ -6174,17 +6179,20 @@ have special characteristics.
 
 The types include
 
-  :: `memory_order`
+[none]
+* `memory_order`
 
 which is an enumerated type whose enumerators identify memory ordering
 constraints;
 
-  :: `memory_scope`
+[none]
+* `memory_scope`
 
 which is an enumerated type whose enumerators identify scope of memory
 ordering constraints;
 
-  :: `atomic_flag`
+[none]
+* `atomic_flag`
 
 which is a 32-bit integer type representing a primitive atomic flag; and
 several atomic analogs of integer types.
@@ -6450,16 +6458,17 @@ NOTE: The use of memory order and scope enumerations must respect the
 
 The list of supported atomic type names are:
 
-  :: `atomic_int`
-  :: `atomic_uint`
-  :: `atomic_long`^45^
-  :: `atomic_ulong`
-  :: `atomic_float`
-  :: `atomic_double`^46^
-  :: `atomic_intptr_t`^47^
-  :: `atomic_uintptr_t`
-  :: `atomic_size_t`
-  :: `atomic_ptrdiff_t`
+[none]
+* `atomic_int`
+* `atomic_uint`
+* `atomic_long`^45^
+* `atomic_ulong`
+* `atomic_float`
+* `atomic_double`^46^
+* `atomic_intptr_t`^47^
+* `atomic_uintptr_t`
+* `atomic_size_t`
+* `atomic_ptrdiff_t`
 
 [45] The atomic_long and atomic_ulong types are supported if the
 *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions
@@ -7330,7 +7339,8 @@ argument, where __n__ is the size of the vector and must be 2, 3, 4, 8 or 16.
 
 The vector value is displayed in the following general form:
 
-  :: value1 C value2 C ... C value__n__
+[none]
+* value1 C value2 C ... C value__n__
 
 where C is a separator character.
 The value for this separator character is a comma.
@@ -11073,57 +11083,58 @@ Where the {plusmn} symbol is used, the sign shall be preserved.
 For example, *sin*({plusmn}0) = {plusmn}0 shall be interpreted to mean
 *sin*(+0) is +0 and *sin*(-0) is -0.
 
-  :: *acospi*(1) = +0.
-  :: *acospi*(_x_) returns a NaN for |_x_| > 1.
-  :: *asinpi*({plusmn}0) = {plusmn}0.
-  :: *asinpi*(_x_) returns a NaN for |_x_| > 1.
-  :: *atanpi*({plusmn}0) = {plusmn}0.
-  :: *atanpi*({plusmn}{inf}) = {plusmn}0.5.
-  :: *atan2pi*({plusmn}0, -0) = {plusmn}1.
-  :: *atan2pi*({plusmn}0, +0) = {plusmn}0.
-  :: *atan2pi*({plusmn}0, _x_) returns {plusmn}1 for _x_ < 0.
-  :: *atan2pi*({plusmn}0, _x_) returns {plusmn}0 for _x_ > 0.
-  :: *atan2pi*(_y_, {plusmn}0) returns -0.5 for _y_ < 0.
-  :: *atan2pi*(_y_, {plusmn}0) returns 0.5 for _y_ > 0.
-  :: *atan2pi*({plusmn}_y_, -{inf}) returns {plusmn}1 for finite _y_ > 0.
-  :: *atan2pi*({plusmn}_y_, +{inf}) returns {plusmn}0 for finite _y_ > 0.
-  :: *atan2pi*({plusmn}{inf}, _x_) returns {plusmn}0.5 for finite _x._
-  :: *atan2pi*({plusmn}{inf}, -{inf}) returns {plusmn}0.75.
-  :: *atan2pi*({plusmn}{inf}, +{inf}) returns {plusmn}0.25.
-  :: *ceil*(-1 < _x_ < 0) returns -0.
-  :: *cospi*({plusmn}0) returns 1
-  :: *cospi*(_n_ + 0.5) is +0 for any integer _n_ where _n_ + 0.5 is
+[none]
+* *acospi*(1) = +0.
+* *acospi*(_x_) returns a NaN for |_x_| > 1.
+* *asinpi*({plusmn}0) = {plusmn}0.
+* *asinpi*(_x_) returns a NaN for |_x_| > 1.
+* *atanpi*({plusmn}0) = {plusmn}0.
+* *atanpi*({plusmn}{inf}) = {plusmn}0.5.
+* *atan2pi*({plusmn}0, -0) = {plusmn}1.
+* *atan2pi*({plusmn}0, +0) = {plusmn}0.
+* *atan2pi*({plusmn}0, _x_) returns {plusmn}1 for _x_ < 0.
+* *atan2pi*({plusmn}0, _x_) returns {plusmn}0 for _x_ > 0.
+* *atan2pi*(_y_, {plusmn}0) returns -0.5 for _y_ < 0.
+* *atan2pi*(_y_, {plusmn}0) returns 0.5 for _y_ > 0.
+* *atan2pi*({plusmn}_y_, -{inf}) returns {plusmn}1 for finite _y_ > 0.
+* *atan2pi*({plusmn}_y_, +{inf}) returns {plusmn}0 for finite _y_ > 0.
+* *atan2pi*({plusmn}{inf}, _x_) returns {plusmn}0.5 for finite _x._
+* *atan2pi*({plusmn}{inf}, -{inf}) returns {plusmn}0.75.
+* *atan2pi*({plusmn}{inf}, +{inf}) returns {plusmn}0.25.
+* *ceil*(-1 < _x_ < 0) returns -0.
+* *cospi*({plusmn}0) returns 1
+* *cospi*(_n_ + 0.5) is +0 for any integer _n_ where _n_ + 0.5 is
      representable.
-  :: *cospi*({plusmn}{inf}) returns a NaN.
-  :: *exp10*(-{inf}) returns +0.
-  :: *exp10*(+{inf}) returns +{inf}.
-  :: *distance*(_x_, _y_) calculates the distance from _x_ to _y_ without
+* *cospi*({plusmn}{inf}) returns a NaN.
+* *exp10*(-{inf}) returns +0.
+* *exp10*(+{inf}) returns +{inf}.
+* *distance*(_x_, _y_) calculates the distance from _x_ to _y_ without
      overflow or extraordinary precision loss due to underflow.
-  :: *fdim*(any, NaN) returns NaN.
-  :: *fdim*(NaN, any) returns NaN.
-  :: *fmod*({plusmn}0, NaN) returns NaN.
-  :: *frexp*({plusmn}{inf}, _exp_) returns {plusmn}{inf} and stores 0 in
+* *fdim*(any, NaN) returns NaN.
+* *fdim*(NaN, any) returns NaN.
+* *fmod*({plusmn}0, NaN) returns NaN.
+* *frexp*({plusmn}{inf}, _exp_) returns {plusmn}{inf} and stores 0 in
      _exp_.
-  :: *frexp*(NaN, _exp_) returns the NaN and stores 0 in _exp_.
-  :: *fract*(_x_, _iptr_) shall not return a value greater than or equal to
+* *frexp*(NaN, _exp_) returns the NaN and stores 0 in _exp_.
+* *fract*(_x_, _iptr_) shall not return a value greater than or equal to
      1.0, and shall not return a value less than 0.
-  :: *fract*(+0, _iptr_) returns +0 and +0 in iptr.
-  :: *fract*(-0, _iptr_) returns -0 and -0 in iptr.
-  :: *fract*(+{inf}, _iptr_) returns +0 and +{inf} in _iptr_.
-  :: *fract*(-{inf}, _iptr_) returns -0 and -{inf} in _iptr_.
-  :: *fract*(NaN, _iptr_) returns the NaN and NaN in _iptr_.
-  :: *length* calculates the length of a vector without overflow or
+* *fract*(+0, _iptr_) returns +0 and +0 in iptr.
+* *fract*(-0, _iptr_) returns -0 and -0 in iptr.
+* *fract*(+{inf}, _iptr_) returns +0 and +{inf} in _iptr_.
+* *fract*(-{inf}, _iptr_) returns -0 and -{inf} in _iptr_.
+* *fract*(NaN, _iptr_) returns the NaN and NaN in _iptr_.
+* *length* calculates the length of a vector without overflow or
      extraordinary precision loss due to underflow.
-  :: *lgamma_r*(_x_, _signp_) returns 0 in _signp_ if _x_ is zero or a
+* *lgamma_r*(_x_, _signp_) returns 0 in _signp_ if _x_ is zero or a
      negative integer.
-  :: *nextafter*(-0, _y_ > 0) returns smallest positive denormal value.
-  :: *nextafter*(+0, _y_ < 0) returns smallest negative denormal value.
-  :: *normalize* shall reduce the vector to unit length, pointing in the
+* *nextafter*(-0, _y_ > 0) returns smallest positive denormal value.
+* *nextafter*(+0, _y_ < 0) returns smallest negative denormal value.
+* *normalize* shall reduce the vector to unit length, pointing in the
      same direction without overflow or extraordinary precision loss due to
      underflow.
-  :: *normalize*(_v_) returns _v_ if all elements of _v_ are zero.
-  :: *normalize*(_v_) returns a vector full of NaNs if any element is a NaN.
-  :: *normalize*(_v_) for which any element in _v_ is infinite shall proceed
+* *normalize*(_v_) returns _v_ if all elements of _v_ are zero.
+* *normalize*(_v_) returns a vector full of NaNs if any element is a NaN.
+* *normalize*(_v_) for which any element in _v_ is infinite shall proceed
      as if the elements in _v_ were replaced as follows:
 +
 [source,c]
@@ -11131,47 +11142,47 @@ For example, *sin*({plusmn}0) = {plusmn}0 shall be interpreted to mean
 for (i = 0; i < sizeof(v) / sizeof(v[0]); i++)
    v[i] = isinf(v[i]) ? copysign(1.0, v[i]) : 0.0 * v[i];
 ----------
-  :: *pow*({plusmn}0, -{inf}) returns +{inf}
-  :: *pown*(_x_, 0) is 1 for any _x_, even zero, NaN or infinity.
-  :: *pown*({plusmn}0, _n_) is {plusmn}{inf} for odd _n_ < 0.
-  :: *pown*({plusmn}0, _n_) is +{inf} for even _n_ < 0.
-  :: *pown*({plusmn}0, _n_) is +0 for even _n_ > 0.
-  :: *pown*({plusmn}0, _n_) is {plusmn}0 for odd _n_ > 0.
-  :: *powr*(_x_, {plusmn}0) is 1 for finite _x_ > 0.
-  :: *powr*({plusmn}0, _y_) is +{inf} for finite _y_ < 0.
-  :: *powr*({plusmn}0, -{inf}) is +{inf}.
-  :: *powr*({plusmn}0, _y_) is +0 for _y_ > 0.
-  :: *powr*(+1, _y_) is 1 for finite _y._
-  :: *powr*(_x_, _y_) returns NaN for _x_ < 0.
-  :: *powr*({plusmn}0, {plusmn}0) returns NaN.
-  :: *powr*(+{inf}, {plusmn}0) returns NaN.
-  :: *powr*(+1, {plusmn}{inf}) returns NaN.
-  :: *powr*(_x_, NaN) returns the NaN for _x_ >= 0.
-  :: *powr*(NaN, _y_) returns the NaN.
-  :: *rint*(-0.5 \<= _x_ < 0) returns -0.
-  :: *remquo*(_x_, _y_, &_quo_) returns a NaN and 0 in _quo_ if _x_ is
+* *pow*({plusmn}0, -{inf}) returns +{inf}
+* *pown*(_x_, 0) is 1 for any _x_, even zero, NaN or infinity.
+* *pown*({plusmn}0, _n_) is {plusmn}{inf} for odd _n_ < 0.
+* *pown*({plusmn}0, _n_) is +{inf} for even _n_ < 0.
+* *pown*({plusmn}0, _n_) is +0 for even _n_ > 0.
+* *pown*({plusmn}0, _n_) is {plusmn}0 for odd _n_ > 0.
+* *powr*(_x_, {plusmn}0) is 1 for finite _x_ > 0.
+* *powr*({plusmn}0, _y_) is +{inf} for finite _y_ < 0.
+* *powr*({plusmn}0, -{inf}) is +{inf}.
+* *powr*({plusmn}0, _y_) is +0 for _y_ > 0.
+* *powr*(+1, _y_) is 1 for finite _y._
+* *powr*(_x_, _y_) returns NaN for _x_ < 0.
+* *powr*({plusmn}0, {plusmn}0) returns NaN.
+* *powr*(+{inf}, {plusmn}0) returns NaN.
+* *powr*(+1, {plusmn}{inf}) returns NaN.
+* *powr*(_x_, NaN) returns the NaN for _x_ >= 0.
+* *powr*(NaN, _y_) returns the NaN.
+* *rint*(-0.5 \<= _x_ < 0) returns -0.
+* *remquo*(_x_, _y_, &_quo_) returns a NaN and 0 in _quo_ if _x_ is
      {plusmn}{inf}, or if _y_ is 0 and the other argument is non-NaN or if
      either argument is a NaN.
-  :: *rootn*({plusmn}0, _n_) is {plusmn}{inf} for odd _n_ < 0.
-  :: *rootn*({plusmn}0, _n_) is +{inf} for even _n_ < 0.
-  :: *rootn*({plusmn}0, _n_) is +0 for even _n_ > 0.
-  :: *rootn*({plusmn}0, _n_) is {plusmn}0 for odd _n_ > 0.
-  :: *rootn*(_x_, _n_) returns a NaN for _x_ < 0 and _n_ is even.
-  :: *rootn*(_x_, 0) returns a NaN.
-  :: *round*(-0.5 < _x_ < 0) returns -0.
-  :: *sinpi*({plusmn}0) returns {plusmn}0.
-  :: *sinpi*(+__n__) returns +0 for positive integers _n_.
-  :: *sinpi*(-_n_) returns -0 for negative integers _n_.
-  :: *sinpi*({plusmn}{inf}) returns a NaN.
-  :: *tanpi*({plusmn}0) returns {plusmn}0.
-  :: *tanpi*({plusmn}{inf}) returns a NaN.
-  :: *tanpi*(_n_) is *copysign*(0.0, _n_) for even integers _n_.
-  :: *tanpi*(_n_) is *copysign*(0.0, - _n_) for odd integers _n_.
-  :: *tanpi*(_n_ + 0.5) for even integer _n_ is +{inf} where _n_ + 0.5 is
+* *rootn*({plusmn}0, _n_) is {plusmn}{inf} for odd _n_ < 0.
+* *rootn*({plusmn}0, _n_) is +{inf} for even _n_ < 0.
+* *rootn*({plusmn}0, _n_) is +0 for even _n_ > 0.
+* *rootn*({plusmn}0, _n_) is {plusmn}0 for odd _n_ > 0.
+* *rootn*(_x_, _n_) returns a NaN for _x_ < 0 and _n_ is even.
+* *rootn*(_x_, 0) returns a NaN.
+* *round*(-0.5 < _x_ < 0) returns -0.
+* *sinpi*({plusmn}0) returns {plusmn}0.
+* *sinpi*(+__n__) returns +0 for positive integers _n_.
+* *sinpi*(-_n_) returns -0 for negative integers _n_.
+* *sinpi*({plusmn}{inf}) returns a NaN.
+* *tanpi*({plusmn}0) returns {plusmn}0.
+* *tanpi*({plusmn}{inf}) returns a NaN.
+* *tanpi*(_n_) is *copysign*(0.0, _n_) for even integers _n_.
+* *tanpi*(_n_) is *copysign*(0.0, - _n_) for odd integers _n_.
+* *tanpi*(_n_ + 0.5) for even integer _n_ is +{inf} where _n_ + 0.5 is
      representable.
-  :: *tanpi*(_n_ + 0.5) for odd integer _n_ is -{inf} where _n_ + 0.5 is
+* *tanpi*(_n_ + 0.5) for odd integer _n_ is -{inf} where _n_ + 0.5 is
      representable.
-  :: *trunc*(-1 < _x_ < 0) returns -0.
+* *trunc*(-1 < _x_ < 0) returns -0.
      Binary file (standard input) matches
 
 
@@ -11214,10 +11225,11 @@ If subnormals are flushed to zero, a device may choose to conform to the
 following edge cases for *nextafter* instead of those listed in the
 <<additional-requirements-beyond-c99-tc2,additional requirements>> section.
 
-  :: *nextafter*(+smallest normal, _y_ < +smallest normal) = +0.
-  :: *nextafter*(-smallest normal, _y_ > -smallest normal) = -0.
-  :: *nextafter*(-0, _y_ > 0) returns smallest positive normal value.
-  :: *nextafter*(+0, _y_ < 0) returns smallest negative normal value.
+[none]
+* *nextafter*(+smallest normal, _y_ < +smallest normal) = +0.
+* *nextafter*(-smallest normal, _y_ > -smallest normal) = -0.
+* *nextafter*(-0, _y_ > 0) returns smallest positive normal value.
+* *nextafter*(+0, _y_ < 0) returns smallest negative normal value.
 
 For clarity, subnormals or denormals are defined to be the set of
 representable numbers in the range 0 < _x_ < `TYPE_MIN` and `-TYPE_MIN` <
@@ -11687,53 +11699,63 @@ These conversions are performed as follows:
 
 `CL_UNORM_INT8` (8-bit unsigned integer) {rightarrow} `float`
 
-  :: normalized `float` value = `(float)c / 255.0f`
+[none]
+* normalized `float` value = `(float)c / 255.0f`
 
 `CL_UNORM_INT_101010` (10-bit unsigned integer) {rightarrow} `float`
 
-  :: normalized `float` value = `(float)c / 1023.0f`
+[none]
+* normalized `float` value = `(float)c / 1023.0f`
 
 `CL_UNORM_INT16` (16-bit unsigned integer) {rightarrow} `float`
 
-  :: normalized `float` value = `(float)c / 65535.0f`
+[none]
+* normalized `float` value = `(float)c / 65535.0f`
 
 `CL_SNORM_INT8` (8-bit signed integer) {rightarrow} `float`
 
-  :: normalized `float` value = *max*(`-1.0f`, `(float)c / 127.0f`)
+[none]
+* normalized `float` value = *max*(`-1.0f`, `(float)c / 127.0f`)
 
 `CL_SNORM_INT16` (16-bit signed integer) {rightarrow} `float`
 
-  :: normalized `float` value = *max*(`-1.0f`, `(float)c / 32767.0f`)
+[none]
+* normalized `float` value = *max*(`-1.0f`, `(float)c / 32767.0f`)
 
 The precision of the above conversions is \<= 1.5 ulp except for the
 following cases.
 
 For `CL_UNORM_INT8`
 
-  :: 0 must convert to `0.0f` and
-  :: 255 must convert to `1.0f`
+[none]
+* 0 must convert to `0.0f` and
+* 255 must convert to `1.0f`
 
 For `CL_UNORM_INT_101010`
 
-  :: 0 must convert to `0.0f` and
-  :: 1023 must convert to `1.0f`
+[none]
+* 0 must convert to `0.0f` and
+* 1023 must convert to `1.0f`
 
 For `CL_UNORM_INT16`
 
-  :: 0 must convert to `0.0f` and
-  :: 65535 must convert to `1.0f`
+[none]
+* 0 must convert to `0.0f` and
+* 65535 must convert to `1.0f`
 
 For `CL_SNORM_INT8`
 
-  :: -128 and -127 must convert to `-1.0f`,
-  :: 0 must convert to `0.0f` and
-  :: 127 must convert to `1.0f`
+[none]
+* -128 and -127 must convert to `-1.0f`,
+* 0 must convert to `0.0f` and
+* 127 must convert to `1.0f`
 
 For `CL_SNORM_INT16`
 
-  :: -32768 and -32767 must convert to `-1.0f`,
-  :: 0 must convert to `0.0f` and
-  :: 32767 must convert to `1.0f`
+[none]
+* -32768 and -32767 must convert to `-1.0f`,
+* 0 must convert to `0.0f` and
+* 32767 must convert to `1.0f`
 
 
 [[converting-floating-point-values-to-normalized-integer-channel-data-types]]
@@ -11752,23 +11774,28 @@ normalized integer values are performed is as follows:
 
 `float` {rightarrow} `CL_UNORM_INT8` (8-bit unsigned integer)
 
-  :: *convert_uchar_sat_rte*(`f * 255.0f`)
+[none]
+* *convert_uchar_sat_rte*(`f * 255.0f`)
 
 `float` {rightarrow} `CL_UNORM_INT_101010` (10-bit unsigned integer)
 
-  :: *min*(*convert_ushort_sat_rte*(`f * 1023.0f`), `0x3ff`)
+[none]
+* *min*(*convert_ushort_sat_rte*(`f * 1023.0f`), `0x3ff`)
 
 `float` {rightarrow} `CL_UNORM_INT16` (16-bit unsigned integer)
 
-  :: *convert_ushort_sat_rte*(`f * 65535.0f`)
+[none]
+* *convert_ushort_sat_rte*(`f * 65535.0f`)
 
 `float` {rightarrow} `CL_SNORM_INT8` (8-bit signed integer)
 
-  :: *convert_char_sat_rte*(`f * 127.0f`)
+[none]
+* *convert_char_sat_rte*(`f * 127.0f`)
 
 `float` {rightarrow} `CL_SNORM_INT16` (16-bit signed integer)
 
-  :: *convert_short_sat_rte*(`f * 32767.0f`)
+[none]
+* *convert_short_sat_rte*(`f * 32767.0f`)
 
 Please refer to the <<out-of-range-behavior,out-of-range behavior and
 saturated conversion>> rules.
@@ -11782,36 +11809,41 @@ the result produced by the round to nearest even rounding mode must be {leq}
 
 `float` {rightarrow} `CL_UNORM_INT8` (8-bit unsigned integer)
 
-  :: Let f~preferred~ = *convert_uchar_sat_rte*(f * `255.0f`)
-  :: Let f~approx~ = *convert_uchar_sat_<impl-rounding-mode>*(f * `255.0f`)
-  :: *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
+[none]
+* Let f~preferred~ = *convert_uchar_sat_rte*(f * `255.0f`)
+* Let f~approx~ = *convert_uchar_sat_<impl-rounding-mode>*(f * `255.0f`)
+* *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
 
 `float` {rightarrow} `CL_UNORM_INT_101010` (10-bit unsigned integer)
 
-  :: Let f~preferred~ = *convert_ushort_sat_rte*(f * `1023.0f`)
-  :: Let f~approx~ = *convert_ushort_sat_<impl-rounding-mode>*(f *
+[none]
+* Let f~preferred~ = *convert_ushort_sat_rte*(f * `1023.0f`)
+* Let f~approx~ = *convert_ushort_sat_<impl-rounding-mode>*(f *
      `1023.0f`)
-  :: *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
+* *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
 
 `float` {rightarrow} `CL_UNORM_INT16` (16-bit unsigned integer)
 
-  :: Let f~preferred~ = *convert_ushort_sat_rte*(f * `65535.0f`)
-  :: Let f~approx~ = *convert_ushort_sat_<impl-rounding-mode>*(f *
+[none]
+* Let f~preferred~ = *convert_ushort_sat_rte*(f * `65535.0f`)
+* Let f~approx~ = *convert_ushort_sat_<impl-rounding-mode>*(f *
      `65535.0f`)
-  :: *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
+* *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
 
 `float` {rightarrow} `CL_SNORM_INT8` (8-bit signed integer)
 
-  :: Let f~preferred~ = *convert_char_sat_rte*(f * `127.0f`)
-  :: Let f~approx~ = *convert_char_sat_<impl_rounding_mode>*(f * `127.0f`)
-  :: *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
+[none]
+* Let f~preferred~ = *convert_char_sat_rte*(f * `127.0f`)
+* Let f~approx~ = *convert_char_sat_<impl_rounding_mode>*(f * `127.0f`)
+* *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
 
 `float` {rightarrow} `CL_SNORM_INT16` (16-bit signed integer)
 
-  :: Let f~preferred~ = *convert_short_sat_rte*(f * `32767.0f`)
-  :: Let f~approx~ = *convert_short_sat_<impl-rounding-mode>*(f *
+[none]
+* Let f~preferred~ = *convert_short_sat_rte*(f * `32767.0f`)
+* Let f~approx~ = *convert_short_sat_<impl-rounding-mode>*(f *
      `32767.0f`)
-  :: *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
+* *fabs*(f~preferred~ - f~approx~) must be \<= 0.6
 
 
 [[conversion-rules-for-half-precision-floating-point-channel-data-type]]
@@ -11855,29 +11887,35 @@ Calls to *write_imagei* will perform one of the following conversions:
 
 32 bit signed integer {rightarrow} 8-bit signed integer
 
-  :: *convert_char_sat*(i)
+[none]
+* *convert_char_sat*(i)
 
 32 bit signed integer {rightarrow} 16-bit signed integer
 
-  :: *convert_short_sat*(i)
+[none]
+* *convert_short_sat*(i)
 
 32 bit signed integer {rightarrow} 32-bit signed integer
 
-  :: no conversion is performed
+[none]
+* no conversion is performed
 
 Calls to *write_imageui* will perform one of the following conversions:
 
 32 bit unsigned integer {rightarrow} 8-bit unsigned integer
 
-  :: *convert_uchar_sat*(i)
+[none]
+* *convert_uchar_sat*(i)
 
 32 bit unsigned integer {rightarrow} 16-bit unsigned integer
 
-  :: *convert_ushort_sat*(i)
+[none]
+* *convert_ushort_sat*(i)
 
 32 bit unsigned integer {rightarrow} 32-bit unsigned integer
 
-  :: no conversion is performed
+[none]
+* no conversion is performed
 
 The conversions described in this section must be correctly saturated.
 
@@ -11954,7 +11992,8 @@ channel_component = floor(scaled_reference_result + 0.5);
 
 The precision of the above conversion should be such that
 
-  :: `|generated_channel_component - scaled_reference_result|` {leq} 0.6
+[none]
+* `|generated_channel_component - scaled_reference_result|` {leq} 0.6
 
 where `generated_channel_component` is the actual value that the
 implementation produces and being checked for conformance.
@@ -11968,11 +12007,13 @@ reading from and/or writing to a 2D image in a 2D image array.
 
 When read using a sampler, the 2D image layer selected is computed as:
 
-  :: layer = *clamp*(*rint*(_w_), 0, d~t~ - 1)
+[none]
+* layer = *clamp*(*rint*(_w_), 0, d~t~ - 1)
 
 otherwise the layer selected is computed as:
 
-  :: layer = _w_
+[none]
+* layer = _w_
 
 (since _w_ is already an integer) and the result is undefined if _w_ is not
 one of the integers 0, 1, ... d~t~ - 1.
@@ -11982,11 +12023,13 @@ from and/or writing to a 1D image in a 1D image array.
 
 When read using a sampler, the 1D image layer selected is computed as:
 
-  :: layer = *clamp*(*rint*(_v_), 0, h~t~ - 1)
+[none]
+* layer = *clamp*(*rint*(_v_), 0, h~t~ - 1)
 
 otherwise the layer selected is computed as:
 
-  :: layer = _v_
+[none]
+* layer = _v_
 
 (since _v_ is already an integer) and the result is undefined if _v_ is not
 one of the integers 0, 1, ... h~t~ - 1.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -120,10 +120,11 @@ Note that a device that provides the same level of capabilities as an OpenCL 2.x
 OpenCL C compilers supporting atomics orders or scopes beyond the mandated
 minimum will define some or all of following feature macros as appropriate:
 
-  :: `__opencl_c_atomic_order_acq_rel` -- Indicating atomic operations support acquire-release orderings.
-  :: `__opencl_c_atomic_order_seq_cst` -- Indicating atomic operations and fences support acquire sequentially consistent orderings.
-  :: `__opencl_c_atomic_scope_device` -- Indicating atomic operations and fences support device-wide memory ordering constraints.
-  :: `__opencl_c_atomic_scope_all_devices` -- Indicating atomic operations and fences support all-device memory ordering constraints, across any host threads and all devices that can share SVM memory with each other and the host process.
+[none]
+* `__opencl_c_atomic_order_acq_rel` -- Indicating atomic operations support acquire-release orderings.
+* `__opencl_c_atomic_order_seq_cst` -- Indicating atomic operations and fences support acquire sequentially consistent orderings.
+* `__opencl_c_atomic_scope_device` -- Indicating atomic operations and fences support device-wide memory ordering constraints.
+* `__opencl_c_atomic_scope_all_devices` -- Indicating atomic operations and fences support all-device memory ordering constraints, across any host threads and all devices that can share SVM memory with each other and the host process.
 
 == Device-Side Enqueue
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -367,16 +367,19 @@ combination of the work-group ID (_w_~x~, _w_~y~), the size of each
 work-group (S~x~,S~y~) and the local ID (s~x~, s~y~) inside the work-group
 such that
 
-  :: (g~x~ , g~y~) = (w~x~ S~x~ + s~x~ + F~x~, w~y~ S~y~ + s~y~ + F~y~)
+[none]
+* (g~x~ , g~y~) = (w~x~ S~x~ + s~x~ + F~x~, w~y~ S~y~ + s~y~ + F~y~)
 
 The number of work-groups can be computed as:
 
-  :: (W~x~, W~y~) = (ceil(G~x~ / S~x~), ceil(G~y~ / S~y~))
+[none]
+* (W~x~, W~y~) = (ceil(G~x~ / S~x~), ceil(G~y~ / S~y~))
 
 Given a global ID and the work-group size, the work-group ID for a work-item
 is computed as:
 
-  :: (w~x~, w~y~) = ( (g~x~ s~x~ F~x~) / S~x~, (g~y~ s~y~ F~y~) / S~y~ )
+[none]
+* (w~x~, w~y~) = ( (g~x~ s~x~ F~x~) / S~x~, (g~y~ s~y~ F~y~) / S~y~ )
 
 [[index-space-image]]
 image::images/index_space.jpg[align="center", title="An example of an NDRange index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global NDRange size (i.e. all work-groups have the same size) and that the offset is equal to zero."]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6576,13 +6576,12 @@ The following options can be specified when linking a program executable.
 `-cl-fast-relaxed-math` +
 `-cl-no-subgroup-ifp` (<<unified-spec, missing before>> version 2.1)
 
-::
-    The options are described in <<math-intrinsics-options, Math Intrinsics
-    Options>> and <<optimization-options, Optimization Options>>.
-    The linker may apply these options to all compiled program objects
-    specified to {clLinkProgram}.
-    The linker may apply these options only to libraries which were created
-    with the option `-enable-link-options`.
+The options are described in <<math-intrinsics-options, Math Intrinsics
+Options>> and <<optimization-options, Optimization Options>>.
+The linker may apply these options to all compiled program objects
+specified to {clLinkProgram}.
+The linker may apply these options only to libraries which were created
+with the option `-enable-link-options`.
 
 
 === Unloading the OpenCL Compiler

--- a/cxx/image_addressing_and_filtering.txt
+++ b/cxx/image_addressing_and_filtering.txt
@@ -68,7 +68,8 @@ The size term in <<addressing_modes_to_generate_texel_location,Addressing modes 
 
 The clamp function used in <<addressing_modes_to_generate_texel_location,Addressing modes to generate texel location>> table is defined as:
 
-  :: latexmath:[clamp(a, b, c) = return (a < b) ? b : ((a > c) ? c : a)]
+[none]
+* latexmath:[clamp(a, b, c) = return (a < b) ? b : ((a > c) ? c : a)]
 
 If the selected texel location (i,j,k) refers to a location outside the image, the border color is used as the color value for this texel.
 


### PR DESCRIPTION
The spec source currently uses a [description list](https://asciidoctor.org/docs/user-manual/#description-list) with an empty "term" to indent a line, for example:

```
  :: _lvalue_ = _expression_
```

This renders OK in the currently published specs (see example [here](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#operators-assignment)), but it doesn't render OK with the latest Travis builds (see example [here](https://bashbaug.github.io/OpenCL-Docs/html/OpenCL_C.html#operators-assignment)), so something changed in the updated Asciidoctor toolchain.

Since a description list is supposed to have "one or more terms", it was probably by chance that the old toolchain was "working".  This change switches to an unordered list with [no markers](https://asciidoctor.org/docs/user-manual/#custom-markers) instead, which is supported and renders correctly with the latest toolchains.

```
[none]
* _lvalue_ = _expression_
```