### PR TITLE
correct formatting around OpenCL C feature macros

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -426,25 +426,25 @@ OpenCL.
       This queue can only be used to enqueue commands from kernels executing
       on the device.
 
-      Requires support for OpenCL C 2.0 or the `__opencl_c_device_enqueue`
+      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
       feature macro.
 | `ndrange_t`
     | The N-dimensional range over which a kernel executes.
 
-      Requires support for OpenCL C 2.0 or the `__opencl_c_device_enqueue`
+      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
       feature macro.
 | `clk_event_t`
     | A device side event that identifies a command enqueue to
       a device command queue.
 
-      Requires support for OpenCL C 2.0 or the `__opencl_c_device_enqueue`
+      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
       feature macro.
 | `reserve_id_t`
     | A reservation ID.
       This opaque type is used to identify the reservation for
       <<pipe-functions,reading and writing a pipe>>.
 
-      Requires support for OpenCL C 2.0 or the `__opencl_c_pipes`
+      Requires support for OpenCL C 2.0 or the `+__opencl_c_pipes+`
       feature macro.
 | `event_t`
     | An event.
@@ -2045,7 +2045,7 @@ All function arguments shall be in the `+__private+` address space.
 
 Additionally, all function return values shall be in the `+__private+` address space.
 
-For OpenCL C 2.0 or with the `__opencl_c_program_scope_global_variables`
+For OpenCL C 2.0 or with the `+__opencl_c_program_scope_global_variables+`
 feature macro, the address space for a variable at program scope or a `static`
 or `extern` variable inside a function may be either `+__constant+` or `+__global+`,
 and the address space defaults to `+__global+` if not specified.
@@ -2068,7 +2068,7 @@ void foo (...)
 }
 ----------
 
-For OpenCL C 2.0, or with the `__opencl_c_generic_address_space` feature
+For OpenCL C 2.0, or with the `+__opencl_c_generic_address_space+` feature
 macro, there is an additional unnamed generic address space.
 The unnamed generic address space overlaps the named `+__global+`,
 `+__local+`, and `+__private+` address spaces.
@@ -2156,7 +2156,7 @@ As image objects are always allocated from the `global` address space, the
 The elements of an image object cannot be directly accessed.
 Built-in functions to read from and write to an image object are provided.
 
-For OpenCL C 2.0, or with the `__opencl_c_program_scope_global_variables`
+For OpenCL C 2.0, or with the `+__opencl_c_program_scope_global_variables+`
 feature macro,
 variables defined at program scope and `static` variables inside a function
 can also be declared in the `global` address space.
@@ -2341,7 +2341,7 @@ arguments are in the `+__private+` or `private` address space.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_generic_address_space` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature macro.
 
 The following rules apply when using pointers that point to the generic
 address space:
@@ -2768,7 +2768,7 @@ spaces.
 Image objects specified as arguments to a kernel can be declared to be
 read-only or write-only.
 
-For OpenCL C 2.0, or with the `__opencl_c_read_write_images` feature macro,
+For OpenCL C 2.0, or with the `+__opencl_c_read_write_images+` feature macro,
 image objects specified as arguments to a kernel can additionally be
 declared to be read-write.
 
@@ -3739,7 +3739,7 @@ information provided is in some sense correct.
 [open,refpage='blocks',desc='Blocks',type='freeform',spec='clang',anchor='blocks']
 --
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_device_enqueue` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
 
 This section describes the clang block syntax^26^.
 
@@ -4218,7 +4218,7 @@ identifier of each work-item when this kernel is being executed on a device.
 [28] I.e. the _global_work_size_ values specified to *clEnqueueNDRangeKernel*
 are not evenly divisible by the _local_work_size_ values for each dimension.
 
-NOTE: The functionality described in the following table requires support for the `__opencl_c_subgroups` feature macro.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro.
 
 The following table describes the list of built-in work-item functions that
 can be used to query the size of a subgroup, number of subgroups per work group,
@@ -5934,7 +5934,7 @@ in a work-group.
 [40] Refer to the description and restrictions for <<memory-scope,`memory_scope`>>.
 --
 
-NOTE: The functionality described in the following table requires support for the `__opencl_c_subgroups` feature macro.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro.
 
 The following table desribes built-in functions to synchronize the work-items
 in a subgroup.
