### PR TITLE
clarify there is no mixed signedness for atomic intptr_t overloads

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6732,8 +6732,8 @@ The key, operator, and computation correspondence is given in table below:
 For *atomic_fetch* and modify functions with *key* = `add` or `sub` on
 atomic types `atomic_intptr_t` and `atomic_uintptr_t`, `M` is `ptrdiff_t`.
 For *atomic_fetch* and modify functions with *key* = `or`, `xor`, `and`,
-`min` and `max` on atomic types `atomic_intptr_t` and `atomic_uintptr_t`,
-`M` is `intptr_t` and `uintptr_t`.
+`min` and `max` on atomic type `atomic_intptr_t`, `M` is `intptr_t`,
+and on atomic type `atomic_uintptr_t`, `M` is `uintptr_t`.
 ====
 
 [source,c]


### PR DESCRIPTION
Fixes #51

Ping @StuartDBrady - I can't request you as a reviewer via GitHub, but please take a look.  This PR should contain the changes we discussed in #51.  Thanks!