### PR TITLE
Correct rendering of 3D get_global_linear_id formula

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4186,13 +4186,13 @@ identifier of each work-item when this kernel is being executed on a device.
       *get_global_offset*(0).
 
       For 2D work-groups, it is computed as (*get_global_id*(1) -
-      *get_global_offset*(1)) * *get_global_size*(0) + (*get_global_id*(0) -
+      *get_global_offset*(1)) * *get_global_size*(0) {plus} (*get_global_id*(0) -
       *get_global_offset*(0)).
 
-      For 3D work-groups, it is computed as ((*get_global_id*(2) -
-      *get_global_offset*(2)) * *get_global_size*(1) * *get_global_size*(0))
-      + ((*get_global_id*(1) - *get_global_offset*(1)) * *get_global_size*
-      (0)) + (*get_global_id*(0) - *get_global_offset*(0)).
+      For 3D work-groups, it is computed as +((+*get_global_id*(2) -
+      *get_global_offset*(2)+)+ * *get_global_size*(1) * *get_global_size*(0)+)+
+      {plus} +((+*get_global_id*(1) - *get_global_offset*(1)+)+ * *get_global_size*(0)+)+
+      {plus} (*get_global_id*(0) - *get_global_offset*(0)+)+.
 | size_t *get_local_linear_id*()
     | Returns the work-items 1-dimensional local ID.
 
@@ -4202,12 +4202,12 @@ identifier of each work-item when this kernel is being executed on a device.
 
       For 2D work-groups, it is computed as
 
-      *get_local_id*(1) * *get_local_size*(0) + *get_local_id*(0).
+      *get_local_id*(1) * *get_local_size*(0) {plus} *get_local_id*(0).
 
       For 3D work-groups, it is computed as
 
-      *(get_local_id*(2) * *get_local_size*(1) * *get_local_size*(0)) {plus}
-      (*get_local_id*(1) * *get_local_size*(0)) + *get_local_id*(0).
+      (*get_local_id*(2) * *get_local_size*(1) * *get_local_size*(0)) {plus}
+      (*get_local_id*(1) * *get_local_size*(0)) {plus} *get_local_id*(0).
 |====
 
 [28] I.e. the _global_work_size_ values specified to *clEnqueueNDRangeKernel*


### PR DESCRIPTION
Currently the 3d `get_global_linear_id` formula renders as

> get_global_id(2) - get_global_offset(2 * get_global_size(1) * get_global_size(0)) + get_global_id(1) - get_global_offset(1 * get_global_size (0)) + (get_global_id(0) - get_global_offset(0))

where the brackets are obviously incorrect.  With this change the formula renders as

> ((get_global_id(2) - get_global_offset(2)) * get_global_size(1) * get_global_size(0)) + ((get_global_id(1) - get_global_offset(1)) * get_global_size(0)) + (get_global_id(0) - get_global_offset(0))

The changes of mathematical (rather than formatting) `+` to `{plus}` are not actually essential, but helped me separate them.