### PR TITLE
reserve cl_mem_flags bit for upcoming Intel extension

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -703,7 +703,9 @@ server's OpenCL/api-docs repository.
         <enum bitpos="10"           name="CL_MEM_SVM_FINE_GRAIN_BUFFER"/>
         <enum bitpos="11"           name="CL_MEM_SVM_ATOMICS"/>
         <enum bitpos="12"           name="CL_MEM_KERNEL_READ_AND_WRITE"/>
-            <unused start="13" end="23"/>
+            <unused start="13" end="19"/>
+        <!-- reserved <enum bitpos=20"  name="for upcoming Intel extension"/> -->
+            <unused start="21" end="23"/>
         <enum bitpos="24"           name="CL_MEM_NO_ACCESS_INTEL"/>
         <enum bitpos="25"           name="CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL"/>
         <enum bitpos="26"           name="CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG"/>


### PR DESCRIPTION
Please reserve one `cl_mem_flags` bit for an upcoming Intel extension.

In this PR I am reserving bit 20 because we have a POC that is currently using this bit and this will save us some thrash, but if it is important to use the next bit (23?) to avoid gaps, please us know ASAP and we will switch.  Thanks!