@@ -6005,7 +6005,7 @@ in a subgroup.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_generic_address_space` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature macro.
 
 This section describes built-in functions to safely convert from pointers
 to the generic address space to pointers to named address spaces, and to
@@ -6383,13 +6383,13 @@ The following table lists the enumeration constants:
     |
 | `memory_scope_device`
     | Requires support for OpenCL C 2.0 or the
-      `__opencl_c_atomic_scope_device` feature macro.
+      `+__opencl_c_atomic_scope_device+` feature macro.
 | `memory_scope_all_svm_devices`
     | Requires support for OpenCL C 2.0 or the
-      `__opencl_c_atomic_scope_all_devices` feature macro.
+      `+__opencl_c_atomic_scope_all_devices+` feature macro.
 | `memory_scope_all_devices`
     | An alias for `memory_scope_all_svm_devices`.
-      Requires support for the `__opencl_c_atomic_scope_all_devices` feature
+      Requires support for the `+__opencl_c_atomic_scope_all_devices+` feature
       macro.
 |====
 
@@ -6737,7 +6737,6 @@ For *atomic_fetch* and modify functions with *key* = `or`, `xor`, `and`,
 ====
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 // Requires OpenCL C 2.0, or both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device feature macros.
@@ -8862,7 +8861,7 @@ For write functions this may be `write_only` or `read_write`.
       are not in the range [0, image width-1], [0, image height-1], and [0,
       image depth-1], respectively, is undefined.
 
-      Requires support for OpenCL C 2.0, the `__opencl_c_3d_image_writes`
+      Requires support for OpenCL C 2.0, the `+__opencl_c_3d_image_writes+`
       feature macro, or the `cl_khr_3d_image_writes` extension.
 |====
 --
@@ -9082,7 +9081,7 @@ support will result in a `CL_OUT_OF_RESOURCES` error being returned.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_work_group_collective_functions` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_work_group_collective_functions+` feature macro.
 
 This section decribes built-in functions that perform collective options
 across a work-group.
@@ -9195,7 +9194,7 @@ given work-group.
 === Pipe Functions
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_pipes` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_pipes+` feature macro.
 
 A pipe is identified by specifying the `pipe` keyword with a type.
 The data type specifies the size of each packet in the pipe.
@@ -9476,7 +9475,7 @@ The following behavior is undefined:
 [open,refpage='enqueue_kernel',desc='Enqueuing Kernels',type='freeform',spec='clang',anchor='enqueuing-kernels',xrefs='enqueue_marker']
 --
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `__opencl_c_device_enqueue` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
 
 This section describes built-in functions that allow a kernel to
 enqueue additional work to the same device, without host interaction.
@@ -10160,7 +10159,7 @@ foo(queue_t q, ...)
 [open,refpage='subgroupFunctions',desc='Subgroup Functions',type='freeform',spec='clang',anchor='subgroup-functions',xrefs='',alias='sub_group_all sub_group_any sub_group_broadcast sub_group_reduce sub_group_scan_exclusive sub_group_scan_inclusive sub_group_reserve_read_pipe sub_gorup_reserve_write_pipe sub_group_commit_read_pipe sub_group_commit_write_pipe get_kernel_sub_group_count_for_ndrange get_kernel_max_sub_group_size_for_ndrange']
 --
 
-NOTE: The functionality described in this section requires support for the `__opencl_c_subgroups` feature macro.
+NOTE: The functionality described in this section requires support for the `+__opencl_c_subgroups+` feature macro.
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
@@ -10233,7 +10232,7 @@ The order of floating-point operations is not guaranteed for the *sub_group_redu
 The order of these floating-point operations is also non-deterministic for a given sub-group.
 ====
 
-NOTE: The functionality described in the following table requires support for the `__opencl_c_subgroups` and `__opencl_c_pipes` feature macros.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_pipes+` feature macros.
 
 The following table describes built-in pipe functions that operate at a
 subgroup level.
@@ -10284,7 +10283,7 @@ can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
 groups is implementation defined.
 
-NOTE: The functionality described in the following table requires support for the `__opencl_c_subgroups` feature macro and either OpenCL C 2.0 or the `__opencl_c_device_enqueue` feature macro.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro and either OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
 
 The following table describes built-in functions to query subgroup
 information for a block to be enqueued.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -121,10 +121,10 @@ OpenCL C compilers supporting atomics orders or scopes beyond the mandated
 minimum will define some or all of following feature macros as appropriate:
 
 [none]
-* `__opencl_c_atomic_order_acq_rel` -- Indicating atomic operations support acquire-release orderings.
-* `__opencl_c_atomic_order_seq_cst` -- Indicating atomic operations and fences support acquire sequentially consistent orderings.
-* `__opencl_c_atomic_scope_device` -- Indicating atomic operations and fences support device-wide memory ordering constraints.
-* `__opencl_c_atomic_scope_all_devices` -- Indicating atomic operations and fences support all-device memory ordering constraints, across any host threads and all devices that can share SVM memory with each other and the host process.
+* `+__opencl_c_atomic_order_acq_rel+` -- Indicating atomic operations support acquire-release orderings.
+* `+__opencl_c_atomic_order_seq_cst+` -- Indicating atomic operations and fences support acquire sequentially consistent orderings.
+* `+__opencl_c_atomic_scope_device+` -- Indicating atomic operations and fences support device-wide memory ordering constraints.
+* `+__opencl_c_atomic_scope_all_devices+` -- Indicating atomic operations and fences support all-device memory ordering constraints, across any host threads and all devices that can share SVM memory with each other and the host process.
 
 == Device-Side Enqueue
 
