### PR TITLE
rename prefix and suffix defines for clSetProgramReleaseCallback

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2796,7 +2796,7 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                                   <name>user_data</name></param>
             <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
         </command>
-        <command prefix="CL_API_PREFIX__VERSION_2_2_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_2_2_DEPRECATED">
+        <command prefix="CL_EXT_PREFIX__VERSION_2_2_DEPRECATED" suffix="CL_EXT_SUFFIX__VERSION_2_2_DEPRECATED">
             <proto><type>cl_int</type>                                  <name>clSetProgramReleaseCallback</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>


### PR DESCRIPTION
This PR has a minor fix for the prefix and suffix defines for the clSetProgramReleaseCallback function.

Even though this is a core API function, we don't currently define deprecation prefix and suffix defines beginning with `CL_API`, so use the prefix and suffix defines beginning with `CL_EXT` instead.  This is consistent with other deprecated core API functions.

See also discussion in: https://github.com/KhronosGroup/OpenCL-Headers/issues/95#issuecomment-663681382