### PR TITLE
[OpenCL C 3.0] Extended description of optional functionality (#330).

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -72,14 +72,6 @@ in OpenCL C.
 Please refer to the C99 specification for a detailed description of the
 language grammar.
 
-[NOTE]
---
-The OpenCL 3.0 C programming language described in this specification is provisional.
-It has been Ratified under the Khronos Intellectual Property Framework and is being made publicly available to enable review and feedback from the community.
-
-If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
---
-
 [[optional-functionality]]
 == Optional functionality
 
@@ -92,9 +84,9 @@ by the presence of special predefined macros.
 === Features
 
 Optional language features are described in this document. They are optional
-from OpenCL 3.0 and therefore are not supported by all devices. When an OpenCL
-C 3.0 optional feature is supported, an associated __feature test macro__ will
-be predefined.
+from OpenCL C 3.0 and therefore are not supported by all implementations. When
+an OpenCL C 3.0 optional feature is supported, an associated __feature test
+macro__ will be predefined.
 
 The following table describes OpenCL C 3.0 features and their meaning. The
 naming convension for the feature macros is `+__opencl_c_<name>+`.
@@ -201,11 +193,11 @@ as extensions. Extensions are described in
 
 [NOTE]
 --
-Prior to OpenCL 3.0 some optional features described in this document were
+Prior to OpenCL C 3.0 some optional features described in this document were
 referred to as optional core language extensions. Their presence could be
 indicated by the predefined extension macros. If any of the features has been
 an optional extension in earlier OpenCL versions it can still be used as an
-extension i.e. the same predefined extension macros are still valid in OpenCL
+extension i.e. the same predefined extension macros are still valid in OpenCL C
 3.0. However, the use of feature macros is preferred whenever possible.
 --
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -89,7 +89,7 @@ an OpenCL C 3.0 optional feature is supported, an associated __feature test
 macro__ will be predefined.
 
 The following table describes OpenCL C 3.0 features and their meaning. The
-naming convension for the feature macros is `+__opencl_c_<name>+`.
+naming convention for the feature macros is `+__opencl_c_<name>+`.
 
 Feature macro identifiers are used as names of features in this document.
 
@@ -3350,7 +3350,7 @@ by OpenCL are reserved for future use.
 
 The predefined identifier `+__func__+` is available.
 
-In OpenCL C 3.0 there are a number of optional predefined macro indicating
+In OpenCL C 3.0 there are a number of optional predefined macros indicating
 optional language features. Such macros are listed in the
 <<table-optional-lang-features, optional features in OpenCL C 3.0 table>>.
 --

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -524,25 +524,25 @@ OpenCL.
       on the device.
 
       Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature macro.
+      feature.
 | `ndrange_t`
     | The N-dimensional range over which a kernel executes.
 
       Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature macro.
+      feature.
 | `clk_event_t`
     | A device side event that identifies a command enqueue to
       a device command queue.
 
       Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature macro.
+      feature.
 | `reserve_id_t`
     | A reservation ID.
       This opaque type is used to identify the reservation for
       <<pipe-functions,reading and writing a pipe>>.
 
       Requires support for OpenCL C 2.0 or the `+__opencl_c_pipes+`
-      feature macro.
+      feature.
 | `event_t`
     | An event.
       This can be used to identify <<async-copies,async copies>> from
@@ -2144,7 +2144,7 @@ All function arguments shall be in the `+__private+` address space.
 Additionally, all function return values shall be in the `+__private+` address space.
 
 For OpenCL C 2.0 or with the `+__opencl_c_program_scope_global_variables+`
-feature macro, the address space for a variable at program scope or a `static`
+feature, the address space for a variable at program scope or a `static`
 or `extern` variable inside a function may be either `+__constant+` or `+__global+`,
 and the address space defaults to `+__global+` if not specified.
 Otherwise, the address space for a variable at program scope or a `static` or `extern`
@@ -2166,13 +2166,12 @@ void foo (...)
 }
 ----------
 
