### PR TITLE
unify atomic acquire and release capabilities for ops and fences

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6518,13 +6518,13 @@ The following table lists the enumeration constants:
 | `memory_order_relaxed`
     |
 | `memory_order_acquire`
-    | Always present but some uses require support for OpenCL C 2.0 or the
+    | Requires support for OpenCL C 2.0, or the
       `+__opencl_c_atomic_order_acq_rel+` feature macro.
 | `memory_order_release`
-    | Always present but some uses require support for OpenCL C 2.0 or the
+    | Requires support for OpenCL C 2.0, or the
       `+__opencl_c_atomic_order_acq_rel+` feature macro.
 | `memory_order_acq_rel`
-    | Always present but some uses require support for OpenCL C 2.0 or the
+    | Requires support for OpenCL C 2.0, or the
       `+__opencl_c_atomic_order_acq_rel+` feature macro.
 | `memory_order_seq_cst`
     | Requires support for OpenCL C 2.0, or the
@@ -7661,14 +7661,8 @@ semantics of the minimum requirements.
   * The behavior of atomic operations where pointer arguments to the atomic
     functions refers to an atomic type in the `private` address space is
     undefined.
-  * Using `memory_order_acquire` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature macro.
-  * Using `memory_order_release` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature macro.
-  * Using `memory_order_acq_rel` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
+  * Using `memory_order_acquire`, `memory_order_release`, or `memory_order_acq_rel`
+    with any built-in atomic function requires OpenCL C 2.0 or the
     `+__opencl_c_atomic_order_acq_rel+` feature macro.
   * Using `memory_order_seq_cst` with any built-in atomic function requires
     OpenCL C 2.0 or the `+__opencl_c_atomic_order_seq_cst+` feature macro.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -89,7 +89,6 @@ Note that a device that provides the same level of capabilities as an OpenCL 2.x
 | May return:
 
 {CL_DEVICE_ATOMIC_ORDER_RELAXED} \| +
-{CL_DEVICE_ATOMIC_ORDER_ACQ_REL} \| +
 {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP}
 
 indicating that _device_ does not support the full memory consistency model for atomic fence operations.
@@ -121,7 +120,7 @@ OpenCL C compilers supporting atomics orders or scopes beyond the mandated
 minimum will define some or all of following feature macros as appropriate:
 
 [none]
-* `+__opencl_c_atomic_order_acq_rel+` -- Indicating atomic operations support acquire-release orderings.
+* `+__opencl_c_atomic_order_acq_rel+` -- Indicating atomic operations and fences support acquire-release orderings.
 * `+__opencl_c_atomic_order_seq_cst+` -- Indicating atomic operations and fences support acquire sequentially consistent orderings.
 * `+__opencl_c_atomic_scope_device+` -- Indicating atomic operations and fences support device-wide memory ordering constraints.
 * `+__opencl_c_atomic_scope_all_devices+` -- Indicating atomic operations and fences support all-device memory ordering constraints, across any host threads and all devices that can share SVM memory with each other and the host process.


### PR DESCRIPTION
This is a draft PR for discussion.  It describes an alternative way of expressing atomic capabilities and feature macros that is simpler to understand and implement, but is not as expressive as the current method of expressing atomic capabilities.  The alternative was first discussed in an issue here: https://github.com/KhronosGroup/OpenCL-Docs/issues/354#issuecomment-662768559.

In short, this PR unifies the atomic acquire and release capabilities for atomic operations (e.g. `atomic_fetch_add_explicit` and atomic fences (e.g. `atomic_work_item_fence`).  Without this change, the atomic acquire and release memory orders could be supported for fences only but not other atomic operations, to match the semantics of the OpenCL 1.2 atomic operations and memory fences.  With this change, an implementation coming from OpenCL 1.2 will either be unable to express the OpenCL 1.2 memory fences via the C11-style atomics (if it does not support the acquire and release memory orders), or will need to add support for acquire and release memory orders for atomic operations (if it does support the acquire and release memory orders).

Note that this PR does NOT change the availability of the OpenCL 1.2 memory fence functions `mem_fence`, `read_mem_fence`, and `write_mem_fence`, and these functions will remain required even if an implementation does not support the explicit acquire and release memory orders.

Please also see the comment in the PR itself regarding the host API queries for atomic memory capabilities.