### PR TITLE
OpenCL C features macros must expand to 1 in OpenCL C 3.0

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -126,6 +126,10 @@ OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must also 
 
 |====
 
+In OpenCL C 3.0, feature macros must expand to the value `1` if the feature macro is defined by the OpenCL C compiler.
+A feature macro must not be defined if the feature is not supported by the OpenCL C compiler.
+A feature macro may expand to a different value in the future, but if this occurs the value of the feature macro must compare greater than the prior value of the feature macro.
+
 [NOTE]
 --
 The OpenCL 3.0 C programming language described in this specification is provisional.


### PR DESCRIPTION
This PR specifies that in OpenCL C 3.0 feature macros must expand to `1` in OpenCL C 3.0 if the feature macro is defined.

I've also included a line that some feature macros may expand to different values in the future, but if they do the value of the feature macro must compare greater than the prior value of the feature macro.  This would enable switching to an OpenCL C version-based feature macro, or a value based on the date of the feature (similar to feature macros in C and C++), if desired.

Fixes #311.