### PR TITLE
add clSetContextDestructorCallback

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -390,6 +390,12 @@ describe supported features and versions:
   * {CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION} to describe supported
     built-in kernels and their supported version.
 
+OpenCL 3.0 adds a new API to register a function that will be called
+when a context is destroyed, enabling an application to safely free
+user data associated with a context callback function.
+
+  * {clSetContextDestructorCallback}
+
 OpenCL 3.0 adds two new APIs to support creating buffer and image
 memory objects with additional properties.
 Although no new properties are added in OpenCL 3.0, these APIs enable

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -2205,3 +2205,52 @@ Otherwise, it returns one of the following errors:
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 --
+
+[open,refpage='clSetContextDestructorCallback',desc='Registers a destructor callback function with a context.',type='protos']
+--
+To register a callback function with a context that is called when
+the context is destroyed, call the function
+
+include::{generated}/api/protos/clSetContextDestructorCallback.txt[]
+include::{generated}/api/version-notes/clSetContextDestructorCallback.asciidoc[]
+
+  * _context_ specifies the OpenCL context to register the callback to.
+  * _pfn_notify_ is the callback function to register.
+    This callback function may be called asynchronously by the OpenCL
+    implementation.
+    It is the application's responsibility to ensure that the callback function
+    is thread-safe.
+    The parameters to this callback function are:
+  ** _context_ is the OpenCL context being deleted.
+     When the callback function is called by the implementation, this context
+     is no longer valid.
+     _context_ is only provided for reference purposes.
+  ** _user_data_ is a pointer to user-supplied data.
+  * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
+    called.
+    _user_data_ can be `NULL`.
+
+Each call to {clSetContextDestructorCallback} registers the specified
+callback function on a destructor callback stack associated with _context_.
+The registered callback functions are called in the reverse order in
+which they were registered.
+If a context callback function was specified when _context_ was created,
+it will not be called after any context destructor callback is called.
+Therefore, the context destructor callback provides a mechanism for an
+application to safely re-use or free any _user_data_ specified for the
+context callback function when _context_ was created.
+
+// refError
+
+{clSetContextDestructorCallback} returns {CL_SUCCESS} if the function is
+executed successfully.
+Otherwise, it returns one of the following errors:
+
+  * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
+  * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL`.
+  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
+    by the OpenCL implementation on the device.
+  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
+    required by the OpenCL implementation on the host.
+--
+

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3792,40 +3792,39 @@ Using this function to release a reference that was not obtained by creating
 the object or by calling {clRetainMemObject} causes undefined behavior.
 --
 
-[open,refpage='clSetMemObjectDestructorCallback',desc='Registers a user callback function with a memory object.',type='protos']
+[open,refpage='clSetMemObjectDestructorCallback',desc='Registers a destructor callback function with a memory object.',type='protos']
 --
-To register a user callback function with a memory object, call the function
+To register a callback function with a memory object that is called when
+the memory object is destroyed, call the function
 
 include::{generated}/api/protos/clSetMemObjectDestructorCallback.txt[]
 include::{generated}/api/version-notes/clSetMemObjectDestructorCallback.asciidoc[]
 
-  * _memobj_ is a valid memory object.
-  * _pfn_notify_ is the callback function that can be registered by the
-    application.
+  * _memobj_ specifies the memory object to register the callback to.
+  * _pfn_notify_ is the callback function to register.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread-safe.
     The parameters to this callback function are:
   ** _memobj_ is the memory object being deleted.
-     When the user callback is called by the implementation, this memory
+     When the callback function is called by the implementation, this memory
      object is not longer valid.
      _memobj_ is only provided for reference purposes.
-  ** _user_data_ is a pointer to user supplied data.
+  ** _user_data_ is a pointer to user-supplied data.
   * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
     called.
     _user_data_ can be `NULL`.
 
-Each call to {clSetMemObjectDestructorCallback} registers the specified user
-callback function on a callback stack associated with _memobj_.
-The registered user callback functions are called in the reverse order in
+Each call to {clSetMemObjectDestructorCallback} registers the specified
+callback function on a destructor callback stack associated with _memobj_.
+The registered callback functions are called in the reverse order in
 which they were registered.
-The user callback functions are called and then the memory objects resources
-are freed and the memory object is deleted.
-This provides a mechanism for the application (and libraries) using _memobj_
-to be notified when the memory referenced by _host_ptr_, specified when the
-memory object is created and used as the storage bits for the memory object,
-can be reused or freed.
+The registered callback functions are called and then the memory object's
+resources are freed and the memory object is deleted.
+Therefore, the memory object destructor callback provides a mechanism for
+an application to safely re-use or free a _host_ptr_ that was specified when
+_memobj_ was created and used as the storage bits for the memory object.
 
 // refError
 
@@ -5715,40 +5714,39 @@ Using this function to release a reference that was not obtained by creating
 the object or by calling {clRetainProgram} causes undefined behavior.
 --
 
-[open,refpage='clSetProgramReleaseCallback',desc='',type='protos']
+[open,refpage='clSetProgramReleaseCallback',desc='Registers a destructor callback function with a program object.',type='protos']
 --
-To register a user callback function with a program object, call the
-function
+To register a callback function with a program object that is called when
+the program object is destroyed, call the function
 
 include::{generated}/api/protos/clSetProgramReleaseCallback.txt[]
 include::{generated}/api/version-notes/clSetProgramReleaseCallback.asciidoc[]
 
-  * _program_ is a valid program object
-  * _pfn_notify_ is the callback function that can be registered by the
-    application.
+  * _program_ specifies the memory object to register the callback to.
+  * _pfn_notify_ is the callback function to register.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread safe.
     The parameters to this callback function are:
-  ** _prog_ is the program object whose destructors are being called.
-     When the user callback is called by the implementation, this program object
-     is not longer valid.
-     prog is only provided for reference purposes.
+  ** _program_ is the program being deleted.
+     When the callback function is called by the implementation, this program
+     object is not longer valid.
+     _program_ is only provided for reference purposes.
   ** _user_data_ is a pointer to user supplied data.
-     _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
-     called.
-     user data can be `NULL`.
+  * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
+    called.
+    user data can be `NULL`.
 
-Each call to {clSetProgramReleaseCallback} registers the specified user
-callback function on a callback stack associated with program.
-The registered user callback functions are called in the reverse order in
+Each call to {clSetProgramReleaseCallback} registers the specified
+callback function on a callback stack associated with _program_.
+The registered callback functions are called in the reverse order in
 which they were registered.
-The user callback functions are called after destructors (if any) for
-program scope global variables (if any) are called and before the program is
-released.
-This provides a mechanism for the application (and libraries) to be notified
-when destructors are complete.
+The registered callback functions are called after destructors (if any) for
+program scope global variables (if any) are called and before the program
+object is deleted.
+This provides a mechanism for an application to be notified when destructors
+for program scope global variables are complete.
 
 // refError
 

--- a/man/toctail
+++ b/man/toctail
@@ -31,6 +31,7 @@
                             <li><a href="clGetContextInfo.html" target="pagedisplay">clGetContextInfo</a></li>
                             <li><a href="clReleaseContext.html" target="pagedisplay">clReleaseContext</a></li>
                             <li><a href="clRetainContext.html" target="pagedisplay">clRetainContext</a></li>
+                            <li><a href="clSetContextDestructorCallback.html" target="pagedisplay">clSetContextDestructorCallback</a></li>
                         </ul>
                     </li>
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2551,6 +2551,12 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
+        <command suffix="CL_API_SUFFIX__VERSION_3_0">
+            <proto><type>cl_int</type>                                  <name>clSetContextDestructorCallback</name></proto>
+            <param><type>cl_context</type>                              <name>context</name></param>
+            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_context context, void* user_data)</param>
+            <param><type>void</type>*                                   <name>user_data</name></param>
+        </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_command_queue</type>                        <name>clCreateCommandQueueWithProperties</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
@@ -4244,10 +4250,10 @@ server's OpenCL/api-docs repository.
         <require comment="cl_profiling_info">
             <enum name="CL_PROFILING_COMMAND_COMPLETE"/>
         </require>
-        <require comment="Context APIs">
+        <require comment="Command Queue APIs">
             <command name="clCreateCommandQueueWithProperties"/>
         </require>
-        <require comment="Command Queue APIs">
+        <require comment="Pipe APIs">
             <command name="clCreatePipe"/>
             <command name="clGetPipeInfo"/>
         </require>
@@ -4336,11 +4342,11 @@ server's OpenCL/api-docs repository.
     <feature api="opencl" name="CL_VERSION_3_0" number="3.0" comment="OpenCL experimental API interface definitions">
         <require>
             <type name="cl_device_atomic_capabilities"/>
+            <type name="cl_device_device_enqueue_capabilities"/>
             <type name="cl_khronos_vendor_id"/>
             <type name="cl_mem_properties"/>
             <type name="cl_version"/>
             <type name="cl_name_version"/>
-            <type name="cl_device_device_enqueue_capabilities"/>
         </require>
         <require comment="cl_device_atomic_capabilities - bitfield">
             <enum name="CL_DEVICE_ATOMIC_ORDER_RELAXED"/>
@@ -4350,6 +4356,10 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP"/>
             <enum name="CL_DEVICE_ATOMIC_SCOPE_DEVICE"/>
             <enum name="CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES"/>
+        </require>
+        <require comment="cl_device_device_enqueue_capabilities - bitfield">
+            <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
+            <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
         </require>
         <require comment="cl_platform_info">
             <enum name="CL_PLATFORM_NUMERIC_VERSION"/>
@@ -4392,13 +4402,12 @@ server's OpenCL/api-docs repository.
             <enum name="CL_VERSION_PATCH_BITS"/>
             <enum name="CL_NAME_VERSION_MAX_NAME_SIZE"/>
         </require>
+        <require comment="Context APIs">
+            <command name="clSetContextDestructorCallback"/>
+        </require>
         <require comment="Memory Object APIs">
             <command name="clCreateBufferWithProperties"/>
             <command name="clCreateImageWithProperties"/>
-        </require>
-        <require comment="cl_device_device_enqueue_capabilities - bitfield">
-            <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
-            <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
         </require>
     </feature>
 


### PR DESCRIPTION
Fixes #187.

This PR adds a new API to register a callback for a context that is called when the context is destroyed.