### PR TITLE
clarify behavior for CL_QUEUE_SIZE for non-device queues

### DIFF
--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -152,9 +152,12 @@ When Device-Side Enqueue is not supported:
 | Returns `0` if _device_ does not support Device-Side Enqueue and On-Device Queues.
 
 | {clGetCommandQueueInfo}, passing +
-{CL_QUEUE_SIZE} or +
+{CL_QUEUE_SIZE}
+| Returns {CL_INVALID_COMMAND_QUEUE} since _command_queue_ cannot be a valid device command-queue.
+
+| {clGetCommandQueueInfo}, passing +
 {CL_QUEUE_DEVICE_DEFAULT}
-| Returns `0` or `NULL` if the device associated with _command_queue_ does not support On-Device Queues.
+| Returns `NULL` if the device associated with _command_queue_ does not support On-Device Queues.
 
 | {clGetEventProfilingInfo}, passing +
 {CL_PROFILING_COMMAND_COMPLETE}

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -383,8 +383,10 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
   | cl_uint
-      | Return the currently specified size for the device command-queue.
-        This query is only supported for device command queues.
+      | Return the size of the device command-queue.
+        To be considered valid for this query, _command_queue_ must be a
+        device command-queue.
+
 | {CL_QUEUE_DEVICE_DEFAULT_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE_DEFAULT.asciidoc[]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -406,7 +406,8 @@ successfully.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid
-    command-queue.
+    command-queue, or if _command_queue_ is not a valid command-queue
+    for _param_name_.
   * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values or
     if size in bytes specified by _param_value_size_ is < size of return
     type as specified in the <<command-queue-param-table,Command Queue


### PR DESCRIPTION
Fixes #402

This PR clarifies that querying `CL_QUEUE_SIZE` requires that _command_queue_ be a device command-queue.  Otherwise, it is considered an invalid command queue and `clGetCommandQueueInfo` will return `CL_INVALID_COMMAND_QUEUE`.

Also updates Appendix H to describe that this query will return an error rather than returning `0` when an implementation does not support device-side enqueue and on-device queues.