### PR TITLE
add missing kernel enum CLK_UNORM_INT_101010_2

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -8906,6 +8906,7 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       `CLK_UNORM_SHORT_565` +
       `CLK_UNORM_SHORT_555` +
       `CLK_UNORM_INT_101010` +
+      `CLK_UNORM_INT_101010_2` +
       `CLK_SIGNED_INT8` +
       `CLK_SIGNED_INT16` +
       `CLK_SIGNED_INT32` +

--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -307,6 +307,9 @@ channel data types.
 | `UnormInt101010`
 | `CL_UNORM_INT_101010`
 
+| `UnormInt101010_2`
+| `CL_UNORM_INT_101010_2`
+
 | `SignedInt8`
 | `CL_SIGNED_INT8`
 


### PR DESCRIPTION
Fixes #292.

This change adds the kernel enum `CLK_UNORM_INT_101010_2` to OpenCL C, which is returned by  `get_image_channel_data_type` for images that were created with image channel data types  `CL_UNORM_INT_101010_2`.  It also adds the expected SPIR-V mappings for these images.