### PR TITLE
clarify KHR extension requirements for OpenCL 3.0 devices

### DIFF
--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -323,10 +323,32 @@ __mem_object__ not equal to `NULL`
 == sRGB Images
 
 All of the sRGB Image Channel Orders (such as {CL_sRGBA}) are optional for devices supporting OpenCL 3.0.
+When sRGB Images are not supported:
+
+[cols="2,3",options="header",]
+|====
+|*API*
+|*Behavior*
+
+| {clGetSupportedImageFormats}
+| Will not return return any image formats with `image_channel_order` equal to an sRGB Image Channel Order if no devices in _context_ support sRGB Images.
+
+|====
 
 == Depth Images
 
 The {CL_DEPTH} Image Channel Order is optional for devices supporting OpenCL 3.0.
+When Depth Images are not supported:
+
+[cols="2,3",options="header",]
+|====
+|*API*
+|*Behavior*
+
+| {clGetSupportedImageFormats}
+| Will not return any image formats with `image_channel_order` equal to {CL_DEPTH} if no devices in _context_ support Depth Images.
+
+|====
 
 == Device and Host Timer Synchronization
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1167,20 +1167,19 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
         *cl_khr_local_int32_extended_atomics*
 
         Additionally, the following Khronos extension names must be returned
-        by all devices that support OpenCL 1.2 when the optional feature is
-        supported:
+        by all devices that support OpenCL 1.2 when and only when the optional
+        feature is supported:
 
-        *cl_khr_fp64* (if double precision is supported)
+        *cl_khr_fp64*
 
         Additionally, the following Khronos extension names must be returned
         by all devices that support OpenCL 2.0, OpenCL 2.1, or OpenCL 2.2.
         For devices that support OpenCL 3.0, these extension names must only
-        be returned when the optional feature is supported:
+        be returned when and only when the optional feature is supported:
 
-        *cl_khr_3d_image_writes* (if 3D image writes are supported) +
-        *cl_khr_depth_images* (if depth images are supported) +
-        *cl_khr_image2d_from_buffer* (if creating 2D images from a buffer is
-        supported)
+        *cl_khr_3d_image_writes* +
+        *cl_khr_depth_images* +
+        *cl_khr_image2d_from_buffer*
 
         Please refer to the OpenCL Extension Specification or vendor
         provided documentation for a detailed description of these extensions.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1167,18 +1167,20 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
         *cl_khr_local_int32_extended_atomics*
 
         Additionally, the following Khronos extension names must be returned
-        by all devices that support OpenCL 1.2:
+        by all devices that support OpenCL 1.2 when the optional feature is
+        supported:
 
         *cl_khr_fp64* (if double precision is supported)
 
         Additionally, the following Khronos extension names must be returned
         by all devices that support OpenCL 2.0, OpenCL 2.1, or OpenCL 2.2.
-        Note that these Khronos extension names are *not* required for
-        devices supporting OpenCL 3.0:
+        For devices that support OpenCL 3.0, these extension names must only
+        be returned when the optional feature is supported:
 
-        *cl_khr_3d_image_writes* +
-        *cl_khr_depth_images* +
-        *cl_khr_image2d_from_buffer*
+        *cl_khr_3d_image_writes* (if 3D image writes are supported) +
+        *cl_khr_depth_images* (if depth images are supported) +
+        *cl_khr_image2d_from_buffer* (if creating 2D images from a buffer is
+        supported)
 
         Please refer to the OpenCL Extension Specification or vendor
         provided documentation for a detailed description of these extensions.


### PR DESCRIPTION
This PR adds the KHR extension requirements for OpenCL 3.0 devices discussed in the August 18th teleconference.

Specifically, when the optional OpenCL 3.0 features 3D image writes, depth images, or creating a 2D image from a buffer are supported by an OpenCL 3.0 device, the equivalent KHR extensions cl_khr_3d_image_writes, cl_khr_depth_images, or cl_khr_2d_image_from_buffer must also be returned in the device extension string.