### PR TITLE
Reduce the verbosity of int64 and fp64 feature macros

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5119,9 +5119,6 @@ indicated by the presence of the `+__opencl_c_int64+` feature macro.
   ulong__n__ *upsample*(uint__n__ _hi_, uint__n__ _lo_)
     | _result_[i] = ((long)_hi_[i] << 32) \| _lo_[i] +
       _result_[i] = ((ulong)_hi_[i] << 32) \| _lo_[i]
-
-      Requires support for longs, e.g. with the `+__opencl_c_int64+` feature
-      macro. +
 | gentype *popcount*(gentype _x_)
     | Returns the number of non-zero bits in _x_.
 |====

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4338,17 +4338,20 @@ if called with the round to nearest even rounding mode.
 The <<table-builtin-math, following table>> describes the list of built-in
 math functions that can take scalar or vector arguments.
 We use the generic type name `gentype` to indicate that the function can
-take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`,
+take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`^d01^,
 `double2`, `double3`, `double4`, `double8` or `double16` as the type for the
 arguments.
 We use the generic type name `gentypef` to indicate that the function can
 take `float`, `float2`, `float3`, `float4`, `float8`, or `float16` as the
 type for the arguments.
-We use the generic type name `gentyped` to indicate that the function can
+We use the generic type name `gentyped`^d01^ to indicate that the function can
 take `double`, `double2`, `double3`, `double4`, `double8` or `double16` as
 the type for the arguments.
 For any specific use of a function, the actual type has to be the same for
 all arguments and the return type, unless otherwise specified.
+
+[d01] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-builtin-math]]
 .Built-in Scalar and Vector Argument Math Functions