-For OpenCL C 2.0, or with the `+__opencl_c_generic_address_space+` feature
-macro, there is an additional unnamed generic address space.
-The unnamed generic address space overlaps the named `+__global+`,
-`+__local+`, and `+__private+` address spaces.
-The unnamed generic address space does not overlap the named `+__constant+`
-address space; the named `+__constant+` address space is not in the generic
-address space.
+For OpenCL C 2.0, or with the `+__opencl_c_generic_address_space+` feature,
+there is an additional unnamed generic address space. The unnamed generic
+address space overlaps the named `+__global+`, `+__local+`, and `+__private+
+address spaces. The unnamed generic address space does not overlap the named
+`+__constant+` address space; the named `+__constant+` address space is not in
+the generic address space.
 
 If the generic address space is supported,
 pointers that are declared without pointing to a named address space point
@@ -2255,7 +2254,7 @@ The elements of an image object cannot be directly accessed.
 Built-in functions to read from and write to an image object are provided.
 
 For OpenCL C 2.0, or with the `+__opencl_c_program_scope_global_variables+`
-feature macro,
+feature,
 variables defined at program scope and `static` variables inside a function
 can also be declared in the `global` address space.
 They can be defined with any valid OpenCL C data type except for those in
@@ -2279,7 +2278,7 @@ Examples:
 [source,c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
-// __opencl_c_program_scope_global_variables feature macro.
+// __opencl_c_program_scope_global_variables feature.
 
 global int foo;         // OK.
 int foo;                // OK. Declared in the global address space.
@@ -2439,7 +2438,7 @@ arguments are in the `+__private+` or `private` address space.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature.
 
 The following rules apply when using pointers that point to the generic
 address space:
@@ -2866,7 +2865,7 @@ spaces.
 Image objects specified as arguments to a kernel can be declared to be
 read-only or write-only.
 
-For OpenCL C 2.0, or with the `+__opencl_c_read_write_images+` feature macro,
+For OpenCL C 2.0, or with the `+__opencl_c_read_write_images+` feature,
 image objects specified as arguments to a kernel can additionally be
 declared to be read-write.
 
@@ -3341,7 +3340,7 @@ __kernel __attribute__((work_group_size_hint(X, 1, 1))) \
     undefined otherwise.
     Also refer to the value of the <<opencl-device-queries,
     `CL_DEVICE_IMAGE_SUPPORT` device query>> and the `+__opencl_c_images+`
-    feature macro.
+    feature.
 
 `+__FAST_RELAXED_MATH__+` ::
     Used to determine if the `-cl-fast-relaxed-math` optimization option is
@@ -3841,7 +3840,7 @@ information provided is in some sense correct.
 [open,refpage='blocks',desc='Blocks',type='freeform',spec='clang',anchor='blocks']
 --
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature.
 
 This section describes the clang block syntax^26^.
 
@@ -4320,7 +4319,8 @@ identifier of each work-item when this kernel is being executed on a device.
 [28] I.e. the _global_work_size_ values specified to *clEnqueueNDRangeKernel*
 are not evenly divisible by the _local_work_size_ values for each dimension.
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro.
+NOTE: The functionality described in the following table requires support for
+the `+__opencl_c_subgroups+` feature.
 
 The following table describes the list of built-in work-item functions that
 can be used to query the size of a subgroup, number of subgroups per work group,
@@ -4502,7 +4502,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   gentype *fract*(gentype _x_, {private} gentype _*iptr_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   gentype *fract*(gentype _x_, gentype _*iptr_)
     | Returns *fmin*(_x_ - *floor*(_x_), `0x1.fffffep-1f`).
@@ -4517,7 +4517,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   float **frexp**(float _x_, {private} int *exp) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float__n__ **frexp**(float__n__ _x_, int__n__ *exp) +
   float **frexp**(float _x_, int *exp)
@@ -4535,7 +4535,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   double **frexp**(double _x_, {private} int *exp) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   double__n__ **frexp**(double__n__ _x_, int__n__ *exp) +
   double **frexp**(double _x_, int *exp)
@@ -4576,7 +4576,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   double **lgamma_r**(double _x_, {private} int *_signp_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float__n__ **lgamma_r**(float__n__ _x_, int__n__ *_signp_) +
   float **lgamma_r**(float _x_, int *_signp_) +
@@ -4615,7 +4615,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   gentype *modf*(gentype _x_, {private} gentype _*iptr_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   gentype *modf*(gentype _x_, gentype _*iptr_)
     | Decompose a floating-point number.
@@ -4658,7 +4658,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   float **remquo**(float _x_, float _y_, {private} int _*quo_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float__n__ **remquo**(float__n__ _x_, float__n__ _y_, int__n__ _*quo_) +
   float **remquo**(float _x_, float _y_, int _*quo_)
@@ -4681,7 +4681,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   double **remquo**(double _x_, double _y_, {private} int _*quo_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   double__n__ **remquo**(double__n__ _x_, double__n__ _y_, int__n__ _*quo_) +
   double **remquo**(double _x_, double _y_, int _*quo_)
@@ -4715,7 +4715,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   gentype *sincos*(gentype _x_, {private} gentype _*cosval_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   gentype *sincos*(gentype _x_, gentype _*cosval_)
     | Compute sine and cosine of x.
@@ -5667,7 +5667,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   gentype__n__ **vload__n__**(size_t _offset_, const {private} gentype *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   gentype__n__ **vload__n__**(size_t _offset_, const gentype *_p_)
     | Return `sizeof(gentype__n__)` bytes of data, where the first `(__n__ *
@@ -5682,7 +5682,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {private} gentype *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, gentype *_p_)
     | Write `_n_ * sizeof(gentype)` bytes given by _data_ to the address
