### PR TITLE
cl_ext_cxx_for_opencl

### DIFF
--- a/extensions/cl_ext_cxx_for_opencl.asciidoc
+++ b/extensions/cl_ext_cxx_for_opencl.asciidoc
@@ -1,0 +1,139 @@
+// Copyright 2018-2020 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+:data-uri:
+:icons: font
+include::../config/attribs.txt[]
+:source-highlighter: coderay
+
+= cl_ext_cxx_for_opencl
+:R: pass:q,r[^(R)^]
+Khronos{R} OpenCL Working Group
+
+== Name Strings
+
+`cl_ext_cxx_for_opencl`
+
+== Contact
+
+Please see the *Issues* list in the Khronos *OpenCL-Docs* repository: +
+https://github.com/KhronosGroup/OpenCL-Docs
+
+== Contributors
+
+Kevin Petit, Arm Ltd. +
+Sven Van Haastregt, Arm Ltd. +
+Anastasia Stulova, Arm Ltd. +
+Marco Antognini, Arm Ltd. +
+Neil Hickey, Arm Ltd. +
+Alastair Murray, Codeplay +
+
+== Notice
+
+include::../copyrights.txt[]
+
+== Version
+
+Built On: {docdate} +
+Version: 1.0.0
+
+== Dependencies
+
+This extension is written against the OpenCL Specification
+Version 3.0.3.
+
+This extension requires OpenCL 3.0 with OpenCL C 2.0 support or OpenCL 2.x and
+`cl_khr_extended_versioning`.
+
+== Overview
+
+This extension adds support for building programs written using the C++ for
+OpenCL kernel language. It also enables applications to query the version of
+the language supported by the device compiler.
+
+== New build option
+
+This extension adds support for a new `CLC++` value to be passed to the
+`-cl-std` build option accepted by *clBuildProgram* and *clCompileProgram*.
+
+== New API Enums
+
+Accepted value for the _param_name_ parameter to *clGetDeviceInfo*:
+
+[source,c]
+----
+CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT       0x4230
+----
+
+
+== Modifications to the OpenCL API Specification
+
+(Modify Section 4.2, *Querying Devices*) ::
++
+--
+
+(Add the following to Table 4.3, _Device Queries_) ::
++
+--
+
+[cols="1,1,4",options="header"]
+|====
+| cl_device_info
+| Return Type
+| Description
+
+| `CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT`
+| `cl_version`
+| Returns the version of the C++ for OpenCL language supported by the
+  device compiler.
+
+|====
+
+--
+--
+
+(Modify Section 5.8.1, *Creating Program Objects*) ::
++
+--
+Add the following text to the description for *clCreateProgramWithSource*:
+
+The source code specified by _strings_ may also be a C++ for OpenCL program source
+or header.
+--
+
+(Modify section to 5.8.6, *Compiler Options*) ::
++
+--
+
+(Add subsection, *C++ for OpenCL*) ::
++
+--
+Applications may pass `-cl-std=CLC\++` to *clCompileProgram* and *clBuildProgram*
+for programs created using *clCreateProgramFromSource* to request the program
+be built as C++ for OpenCL.
+--
+
+--
+
+== Conformance tests
+
+. Test that a program can successfully be compiled with `-cl-std=CLC++`.
+. Test with a program compiled with `-cl-std=CLC++` that the value of the
+  +__OPENCL_CPP_VERSION__+ macro agrees with the version returned by
+  `CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT`.
+
+== Issues
+
+None.
+
+== Version History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|====
+| Version | Date       | Author       | Changes
+| 1.0.0   | 2020-08-25 | Kevin Petit  | *Initial revision*
+|====
+

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1803,8 +1803,13 @@ server's OpenCL/api-docs repository.
             <unused start="0x4220" end="0x422F"/>
     </enums>
 
-     <enums start="0x4230" end="0x4FFF" name="enums.4230" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x4230" end="0x4FFF"/>
+    <enums start="0x4230" end="0x423F" name="enums.4230" comment="Reserved for EXT extensions">
+        <enum value="0x4230"        name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
+            <unused start="0x4231" end="0x423F"/>
+    </enums>
+
+    <enums start="0x4240" end="0x4FFF" name="enums.4240" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x4240" end="0x4FFF"/>
     </enums>
 
     <enums start="0x10000" end="0x10FFF" name="enums.10000" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">
@@ -5696,6 +5701,11 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_queue_properties">
                 <enum name="CL_QUEUE_KERNEL_BATCHING_ARM"/>
+            </require>
+        </extension>
+        <extension name="cl_ext_cxx_for_opencl" supported="opencl">
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Draft specification to expose C++ for OpenCL as a supported language.

This change also allocates an enum block for EXT extensions.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>