### PR TITLE
several asciidoctor formatting improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ ATTRIBOPTS   = -a revnumber="$(SPECREVISION)" \
 	       -a revdate="$(SPECDATE)" \
 	       -a revremark="$(SPECREMARK)" \
 	       -a stem=latexmath \
-	       -a generated=$(GENERATED)
+	       -a generated=$(GENERATED) \
+	       -a sectnumlevels=5
 
 ADOCEXTS     = -r $(CURDIR)/config/sectnumoffset-treeprocessor.rb -r $(CURDIR)/config/spec-macros.rb
 ADOCOPTS     = -d book $(ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
@@ -87,7 +88,8 @@ ADOCMANOPTS  = -d manpage $(ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
 KATEXDIR     = ../katex
 ADOCHTMLEXTS = -r $(CURDIR)/config/katex_replace.rb
 ADOCHTMLOPTS = $(ADOCHTMLEXTS) -a katexpath=$(KATEXDIR) \
-	       -a stylesheet=khronos.css -a stylesdir=$(CURDIR)/config
+	       -a stylesheet=khronos.css -a stylesdir=$(CURDIR)/config \
+	       -a sectanchors
 
 ADOCPDFEXTS  = -r asciidoctor-pdf -r asciidoctor-mathematical --trace
 ADOCPDFOPTS  = $(ADOCPDFEXTS) -a mathematical-format=svg \

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1333,7 +1333,6 @@ reinterpret data to a type of a different number of bytes.
 Examples:
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 float f = 1.0f;
 uint u = as_uint(f); // Legal. Contains:  0x3f800000
@@ -3170,7 +3169,6 @@ performed on the directive, and the directive shall have one of the
 following forms whose meanings are described elsewhere:
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 // on-off-switch is one of ON, OFF, or DEFAULT
 #pragma OPENCL FP_CONTRACT on-off-switch
@@ -4827,7 +4825,6 @@ If this pragma is used in any other context, the behavior is undefined.
 The pragma definition to set `FP_CONTRACT` is:
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 // on-off-switch is one of ON, OFF, or DEFAULT.
 // The DEFAULT value is ON.
@@ -11736,7 +11733,6 @@ _w_.
 The `clamp` function used in this table is defined as:
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 clamp(a, b, c) = return (a < b) ? b : ((a > c) ? c : a)
 ----------
@@ -11772,7 +11768,6 @@ floor(x)`.
 For a 3D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -11789,7 +11784,6 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 For a 2D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -11821,7 +11815,6 @@ When filter mode is `CLK_FILTER_NEAREST`, the image element at location
 computed as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 u = (s - floor(s)) * w_t
 i = (int)floor(u)
@@ -11855,7 +11848,6 @@ This 2{times}2 square or 2{times}2{times}2 cube is obtained as follows.
 Let
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 u = (s - floor(s)) * w_t
 i0 = (int)floor(u - 0.5)
@@ -11892,7 +11884,6 @@ floor(x)`.
 For a 3D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -11909,7 +11900,6 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 For a 2D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -11941,7 +11931,6 @@ When filter mode is `CLK_FILTER_NEAREST`, the image element at location
 as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 s' = 2.0f * rint(0.5f * s)
 s' = fabs(s - s')
@@ -11977,7 +11966,6 @@ This 2{times}2 square or 2{times}2{times}2 cube is obtained as follows.
 Let
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 s' = 2.0f * rint(0.5f * s)
 s' = fabs(s - s')
@@ -12014,7 +12002,6 @@ floor(x)`.
 For a 3D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -12031,7 +12018,6 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 For a 2D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -12044,7 +12030,6 @@ where `T_ij` is the image element at location (_i_,_j_) in the 2D image.
 For a 1D image, the image element value is found as
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 T = (1 - a) * T_i0
     + a * T_i1
@@ -12365,7 +12350,6 @@ unsigned integer sRGB color value to a floating-point linear RGB color value
 using *read_imagef*.
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 // Convert the normalized 8-bit unsigned integer R, G and B channel values
 // to a floating-point value (call it c) as per rules described in section
@@ -12386,7 +12370,6 @@ floating-point color value (call it _c_) to a normalized 8-bit unsigned
 integer sRGB value using *write_imagef*.
 
 [source,c]
-[subs="verbatim,quotes,macros"]
 ----------
 if (c is NaN)
     c = 0.0;


### PR DESCRIPTION
This PR should be considered low priority.  It has no functional changes and only contains formatting improvements:

* adds section anchors to the HTML document for easier linking
* increases section numbering to five levels
* remove some unnecessary substitution tags

For easier reviewing, I've temporarily cherry-picked this change into my travis-ci automated builds.  An example OpenCL C spec build with these changes can be found here: [HTML](https://bashbaug.github.io/OpenCL-Docs/html/OpenCL_C.html), [PDF](https://bashbaug.github.io/OpenCL-Docs/pdf/OpenCL_C.pdf).

A good place to see the affect of these changes is to look at the Atomic Functions, because that's where sections go five levels deep.  As an aside, we might want to fix that!

> 6.13.11.7.2. The atomic_load Functions