### PR TITLE
clarify program scope global variable constructor and destructor behavior

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5748,6 +5748,12 @@ object is deleted.
 This provides a mechanism for an application to be notified when destructors
 for program scope global variables are complete.
 
+{clSetProgramReleaseCallback} may unconditionally return an error if no
+devices in the context associated with _program_ support destructors for
+program scope global variables.
+Support for constructors and destructors for program scope global variables
+is required only for OpenCL 2.2 devices.
+
 // refError
 
 {clSetProgramReleaseCallback} returns {CL_SUCCESS} if the function is executed
@@ -6792,6 +6798,12 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asc
       | This indicates that the _program_ object contains non-trivial
         constructor(s) that will be executed by runtime before any kernel
         from the program is executed.
+
+        Querying {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT} may unconditionally
+        return {CL_FALSE} if no devices associated with _program_ support
+        constructors for program scope global variables.
+        Support for constructors and destructors for program scope global
+        variables is required only for OpenCL 2.2 devices.
 | {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asciidoc[]
@@ -6799,6 +6811,12 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asc
       | This indicates that the program object contains non-trivial
         destructor(s) that will be executed by runtime when _program_ is
         destroyed.
+
+        Querying {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT} may unconditionally
+        return {CL_FALSE} if no devices associated with _program_ support
+        destructors for program scope global variables.
+        Support for constructors and destructors for program scope global
+        variables is required only for OpenCL 2.2 devices.
 |====
 
 14::


### PR DESCRIPTION
Fixes #347 

For OpenCL 3.0 devices that do not support program scope global variable constructors and destructors, `clSetProgramReleaseCallback` may unconditionally return an error, and program object queries for `CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT` and `CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT` may unconditionally return `CL_FALSE`.

I chose to explicitly describe when this functionality **is** supported (OpenCL 2.2 devices), rather than when it **is not supported** (all other OpenCL devices, including OpenCL 3.0 devices) since I thought this extends better into the future when we add additional OpenCL versions.  I can add additional text for OpenCL 3.0 devices (or maybe something like "devices newer than OpenCL 2.2"?) if that is preferred, though.

Note that these changes are a companion to the changes in #351, which deprecates this API and these queries.