### PR TITLE
add a separate table for event command types

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8706,61 +8706,8 @@ include::{generated}/api/version-notes/CL_EVENT_CONTEXT.asciidoc[]
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_TYPE.asciidoc[]
   | cl_command_type
-      | Return the command type associated with _event_.
-        Can be one of the following values:
-
-// OpenCL 1.0
-        {CL_COMMAND_NDRANGE_KERNEL_anchor} +
-        {CL_COMMAND_TASK_anchor} +
-        {CL_COMMAND_NATIVE_KERNEL_anchor} +
-        {CL_COMMAND_READ_BUFFER_anchor} +
-        {CL_COMMAND_WRITE_BUFFER_anchor} +
-        {CL_COMMAND_COPY_BUFFER_anchor} +
-        {CL_COMMAND_READ_IMAGE_anchor} +
-        {CL_COMMAND_WRITE_IMAGE_anchor} +
-        {CL_COMMAND_COPY_IMAGE_anchor} +
-        {CL_COMMAND_COPY_BUFFER_TO_IMAGE_anchor} +
-        {CL_COMMAND_COPY_IMAGE_TO_BUFFER_anchor} +
-        {CL_COMMAND_MAP_BUFFER_anchor} +
-        {CL_COMMAND_MAP_IMAGE_anchor} +
-        {CL_COMMAND_UNMAP_MEM_OBJECT_anchor} +
-        {CL_COMMAND_MARKER_anchor} +
-        {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor} +
-        {CL_COMMAND_RELEASE_GL_OBJECTS_anchor}
-
-// OpenCL 1.1
-        These event command types are
-        <<unified-spec, missing before>> version 1.1:
-
-        {CL_COMMAND_READ_BUFFER_RECT_anchor} +
-        {CL_COMMAND_WRITE_BUFFER_RECT_anchor} +
-        {CL_COMMAND_COPY_BUFFER_RECT_anchor} +
-        {CL_COMMAND_USER_anchor}
-
-// OpenCL 1.2
-        These event command types are
-        <<unified-spec, missing before>> version 1.2:
-
-        {CL_COMMAND_BARRIER_anchor} +
-        {CL_COMMAND_MIGRATE_MEM_OBJECTS_anchor} +
-        {CL_COMMAND_FILL_BUFFER_anchor} +
-        {CL_COMMAND_FILL_IMAGE_anchor}
-
-// OpenCL 2.0
-        These event command types are
-        <<unified-spec, missing before>> version 2.0:
-
-        {CL_COMMAND_SVM_FREE_anchor} +
-        {CL_COMMAND_SVM_MEMCPY_anchor} +
-        {CL_COMMAND_SVM_MEMFILL_anchor} +
-        {CL_COMMAND_SVM_MAP_anchor} +
-        {CL_COMMAND_SVM_UNMAP_anchor}
-
-// OpenCL 3.0 - should have been in OpenCL 2.1, but missed:
-        These event command types are
-        <<unified-spec, missing before>> version 3.0:
-
-        {CL_COMMAND_SVM_MIGRATE_MEM_anchor}
+      | Return the command type associated with _event_ as described in the
+        <<event-command-type-table,Event Command Types>> table.
 
 | {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor}^19^
 
@@ -8802,6 +8749,146 @@ include::{generated}/api/version-notes/CL_EVENT_REFERENCE_COUNT.asciidoc[]
     The reference count returned should be considered immediately stale.
     It is unsuitable for general use in applications.
     This feature is provided for identifying memory leaks.
