### PR TITLE
Minor Updates to the Event Command Type Table

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8693,71 +8693,86 @@ include::{generated}/api/version-notes/CL_EVENT_REFERENCE_COUNT.asciidoc[]
 
 [[event-command-type-table]]
 .List of supported event command types
-[width="100%",cols="1,1",options="header"]
+[width="100%",cols="2,3",options="header"]
 |====
-| *Event Command Type* | *Events Created By*
+| *Events Created By*
+| *Event Command Type*
 
+| {clEnqueueNDRangeKernel}
 | {CL_COMMAND_NDRANGE_KERNEL_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_NDRANGE_KERNEL.asciidoc[]
-  | {clEnqueueNDRangeKernel}
+
+| {clEnqueueTask}
 | {CL_COMMAND_TASK_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_TASK.asciidoc[]
-  | {clEnqueueTask}
+
+| {clEnqueueNativeKernel}
 | {CL_COMMAND_NATIVE_KERNEL_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_NATIVE_KERNEL.asciidoc[]
-  | {clEnqueueNativeKernel}
+
+| {clEnqueueReadBuffer}
 | {CL_COMMAND_READ_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_READ_BUFFER.asciidoc[]
-  | {clEnqueueReadBuffer}
+
+| {clEnqueueWriteBuffer}
 | {CL_COMMAND_WRITE_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_WRITE_BUFFER.asciidoc[]
-  | {clEnqueueWriteBuffer}
+
+| {clEnqueueCopyBuffer}
 | {CL_COMMAND_COPY_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER.asciidoc[]
-  | {clEnqueueCopyBuffer}
+
+| {clEnqueueReadImage}
 | {CL_COMMAND_READ_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_READ_IMAGE.asciidoc[]
-  | {clEnqueueReadImage}
+
+| {clEnqueueWriteImage}
 | {CL_COMMAND_WRITE_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_WRITE_IMAGE.asciidoc[]
-  | {clEnqueueWriteImage}
+
+| {clEnqueueCopyImage}
 | {CL_COMMAND_COPY_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_COPY_IMAGE.asciidoc[]
-  | {clEnqueueCopyImage}
+
+| {clEnqueueCopyBufferToImage}
 | {CL_COMMAND_COPY_BUFFER_TO_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER_TO_IMAGE.asciidoc[]
-  | {clEnqueueCopyBufferToImage}
+
+| {clEnqueueCopyImageToBuffer}
 | {CL_COMMAND_COPY_IMAGE_TO_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_COPY_IMAGE_TO_BUFFER.asciidoc[]
-  | {clEnqueueCopyImageToBuffer}
+
+| {clEnqueueMapBuffer}
 | {CL_COMMAND_MAP_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_MAP_BUFFER.asciidoc[]
-  | {clEnqueueMapBuffer}
+
+| {clEnqueueMapImage}
 | {CL_COMMAND_MAP_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_MAP_IMAGE.asciidoc[]
-  | {clEnqueueMapImage}
+
+| {clEnqueueUnmapMemObject}
 | {CL_COMMAND_UNMAP_MEM_OBJECT_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_UNMAP_MEM_OBJECT.asciidoc[]
-  | {clEnqueueUnmapMemObject}
+
+| {clEnqueueMarker}, +
+  {clEnqueueMarkerWithWaitList}
 | {CL_COMMAND_MARKER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_MARKER.asciidoc[]
-  | {clEnqueueMarker}, +
-    {clEnqueueMarkerWithWaitList}
 
 // Since these enums are for an extension they shouldn't be in this table.
 //| {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor}
@@ -8769,65 +8784,80 @@ include::{generated}/api/version-notes/CL_COMMAND_MARKER.asciidoc[]
 //include::{generated}/api/version-notes/CL_COMMAND_RELEASE_GL_OBJECTS.asciidoc[]
 //  | {clEnqueueReleaseGLObjects}
 
+| {clEnqueueReadBufferRect}
 | {CL_COMMAND_READ_BUFFER_RECT_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_READ_BUFFER_RECT.asciidoc[]
-  | {clEnqueueReadBufferRect}
+
+| {clEnqueueWriteBufferRect}
 | {CL_COMMAND_WRITE_BUFFER_RECT_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_WRITE_BUFFER_RECT.asciidoc[]
-  | {clEnqueueWriteBufferRect}
+
+| {clEnqueueCopyBufferRect}
 | {CL_COMMAND_COPY_BUFFER_RECT_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_COPY_BUFFER_RECT.asciidoc[]
-  | {clEnqueueCopyBufferRect}
+
+| {clCreateUserEvent}
 | {CL_COMMAND_USER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_USER.asciidoc[]
-  | {clCreateUserEvent}
+
+| {clEnqueueBarrier}, +
+  {clEnqueueBarrierWithWaitList}
 | {CL_COMMAND_BARRIER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_BARRIER.asciidoc[]
-  | {clEnqueueBarrier}, +
-    {clEnqueueBarrierWithWaitList}
+
+| {clEnqueueMigrateMemObjects}
 | {CL_COMMAND_MIGRATE_MEM_OBJECTS_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_MIGRATE_MEM_OBJECTS.asciidoc[]
-  | {clEnqueueMigrateMemObjects}
+
+| {clEnqueueFillBuffer}
 | {CL_COMMAND_FILL_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_FILL_BUFFER.asciidoc[]
-  | {clEnqueueFillBuffer}
+
+| {clEnqueueFillImage}
 | {CL_COMMAND_FILL_IMAGE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_FILL_IMAGE.asciidoc[]
-  | {clEnqueueFillImage}
+
+| {clEnqueueSVMFree}
 | {CL_COMMAND_SVM_FREE_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_FREE.asciidoc[]
-  | {clEnqueueSVMFree}
+
+| {clEnqueueSVMMemcpy}
 | {CL_COMMAND_SVM_MEMCPY_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_MEMCPY.asciidoc[]
-  | {clEnqueueSVMMemcpy}
+
+| {clEnqueueSVMMemFill}
 | {CL_COMMAND_SVM_MEMFILL_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_MEMFILL.asciidoc[]
-  | {clEnqueueSVMMemFill}
+
+| {clEnqueueSVMMap}
 | {CL_COMMAND_SVM_MAP_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_MAP.asciidoc[]
-  | {clEnqueueSVMMap}
+
+| {clEnqueueSVMUnmap}
 | {CL_COMMAND_SVM_UNMAP_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_UNMAP.asciidoc[]
-  | {clEnqueueSVMUnmap}
+
+| {clEnqueueSVMMigrateMem}
 | {CL_COMMAND_SVM_MIGRATE_MEM_anchor}
 
 include::{generated}/api/version-notes/CL_COMMAND_SVM_MIGRATE_MEM.asciidoc[]
 
-Prior to OpenCL 3.0, the event command type returned by {clEnqueueSVMMigrateMem} is implementation-defined.
-  | {clEnqueueSVMMigrateMem}
+Prior to OpenCL 3.0, implementations should return
+{CL_COMMAND_MIGRATE_MEM_OBJECTS}, but may return an implementation-defined
+event command type for {clEnqueueSVMMigrateMem}.
 
 |====
 


### PR DESCRIPTION
This PR is optional and has a few minor updates to the event command type table added in #394:

* It adds a recommended event command type that should be returned for `clEnqueueSVMMigrateMem` pre-OpenCL 3.0, specifically `CL_COMMAND_MIGRATE_MEM_OBJECTS`, even though other implementation-defined event command types may also be returned.

Also, two editorial updates:

* It swaps the columns of the table, which I think is a little easier to follow.

* It adjusts the widths of the columns of the table to give a little more space to the event command types and a little less to the API names.