### PR TITLE
Remove extraneous wording for fp64 vload/vstore alignment

### DIFF
--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -751,8 +751,8 @@ components from a 3-component vector to address (_p_ + (_offset_ * 3)).
   gentype__n__ **vload__n__**(size_t _offset_, const gentype *_p_)
 | Return sizeof (gentype__n__) bytes of data read from address
   (_p_ + (_offset * n_)).
-  The read address computed as (_p_ + (_offset * n_)) must be 16-bit
-  aligned.
+  If gentype is half, the read address computed as (_p_ + (_offset * n_))
+  must be 16-bit aligned.
 
 | void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {global} gentype *_p_) +
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {local} gentype *_p_) +
@@ -764,8 +764,8 @@ components from a 3-component vector to address (_p_ + (_offset_ * 3)).
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, gentype *_p_)
 | Write sizeof (gentype__n__) bytes given by _data_ to address
   (_p_ + (_offset * n_)).
-  The write address computed as (_p_ + (_offset * n_)) must be 16-bit
-  aligned.
+  If gentype is half, the write address computed as (_p_ + (_offset * n_))
+  must be 16-bit aligned.
 
 |====
 

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -727,10 +727,8 @@ on hardware that can take advantage of the increased alignment.
   gentype__n__ **vload__n__**(size_t _offset_, const {private} gentype *_p_)
 | Return sizeof (gentype__n__) bytes of data read from address
   (_p_ + (_offset * n_)).
-  The read address computed as (_p_ + (_offset * n_)) must be 8-bit aligned
-  if gentype is char, uchar; 16-bit aligned if gentype is short, ushort;
-  32-bit aligned if gentype is int, uint, float; 64-bit aligned if
-  gentype is long, ulong or double.
+  If gentype is double, the read address computed as (_p_ + (_offset * n_))
+  must be 64-bit aligned.
 
 | void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {global} gentype *_p_)
 
@@ -739,10 +737,8 @@ on hardware that can take advantage of the increased alignment.
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {private} gentype *_p_)
 | Write sizeof (gentype__n__) bytes given by _data_ to address
   (_p_ + (_offset * n_)).
-  The address computed as (_p_ + (_offset * n_)) must be 8-bit aligned
-  if gentype is char, uchar; 16-bit aligned if gentype is short, ushort;
-  32-bit aligned if gentype is int, uint, float; 64-bit aligned
-  if gentype is long, ulong or double.
+  If gentype is double, the write address computed as (_p_ + (_offset * n_))
+  must be 64-bit aligned.
 
 | void **vstore_half**(double _data_, size_t _offset_, {global} half *_p_) +
   void **vstore_half{rte}**(double _data_, size_t _offset_, {global} half *_p_) +


### PR DESCRIPTION
This also clarifies the wording slightly for fp16.