### PR TITLE
Describe how new profiles may affect backwards compatibility

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -2105,18 +2105,16 @@ Whenever an OpenCL C feature is optional in the new version of the OpenCL C prog
 If a feature macro is defined then the feature is supported by the OpenCL C compiler, otherwise the optional feature is not supported.
 
 In order to allow future versions of OpenCL to support new types of
-devices, some capabilities that are currently required of all OpenCL
-devices may become optional in future versions of OpenCL.
-When a required capability becomes optional, all existing profiles
-will continue to require that it be supported, thereby guaranteeing
-that applications targeting any of these profiles will continue to run
-with subsequent minor releases of OpenCL.
-New profiles that are introduced in or after the version of the
-standard that made the capability optional will not be required to
-support the capability.
+devices, minor releases of OpenCL may add new profiles where some
+features that are currently required for all OpenCL devices become
+optional.
+All features that are required for an OpenCL profile will also be
+required for that profile in subsequent minor releases of OpenCL,
+thereby guaranteeing backwards compatibility for applications
+targeting specific profiles.
 It is therefore strongly recommended that applications
 <<CL_DEVICE_PROFILE,query the profile>> supported by the OpenCL device
-they are running on, in order to remain robust to future changes.
+they are running on in order to remain robust to future changes.
 
 === Versioning
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -2104,6 +2104,20 @@ The new version of OpenCL C must be explicitly requested via the `-cl-std=` buil
 Whenever an OpenCL C feature is optional in the new version of the OpenCL C programming language, it will be paired with a feature macro, such as `+__opencl_c_feature_name+`, and a corresponding API query.
 If a feature macro is defined then the feature is supported by the OpenCL C compiler, otherwise the optional feature is not supported.
 
+In order to allow future versions of OpenCL to support new types of
+devices, some capabilities that are currently required of all OpenCL
+devices may become optional in future versions of OpenCL.
+When a required capability becomes optional, all existing profiles
+will continue to require that it be supported, thereby guaranteeing
+that applications targeting any of these profiles will continue to run
+with subsequent minor releases of OpenCL.
+New profiles that are introduced in or after the version of the
+standard that made the capability optional will not be required to
+support the capability.
+It is therefore strongly recommended that applications
+<<CL_DEVICE_PROFILE,query the profile>> supported by the OpenCL device
+they are running on, in order to remain robust to future changes.
+
 === Versioning
 
 The OpenCL specification is regularly updated with bug fixes and clarifications.
@@ -2120,7 +2134,7 @@ A version number comprises three logical fields:
 * The _major_ version indicates a significant change. Backwards compatibility may
   break across major versions.
 * The _minor_ version indicates the addition of new functionality with backwards
-  compatibility.
+  compatibility for any existing profiles.
 * The _patch_ version indicates bug fixes, clarifications and general improvements.
 
 Version numbers are represented using the `cl_version` type that is an alias for


### PR DESCRIPTION
This adds a paragraph to the backwards compatibility section documenting the fact that minor versions of the standard may introduce new profiles that make existing capabilities optional, and includes a recommendation that applications check the profile supported by the device they are running on.

Discussed in internal issue !254 and on the 2020-08-25 teleconference.