### PR TITLE
clarify spec constant behavior for non-SPIR-V intermediate langauges

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5817,9 +5817,10 @@ executed successfully.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_PROGRAM} if _program_ is not a valid program object created
-    from an intermediate language (e.g. SPIR-V).
+    from an intermediate language (e.g. SPIR-V), or if the intermediate
+    language does not support specialization constants.
   * {CL_INVALID_SPEC_ID} if _spec_id_ is not a valid specialization constant
-    ID
+    identifier.
   * {CL_INVALID_VALUE} if _spec_size_ does not match the size of the
     specialization constant in the module, or if _spec_value_ is
     `NULL`.


### PR DESCRIPTION
This PR adds the small clarification described in https://github.com/KhronosGroup/OpenCL-Docs/issues/303#issuecomment-634181292 regarding specialization constants for non-SPIR-V intermediate languages.  Specifically, if a program is created from an intermediate language that does not support specialization constants, then `clSetProgramSpecializationConstant` should return `CL_INVALID_PROGRAM`, similar to programs created from source or native device binaries.