### PR TITLE
deprecate APIs and queries for program init and cleanup kernels

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -406,6 +406,16 @@ when creating buffers, images, pipes, samplers, and command queues:
   * {CL_SAMPLER_PROPERTIES}
   * {CL_QUEUE_PROPERTIES_ARRAY}
 
+// GitHub issue #348
+Program Initialization and Clean-Up kernels are not supported in OpenCL
+3.0 due to implementation complexity and lack of demand.
+The following APIs and queries for Program Initialization and Clean-Up
+kernels are deprecated in OpenCL 3.0:
+
+  * {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT}
+  * {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT}
+  * {clSetProgramReleaseCallback}
+
 OpenCL 3.0 adds the OpenCL 3.0 C kernel language, which includes
 feature macros to describe OpenCL C language support.
 Please refer to the OpenCL C specification for details.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -409,7 +409,7 @@ OpenCL C compilers supporting Subgroups will define the feature macro `__opencl_
 
 == Program Initialization and Clean-Up Kernels
 
-Program Initialization and Clean-Up Kernels are not supported in OpenCL 3.0.
+Program Initialization and Clean-Up Kernels are not supported in OpenCL 3.0, and the APIs and queries for Program Initialization and Clean-Up kernels are deprecated in OpenCL 3.0.
 When Program Initialization and Clean-Up Kernels are not supported:
 
 [cols="2,3",options="header",]

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2788,7 +2788,7 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
-        <command suffix="CL_API_SUFFIX__VERSION_2_2">
+        <command prefix="CL_API_PREFIX__VERSION_2_2_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_2_2_DEPRECATED">
             <proto><type>cl_int</type>                                  <name>clSetProgramReleaseCallback</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
@@ -3909,9 +3909,6 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE"/>
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF"/>
         </require>
-        <require comment="cl_device_info enums deprecated in OpenCL 3.0">
-            <enum name="CL_DEVICE_OPENCL_C_VERSION"/>
-        </require>
         <require comment="cl_device_fp_config - bitfield">
             <enum name="CL_FP_SOFT_FLOAT"/>
         </require>
@@ -3958,6 +3955,9 @@ server's OpenCL/api-docs repository.
         </require>
         <require comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 2.0">
             <enum name="CL_DEVICE_HOST_UNIFIED_MEMORY"/>
+        </require>
+        <require comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 3.0">
+            <enum name="CL_DEVICE_OPENCL_C_VERSION"/>
         </require>
     </feature>
 
@@ -4323,13 +4323,15 @@ server's OpenCL/api-docs repository.
             <enum name="CL_INVALID_SPEC_ID"/>
             <enum name="CL_MAX_SIZE_RESTRICTION_EXCEEDED"/>
         </require>
-        <require comment="cl_program_info">
+        <require comment="Program Object APIs">
+            <command name="clSetProgramSpecializationConstant"/>
+        </require>
+        <require comment="OpenCL 2.2 Program Object APIs that were deprecated in OpenCL 3.0">
+            <command name="clSetProgramReleaseCallback"/>
+        </require>
+        <require comment="OpenCL 2.2 cl_program_info enums that were deprecated in OpenCL 3.0">
             <enum name="CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT"/>
             <enum name="CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT"/>
-        </require>
-        <require comment="Program Object APIs">
-            <command name="clSetProgramReleaseCallback"/>
-            <command name="clSetProgramSpecializationConstant"/>
         </require>
     </feature>
 


### PR DESCRIPTION
This PR describes the changes needed to deprecate the APIs and queries for Program Initialization and Cleanup Kernels, also known as Program Scope Constructors and Destructors.

The "deprecated by" text will be inserted automatically into the OpenCL specs with the changes to the XML grammar.

edit:

This PR fixes #348 

A slightly different change is needed to address #347.  I will create a separate PR for it shortly.