@@ -4418,16 +4421,12 @@ all arguments and the return type, unless otherwise specified.
       Edge case behavior is per the IEEE 754-2008 standard.
 | gentype *fmax*(gentype _x_, gentype _y_) +
   gentypef *fmax*(gentypef _x_, float _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *fmax*(gentyped _x_, double _y_)
     | Returns _y_ if _x_ < _y_, otherwise it returns _x_.
       If one argument is a NaN, *fmax*() returns the other argument.
       If both arguments are NaNs, *fmax*() returns a NaN.
 | gentype *fmin*^29^(gentype _x_, gentype _y_) +
   gentypef *fmin*(gentypef _x_, float _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *fmin*(gentyped _x_, double _y_)
     | Returns _y_ if _y_ < _x_, otherwise it returns _x_.
       If one argument is a NaN, *fmin*() returns the other argument.
@@ -4481,8 +4480,6 @@ all arguments and the return type, unless otherwise specified.
       For each component the mantissa returned is a `double` with magnitude
       in the interval [1/2, 1) or 0.
       Each component of _x_ equals mantissa returned * 2__^exp^__.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro. +
 | gentype *hypot*(gentype _x_, gentype _y_)
     | Compute the value of the square root of __x__^2^+ __y__^2^ without
       undue overflow or underflow.
@@ -4494,8 +4491,6 @@ all arguments and the return type, unless otherwise specified.
 | float__n__ *ldexp*(float__n__ _x_, int__n__ _k_) +
   float__n__ *ldexp*(float__n__ _x_, int _k_) +
   float *ldexp*(float _x_, int _k_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double__n__ *ldexp*(double__n__ _x_, int__n__ _k_) +
   double__n__ *ldexp*(double__n__ _x_, int _k_) +
   double *ldexp*(double _x_, int _k_)
@@ -4504,35 +4499,24 @@ all arguments and the return type, unless otherwise specified.
 
   float__n__ **lgamma_r**(float__n__ _x_, {global} int__n__ *_signp_) +
   float **lgamma_r**(float _x_, {global} int *_signp_) +
+  double__n__ **lgamma_r**(double__n__ _x_, {global} int__n__ *_signp_) +
+  double **lgamma_r**(double _x_, {global} int *_signp_) +
 
   float__n__ **lgamma_r**(float__n__ _x_, {local} int__n__ *_signp_) +
   float **lgamma_r**(float _x_, {local} int *_signp_) +
-
-  float__n__ **lgamma_r**(float__n__ _x_, {private} int__n__ *_signp_) +
-  float **lgamma_r**(float _x_, {private} int *_signp_) +
-
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
-
-  float__n__ **lgamma_r**(float__n__ _x_, int__n__ *_signp_) +
-  float **lgamma_r**(float _x_, int *_signp_)
-    | Log gamma function.
-      Returns the natural logarithm of the absolute value of the gamma
-      function.
-      The sign of the gamma function is returned in the _signp_ argument of
-      *lgamma_r*.
-| double__n__ **lgamma_r**(double__n__ _x_, {global} int__n__ *_signp_) +
-  double **lgamma_r**(double _x_, {global} int *_signp_) +
-
   double__n__ **lgamma_r**(double__n__ _x_, {local} int__n__ *_signp_) +
   double **lgamma_r**(double _x_, {local} int *_signp_) +
 
+  float__n__ **lgamma_r**(float__n__ _x_, {private} int__n__ *_signp_) +
+  float **lgamma_r**(float _x_, {private} int *_signp_) +
   double__n__ **lgamma_r**(double__n__ _x_, {private} int__n__ *_signp_) +
   double **lgamma_r**(double _x_, {private} int *_signp_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
   feature macro: +
 
+  float__n__ **lgamma_r**(float__n__ _x_, int__n__ *_signp_) +
+  float **lgamma_r**(float _x_, int *_signp_) +
   double__n__ **lgamma_r**(double__n__ _x_, int__n__ *_signp_) +
   double **lgamma_r**(double _x_, int *_signp_)
     | Log gamma function.
@@ -4540,8 +4524,6 @@ all arguments and the return type, unless otherwise specified.
       function.
       The sign of the gamma function is returned in the _signp_ argument of
       *lgamma_r*.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro. +
 | gentype *log*(gentype)
     | Compute natural logarithm.
 | gentype *log2*(gentype)
@@ -4579,9 +4561,6 @@ all arguments and the return type, unless otherwise specified.
       It stores the integral part in the object pointed to by _iptr_.
 | float__n__ *nan*(uint__n__ _nancode_) +
   float *nan*(uint _nancode_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   double__n__ *nan*(ulong__n__ _nancode_) +
   double *nan*(ulong _nancode_)
     | Returns a quiet NaN.
@@ -4595,8 +4574,6 @@ all arguments and the return type, unless otherwise specified.
     | Compute _x_ to the power _y_.
 | float__n__ *pown*(float__n__ _x_, int__n__ _y_) +
   float *pown*(float _x_, int _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double__n__ *pown*(double__n__ _x_, int__n__ _y_) +
   double *pown*(double _x_, int _y_)
     | Compute _x_ to the power _y_, where _y_ is an integer.
@@ -4654,16 +4631,12 @@ all arguments and the return type, unless otherwise specified.
       *remquo* also calculates the lower seven bits of the integral quotient
       _x_/_y_, and gives that value the same sign as _x_/_y_.
       It stores this signed value in the object pointed to by _quo_.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro. +
 | gentype *rint*(gentype)
     | Round to integral value (using round to nearest even rounding mode) in
       floating-point format.
       Refer to section 7.1 for description of rounding modes.
 | float__n__ *rootn*(float__n__ _x_, int__n__ _y_) +
   float *rootn*(float _x_, int _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double__n__ *rootn*(double__n__ _x_, int__n__ _y_) +
   double *rootn*(double _x_, int _y_)
     | Compute _x_ to the power 1/_y_.
@@ -5047,8 +5020,8 @@ double type.
 
 [open,refpage='integerFunctions',desc='Integer Functions',type='freeform',spec='clang',anchor='integer-functions',xrefs='commonFunctions',alias='abs add_sat clamp_integer clz ctz hadd mad24 mad_hi mad_sat integerMax integerMin mul24 mul_hi popcount rotate sub_sat upsample']
 --
-The following table describes the built-in integer functions that take
-scalar or vector arguments.
+The <<table-builtin-functions, following table>> describes the built-in integer
+functions that take scalar or vector arguments.
 The vector versions of the integer functions operate component-wise.
 The description is per-component.
 
@@ -5056,7 +5029,7 @@ We use the generic type name `gentype` to indicate that the function can
 take `char`, `char{2|3|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`,
 `short{2|3|4|8|16}`, `ushort`, `ushort{2|3|4|8|16}`, `int`,
 `int{2|3|4|8|16}`, `uint`, `uint{2|3|4|8|16}`, `long`, `long{2|3|4|8|16}
-ulong`, or `ulong{2|3|4|8|16}` as the type for the arguments.
+ulong`^l00^, or `ulong{2|3|4|8|16}` as the type for the arguments.
 We use the generic type name `ugentype` to refer to unsigned versions of
 `gentype`.
 For example, if `gentype` is `char4`, `ugentype` is `uchar4`.
@@ -5073,6 +5046,9 @@ described for <<operators-arithmetic,arithmetic operators>>.
 
 For any specific use of a function, the actual type has to be the same for
 all arguments and the return type unless otherwise specified.
+
+[l00] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
 
 [[table-builtin-functions]]
 .Built-in Scalar and Vector Integer Argument Functions
@@ -5247,11 +5223,12 @@ contractions such as *mad* or *fma*.
 
 [open,refpage='commonFunctions',desc='Common Functions',type='freeform',spec='clang',anchor='common-functions',xrefs='integerFunctions',alias='commonClamp degrees commonMax commonMin mix radians sign smoothstep step']
 --
-The following table describes the list of built-in common functions.
+The <<table-builtin-common, following table>> describes the list of built-in
+common functions.
 These all operate component-wise.
 The description is per-component.
 We use the generic type name `gentype` to indicate that the function can
-take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`,
+take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`^d02^,
 `double2`, `double3`, `double4`, `double8` or `double16` as the type for the
 arguments.
 We use the generic type name `gentypef` to indicate that the function can
@@ -5260,6 +5237,9 @@ type for the arguments.
 We use the generic type name `gentyped` to indicate that the function can
 take `double`, `double2`, `double3`, `double4`, `double8` or `double16` as
 the type for the arguments.
+
+[d02] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 The built-in common functions are implemented using the round to nearest
 even rounding mode.
@@ -5271,8 +5251,6 @@ even rounding mode.
 | *Function* | *Description*
 | gentype *clamp*(gentype _x_, gentype _minval_, gentype _maxval_) +
   gentypef *clamp*(gentypef _x_, float _minval_, float _maxval_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *clamp*(gentyped _x_, double _minval_, double _maxval_)
     | Returns *fmin*(*fmax*(_x_, _minval_), _maxval_).
       Results are undefined if _minval_ > _maxval_.
@@ -5280,22 +5258,16 @@ even rounding mode.
     | Converts _radians_ to degrees, i.e. (180 / {pi}) * _radians_.
 | gentype *max*(gentype _x_, gentype _y_) +
   gentypef *max*(gentypef _x_, float _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *max*(gentyped _x_, double _y_)
     | Returns _y_ if _x_ < _y_, otherwise it returns _x_.
       If _x_ or _y_ are infinite or NaN, the return values are undefined.
 | gentype *min*(gentype _x_, gentype _y_) +
   gentypef *min*(gentypef _x_, float _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *min*(gentyped _x_, double _y_)
     | Returns _y_ if _y_ < _x_, otherwise it returns _x_.
       If _x_ or _y_ are infinite or NaN, the return values are undefined.
 | gentype *mix*(gentype _x_, gentype _y_, gentype _a_) +
   gentypef *mix*(gentypef _x_, gentypef _y_, float _a_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *mix*(gentyped _x_, gentyped _y_, double _a_)
     | Returns the linear blend of _x_ & _y_ implemented as:
 
@@ -5308,14 +5280,10 @@ even rounding mode.
     | Converts _degrees_ to radians, i.e. ({pi} / 180) * _degrees_.
 | gentype *step*(gentype _edge_, gentype _x_) +
   gentypef *step*(float _edge_, gentypef _x_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *step*(double _edge_, gentyped _x_)
     | Returns 0.0 if _x_ < _edge_, otherwise it returns 1.0.
 | gentype *smoothstep*(gentype _edge0_, gentype _edge1_, gentype _x_) +
   gentypef *smoothstep*(float _edge0_, float _edge1_, gentypef _x_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   gentyped *smoothstep*(double _edge0_, double _edge1_, gentyped _x_)
    a| Returns 0.0 if _x_ \<= _edge0_ and 1.0 if _x_ >= _edge1_ and performs
       smooth Hermite interpolation between 0 and 1 when _edge0_ < _x_ <
@@ -5352,13 +5320,17 @@ a NaN.
 [open,refpage='geometricFunctions',desc='Geometric Functions',type='freeform',spec='clang',anchor='geometric-functions',xrefs='integerFunctions',alias='cross dot distance length normalize fast_distance fast_length fast_normalize']
 --
 
-The following table describes the list of built-in geometric functions.
+The <<table-builtin-geometric, following table>> describes the list of built-in
+geometric functions.
 These all operate component-wise.
 The description is per-component.
 `float__n__` is `float`, `float2`, `float3`, or `float4` and `double__n__`
-is `double`, `double2`, `double3`, or `double4`.
+is `double`^d03^, `double2`, `double3`, or `double4`.
 The built-in geometric functions are implemented using the round to nearest
 even rounding mode.
+
+[d03] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-builtin-geometric]]
 .Built-in Scalar and Vector Argument Geometric Functions
@@ -5367,32 +5339,22 @@ even rounding mode.
 | *Function* | *Description*
 | float4 *cross*(float4 _p0_, float4 _p1_) +
   float3 *cross*(float3 _p0_, float3 _p1_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double4 *cross*(double4 _p0_, double4 _p1_) +
   double3 *cross*(double3 _p0_, double3 _p1_)
     | Returns the cross product of _p0.xyz_ and _p1.xyz_.
       The _w_ component of `float4` result returned will be 0.0.
 | float *dot*(float__n__ _p0_, float__n__ _p1_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double *dot*(double__n__ _p0_, double__n__ _p1_)
      | Compute dot product.
 | float *distance*(float__n__ _p0_, float__n__ _p1_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double *distance*(double__n__ _p0_, double__n__ _p1_)
     | Returns the distance between _p0_ and _p1_.
       This is calculated as *length*(_p0_ - _p1_).
 | float *length*(float__n__ _p_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double *length*(double__n__ _p_)
     | Return the length of vector _p_, i.e., {sqrt} __p.x__^2^ + _p.y_ ^2^
       {plus} ...
 | float__n__ *normalize*(float__n__ _p_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   double__n__ *normalize*(double__n__ _p_)
     | Returns a vector in the same direction as _p_ but with a length of 1.
 | |
@@ -5444,25 +5406,32 @@ operators (*<*, *\<=*, *>*, *>=*, *!=*, *==*) can be used with scalar and
 vector built-in types and produce a scalar or vector signed integer result
 respectively.
 
-The functions^35^ described in the following table can be used with built-in
-scalar or vector types as arguments and return a scalar or vector integer
-result.
+The functions^35^ described in the <<table-builtin-relational, following
+table>> can be used with built-in scalar or vector types as arguments and
+return a scalar or vector integer result.
 The argument type `gentype` refers to the following built-in types: `char`,
 `char__n__`, `uchar`, `uchar__n__`, `short`, `short__n__`, `ushort`,
-`ushort__n__`, `int`, `int__n__`, `uint`, `uint__n__`, `long`, `long__n__`,
-`ulong`, `ulong__n__`, `float`, `float__n__`, `double`, and `double__n__`.
+`ushort__n__`, `int`, `int__n__`, `uint`, `uint__n__`, `long`^l01^,
+`long__n__`, `ulong`, `ulong__n__`, `float`, `float__n__`, `double`^d04^, and
+`double__n__`.
 The argument type `igentype` refers to the built-in signed integer types
 i.e. `char`, `char__n__`, `short`, `short__n__`, `int`, `int__n__`, `long`
 and `long__n__`.
 The argument type `ugentype` refers to the built-in unsigned integer types
 i.e. `uchar`, `uchar__n__`, `ushort`, `ushort__n__`, `uint`, `uint__n__`,
-`ulong` and `ulong__n__`.
+`ulong`^l01^ and `ulong__n__`.
 _n_ is 2, 3, 4, 8, or 16.
 
 [35] If an implementation extends this specification to support IEEE-754
 flags or exceptions, then all built-in functions defined in the following
 table shall proceed without raising the _invalid_ floating-point exception
 when one or more of the operands are NaNs.
+
+[l01] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[d04] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 The functions *isequal*, *isnotequal*, *isgreater*, *isgreaterequal*,
 *isless*, *islessequal*, *islessgreater*, *isfinite*, *isinf*, *isnan*,
@@ -5487,147 +5456,77 @@ not a number (NaN) and the argument type is a vector.
 | *Function* | *Description*
 | int *isequal*(float _x_, float _y_) +
   int__n__ *isequal*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isequal*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isequal*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ == _y_.
 | int *isnotequal*(float _x_, float _y_) +
   int__n__ *isnotequal*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isnotequal*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isnotequal*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ != _y_.
 | int *isgreater*(float _x_, float _y_) +
   int__n__ *isgreater*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isgreater*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isgreater*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ > _y_.
 | int *isgreaterequal*(float _x_, float _y_) +
   int__n__ *isgreaterequal*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isgreaterequal*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isgreaterequal*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ >= _y_.
 | int *isless*(float _x_, float _y_) +
   int__n__ *isless*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isless*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isless*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ < _y_.
 | int *islessequal*(float _x_, float _y_) +
   int__n__ *islessequal*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *islessequal*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *islessequal*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of _x_ \<= _y_.
 | int *islessgreater*(float _x_, float _y_) +
   int__n__ *islessgreater*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *islessgreater*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *islessgreater*(double__n__ _x_, double__n__ _y_)
     | Returns the component-wise compare of (_x_ < _y_) \|\| (_x_ > _y_) .
 | |
 | int *isfinite*(float) +
   int__n__ *isfinite*(float__n__) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isfinite*(double) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isfinite*(double__n__)
     | Test for finite value.
 | int *isinf*(float) +
   int__n__ *isinf*(float__n__) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isinf*(double) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isinf*(double__n__)
     | Test for infinity value (positive or negative).
 | int *isnan*(float) +
   int__n__ *isnan*(float__n__) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isnan*(double) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isnan*(double__n__)
     | Test for a NaN.
 | int *isnormal*(float) +
   int__n__ *isnormal*(float__n__) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isnormal*(double) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isnormal*(double__n__)
 | Test for a normal value.
 | int *isordered*(float _x_, float _y_) +
   int__n__ *isordered*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isordered*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isordered*(double__n__ _x_, double__n__ _y_)
     | Test if arguments are ordered.
      *isordered*() takes arguments _x_ and _y_, and returns the result
      *isequal*(_x_, _x_) && *isequal*(_y_, _y_).
 | int *isunordered*(float _x_, float _y_) +
   int__n__ *isunordered*(float__n__ _x_, float__n__ _y_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *isunordered*(double _x_, double _y_) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *isunordered*(double__n__ _x_, double__n__ _y_)
     | Test if arguments are unordered.
      *isunordered*() takes arguments _x_ and _y_, returning non-zero if _x_
      or _y_ is NaN, and zero otherwise.
 | int *signbit*(float) +
   int__n__ *signbit*(float__n__) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
   int *signbit*(double) +
-
-  If doubles and longs are supported, e.g. with the `+__opencl_c_fp64+` and
-  `+__opencl_c_int64+` feature macros: +
   long__n__ *signbit*(double__n__)
     | Test for sign bit.
      The scalar version of the function returns a 1 if the sign bit in the
@@ -5675,17 +5574,24 @@ interpretations of the bit pattern of _c_.
 [open,refpage='vectorDataLoadandStoreFunctions',desc='Vector Data Load and Store Functions',type='freeform',spec='clang',anchor='vector-data-load-and-store-functions',xrefs='',alias='vloadn vload_half vload_halfn vloada_halfn vstoren vstore_half vstore_halfn vstorea_halfn']
 --
 
-The following table describes the list of supported functions that allow you
-to read and write vector types from a pointer to memory.
+The <<table-vector-loadstore, following table>> describes the list of supported
+functions that allow you to read and write vector types from a pointer to
+memory.
 We use the generic type `gentype` to indicate the built-in data types
-`char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`
-or `double`.
+`char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`^l02^, `ulong`,
+`float` or `double`^d05^.
 We use the generic type name `gentype__n__` to represent n-element vectors
 of `gentype` elements.
 We use the type name `half__n__` to represent n-element vectors of half
 elements^37^.
 The suffix _n_ is also used in the function names (i.e. *vload__n__*,
 *vstore__n__* etc.), where _n_ = 2, 3, 4, 8 or 16.
+
+[l02] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[d05] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [37] The `half__n__` type is only defined by the *cl_khr_fp16* extension
 described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
@@ -5858,8 +5764,6 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
 
       *vstore_half* uses the default rounding mode.
       The default rounding mode is round to nearest even.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro.
 | void **vstore_half__n__**(double__n__ _data_, size_t _offset_, {global} half *_p_) +
   void **vstore_half__n__{rte}**(double__n__ _data_, size_t _offset_, {global} half *_p_) +
   void **vstore_half__n__{rtz}**(double__n__ _data_, size_t _offset_, {global} half *_p_) +
@@ -5894,8 +5798,6 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
 
       *vstore_half__n__* uses the default rounding mode.
       The default rounding mode is round to nearest even.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro.
 | |
 | float__n__ **vloada_half__n__**(size_t _offset_, const {global} half *_p_) +
   float__n__ **vloada_half__n__**(size_t _offset_, const {local} half *_p_) +
@@ -5995,8 +5897,6 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
 
       *vstorea_half__n__* uses the default rounding mode.
       The default rounding mode is round to nearest even.
-
-      Requires support for doubles, e.g. with the `+__opencl_c_fp64+` feature macro.
 |====
 
 [38] *vload3* and *vload_half3* read (_x_,_y_,_z_) components from address
@@ -6217,20 +6117,26 @@ types supported by OpenCL C or a user defined type.
 [open,refpage='asyncCopyFunctions',desc='Async Copy Functions',type='freeform',spec='clang',anchor='async-copies',xrefs='',alias='async_work_group_copy async_work_group_strided_copy prefetch wait_group_events']
 --
 
-The OpenCL C programming language implements the following functions that
-provide asynchronous copies between `global` and local memory and a prefetch
-from `global` memory.
+The OpenCL C programming language implements the <<table-builtin-async-copy,
+following functions>> that provide asynchronous copies between `global` and
+local memory and a prefetch from `global` memory.
 
 We use the generic type name `gentype` to indicate the built-in data types
 char, `char{2|3^41^|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`,
 `short{2|3|4|8|16}`, `ushort`, `ushort{2|3|4|8|16}`, `int`,
-`int{2|3|4|8|16}`, `uint`, `uint{2|3|4|8|16}`, `long`, `long{2|3|4|8|16}`,
-`ulong`, `ulong{2|3|4|8|16}`, `float`, `float{2|3|4|8|16}`, or `double`,
+`int{2|3|4|8|16}`, `uint`, `uint{2|3|4|8|16}`, `long`^l03^, `long{2|3|4|8|16}`,
+`ulong`, `ulong{2|3|4|8|16}`, `float`, `float{2|3|4|8|16}`, or `double`^d06^,
 `double{2|3|4|8|16}` as the type for the arguments unless otherwise stated.
 
 [41] *async_work_group_copy* and *async_work_group_strided_copy* for
 3-component vector types behave as *async_work_group_copy* and
 *async_work_group_strided_copy* respectively for 4-component vector types.
+
+[l03] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[d06] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-builtin-async-copy]]
 .Built-in Async Copy and Prefetch Functions
@@ -7692,14 +7598,19 @@ built-in vector functions.
 We use the generic type name `gentype__n__` (or `gentype__m__`) to indicate
 the built-in data types `char{2|4|8|16}`, `uchar{2|4|8|16}`,
 `short{2|4|8|16}`, `ushort{2|4|8|16}`, `half{2|4|8|16}`^49^, `int{2|4|8|16}`,
-`uint{2|4|8|16}`, `long{2|4|8|16}`, `ulong{2|4|8|16}`, `float{2|4|8|16}`, or
-`double{2|4|8|16}`^50^ as the type for the arguments unless otherwise stated.
+`uint{2|4|8|16}`, `long{2|4|8|16}`^l04^, `ulong{2|4|8|16}`, `float{2|4|8|16}`,
+or `double{2|4|8|16}`^50^ as the type for the arguments unless otherwise
+stated.
 We use the generic name `ugentype__n__` to indicate the built-in unsigned
 integer data types.
 
 [49] Only if the *cl_khr_fp16* extension is supported and has been enabled.
 
-[50] Only if double precision is supported.
+[l04] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[50] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-misc-vector]]
 .Built-in Miscellaneous Vector Functions
@@ -7714,15 +7625,11 @@ integer data types.
   int *vec_step*(half3 _a_) +
   int *vec_step*(int3 _a_) +
   int *vec_step*(uint3 _a_) +
-  int *vec_step*(float3 _a_) +
-  int *vec_step*(_type_) +
-
-  If longs are supported, e.g. with the `+__opencl_c_int64+` feature macro: +
   int *vec_step*(long3 _a_) +
   int *vec_step*(ulong3 _a_) +
-
-  If doubles are supported, e.g. with the `+__opencl_c_fp64+` feature macro: +
-  int *vec_step*(double3 _a_)
+  int *vec_step*(float3 _a_) +
+  int *vec_step*(double3 _a_) +
+  int *vec_step*(_type_)
     | The *vec_step* built-in function takes a built-in scalar or vector
       data type argument and returns an integer value representing the
       number of elements in the scalar or vector.
@@ -8109,7 +8016,7 @@ the decimal-point character so that subsequent digits align to nibble
 ====
 The conversion specifiers *e,E,g,G,a,A* convert a `float` or `half` argument
 that is a scalar type to a `double` only if the `double` data type is
-supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+`` feature macro is
+supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro is
 present.
 If the `double` data type is not supported, the argument will be a `float`
 instead of a `double` and the `half` type will be converted to a `float`.
@@ -9688,13 +9595,16 @@ across a work-group.
 These built-in functions must be encountered by all work-items in a
 work-group executing the kernel.
 We use the generic type name `gentype` to indicate the built-in data types
-`half`^59^, `int`, `uint`, `long`, `ulong`, `float` or `double`^60^ as the
+`half`^59^, `int`, `uint`, `long`^l05^, `ulong`, `float` or `double`^60^ as the
 type for the arguments.
 
 [59] Only if the *cl_khr_fp16* extension is supported and has been enabled.
 
-[60] Only if double precision is supported, e.g. for OpenCL C 3.0 the
-`+__opencl_c_fp64+` feature macro is present.
+[l05] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[60] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-builtin-work-group]]
 .Built-in Work-group Collective Functions
@@ -10767,7 +10677,15 @@ NOTE: The functionality described in this section requires support for the `+__o
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
-For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `int`, `uint`, `long`^l06^, `ulong`, `float`, `double`^d07^, or `half`^h01^.
+
+[l06] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_int64+` feature macro.
+
+[d07] Only if double precision is supported.  In OpenCL C 3.0 this will be
+indicated by the presence of the `+__opencl_c_fp64+` feature macro.
+
+[h01] Only if the *cl_khr_fp16* extension is supported and has been enabled.
 
 .Built-in Subgroup Collective Functions
 [cols=",",options="header",]


### PR DESCRIPTION
Undo some of the wording from https://github.com/KhronosGroup/OpenCL-Docs/pull/372 and replace it with simpler footnotes.