### PR TITLE
unify the descriptions for event for all enqueue APIs

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -816,15 +816,13 @@ include::{generated}/api/version-notes/clEnqueueWriteBuffer.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular read / write
-    command and can be used to query or queue a wait for this particular command
-    to complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this read / write command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _blocking_read_ is {CL_TRUE} i.e. the read command is blocking,
 {clEnqueueReadBuffer} does not return until the buffer data has been read
@@ -960,15 +958,13 @@ include::{generated}/api/version-notes/clEnqueueWriteBufferRect.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular read / write
-    command and can be used to query or queue a wait for this particular command
-    to complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this read / write command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 
 If _blocking_read_ is {CL_TRUE} i.e. the read command is blocking,
@@ -1137,16 +1133,13 @@ include::{generated}/api/version-notes/clEnqueueCopyBuffer.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular copy command
-    and can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this copy command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 // refError
 
@@ -1250,16 +1243,13 @@ include::{generated}/api/version-notes/clEnqueueCopyBufferRect.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular copy command
-    and can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this copy command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 Copying begins at the source offset and destination offset which are
 computed as described below in the description for _src_origin_ and
@@ -1387,16 +1377,13 @@ include::{generated}/api/version-notes/clEnqueueFillBuffer.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
 or written by a kernel and/or the host and is given by the cl_mem_flags
@@ -1486,15 +1473,13 @@ of the mapped region using the pointer returned by {clEnqueueMapBuffer}.
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
   * _errcode_ret_ will return an appropriate error code.
     If _errcode_ret_ is `NULL`, no error code is returned.
 
@@ -2680,15 +2665,13 @@ include::{generated}/api/version-notes/clEnqueueWriteImage.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular read / write
-    command and can be used to query or queue a wait for this particular command
-    to complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this read / write command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _blocking_read_ is {CL_TRUE} i.e. the read command is blocking,
 {clEnqueueReadImage} does not return until the buffer data has been read and
@@ -2860,16 +2843,13 @@ include::{generated}/api/version-notes/clEnqueueCopyImage.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular copy command
-    and can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this copy command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 It is currently a requirement that the _src_image_ and _dst_image_ image
 memory objects for {clEnqueueCopyImage} must have the exact same image
@@ -2985,16 +2965,13 @@ include::{generated}/api/version-notes/clEnqueueFillImage.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
 or written by a kernel and/or the host and is given by the cl_mem_flags
@@ -3096,16 +3073,13 @@ include::{generated}/api/version-notes/clEnqueueCopyImageToBuffer.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular copy command
-    and can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this copy command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 // refError
 
@@ -3204,16 +3178,13 @@ include::{generated}/api/version-notes/clEnqueueCopyBufferToImage.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular copy command
-    and can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this copy command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 The size in bytes of the region to be copied from _src_buffer_ referred to
 as _src_cb_ is computed as _width_ {times} _height_ {times} _depth_ {times}
@@ -3336,15 +3307,13 @@ include::{generated}/api/version-notes/clEnqueueMapImage.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
   * _errcode_ret_ will return an appropriate error code.
     If _errcode_ret_ is `NULL`, no error code is returned.
 
@@ -3910,16 +3879,13 @@ include::{generated}/api/version-notes/clEnqueueUnmapMemObject.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 Reads or writes from the host using the pointer returned by
 {clEnqueueMapBuffer} or {clEnqueueMapImage} are considered to be complete.
@@ -4059,15 +4025,13 @@ include::{generated}/api/version-notes/clEnqueueMigrateMemObjects.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 [[migration-flags-table]]
 .Supported values for cl_mem_migration_flags
@@ -4623,15 +4587,13 @@ include::{generated}/api/version-notes/clEnqueueSVMFree.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 // refError
 
@@ -4689,15 +4651,13 @@ include::{generated}/api/version-notes/clEnqueueSVMMemcpy.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular read / write
-    command and can be used to query or queue a wait for this particular command
-    to complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this read / write command
+    and can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _blocking_copy_ is {CL_FALSE} i.e. the copy command is non-blocking,
 {clEnqueueSVMMemcpy} queues a non-blocking copy command and returns.
@@ -4786,16 +4746,13 @@ include::{generated}/api/version-notes/clEnqueueSVMMemFill.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 // refError
 
@@ -4854,16 +4811,13 @@ include::{generated}/api/version-notes/clEnqueueSVMMap.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _blocking_map_ is {CL_TRUE}, {clEnqueueSVMMap} does not return until the
 application can access the contents of the SVM region specified by _svm_ptr_
@@ -4935,16 +4889,13 @@ include::{generated}/api/version-notes/clEnqueueSVMUnmap.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    {clEnqueueBarrierWithWaitList} can be used instead.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 {clEnqueueSVMMap} and {clEnqueueSVMUnmap} act as synchronization points for
 the region of the SVM buffer specified in these calls.
