### PR TITLE
clarified rationale for the new buffer and image creation APIs

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -391,7 +391,9 @@ describe supported features and versions:
     built-in kernels and their supported version.
 
 OpenCL 3.0 adds two new APIs to support creating buffer and image
-memory objects with additional properties:
+memory objects with additional properties.
+Although no new properties are added in OpenCL 3.0, these APIs enable
+new buffer and image extensions to be added easily and consistently:
 
   * {clCreateBufferWithProperties}
   * {clCreateImageWithProperties}


### PR DESCRIPTION
Fixes #310.

Adds a line to the change log appendix describing why OpenCL 3.0 adds new buffer and image creation APIs, but does not define any new properties:

> Although no new properties are added in OpenCL 3.0, these APIs enable new buffer and image extensions to be added easily and consistently.