### PR TITLE
Use consistent naming for the OpenCL SPIR-V Environment Specification

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4556,7 +4556,7 @@ all arguments and the return type, unless otherwise specified.
 | gentype *mad*(gentype _a_, gentype _b_, gentype _c_)
     | *mad* computes _a_ * _b_ + _c_.
     The function may compute _a_ * _b_ + _c_ with reduced accuracy
-    in the embedded profile.  See the SPIR-V OpenCL environment specification
+    in the embedded profile.  See the OpenCL SPIR-V Environment Specification
     for details. On some hardware the mad instruction may provide better
     performance than expanded computation of _a_ * _b_ + _c_.^31^
 | gentype *maxmag*(gentype _x_, gentype _y_)

--- a/README.adoc
+++ b/README.adoc
@@ -85,7 +85,7 @@ for each Specification:
 | cxxhtml   | HTML outputs for C++ Specification
 | cxxpdf    | PDF outputs for C++ Specification
 |           |
-| env       | HTML and PDF outputs for Environment Specification
+| env       | HTML and PDF outputs for SPIR-V Environment Specification
 | envhtml   | HTML outputs for Environment Specification
 | envpdf    | PDF outputs for Environment Specification
 |           |

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -108,7 +108,7 @@ hardware area budgets.
     converting a float to a half using variants of the *vstore_half*
     function or when converting from a half to a float using variants of the
     *vload_half* function can be flushed to zero.
-    The SPIR-V environment specification for details.
+    The OpenCL SPIR-V Environment Specification for details.
   . The precision of conversions from {CL_UNORM_INT8}, {CL_SNORM_INT8},
     {CL_UNORM_INT16}, {CL_SNORM_INT16}, {CL_UNORM_INT_101010}, and
     {CL_UNORM_INT_101010_2} to float is {leq} 2 ulp for the embedded profile

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -279,7 +279,7 @@ all arguments and the return type.
 | gentype *mad* (gentype _a_, gentype _b_, gentype _c_)
 | *mad* computes _a_ * _b_ + _c_.
   The function may compute _a_ * _b_ + _c_ with reduced accuracy
-  in the embedded profile.  See the SPIR-V OpenCL environment specification
+  in the embedded profile.  See the OpenCL SPIR-V Environment Specification
   for details. On some hardware the mad instruction may provide better
   performance than expanded computation of _a_ * _b_ + _c_.
 

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -258,7 +258,7 @@ all arguments and the return type.
 | gentype *mad* (gentype _a_, gentype _b_, gentype _c_)
 | *mad* computes _a_ * _b_ + _c_.
   The function may compute _a_ * _b_ + _c_ with reduced accuracy
-  in the embedded profile.  See the SPIR-V OpenCL environment specification
+  in the embedded profile.  See the OpenCL SPIR-V Environment Specification
   for details. On some hardware the mad instruction may provide better
   performance than expanded computation of _a_ * _b_ + _c_.
 


### PR DESCRIPTION
In some places, this was referred to as the "SPIR-V OpenCL Environment Specification" or just the "OpenCL Environment Specification" even though the document's title is the "OpenCL SPIR-V Environment Specification". Also, the file names for the specification did not include "SPIR-V".