@@ -5033,14 +4984,13 @@ include::{generated}/api/version-notes/clEnqueueSVMMigrateMem.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command and
-    can be used to query or queue a wait for this particular command to
-    complete.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue another command
-    that waits for this command to complete.
-    If the _event_wait_list_ and _event_ arguments are not `NULL`, the _event_
-    argument should not refer to an element of the _event_wait_list_ array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or queue a wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 Once the event returned by {clEnqueueSVMMigrateMem} has become {CL_COMPLETE},
 the ranges specified by svm pointers and sizes have been successfully
@@ -8119,16 +8069,13 @@ include::{generated}/api/version-notes/clEnqueueNDRangeKernel.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular
-    kernel-instance.
-    Event objects are unique and can be used to identify a particular
-    kernel-instance later on.
-    If _event_ is `NULL`, no event will be created for this kernel-instance and
-    therefore it will not be possible for the application to query or queue a
-    wait for this particular kernel-instance.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 An ND-range kernel command may require uniform work-groups or may support non-uniform work-groups.
 To support non-uniform work-groups:
@@ -8299,16 +8246,13 @@ include::{generated}/api/version-notes/clEnqueueTask.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular
-    kernel-instance.
-    Event objects are unique and can be used to identify a particular
-    kernel-instance later on.
-    If _event_ is `NULL`, no event will be created for this kernel-instance and
-    therefore it will not be possible for the application to query or queue a
-    wait for this particular kernel-instance.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 {clEnqueueTask} is equivalent to calling {clEnqueueNDRangeKernel} with
 _work_dim_ set to 1, _global_work_offset_ set to `NULL`, _global_work_size[0]_
@@ -9005,15 +8949,13 @@ include::{generated}/api/version-notes/clEnqueueMarkerWithWaitList.asciidoc[]
   * _command_queue_ is a valid host command-queue.
   * _event_wait_list_ and _num_events_in_wait_list_ specify events that need to
     complete before this particular command can be executed.
-  * _event_ returns an event object that identifies this particular command.
-    Event objects are unique and can be used to identify this marker command
-    later on.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _event_wait_list_ is `NULL`, _num_events_in_wait_list_ must be 0.
 If _event_wait_list_ is not `NULL`, the list of events pointed to by
@@ -9065,15 +9007,13 @@ include::{generated}/api/protos/clEnqueueMarker.txt[]
 include::{generated}/api/version-notes/clEnqueueMarker.asciidoc[]
 
   * _command_queue_ is a valid host command-queue.
-  * _event_ returns an event object that identifies this particular command.
-    Event objects are unique and can be used to identify this marker command
-    later on.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 The marker command waits for all commands previously enqueued in _command_queue_ to complete before it completes.
 This command returns an _event_ which can be waited on, i.e. this event can be
@@ -9153,15 +9093,13 @@ include::{generated}/api/version-notes/clEnqueueBarrierWithWaitList.asciidoc[]
     must be the same.
     The memory associated with _event_wait_list_ can be reused or freed after
     the function returns.
-  * _event_ returns an event object that identifies this particular command.
-    Event objects are unique and can be used to identify this barrier command
-    later on.
-    _event_ can be `NULL` in which case it will not be possible for the
-    application to query the status of this command or queue a wait for this
-    command to complete.
-    If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-    _event_ argument should not refer to an element of the _event_wait_list_
-    array.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 If _event_wait_list_ is `NULL`, then this particular command waits until all
 previous enqueued commands to _command_queue_ have completed.

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -711,15 +711,14 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular command and
-can be used to query or queue a wait for this particular command to
-complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
+
 
 *clEnqueueAcquireD3D10ObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.
@@ -800,15 +799,14 @@ If _event_wait_list_ is `NULL`, _num_events_in_wait_list_ must be 0.
 If _event_wait_list_ is not `NULL`, the list of events pointed to by
 _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
-The event specified by _event_ returns an event object that identifies this
-particular command and can be used to query or queue a wait for this
-particular command to complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueReleaseD3D10ObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.

--- a/ext/cl_khr_d3d11_sharing.asciidoc
+++ b/ext/cl_khr_d3d11_sharing.asciidoc
@@ -711,15 +711,13 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular command and
-can be used to query or queue a wait for this particular command to
-complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueAcquireD3D11ObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.
@@ -800,15 +798,14 @@ If _event_wait_list_ is `NULL`, _num_events_in_wait_list_ must be 0.
 If _event_wait_list_ is not `NULL`, the list of events pointed to by
 _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
-The event specified by _event_ returns an event object that identifies this
-particular command and can be used to query or queue a wait for this
-particular command to complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueReleaseD3D11ObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -555,15 +555,13 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular command and
-can be used to query or queue a wait for this particular command to
-complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueAcquireDX9MediaSurfacesKHR* returns CL_SUCCESS if the function is
 executed successfully.
@@ -645,15 +643,14 @@ If _event_wait_list_ is `NULL`, _num_events_in_wait_list_ must be 0.
 If _event_wait_list_ is not `NULL`, the list of events pointed to by
 _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