@@ -181,7 +181,7 @@ When Device-Side Enqueue is supported but a replaceable default On-Device Queue 
 
 |====
 
-OpenCL C compilers supporting Device-Side Enqueue and On-Device Queues will define the feature macro `__opencl_c_device_enqueue`.
+OpenCL C compilers supporting Device-Side Enqueue and On-Device Queues will define the feature macro `+__opencl_c_device_enqueue+`.
 OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for Device-Side Enqueue accept pointers to the generic address space.
 
 == Pipes
@@ -213,7 +213,7 @@ When Pipes are not supported:
 
 |====
 
-OpenCL C compilers supporting Pipes will define the feature macro `__opencl_c_pipes`.
+OpenCL C compilers supporting Pipes will define the feature macro `+__opencl_c_pipes+`.
 OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for Pipes accept pointers to the generic address space.
 
 == Program Scope Global Variables
@@ -240,7 +240,7 @@ When Program Scope Global Variables are not supported:
 
 |====
 
-OpenCL C compilers supporting Program Scope Global Variables will define the feature macro `__opencl_c_program_scope_global_variables`.
+OpenCL C compilers supporting Program Scope Global Variables will define the feature macro `+__opencl_c_program_scope_global_variables+`.
 
 // TODO: There is no SPIR-V capability specific to Program Scope Global Variables.
 // May need to update the validation rules to disallow Program Scope Global Variables
@@ -291,7 +291,7 @@ When Read-Write Images are not supported:
 
 |====
 
-OpenCL C compilers supporting Read-Write Images will define the feature macro `__opencl_c_read_write_images`.
+OpenCL C compilers supporting Read-Write Images will define the feature macro `+__opencl_c_read_write_images+`.
 
 == Creating 2D Images from Buffers
 
@@ -405,7 +405,7 @@ When Subgroups are not supported:
 
 |====
 
-OpenCL C compilers supporting Subgroups will define the feature macro `__opencl_c_subgroups`.
+OpenCL C compilers supporting Subgroups will define the feature macro `+__opencl_c_subgroups+`.
 
 == Program Initialization and Clean-Up Kernels
 
@@ -450,7 +450,7 @@ When Writing to 3D Image Objects is not supported:
 
 |====
 
-OpenCL C compilers supporting Writing to 3D Image Objects will define the feature macro `__opencl_c_3d_image_writes`.
+OpenCL C compilers supporting Writing to 3D Image Objects will define the feature macro `+__opencl_c_3d_image_writes+`.
 
 == Work Group Collective Functions
 
@@ -468,7 +468,7 @@ When Work Group Collective Functions are not supported:
 
 |====
 
-OpenCL C compilers supporting Work Group Collective Functions will define the feature macro `__opencl_c_work_group_collective_functions`.
+OpenCL C compilers supporting Work Group Collective Functions will define the feature macro `+__opencl_c_work_group_collective_functions+`.
 
 == Generic Address Space
 
@@ -486,7 +486,7 @@ When the Generic Address Space is not supported:
 
 |====
 
-OpenCL C compilers supporting the Generic Address Space will define the feature macro `__opencl_c_generic_address_space`.
+OpenCL C compilers supporting the Generic Address Space will define the feature macro `+__opencl_c_generic_address_space+`.
 
 //== Required APIs
 //

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -2102,7 +2102,7 @@ OpenCL 3.0 also adds a new version of the OpenCL C programming language, which m
 The new version of OpenCL C is backwards compatible with OpenCL C 1.2, but is not backwards compatible with OpenCL C 2.0.
 The new version of OpenCL C must be explicitly requested via the `-cl-std=` build option, otherwise a program will continue to be compiled using the highest OpenCL C 1.x language version supported for the device.
 +
-Whenever an OpenCL C feature is optional in the new version of the OpenCL C programming language, it will be paired with a feature macro, such as `__opencl_c_feature_name`, and a corresponding API query.
+Whenever an OpenCL C feature is optional in the new version of the OpenCL C programming language, it will be paired with a feature macro, such as `+__opencl_c_feature_name+`, and a corresponding API query.
 If a feature macro is defined then the feature is supported by the OpenCL C compiler, otherwise the optional feature is not supported.
 
 === Versioning


### PR DESCRIPTION
This PR adds the asciidoctor `+` delimiters around all of the OpenCL C feature macros.  This is overkill in some cases, but necessary in some other cases, so we may as well use it consistently.

See #359