### PR TITLE
subbuffers created with clCreateSubBuffer must have no properties

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4260,9 +4260,10 @@ include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
         return the values specified in the properties argument in the
         same order and without including additional properties.
 
-        If _memobj_ was created using {clCreateBuffer}, {clCreateImage},
-        {clCreateImage2D}, or {clCreateImage3D}, or if the _properties_
-        argument specified in {clCreateBufferWithProperties} or
+        If _memobj_ was created using {clCreateBuffer}, 
+        {clCreateSubBuffer}, {clCreateImage}, {clCreateImage2D}, or
+        {clCreateImage3D}, or if the _properties_ argument specified
+        in {clCreateBufferWithProperties} or
         {clCreateImageWithProperties} was `NULL`, the implementation
         must return _param_value_size_ret_ equal to 0, indicating that
         there are no properties to be returned.


### PR DESCRIPTION
Fixes #412 

Adds `clCreateSubBuffer` to the list of APIs that create a buffer with no properties to be returned.