### PR TITLE
clarify the host_ptr usage for images with USE_HOST_PTR

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1638,8 +1638,6 @@ include::{generated}/api/version-notes/clCreateImageWithProperties.asciidoc[]
     description of the image descriptor.
   * _host_ptr_ is a pointer to the image data that may already be allocated by
     the application.
-    It is only used to initialize the image, and can be freed after the call to
-    {clCreateImage} or {clCreateImageWithProperties}.
     Refer to the <<host-ptr-buffer-size-table, table below>> for a description
     of how large the buffer that _host_ptr_ points to must be.
   * _errcode_ret_ will return an appropriate error code.
@@ -1806,8 +1804,6 @@ include::{generated}/api/version-notes/clCreateImage2D.asciidoc[]
     size in bytes.
   * _host_ptr_ is a pointer to the image data that may already be allocated by
     the application.
-    It is only used to initialize the image, and can be freed after the call to
-    {clCreateImage2D}.
     Refer to the {CL_MEM_OBJECT_IMAGE2D} entry in the
     <<host-ptr-buffer-size-table, required _host_ptr_ buffer size table>> for a
     description of how large the buffer that _host_ptr_ points to must be.
@@ -1891,8 +1887,6 @@ include::{generated}/api/version-notes/clCreateImage3D.asciidoc[]
      _image_row_pitch_.
   * _host_ptr_ is a pointer to the image data that may already be allocated by
     the application.
-    It is only used to initialize the image, and can be freed after the call to
-    {clCreateImage3D}.
     Refer to the {CL_MEM_OBJECT_IMAGE3D} entry in the
     <<host-ptr-buffer-size-table, required _host_ptr_ buffer size table>> for a
     description of how large the buffer that _host_ptr_ points to must be.


### PR DESCRIPTION
Fixes #417.

Removes the following sentence from the description of _host_ptr_ for the image creation functions such as `clCreateImage`:

> It is only used to initialize the image, and can be freed after the call to clCreateImage.