### PR TITLE
Delete some zero-width spaces added by mistake

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -218,7 +218,7 @@ value compares equal to 0; otherwise, the result is 1.
 // TODO: Renumber the footnotes from here onwards.
 [2x] The `long`, `unsigned long` and `ulong` scalar types are optional types
 for EMBEDDED profile devices that are supported if the value of the
-<<opencl-device-queries, `CL_​DEVICE_​EXTENSIONS` device query>>
+<<opencl-device-queries, `CL_DEVICE_EXTENSIONS` device query>>
 contains `+cles_khr_int64+`.
 An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature
 macro unconditionally for FULL profile devices, or for EMBEDDED profile
@@ -384,7 +384,7 @@ The following table describes the list of built-in vector data types.
 // TODO include this footnote in the renumbering.
 [5x] The `long` and `ulong` vector types are optional types for
 EMBEDDED profile devices that are supported if the value of the
-<<opencl-device-queries, `CL_​DEVICE_​EXTENSIONS` device query>>
+<<opencl-device-queries, `CL_DEVICE_EXTENSIONS` device query>>
 contains `+cles_khr_int64+`.
 An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature
 macro unconditionally for FULL profile devices, or for EMBEDDED profile


### PR DESCRIPTION
I copy-pasted from rendered HTML spec and accidentally included some
zero-width spaces in the raw text, delete those.