### PR TITLE
clarify when subgroup device enqueue functions are supported

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -10283,7 +10283,7 @@ can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
 groups is implementation defined.
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro and either OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_device_enqueue+` feature macros.
 
 The following table describes built-in functions to query subgroup
 information for a block to be enqueued.


### PR DESCRIPTION
This PR has a minor clarification in the description when the subgroup-related block query functions are supported.  Since subgroups in core OpenCL C requires OpenCL C 3.0 and feature macros, there is no need to include anything about OpenCL C 2.0.

Fixes #359.