### PR TITLE
deprecate scalar inputs for any and all built-in functions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5472,9 +5472,13 @@ not a number (NaN) and the argument type is a vector.
      float is set else returns 0.
 | |
 | int *any*(igentype _x_)
+
+Scalar inputs to *any* are deprecated by OpenCL C version 3.0.
     | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
       any component of _x_ (for vector inputs) is set; otherwise returns 0.
 | int *all*(igentype _x_)
+
+Scalar inputs to *all* are deprecated by OpenCL C version 3.0.
     | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
       all components of _x_ (for vector inputs) is set; otherwise returns 0.
 | |

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -410,6 +410,12 @@ OpenCL 3.0 adds the OpenCL 3.0 C kernel language, which includes
 feature macros to describe OpenCL C language support.
 Please refer to the OpenCL C specification for details.
 
+// GitHub issue #178
+Scalar input arguments to the *any* and *all* built-in functions have
+been deprecated in the OpenCL 3.0 C kernel language.
+These functions behaved inconsistently with the C language's use of
+scalar integers as logical values.
+
 OpenCL 3.0 adds new queries to determine supported OpenCL C language
 versions and supported OpenCL C features:
 

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
             category = type.get('category')
             if category == 'struct':
                 name = type.get('name')
-                print('found type: ' +name)
+                #print('found type: ' +name)
 
                 # Create a variant of the name that precedes underscores with
                 # "zero width" spaces.  This causes some long names to be


### PR DESCRIPTION
This change deprecates scalar inputs for the **any** and **all** built-in functions.

Fixes #178.