### PR TITLE
use CL_INVALID_OPERATION as the error code for unsupported features

### DIFF
--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -211,7 +211,7 @@ When Pipes are not supported:
 | Returns {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
 
 | {clGetPipeInfo}
-| Returns either {CL_INVALID_MEM_OBJECT} since _pipe_ cannot be a valid pipe object, or {CL_INVALID_OPERATION} if Pipes are not supported.
+| Returns {CL_INVALID_OPERATION} if no devices in the context associated with _pipe_ support Pipes.
 
 |====
 

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -211,8 +211,7 @@ When Pipes are not supported:
 | Returns {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
 
 | {clGetPipeInfo}
-| Returns {CL_INVALID_MEM_OBJECT} since _pipe_ cannot be a valid pipe object.
-// Note: for {CL_PIPE_PACKET_SIZE} and {CL_PIPE_MAX_PACKETS}.
+| Returns either {CL_INVALID_MEM_OBJECT} since _pipe_ cannot be a valid pipe object, or {CL_INVALID_OPERATION} if Pipes are not supported.
 
 |====
 
@@ -371,10 +370,10 @@ When Intermediate Language Programs are not supported:
 | Returns an empty buffer (such as _param_value_size_ret_ equal to `0`) if no devices in the context associated with _program_ support Intermediate Language Programs.
 
 | {clCreateProgramWithIL}
-| Returns {CL_INVALID_VALUE} if no devices in _context_ support Intermediate Language Programs.
+| Returns {CL_INVALID_OPERATION} if no devices in _context_ support Intermediate Language Programs.
 
 | {clSetProgramSpecializationConstant}
-| Returns {CL_INVALID_PROGRAM}, since _program_ cannot have been created from an Intermediate Language.
+| Returns {CL_INVALID_OPERATION} if no devices associated with _program_ support Intermediate Language Programs.
 
 |====
 

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -211,7 +211,7 @@ When Pipes are not supported:
 | Returns {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
 
 | {clGetPipeInfo}
-| Returns {CL_INVALID_OPERATION} if no devices in the context associated with _pipe_ support Pipes.
+| Returns {CL_INVALID_MEM_OBJECT} since _pipe_ cannot be a valid pipe object.
 
 |====
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3649,8 +3649,6 @@ include::{generated}/api/version-notes/clGetPipeInfo.asciidoc[]
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_MEM_OBJECT} if _pipe_ is a not a valid pipe object.
-  * {CL_INVALID_OPERATION} if no devices in the context associated with _pipe_
-    support Pipes.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<pipe-info-table,Pipe Object Queries>> table and _param_value_ is

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3591,7 +3591,7 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_OPERATION} if no devices in _context_ support pipes.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
   * {CL_INVALID_VALUE} if values specified in _flags_ are not as defined
     above.
   * {CL_INVALID_VALUE} if _properties_ is not `NULL`.
@@ -3649,7 +3649,7 @@ include::{generated}/api/version-notes/clGetPipeInfo.asciidoc[]
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_MEM_OBJECT} if _pipe_ is a not a valid pipe object.
-  * {CL_INVALID_OPERATION} if pipes are not supported.
+  * {CL_INVALID_OPERATION} if Pipes are not supported.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<pipe-info-table,Pipe Object Queries>> table and _param_value_ is
@@ -4288,11 +4288,11 @@ include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
 successfully.
 Otherwise, it returns one of the following errors:
 
+  * {CL_INVALID_MEM_OBJECT} if _memobj_ is a not a valid memory object.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<mem-info-table,Memory Object Info>> table and _param_value_ is not
     `NULL`.
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is a not a valid memory object.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -5471,8 +5471,8 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_OPERATION} if no devices in _context_ support intermediate
-    language programs.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support Intermediate
+    Language Programs.
   * {CL_INVALID_VALUE} if _il_ is `NULL` or if _length_ is zero.
   * {CL_INVALID_VALUE} if the _length_-byte memory pointed to by _il_ does not
     contain well-formed intermediate language input that can be consumed by
@@ -5777,7 +5777,7 @@ Otherwise, it returns one of the following errors:
     from an intermediate language (e.g. SPIR-V), or if the intermediate
     language does not support specialization constants.
   * {CL_INVALID_OPERATION} if no devices associated with _program_ support
-    intermediate language programs.
+    Intermediate Language Programs.
   * {CL_INVALID_SPEC_ID} if _spec_id_ is not a valid specialization constant
     identifier.
   * {CL_INVALID_VALUE} if _spec_size_ does not match the size of the

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3649,7 +3649,8 @@ include::{generated}/api/version-notes/clGetPipeInfo.asciidoc[]
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_MEM_OBJECT} if _pipe_ is a not a valid pipe object.
-  * {CL_INVALID_OPERATION} if Pipes are not supported.
+  * {CL_INVALID_OPERATION} if no devices in the context associated with _pipe_
+    support Pipes.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<pipe-info-table,Pipe Object Queries>> table and _param_value_ is

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3591,7 +3591,7 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support pipes.
   * {CL_INVALID_VALUE} if values specified in _flags_ are not as defined
     above.
   * {CL_INVALID_VALUE} if _properties_ is not `NULL`.
@@ -3648,11 +3648,12 @@ include::{generated}/api/version-notes/clGetPipeInfo.asciidoc[]
 {clGetPipeInfo} returns {CL_SUCCESS} if the function is executed successfully.
 Otherwise, it returns one of the following errors:
 
+  * {CL_INVALID_MEM_OBJECT} if _pipe_ is a not a valid pipe object.
+  * {CL_INVALID_OPERATION} if pipes are not supported.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<pipe-info-table,Pipe Object Queries>> table and _param_value_ is
     not `NULL`.
-  * {CL_INVALID_MEM_OBJECT} if _pipe_ is a not a valid pipe object.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -5470,6 +5471,8 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support intermediate
+    language programs.
   * {CL_INVALID_VALUE} if _il_ is `NULL` or if _length_ is zero.
   * {CL_INVALID_VALUE} if the _length_-byte memory pointed to by _il_ does not
     contain well-formed intermediate language input that can be consumed by
@@ -5773,6 +5776,8 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_PROGRAM} if _program_ is not a valid program object created
     from an intermediate language (e.g. SPIR-V), or if the intermediate
     language does not support specialization constants.
+  * {CL_INVALID_OPERATION} if no devices associated with _program_ support
+    intermediate language programs.
   * {CL_INVALID_SPEC_ID} if _spec_id_ is not a valid specialization constant
     identifier.
   * {CL_INVALID_VALUE} if _spec_size_ does not match the size of the


### PR DESCRIPTION
Fixes #408.

This PR updates three APIs related to optional OpenCL 3.0 features to use CL_INVALID_OPERATION as the error code when the feature is not supported vs. relying on implied error behavior from earlier versions of OpenCL.

The one case where a different error code may be returned is for clGetPipeInfo, since ICD implementations cannot create a valid
pipe memory object to query and get the ICD dispatch table from.  In these cases, the ICD loader will return CL_INVALID_MEM_OBJECT before calling into the ICD implementation.  Note that non-ICD implementations may return CL_INVALID_OPERATION unconditionally.