### PR TITLE
remove provisional paragraphs from API, C, and Environment specs

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The OpenCL^(TM)^ C 3.0 Specification (Provisional)
+= The OpenCL^(TM)^ C 3.0 Specification
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:
@@ -141,14 +141,6 @@ OpenCL C compilers that define the feature macro `+__opencl_c_read_write_images+
 In OpenCL C 3.0, feature macros must expand to the value `1` if the feature macro is defined by the OpenCL C compiler.
 A feature macro must not be defined if the feature is not supported by the OpenCL C compiler.
 A feature macro may expand to a different value in the future, but if this occurs the value of the feature macro must compare greater than the prior value of the feature macro.
-
-[NOTE]
---
-The OpenCL 3.0 C programming language described in this specification is provisional.
-It has been Ratified under the Khronos Intellectual Property Framework and is being made publicly available to enable review and feedback from the community.
-
-If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
---
 
 [[supported-data-types]]
 == Supported Data Types

--- a/api/introduction.asciidoc
+++ b/api/introduction.asciidoc
@@ -125,11 +125,3 @@ versions of OpenCL support that feature.
     glossary.
   * Universal: Features that have no mention of what version they are missing
     before or deprecated by are available in all versions of OpenCL.
-
-[NOTE]
---
-The OpenCL 3.0 features described in this specification are provisional.
-They have been Ratified under the Khronos Intellectual Property Framework, and are being made publicly available to enable review and feedback from the community.
-
-If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
---

--- a/env/introduction.asciidoc
+++ b/env/introduction.asciidoc
@@ -27,11 +27,3 @@ This document is written for compiler developers who are generating SPIR-V
 modules intended to be consumed by the OpenCL API, for implementors of the
 OpenCL API who are consuming SPIR-V modules, and for software developers who
 are using SPIR-V modules with the OpenCL API.
-
-[NOTE]
---
-The OpenCL 3.0 SPIR-V Environment described in this specification is provisional.
-It has been Ratified under the Khronos Intellectual Property Framework, and is being made publicly available to enable review and feedback from the community.
-
-If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
---


### PR DESCRIPTION
Discussed in the July 28th teleconference.