-The event specified by _event_ returns an event object that identifies this
-particular command and can be used to query or queue a wait for this
-particular command to complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueReleaseDX9MediaSurfaceKHR* returns CL_SUCCESS if the function is
 executed successfully.

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -234,12 +234,13 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular command and
-can be used to query or queue a wait for this particular command to
-complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueAcquireEGLObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.
@@ -307,12 +308,13 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular command and
-can be used to query or queue a wait for this particular command to
-complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
+_event_ returns an event object that identifies this command and
+can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueReleaseEGLObjectsKHR* returns CL_SUCCESS if the function is
 executed successfully.

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -602,14 +602,13 @@ The events specified in
 
 _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this command and can be used
-to query or queue a wait for the command to complete.
-_event_ can be `NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+_event_ returns an event object that identifies this command
+and can be used to query wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueAcquireGLObjects* returns CL_SUCCESS if the function is executed
 successfully.
@@ -670,15 +669,13 @@ _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
 greater than 0.
 The events specified in _event_wait_list_ act as synchronization points.
 
-_event_ returns an event object that identifies this particular
-command and can be used to query or queue a wait for the command to
-complete.
-_event_ can be`NULL` in which case it will not be possible for the
-application to query the status of this command or queue a wait for this
-command to complete.
-If the _event_wait_list_ and the _event_ arguments are not `NULL`, the
-_event_ argument should not refer to an element of the _event_wait_list_
-array.
+_event_ returns an event object that identifies this command
+and can be used to query or wait for this command to complete.
+If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+created and therefore it will not be possible to query the status of this
+command or to wait for this command to complete.
+If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+to an element of the _event_wait_list_ array.
 
 *clEnqueueReleaseGLObjects* returns CL_SUCCESS if the function is executed
 successfully.

--- a/man/static/clEnqueueReleaseD3D10ObjectsKHR.txt
+++ b/man/static/clEnqueueReleaseD3D10ObjectsKHR.txt
@@ -37,12 +37,13 @@ cl_int clEnqueueReleaseD3D10ObjectsKHR(cl_command_queue command_queue,
     _event_wait_list_ is NULL, _num_events_in_wait_list_ must be 0. If
     _event_wait_list_ is not NULL, the list of events pointed to by
     _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
-    greater than 0. The events specified in _event_ returns an event object
-    that identifies this particular command and can be used to query or
-    queue a wait for this particular command to complete. _event_ can be
-    NULL in which case it will not be possible for the application to query
-    the status of this command or queue a wait for this command to complete.
-    If _event_wait_list_ and _event_ are not NULL, _event_ should not refer
+    greater than 0.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
     to an element of the _event_wait_list_ array.
 
 == Notes

--- a/man/static/clEnqueueReleaseD3D11ObjectsKHR.txt
+++ b/man/static/clEnqueueReleaseD3D11ObjectsKHR.txt
@@ -37,13 +37,14 @@ cl_int clEnqueueReleaseD3D11ObjectsKHR(cl_command_queue command_queue,
     _event_wait_list_ is NULL, _num_events_in_wait_list_ must be 0. If
     _event_wait_list_ is not NULL, the list of events pointed to by
     _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
-    greater than 0. The events specified in _event_ returns an event object
-    that identifies this particular command and can be used to query or
-    queue a wait for this particular command to complete. _event_ can be
-    NULL in which case it will not be possible for the application to query
-    the status of this command or queue a wait for this command to complete.
-    If _event_wait_list_ and _event_ are not NULL, _event_ should not refer
-    to an element of the _event_wait_list_ array
+    greater than 0.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
+    to an element of the _event_wait_list_ array.
 
 == Notes
 

--- a/man/static/clEnqueueReleaseDX9MediaSurfacesKHR.txt
+++ b/man/static/clEnqueueReleaseDX9MediaSurfacesKHR.txt
@@ -38,12 +38,13 @@ cl_int clEnqueueReleaseDX9MediaSurfacesKHR(cl_command_queue command_queue,
     _event_wait_list_ is NULL, _num_events_in_wait_list_ must be 0. If
     _event_wait_list_ is not NULL, the list of events pointed to by
     _event_wait_list_ must be valid and _num_events_in_wait_list_ must be
-    greater than 0. The events specified in _event_ returns an event object
-    that identifies this particular command and can be used to query or
-    queue a wait for this particular command to complete. _event_ can be
-    NULL in which case it will not be possible for the application to query
-    the status of this command or queue a wait for this command to complete.
-    If _event_wait_list_ and _event_ are not NULL, _event_ should not refer
+    greater than 0.
+  * _event_ returns an event object that identifies this command and
+    can be used to query or wait for this command to complete.
+    If _event_ is `NULL` or the enqueue is unsuccessful, no event will be
+    created and therefore it will not be possible to query the status of this
+    command or to wait for this command to complete.
+    If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
     to an element of the _event_wait_list_ array.
 
 == Notes


### PR DESCRIPTION
Fixes #312.

* Clarify that events are not created if the enqueue fails.
* Clarify that the event cannot also be in the event wait list.
* Use the same text consistently for all event descriptions.

The exact spec text is:

>   * _event_ returns an event object that identifies this command and can be used to query or queue a wait for this command to complete. If _event_ is `NULL` or the enqueue is unsuccessful, no event will be created and therefore it will not be possible to query the status of this command or to wait for this command to complete. If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer to an element of the _event_wait_list_ array.