### PR TITLE
fix a few more cl_khr_fp64 asciidoctor formatting issues

### DIFF
--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -270,9 +270,9 @@ all arguments and the return type.
 | Returns _x_ if \|_x_\| < \|_y_\|, _y_ if \|_y_\| < \|_x_\|, otherwise
   *fmin*(_x_, _y_).
 
-| gentype *modf* (gentype _x_, {global} gentype *_iptr_) +
-  gentype *modf* (gentype _x_, {local} gentype *_iptr_) +
-  gentype *modf* (gentype _x_, {private} gentype *_iptr_)
+| gentype **modf** (gentype _x_, {global} gentype *_iptr_) +
+  gentype **modf** (gentype _x_, {local} gentype *_iptr_) +
+  gentype **modf** (gentype _x_, {private} gentype *_iptr_)
 | Decompose a floating-point number.
   The *modf* function breaks the argument _x_ into integral and fractional
   parts, each of which has the same sign as the argument.
@@ -339,9 +339,9 @@ all arguments and the return type.
 | gentype *sin* (gentype _x_)
 | Compute sine.
 
-| gentype *sincos* (gentype _x_, {global} gentype *_cosval_) +
-  gentype *sincos* (gentype _x_, {local} gentype *_cosval_) +
-  gentype *sincos* (gentype _x_, {private} gentype *_cosval_)
+| gentype **sincos** (gentype _x_, {global} gentype *_cosval_) +
+  gentype **sincos** (gentype _x_, {local} gentype *_cosval_) +
+  gentype **sincos** (gentype _x_, {private} gentype *_cosval_)
 | Compute sine and cosine of x.
   The computed sine is the return value and computed cosine is returned in
   _cosval_.


### PR DESCRIPTION
This fixes a few more asciidoctor formatting issues in the `cl_khr_fp64` extension.

See also #373.