### PR TITLE
[OpenCL C 3.0] Clarify use of extension pragma (#82).

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3180,6 +3180,19 @@ following forms whose meanings are described elsewhere:
 #pragma OPENCL EXTENSION all : behavior
 ----------
 
+`FP_CONTRACT` directive can be used to specify contraction for some floating
+point operations (more details can be found in <<floating-point-macros-and-pragmas,
+the floating-point macros and pragmas section>>).
+
+`EXTENSION` directive is used to enable logic in the compiler that deviates
+from the standard behavior described in this document. Extensions are not
+guaranteed to be supported by all implementations and their presence can be checked
+by availability of specific predefined macros. More information can be found in
+<<opencl-extension-spec,section 9.1 in the OpenCL Extension Specification>>.
+Pragma directives are only needed for extensions that require changes in the
+language such that the source code is interpreted differently during the
+compilation.
+
 The following predefined macro names are available.
 
 `+__FILE__+` ::
@@ -3719,8 +3732,8 @@ compile-time constant expression.
 The attribute syntax can be extended for standard language extensions and
 vendor specific extensions.
 Any extensions should follow the naming conventions outlined in the
-introduction to <<opencl-extension-spec,section 9 in the OpenCL 2.0
-Extension Specification>>.
+introduction to <<opencl-extension-spec,section 9 in the OpenCL Extension
+Specification>>.
 
 Attributes are intended as useful hints to the compiler.
 It is our intention that a particular implementation of OpenCL be free to

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -9,6 +9,15 @@ This section describes the *cl_khr_fp16* extension.
 This extension adds support for half scalar and vector types as built-in
 types that can be used for arithmetic operations, conversions etc.
 
+This extension modifies behavior of OpenCL C and it has to be
+activated/deactivated using pragma `EXTENSION` directive.
+
+[source,c]
+----
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#pragma OPENCL EXTENSION cl_khr_fp16 : disable
+----
+
 === General information
 
 ==== Version history

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -8,6 +8,15 @@
 This section describes the *cl_khr_fp64* extension.
 This extension became an optional core feature in OpenCL 1.2.
 
+This extension modifies behavior of OpenCL C and it has to be
+activated/deactivated using pragma `EXTENSION` directive.
+
+[source,c]
+----
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#pragma OPENCL EXTENSION cl_khr_fp64 : disable
+----
+
 === General information
 
 ==== Version history

--- a/ext/introduction.asciidoc
+++ b/ext/introduction.asciidoc
@@ -121,7 +121,16 @@ The initial state of the compiler is as if the directive
 ----
 
 was issued, telling the compiler that all error and warning reporting must
-be done according to this specification, ignoring any extensions.
+be done according to the core specification, ignoring any extensions.
+
+Pragma directives are only required for extensions that change the compiler
+behavior i.e. the source code is interpreted differently if the pragma
+directive is used. Each extension should specify whether it adds the
+directive or not. However, if it is not explicitly specified it is assumed
+that the pragma directive is optional for the extension.  As unknown
+directives are ignored by the compiler the use of pragma with extensions
+that do not support them will not cause the compilation to fail but might
+result in a diagnostic.
 
 Every extension which affects the OpenCL language semantics, syntax or adds
 built-in functions to the language must create a preprocessor `#define` that


### PR DESCRIPTION
This change adds clarification for the compiler directive
that enables and disables the extensions.

Summary:
- Add high-level description of OpenCL specific pragma
  directives into the core spec.
- Clarify the use of extension pragma in the extension spec.
- Clarify the need of extension pragma directive in cl_khr_fp64
  and cl_khr_fp16.