@@ -5697,7 +5697,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   float **vload_half**(size_t _offset_, const {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float **vload_half**(size_t _offset_, const half *_p_)
     | Read `sizeof(half)` bytes of data from the address computed as `(_p_
@@ -5712,7 +5712,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   float__n__ **vload_half__n__**(size_t _offset_, const {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float__n__ **vload_half__n__**(size_t _offset_, const half *_p_)
     | Read `(_n_ * sizeof(half))` bytes of data from the address computed as
@@ -5740,7 +5740,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstore_half{rtn}**(float _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstore_half**(float _data_, size_t _offset_, half *_p_) +
   void **vstore_half{rte}**(float _data_, size_t _offset_, half *_p_) +
@@ -5774,7 +5774,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstore_half__n__{rtn}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstore_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
   void **vstore_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
@@ -5809,7 +5809,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstore_half{rtn}**(double _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstore_half**(double _data_, size_t _offset_, half *_p_) +
   void **vstore_half{rte}**(double _data_, size_t _offset_, half *_p_) +
@@ -5843,7 +5843,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstore_half__n__{rtn}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstore_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
   void **vstore_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
@@ -5865,7 +5865,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   float__n__ **vloada_half__n__**(size_t _offset_, const {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   float__n__ **vloada_half__n__**(size_t _offset_, const half *_p_)
     | For n = 2, 4, 8 and 16, read `sizeof(half__n__)` bytes of data from
@@ -5898,7 +5898,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstorea_half__n__{rtn}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstorea_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
   void **vstorea_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
@@ -5937,7 +5937,7 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
   void **vstorea_half__n__{rtn}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
 
   For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature macro: +
+  feature: +
 
   void **vstorea_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
   void **vstorea_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
@@ -6065,7 +6065,8 @@ in a work-group.
 [40] Refer to the description and restrictions for <<memory-scope,`memory_scope`>>.
 --
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` feature macro.
+NOTE: The functionality described in the following table requires support for
+the `+__opencl_c_subgroups+` feature.
 
 The following table desribes built-in functions to synchronize the work-items
 in a subgroup.
@@ -6136,7 +6137,7 @@ in a subgroup.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature.
 
 This section describes built-in functions to safely convert from pointers
 to the generic address space to pointers to named address spaces, and to
@@ -6444,7 +6445,7 @@ pointed to by obj to the value value.
 void atomic_init(volatile __global A *obj, C value)
 void atomic_init(volatile __local A *obj, C value)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 void atomic_init(volatile A *obj, C value)
 ----------
 
@@ -6460,7 +6461,7 @@ work_group_barrier(CLK_LOCAL_MEM_FENCE);
 
 NOTE: The function variant that uses the generic address space, i.e. no
 explicit address space is listed, requires OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -6485,16 +6486,16 @@ The following table lists the enumeration constants:
     |
 | `memory_order_acquire`
     | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature macro.
+      `+__opencl_c_atomic_order_acq_rel+` feature.
 | `memory_order_release`
     | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature macro.
+      `+__opencl_c_atomic_order_acq_rel+` feature.
 | `memory_order_acq_rel`
     | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature macro.
+      `+__opencl_c_atomic_order_acq_rel+` feature.
 | `memory_order_seq_cst`
     | Requires support for OpenCL C 2.0, or the
-      `+__opencl_c_atomic_order_seq_cst+` feature macro.
+      `+__opencl_c_atomic_order_seq_cst+` feature.
 |====
 
 The `memory_order` can be used when performing atomic operations to `global`
@@ -6523,20 +6524,18 @@ The following table lists the enumeration constants:
     | `memory_scope_work_item` can only be used with `atomic_work_item_fence`
       with flags set to `CLK_IMAGE_MEM_FENCE`.
 | `memory_scope_sub_group`
-    | Requires support for the `+__opencl_c_subgroups+` feature
-      macro.
+    | Requires support for the `+__opencl_c_subgroups+` feature.
 | `memory_scope_work_group`
     |
 | `memory_scope_device`
     | Requires support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_scope_device+` feature macro.
+      `+__opencl_c_atomic_scope_device+` feature.
 | `memory_scope_all_svm_devices`
     | Requires support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_scope_all_devices+` feature macro.
+      `+__opencl_c_atomic_scope_all_devices+` feature.
 | `memory_scope_all_devices`
     | An alias for `memory_scope_all_svm_devices`.
-      Requires support for the `+__opencl_c_atomic_scope_all_devices+` feature
-      macro.
+      Requires support for the `+__opencl_c_atomic_scope_all_devices+` feature.
 |====
 
 // This is no longer correct given `memory_scope_sub_group`.
@@ -6624,14 +6623,14 @@ The list of supported atomic type names are:
 *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions
 are supported and have been enabled.
 If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_int64+` feature macro.
+`+__opencl_c_int64+` feature.
 
 [46] The `atomic_double` type is only supported if double precision is
 supported and the *cl_khr_int64_base_atomics* and
 *cl_khr_int64_extended_atomics* extensions are supported and have been
 enabled.
 If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_fp64+` feature macro.
+`+__opencl_c_fp64+` feature.
 
 [47] If the device address space is 64-bits, the data types
 `atomic_intptr_t`, `atomic_uintptr_t`, `atomic_size_t` and
@@ -6664,16 +6663,15 @@ This section specifies each general kind.
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device feature.
 void atomic_store(volatile __global A *object, C desired)
 void atomic_store(volatile __local A *object, C desired)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 void atomic_store(volatile A *object, C desired)
 
-// Requires OpenCL C 3.0 and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 and the __opencl_c_atomic_scope_device feature.
 void atomic_store_explicit(volatile __global A *object,
                            C desired,
                            memory_order order)
@@ -6682,7 +6680,7 @@ void atomic_store_explicit(volatile __local A *object,
                            memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device features.
 void atomic_store_explicit(volatile A *object,
                            C desired,
                            memory_order order)
@@ -6697,7 +6695,7 @@ void atomic_store_explicit(volatile __local A *object,
                            memory_order order,
                            memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 void atomic_store_explicit(volatile A *object,
                            C desired,
                            memory_order order,
@@ -6712,13 +6710,13 @@ Memory is affected according to the value of _order_.
 
 NOTE: The non-explicit `atomic_store` function requires OpenCL C 2.0, or both
 the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -6730,23 +6728,22 @@ explicit address space is listed, require OpenCL C 2.0 or the
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 C atomic_load(volatile __global A *object)
 C atomic_load(volatile __local A *object)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 C atomic_load(volatile A *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 C atomic_load_explicit(volatile __global A *object,
                        memory_order order)
 C atomic_load_explicit(volatile __local A *object,
                        memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device features.
 C atomic_load_explicit(volatile A *object,
                        memory_order order)
 
@@ -6758,7 +6755,7 @@ C atomic_load_explicit(volatile __local A *object,
                        memory_order order,
                        memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 C atomic_load_explicit(volatile A *object,
                        memory_order order,
                        memory_scope scope)
@@ -6771,13 +6768,13 @@ Atomically returns the value pointed to by _object_.
 
 NOTE: The non-explicit `atomic_load` function requires OpenCL C 2.0, or both
 the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -6789,16 +6786,15 @@ explicit address space is listed, require OpenCL C 2.0 or the
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 C atomic_exchange(volatile __global A *object, C desired)
 C atomic_exchange(volatile __local A *object, C desired)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 C atomic_exchange(volatile A *object, C desired)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 C atomic_exchange_explicit(volatile __global A *object,
                            C desired,
                            memory_order order)
@@ -6807,7 +6803,7 @@ C atomic_exchange_explicit(volatile __local A *object,
                            memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device feature.
 C atomic_exchange_explicit(volatile A *object,
                            C desired,
                            memory_order order)
@@ -6822,7 +6818,7 @@ C atomic_exchange_explicit(volatile __local A *object,
                            memory_order order,
                            memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 C atomic_exchange_explicit(volatile A *object,
                            C desired,
                            memory_order order,
@@ -6838,13 +6834,13 @@ effects.
 
 NOTE: The non-explicit `atomic_exchange` function requires OpenCL C 2.0, or
 both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -6856,7 +6852,7 @@ explicit address space is listed, require OpenCL C 2.0 or the
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_strong(
     volatile __global A *object,
     __global C *expected, C desired)
@@ -6877,8 +6873,7 @@ bool atomic_compare_exchange_strong(
     __private C *expected, C desired)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_strong(
     volatile A *object,
     C *expected, C desired)
@@ -6921,7 +6916,7 @@ bool atomic_compare_exchange_strong_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_strong_explicit(
     volatile A *object,
     C *expected,
@@ -6973,7 +6968,7 @@ bool atomic_compare_exchange_strong_explicit(
     memory_order failure,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_strong_explicit(
     volatile A *object,
     C *expected,
@@ -6983,7 +6978,7 @@ bool atomic_compare_exchange_strong_explicit(
     memory_scope scope)
 
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_weak(
     volatile __global A *object,
     __global C *expected, C desired)
@@ -7004,8 +6999,7 @@ bool atomic_compare_exchange_weak(
     __private C *expected, C desired)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_weak(
     volatile A *object,
     C *expected, C desired)
@@ -7048,7 +7042,7 @@ bool atomic_compare_exchange_weak_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_weak_explicit(
     volatile A *object,
     C *expected,
@@ -7100,7 +7094,7 @@ bool atomic_compare_exchange_weak_explicit(
     memory_order failure,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_weak_explicit(
     volatile A *object,
     C *expected,
@@ -7150,13 +7144,13 @@ These generic functions return the result of the comparison.
 NOTE: The non-explicit `atomic_compare_exchange_strong` and
 `atomic_compare_exchange_weak` functions requires OpenCL C 2.0, or both the
 `+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
-feature macros.
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -7194,16 +7188,15 @@ and on atomic type `atomic_uintptr_t`, `M` is `uintptr_t`.
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 C atomic_fetch_key(volatile __global A *object, M operand)
 C atomic_fetch_key(volatile __local A *object, M operand)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 C atomic_fetch_key(volatile A *object, M operand)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 C atomic_fetch_key_explicit(volatile __global A *object,
                             M operand,
                             memory_order order)
@@ -7212,7 +7205,7 @@ C atomic_fetch_key_explicit(volatile __local A *object,
                             memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device features.
 C atomic_fetch_key_explicit(volatile A *object,
                             M operand,
                             memory_order order)
@@ -7227,7 +7220,7 @@ C atomic_fetch_key_explicit(volatile __local A *object,
                             memory_order order,
                             memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 C atomic_fetch_key_explicit(volatile A *object,
                             M operand,
                             memory_order order,
@@ -7250,13 +7243,13 @@ effects.
 
 NOTE: The non-explicit `atomic_fetch_key` functions require OpenCL C 2.0, or
 both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -7296,19 +7289,18 @@ global atomic_flag guard = ATOMIC_FLAG_INIT;
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 bool atomic_flag_test_and_set(
     volatile __global atomic_flag *object)
 bool atomic_flag_test_and_set(
     volatile __local atomic_flag *object)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 bool atomic_flag_test_and_set(
     volatile atomic_flag *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 bool atomic_flag_test_and_set_explicit(
     volatile __global atomic_flag *object,
     memory_order order)
@@ -7317,7 +7309,7 @@ bool atomic_flag_test_and_set_explicit(
     memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device features.
 bool atomic_flag_test_and_set_explicit(
     volatile atomic_flag *object,
     memory_order order)
@@ -7332,7 +7324,7 @@ bool atomic_flag_test_and_set_explicit(
     memory_order order,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 bool atomic_flag_test_and_set_explicit(
     volatile atomic_flag *object,
     memory_order order,
@@ -7347,13 +7339,13 @@ Returns atomically the value of the `object` immediately before the effects.
 
 NOTE: The non-explicit `atomic_flag_test_and_set` function requires OpenCL C
 2.0, or both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 
@@ -7365,16 +7357,15 @@ explicit address space is listed, require OpenCL C 2.0 or the
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature macros.
+// and __opencl_c_atomic_scope_device features.
 void atomic_flag_clear(volatile __global atomic_flag *object)
 void atomic_flag_clear(volatile __local atomic_flag *object)
 
 // Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device feature
-// macros.
+// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 void atomic_flag_clear(volatile atomic_flag *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature macro.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 void atomic_flag_clear_explicit(
     volatile __global atomic_flag *object,
     memory_order order)
@@ -7383,7 +7374,7 @@ void atomic_flag_clear_explicit(
     memory_order order)
 
 // Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature macros.
+// __opencl_c_atomic_scope_device features.
 void atomic_flag_clear_explicit(
     volatile atomic_flag *object,
     memory_order order)
@@ -7398,7 +7389,7 @@ void atomic_flag_clear_explicit(
     memory_order order,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature macro.
+// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
 void atomic_flag_clear_explicit(
     volatile atomic_flag *object,
     memory_order order,
@@ -7412,13 +7403,13 @@ Memory is affected according to the value of order.
 
 NOTE: The non-explicit `atomic_flag_clear` function requires OpenCL C 2.0, or
 both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` feature macros.
+`+__opencl_c_atomic_scope_device+` features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
 explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature macro.
+`+__opencl_c_generic_address_space+` feature.
 --
 
 [[atomic-legacy]]
@@ -7629,21 +7620,21 @@ semantics of the minimum requirements.
     undefined.
   * Using `memory_order_acquire` with any built-in atomic function except
     `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature macro.
+    `+__opencl_c_atomic_order_acq_rel+` feature.
   * Using `memory_order_release` with any built-in atomic function except
     `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature macro.
+    `+__opencl_c_atomic_order_acq_rel+` feature.
   * Using `memory_order_acq_rel` with any built-in atomic function except
     `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature macro.
+    `+__opencl_c_atomic_order_acq_rel+` feature.
   * Using `memory_order_seq_cst` with any built-in atomic function requires
-    OpenCL C 2.0 or the `+__opencl_c_atomic_order_seq_cst+` feature macro.
+    OpenCL C 2.0 or the `+__opencl_c_atomic_order_seq_cst+` feature.
   * Using `memory_scope_sub_group` with any built-in atomic function requires
-    the `+__opencl_c_subgroups+` feature macro.
+    the `+__opencl_c_subgroups+` feature.
   * Using `memory_scope_device` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_scope_device+` feature macro.
+    `+__opencl_c_atomic_scope_device+` feature.
   * Using `memory_scope_all_svm_devices` or `memory_scope_all_devices` requires
-    OpenCL C 2.0 or the `+__opencl_c_atomic_scope_all_devices+` feature macro.
+    OpenCL C 2.0 or the `+__opencl_c_atomic_scope_all_devices+` feature.
 --
 
 
@@ -9429,7 +9420,7 @@ For write functions this may be `write_only` or `read_write`.
       image depth-1], respectively, is undefined.
 
       Requires support for OpenCL C 2.0, the `+__opencl_c_3d_image_writes+`
-      feature macro, or the `cl_khr_3d_image_writes` extension.
+      feature, or the `cl_khr_3d_image_writes` extension.
 |====
 --
 
@@ -9648,7 +9639,7 @@ support will result in a `CL_OUT_OF_RESOURCES` error being returned.
 --
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_work_group_collective_functions+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_work_group_collective_functions+` feature.
 
 This section decribes built-in functions that perform collective options
 across a work-group.
@@ -9765,7 +9756,7 @@ given work-group.
 === Pipe Functions
 
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_pipes+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_pipes+` feature.
 
 A pipe is identified by specifying the `pipe` keyword with a type.
 The data type specifies the size of each packet in the pipe.
@@ -10049,7 +10040,7 @@ The following behavior is undefined:
 [open,refpage='enqueue_kernel',desc='Enqueuing Kernels',type='freeform',spec='clang',anchor='enqueuing-kernels',xrefs='enqueue_marker']
 --
 NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature macro.
+OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature.
 
 This section describes built-in functions that allow a kernel to
 enqueue additional work to the same device, without host interaction.
@@ -10733,7 +10724,7 @@ foo(queue_t q, ...)
 [open,refpage='subgroupFunctions',desc='Subgroup Functions',type='freeform',spec='clang',anchor='subgroup-functions',xrefs='',alias='sub_group_all sub_group_any sub_group_broadcast sub_group_reduce sub_group_scan_exclusive sub_group_scan_inclusive sub_group_reserve_read_pipe sub_gorup_reserve_write_pipe sub_group_commit_read_pipe sub_group_commit_write_pipe get_kernel_sub_group_count_for_ndrange get_kernel_max_sub_group_size_for_ndrange']
 --
 
-NOTE: The functionality described in this section requires support for the `+__opencl_c_subgroups+` feature macro.
+NOTE: The functionality described in this section requires support for the `+__opencl_c_subgroups+` feature.
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
@@ -10814,7 +10805,7 @@ The order of floating-point operations is not guaranteed for the *sub_group_redu
 The order of these floating-point operations is also non-deterministic for a given sub-group.
 ====
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_pipes+` feature macros.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_pipes+` features.
 
 The following table describes built-in pipe functions that operate at a
 subgroup level.
@@ -10865,7 +10856,7 @@ can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
 groups is implementation defined.
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_device_enqueue+` feature macros.
+NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_device_enqueue+` features.
 
 The following table describes built-in functions to query subgroup
 information for a block to be enqueued.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -75,7 +75,7 @@ language grammar.
 [[optional-functionality]]
 == Optional functionality
 
-Some language functionality is optional that will not be supported by all
+Some language functionality is optional and will not be supported by all
 devices. Such functionality is represented by optional language features or
 language extensions. Support of optional functionality in OpenCL C is indicated
 by the presence of special predefined macros.
@@ -94,7 +94,7 @@ naming convension for the feature macros is `+__opencl_c_<name>+`.
 Feature macro identifiers are used as names of features in this document.
 
 [[table-optional-lang-features]]
-.Optional features in OpenCL 3.0 and their predefined macros.
+.Optional features in OpenCL C 3.0 and their predefined macros.
 [cols="1,3",options="header",]
 |====
 | *Feature Macro/Name*
@@ -194,7 +194,7 @@ as extensions. Extensions are described in
 [NOTE]
 --
 Prior to OpenCL C 3.0 some optional features described in this document were
-referred to as optional core language extensions. Their presence could be
+referred to as optional core features. Their presence could be
 indicated by the predefined extension macros. If any of the features has been
 an optional extension in earlier OpenCL versions it can still be used as an
 extension i.e. the same predefined extension macros are still valid in OpenCL C
@@ -3351,8 +3351,8 @@ by OpenCL are reserved for future use.
 The predefined identifier `+__func__+` is available.
 
 In OpenCL C 3.0 there are a number of optional predefined macro indicating
-optional language features. Such macros are listed in
-<<table-optional-lang-features>>.
+optional language features. Such macros are listed in the
+<<table-optional-lang-features, optional features in OpenCL C 3.0 table>>.
 --
 
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -72,75 +72,142 @@ in OpenCL C.
 Please refer to the C99 specification for a detailed description of the
 language grammar.
 
-The OpenCL C 3.0 programming language includes both required features and
-optional features.
-When an OpenCL C 3.0 optional feature is supported in the language, support
-will be indicated using a __feature test macro__.
+[NOTE]
+--
+The OpenCL 3.0 C programming language described in this specification is provisional.
+It has been Ratified under the Khronos Intellectual Property Framework and is being made publicly available to enable review and feedback from the community.
 
-The following table describes OpenCL C 3.0 feature macros and their meaning:
+If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
+--
 
+[[optional-functionality]]
+== Optional functionality
+
+Some language functionality is optional that will not be supported by all
+devices. Such functionality is represented by optional language features or
+language extensions. Support of optional functionality in OpenCL C is indicated
+by the presence of special predefined macros.
+
+[[features]]
+=== Features
+
+Optional language features are described in this document. They are optional
+from OpenCL 3.0 and therefore are not supported by all devices. When an OpenCL
+C 3.0 optional feature is supported, an associated __feature test macro__ will
+be predefined.
+
+The following table describes OpenCL C 3.0 features and their meaning. The
+naming convension for the feature macros is `+__opencl_c_<name>+`.
+
+Feature macro identifiers are used as names of features in this document.
+
+[[table-optional-lang-features]]
+.Optional features in OpenCL 3.0 and their predefined macros.
 [cols="1,3",options="header",]
 |====
-| *Feature Macro*
+| *Feature Macro/Name*
 | *Brief Description*
 
 | `+__opencl_c_3d_image_writes+`
-| The OpenCL C compiler supports built-in functions for writing to 3D image objects.
+| The OpenCL C compiler supports built-in functions for writing to 3D image
+objects.
 
-OpenCL C compilers that define the feature macro `+__opencl_c_3d_image_writes+` must also define the feature macro `+__opencl_c_images+`.
+OpenCL C compilers that define the feature macro `+__opencl_c_3d_image_writes+`
+must also define the feature macro `+__opencl_c_images+`.
+
 | `+__opencl_c_atomic_order_acq_rel+`
-| The OpenCL C compiler supports enumerations and built-in functions for atomic operations with acquire and release memory consistency orders.
+| The OpenCL C compiler supports enumerations and built-in functions for atomic
+operations with acquire and release memory consistency orders.
 
 | `+__opencl_c_atomic_order_seq_cst+`
-| The OpenCL C compiler supports enumerations and built-in functions for atomic operations and fences with sequentially consistent memory consistency order.
+| The OpenCL C compiler supports enumerations and built-in functions for atomic
+operations and fences with sequentially consistent memory consistency order.
 
 | `+__opencl_c_atomic_scope_device+`
-| The OpenCL C compiler supports enumerations and built-in functions for atomic operations and fences with device memory scope.
+| The OpenCL C compiler supports enumerations and built-in functions for atomic
+operations and fences with device memory scope.
 
 | `+__opencl_c_atomic_scope_all_devices+`
-| The OpenCL C compiler supports enumerations and built-in functions for atomic operations and fences with all with memory scope across all devices that can share SVM memory with each other and the host process.
+| The OpenCL C compiler supports enumerations and built-in functions for atomic
+operations and fences with all with memory scope across all devices that can
+share SVM memory with each other and the host process.
 
 | `+__opencl_c_device_enqueue+`
-| The OpenCL C compiler supports built-in functions to enqueue additional work from the device.
+| The OpenCL C compiler supports built-in functions to enqueue additional work
+from the device.
 
-OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_generic_address_space+`.
+OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+`
+must also define the feature macro `+__opencl_c_generic_address_space+`.
 
 | `+__opencl_c_generic_address_space+`
 | The OpenCL C compiler supports the unnamed generic address space.
 
 | `+__opencl_c_fp64+`
-| The OpenCL C compiler supports types and built-in functions with 64-bit floating point types.
+| The OpenCL C compiler supports types and built-in functions with 64-bit
+floating point types.
 
 | `+__opencl_c_images+`
 | The OpenCL C compiler supports types and built-in functions for images.
 
 | `+__opencl_c_int64+`
-| The OpenCL C compiler supports types and built-in functions with 64-bit integers.
+| The OpenCL C compiler supports types and built-in functions with 64-bit
+integers.
 
-OpenCL C compilers for FULL profile devices or devices with 64-bit pointers must always define the `+__opencl_c_int64+` feature macro.
+OpenCL C compilers for FULL profile devices or devices with 64-bit pointers
+must always define the `+__opencl_c_int64+` feature macro.
+
 | `+__opencl_c_pipes+`
-| The OpenCL C compiler supports the pipe modifier and built-in functions to read and write from a pipe.
+| The OpenCL C compiler supports the pipe modifier and built-in functions
+to read and write from a pipe.
 
-OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must also define the feature macro `+__opencl_c_generic_address_space+`.
+OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must
+also define the feature macro `+__opencl_c_generic_address_space+`.
 
 | `+__opencl_c_program_scope_global_variables+`
-| The OpenCL C compiler supports program scope variables in the global address space.
+| The OpenCL C compiler supports program scope variables in the global address
+space.
 
 | `+__opencl_c_read_write_images+`
-| The OpenCL C compiler supports reading from and writing to the same image object in a kernel.
+| The OpenCL C compiler supports reading from and writing to the same image
+object in a kernel.
 
-OpenCL C compilers that define the feature macro `+__opencl_c_read_write_images+` must also define the feature macro `+__opencl_c_images+`.
+OpenCL C compilers that define the feature macro
+`+__opencl_c_read_write_images+` must also define the feature macro
+`+__opencl_c_images+`.
+
 | `+__opencl_c_subgroups+`
-| The OpenCL C compiler supports built-in functions operating on sub-groupings of work-items.
+| The OpenCL C compiler supports built-in functions operating on sub-groupings
+of work-items.
 
 | `+__opencl_c_work_group_collective_functions+`
-| The OpenCL C compiler supports built-in functions that perform collective operations across a work-group.
+| The OpenCL C compiler supports built-in functions that perform collective
+operations across a work-group.
 
 |====
 
-In OpenCL C 3.0, feature macros must expand to the value `1` if the feature macro is defined by the OpenCL C compiler.
-A feature macro must not be defined if the feature is not supported by the OpenCL C compiler.
-A feature macro may expand to a different value in the future, but if this occurs the value of the feature macro must compare greater than the prior value of the feature macro.
+In OpenCL C 3.0, feature macros must expand to the value `1` if the feature
+macro is defined by the OpenCL C compiler. A feature macro must not be
+defined if the feature is not supported by the OpenCL C compiler. A feature
+macro may expand to a different value in the future, but if this occurs the
+value of the feature macro must compare greater than the prior value of the
+feature macro.
+
+[[extensions]]
+=== Extensions
+
+Optional functionality that is not defined in this document is referred to
+as extensions. Extensions are described in
+<<opencl-extension-spec,the OpenCL Extension Specification>>.
+
+[NOTE]
+--
+Prior to OpenCL 3.0 some optional features described in this document were
+referred to as optional core language extensions. Their presence could be
+indicated by the predefined extension macros. If any of the features has been
+an optional extension in earlier OpenCL versions it can still be used as an
+extension i.e. the same predefined extension macros are still valid in OpenCL
+3.0. However, the use of feature macros is preferred whenever possible.
+--
 
 [[supported-data-types]]
 == Supported Data Types
@@ -3291,6 +3358,10 @@ The macro names defined by the C99 specification but not currently supported
 by OpenCL are reserved for future use.
 
 The predefined identifier `+__func__+` is available.
+
+In OpenCL C 3.0 there are a number of optional predefined macro indicating
+optional language features. Such macros are listed in
+<<table-optional-lang-features>>.
 --
 
 


### PR DESCRIPTION
- Added subsections for features and extensions.
- Added title for feature table.
- Explained functionality covered by both features and extensions.
- Referenced feature macros in predefined macros section.
- Updated optional feature description with features name as they are explicitly defined in the spec now.