+
+[[event-command-type-table]]
+.List of supported event command types
+[width="100%",cols="1,1",options="header"]
+|====
+| *Event Command Type* | *Events Created By*
+
+| {CL_COMMAND_NDRANGE_KERNEL_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_NDRANGE_KERNEL.asciidoc[]
+  | {clEnqueueNDRangeKernel}
+| {CL_COMMAND_TASK_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_TASK.asciidoc[]
+  | {clEnqueueTask}
+| {CL_COMMAND_NATIVE_KERNEL_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_NATIVE_KERNEL.asciidoc[]
+  | {clEnqueueNativeKernel}
+| {CL_COMMAND_READ_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_READ_BUFFER.asciidoc[]
+  | {clEnqueueReadBuffer}
+| {CL_COMMAND_WRITE_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_WRITE_BUFFER.asciidoc[]
+  | {clEnqueueWriteBuffer}
+| {CL_COMMAND_COPY_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER.asciidoc[]
+  | {clEnqueueCopyBuffer}
+| {CL_COMMAND_READ_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_READ_IMAGE.asciidoc[]
+  | {clEnqueueReadImage}
+| {CL_COMMAND_WRITE_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_WRITE_IMAGE.asciidoc[]
+  | {clEnqueueWriteImage}
+| {CL_COMMAND_COPY_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_COPY_IMAGE.asciidoc[]
+  | {clEnqueueCopyImage}
+| {CL_COMMAND_COPY_BUFFER_TO_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER_TO_IMAGE.asciidoc[]
+  | {clEnqueueCopyBufferToImage}
+| {CL_COMMAND_COPY_IMAGE_TO_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_COPY_IMAGE_TO_BUFFER.asciidoc[]
+  | {clEnqueueCopyImageToBuffer}
+| {CL_COMMAND_MAP_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_MAP_BUFFER.asciidoc[]
+  | {clEnqueueMapBuffer}
+| {CL_COMMAND_MAP_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_MAP_IMAGE.asciidoc[]
+  | {clEnqueueMapImage}
+| {CL_COMMAND_UNMAP_MEM_OBJECT_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_UNMAP_MEM_OBJECT.asciidoc[]
+  | {clEnqueueUnmapMemObject}
+| {CL_COMMAND_MARKER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_MARKER.asciidoc[]
+  | {clEnqueueMarker}, +
+    {clEnqueueMarkerWithWaitList}
+
+// Since these enums are for an extension they shouldn't be in this table.
+//| {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor}
+//
+//include::{generated}/api/version-notes/CL_COMMAND_ACQUIRE_GL_OBJECTS.asciidoc[]
+//  | {clEnqueueAcquireGLObjects}
+//| {CL_COMMAND_RELEASE_GL_OBJECTS_anchor}
+//
+//include::{generated}/api/version-notes/CL_COMMAND_RELEASE_GL_OBJECTS.asciidoc[]
+//  | {clEnqueueReleaseGLObjects}
+
+| {CL_COMMAND_READ_BUFFER_RECT_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_READ_BUFFER_RECT.asciidoc[]
+  | {clEnqueueReadBufferRect}
+| {CL_COMMAND_WRITE_BUFFER_RECT_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_WRITE_BUFFER_RECT.asciidoc[]
+  | {clEnqueueWriteBufferRect}
+| {CL_COMMAND_COPY_BUFFER_RECT_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER_RECT.asciidoc[]
+  | {clEnqueueCopyBufferRect}
+| {CL_COMMAND_USER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_USER.asciidoc[]
+  | {clCreateUserEvent}
+| {CL_COMMAND_BARRIER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_BARRIER.asciidoc[]
+  | {clEnqueueBarrier}, +
+    {clEnqueueBarrierWithWaitList}
+| {CL_COMMAND_MIGRATE_MEM_OBJECTS_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_MIGRATE_MEM_OBJECTS.asciidoc[]
+  | {clEnqueueMigrateMemObjects}
+| {CL_COMMAND_FILL_BUFFER_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_FILL_BUFFER.asciidoc[]
+  | {clEnqueueFillBuffer}
+| {CL_COMMAND_FILL_IMAGE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_FILL_IMAGE.asciidoc[]
+  | {clEnqueueFillImage}
+| {CL_COMMAND_SVM_FREE_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_FREE.asciidoc[]
+  | {clEnqueueSVMFree}
+| {CL_COMMAND_SVM_MEMCPY_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_MEMCPY.asciidoc[]
+  | {clEnqueueSVMMemcpy}
+| {CL_COMMAND_SVM_MEMFILL_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_MEMFILL.asciidoc[]
+  | {clEnqueueSVMMemFill}
+| {CL_COMMAND_SVM_MAP_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_MAP.asciidoc[]
+  | {clEnqueueSVMMap}
+| {CL_COMMAND_SVM_UNMAP_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_UNMAP.asciidoc[]
+  | {clEnqueueSVMUnmap}
+| {CL_COMMAND_SVM_MIGRATE_MEM_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_SVM_MIGRATE_MEM.asciidoc[]
+
+Prior to OpenCL 3.0, the event command type returned by {clEnqueueSVMMigrateMem} is implementation-defined.
+  | {clEnqueueSVMMigrateMem}
+
+|====
 
 Using {clGetEventInfo} to determine if a command identified by _event_ has
 finished execution (i.e. {CL_EVENT_COMMAND_EXECUTION_STATUS} returns


### PR DESCRIPTION
This is proposed fix for #391.

This PR adds a separate table for event command types, after the table of supported _param_names_ for `clGetEventInfo`.  Moving this information to a separate table shortens a long table cell that was broken in the PDF rendering that was causing `CL_COMMAND_SVM_MIGRATE_MEM` to be missing in the PDF spec.  It also clarifies which event command types are returned by which APIs, which was missing in the current specifications, and is a much better linking target for these event command types.

Open questions:

* What should the event command type for `clEnqueueSVMMigrateMem` be prior to OpenCL 3.0?  In this PR, it's described as "implementation-defined", which is safest, but perhaps we could do a little better.

* I've removed (commented out) the event command types `CL_COMMAND_ACQUIRE_GL_OBJECTS` and `CL_COMMAND_RELEASE_GL_OBJECTS` from this table.  They were in this table previously, but they are returned for extension APIs and not core APIs.  Is this the right thing to do?  If so, I should add these event command types to the proper extension spec.