### PR TITLE
clarify the values returned by properties queries

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -2178,17 +2178,17 @@ include::{generated}/api/version-notes/CL_CONTEXT_PROPERTIES.asciidoc[]
         {clCreateContextFromType}.
 
         If the _properties_ argument specified in {clCreateContext} or
-        {clCreateContextFromType} used to create _context_ is not `NULL`, the
-        implementation must return the values specified in the properties
-        argument.
+        {clCreateContextFromType} used to create _context_ was not `NULL`,
+        the implementation must return the values specified in the
+        properties argument in the same order and without including
+        additional properties.
 
         If the _properties_ argument specified in {clCreateContext} or
-        {clCreateContextFromType} used to create _context_ is `NULL`, the
-        implementation may return either a _param_value_size_ret_ of 0
-        i.e. there is no context property value to be returned or can return
-        a context property value of 0 (where 0 is used to terminate the
-        context properties list) in the memory that _param_value_ points
-        to.
+        {clCreateContextFromType} used to create _context_ was `NULL`, the
+        implementation may return either a
+        _param_value_size_ret_ of 0 (i.e. there are no properties to be
+        returned), or the implementation may return a property value of 0
+        (where 0 is used to terminate the properties list).
 |====
 
 11::

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -2185,10 +2185,8 @@ include::{generated}/api/version-notes/CL_CONTEXT_PROPERTIES.asciidoc[]
 
         If the _properties_ argument specified in {clCreateContext} or
         {clCreateContextFromType} used to create _context_ was `NULL`, the
-        implementation may return either a
-        _param_value_size_ret_ of 0 (i.e. there are no properties to be
-        returned), or the implementation may return a property value of 0
-        (where 0 is used to terminate the properties list).
+        implementation must return _param_value_size_ret_ equal to 0,
+        indicating that there are no properties to be returned.
 |====
 
 11::

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -376,10 +376,8 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
 
         If _command_queue_ was created using {clCreateCommandQueue}, or if the
         _properties_ argument specified in clCreateCommandQueueWithProperties}
-        was `NULL`, the implementation may return either a
-        _param_value_size_ret_ of 0 (i.e. there is are no properties to be
-        returned), or the implementation may return a property value of 0
-        (where 0 is used to terminate the properties list).
+        was `NULL`, the implementation must return _param_value_size_ret_
+        equal to 0, indicating that there are no properties to be returned.
 
 | {CL_QUEUE_SIZE_anchor}
 
@@ -3718,10 +3716,9 @@ include::{generated}/api/version-notes/CL_PIPE_PROPERTIES.asciidoc[]
         without including additional properties.
 
         If the _properties_ argument specified in {clCreatePipe} used to
-        create _pipe_ was `NULL`, the implementation may return either a
-        _param_value_size_ret_ of 0 (i.e. there are no properties to be
-        returned), or the implementation may return a pipe property value
-        of 0 (where 0 is used to terminate the properties list).
+        create _pipe_ was `NULL`, the implementation must return
+        _param_value_size_ret_ equal to 0, indicating that there are no
+        properties to be returned.
 |====
 --
 
@@ -4302,11 +4299,9 @@ include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
         If _memobj_ was created using {clCreateBuffer}, {clCreateImage},
         {clCreateImage2D}, or {clCreateImage3D}, or if the _properties_
         argument specified in {clCreateBufferWithProperties} or
-        {clCreateImageWithProperties} was `NULL`, the implementation may
-        return either a _param_value_size_ret_ of 0 (i.e. there are no
-        properties to be returned), or the implementation may return a
-        property value of 0 (where 0 is used to terminate the properties
-        list).
+        {clCreateImageWithProperties} was `NULL`, the implementation
+        must return _param_value_size_ret_ equal to 0, indicating that
+        there are no properties to be returned.
 |====
 
 11::
@@ -5395,10 +5390,8 @@ include::{generated}/api/version-notes/CL_SAMPLER_PROPERTIES.asciidoc[]
 
         If _sampler_ was created using {clCreateSampler}, or if the _properties_
         argument specified in {clCreateSamplerWithProperties} was `NULL`, the
-        implementation may return either a _param_value_size_ret_ of 0 (i.e.
-        there are no properties to be returned), or the implementation may
-        return a property value of 0 (where 0 is used to terminate the
-        properties list).
+        implementation must return _param_value_size_ret_ equal to 0,
+        indicating that there are no properties to be returned.
 |====
 
 13::

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -369,9 +369,10 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
         {clCreateCommandQueueWithProperties}.
 
         If the _properties_ argument specified in
-        {clCreateCommandQueueWithProperties} used to create _command_queue_ was
-        not `NULL`, the implementation must return the values specified in the
-        properties argument.
+        {clCreateCommandQueueWithProperties} used to create _command_queue_
+        was not `NULL`, the implementation must return the values specified in
+        the properties argument in the same order and without including
+        additional properties.
 
         If _command_queue_ was created using {clCreateCommandQueue}, or if the
         _properties_ argument specified in clCreateCommandQueueWithProperties}
@@ -3712,8 +3713,9 @@ include::{generated}/api/version-notes/CL_PIPE_PROPERTIES.asciidoc[]
       | Return the properties argument specified in {clCreatePipe}.
 
         If the _properties_ argument specified in {clCreatePipe} used to
-        create _pipe_ was not `NULL`, the implementation must return the values
-        specified in the properties argument.
+        create _pipe_ was not `NULL`, the implementation must return the
+        values specified in the properties argument in the same order and
+        without including additional properties.
 
         If the _properties_ argument specified in {clCreatePipe} used to
         create _pipe_ was `NULL`, the implementation may return either a
@@ -4294,12 +4296,13 @@ include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
         If the _properties_ argument specified in
         {clCreateBufferWithProperties} or {clCreateImageWithProperties}
         used to create _memobj_ was not `NULL`, the implementation must
-        return the values specified in the properties argument.
+        return the values specified in the properties argument in the
+        same order and without including additional properties.
 
         If _memobj_ was created using {clCreateBuffer}, {clCreateImage},
         {clCreateImage2D}, or {clCreateImage3D}, or if the _properties_
         argument specified in {clCreateBufferWithProperties} or
-	{clCreateImageWithProperties} was `NULL`, the implementation may
+        {clCreateImageWithProperties} was `NULL`, the implementation may
         return either a _param_value_size_ret_ of 0 (i.e. there are no
         properties to be returned), or the implementation may return a
         property value of 0 (where 0 is used to terminate the properties
@@ -5387,7 +5390,8 @@ include::{generated}/api/version-notes/CL_SAMPLER_PROPERTIES.asciidoc[]
 
         If the _properties_ argument specified in {clCreateSamplerWithProperties}
         used to create _sampler_ was not `NULL`, the implementation must return
-        the values specified in the properties argument.
+        the values specified in the properties argument in the same order and
+        without including additional properties.
 
         If _sampler_ was created using {clCreateSampler}, or if the _properties_
         argument specified in {clCreateSamplerWithProperties} was `NULL`, the


### PR DESCRIPTION
Fixes #317.

Clarifies that the values returned by the new OpenCL 3.0 properties queries must exactly match the values passed when the object was created.  The properties cannot be in a different order, and the properties cannot include other (default) properties.

I have not changed the specified behavior for `NULL` properties in this PR but I will add this if desired - see the last question in https://github.com/KhronosGroup/OpenCL-Docs/issues/317#issuecomment-668730289.

tagging @kerilk  @kpet