### PR TITLE
add event command types for extension APIs

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8778,16 +8778,6 @@ include::{generated}/api/version-notes/CL_COMMAND_UNMAP_MEM_OBJECT.asciidoc[]
 
 include::{generated}/api/version-notes/CL_COMMAND_MARKER.asciidoc[]
 
-// Since these enums are for an extension they shouldn't be in this table.
-//| {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor}
-//
-//include::{generated}/api/version-notes/CL_COMMAND_ACQUIRE_GL_OBJECTS.asciidoc[]
-//  | {clEnqueueAcquireGLObjects}
-//| {CL_COMMAND_RELEASE_GL_OBJECTS_anchor}
-//
-//include::{generated}/api/version-notes/CL_COMMAND_RELEASE_GL_OBJECTS.asciidoc[]
-//  | {clEnqueueReleaseGLObjects}
-
 | {clEnqueueReadBufferRect}
 | {CL_COMMAND_READ_BUFFER_RECT_anchor}
 

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -835,6 +835,31 @@ Otherwise it returns one of the following errors:
   * CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 
+[[cl_khr_d3d10_sharing-event-command-types]]
+==== Event Command Types for Sharing memory objects that map to Direct3D 10 objects
+
+The following table describes event command type for the OpenCL commands
+to acquire and release OpenCL memory objects that have been created from
+Direct3D 10 objects:
+
+.List of supported event command types
+[width="100%",cols="2,3",options="header"]
+|====
+| *Events Created By*
+| *Event Command Type*
+
+| {clEnqueueAcquireD3D10ObjectsKHR}
+| {CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR_anchor}
+
+//include::{generated}/api/version-notes/CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR.asciidoc[]
+
+| {clEnqueueReleaseD3D10ObjectsKHR}
+| {CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR_anchor}
+
+//include::{generated}/api/version-notes/CL_COMMAND_RELEASE_D3D10_OBJECTS.asciidoc[]
+
+|====
+
 [[cl_khr_d3d10_sharing-issues]]
 === Issues
 

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -838,7 +838,7 @@ Otherwise it returns one of the following errors:
 [[cl_khr_d3d10_sharing-event-command-types]]
 ==== Event Command Types for Sharing memory objects that map to Direct3D 10 objects
 
-The following table describes event command type for the OpenCL commands
+The following table describes the event command types for the OpenCL commands
 to acquire and release OpenCL memory objects that have been created from
 Direct3D 10 objects:
 
@@ -851,12 +851,8 @@ Direct3D 10 objects:
 | {clEnqueueAcquireD3D10ObjectsKHR}
 | {CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR_anchor}
 
-//include::{generated}/api/version-notes/CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR.asciidoc[]
-
 | {clEnqueueReleaseD3D10ObjectsKHR}
 | {CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR_anchor}
-
-//include::{generated}/api/version-notes/CL_COMMAND_RELEASE_D3D10_OBJECTS.asciidoc[]
 
 |====
 

--- a/ext/cl_khr_d3d11_sharing.asciidoc
+++ b/ext/cl_khr_d3d11_sharing.asciidoc
@@ -833,3 +833,24 @@ Otherwise it returns one of the following errors:
     _event_wait_list_ are not valid events.
   * CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
+
+[[cl_khr_d3d11_sharing-event-command-types]]
+==== Event Command Types for Sharing memory objects that map to Direct3D 11 objects
+
+The following table describes the event command types for the OpenCL commands
+to acquire and release OpenCL memory objects that have been created from
+Direct3D 11 objects:
+
+.List of supported event command types
+[width="100%",cols="2,3",options="header"]
+|====
+| *Events Created By*
+| *Event Command Type*
+
+| {clEnqueueAcquireD3D11ObjectsKHR}
+| {CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR_anchor}
+
+| {clEnqueueReleaseD3D11ObjectsKHR}
+| {CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR_anchor}
+
+|====

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -679,6 +679,27 @@ Otherwise it returns one of the following errors:
   * CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 
+[[cl_khr_dx9_media_sharing-event-command-types]]
+==== Event Command Types for Sharing Memory Objects created from Media Surfaces
+
+The following table describes the event command types for the OpenCL commands
+to acquire and release OpenCL memory objects that have been created from
+media surfaces:
+
+.List of supported event command types
+[width="100%",cols="2,3",options="header"]
+|====
+| *Events Created By*
+| *Event Command Type*
+
+| {clEnqueueAcquireDX9MediaSurfacesKHR}
+| {CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR_anchor}
+
+| {clEnqueueReleaseDX9MediaSurfacesKHR}
+| {CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR_anchor}
+
+|====
+
 [[cl_khr_dx9_media_sharing-surface-formats-for-media-surface-sharing]]
 ==== Surface formats for Media Surface Sharing
 

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -339,6 +339,27 @@ Otherwise it returns one of the following errors:
   * CL_OUT_OF_HOST_MEMORY if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 
+[[cl_khr_egl_image-event-command-types]]
+==== Event Command Types for Sharing memory objects created from EGL resources
+
+The following table describes the event command types for the OpenCL commands
+to acquire and release OpenCL memory objects that have been created from
+EGL resources:
+
+.List of supported event command types
+[width="100%",cols="2,3",options="header"]
+|====
+| *Events Created By*
+| *Event Command Type*
+
+| {clEnqueueAcquireEGLObjectsKHR}
+| {CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR_anchor}
+
+| {clEnqueueReleaseEGLObjectsKHR}
+| {CL_COMMAND_RELEASE_EGL_OBJECTS_KHR_anchor}
+
+|====
+
 [[cl_khr_egl_image-issues]]
 === Issues
 

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -751,3 +751,28 @@ behavior.
 Similarly, attempting to access a shared CL/GL object from OpenCL before it
 has been acquired by the OpenCL command queue, or after it has been
 released, will result in undefined behavior.
+
+[[cl_khr_gl_sharing__memobjs-event-command-types]]
+==== Event Command Types for Sharing memory objects that map to GL objects
+
+The following table describes the event command types for the OpenCL commands
+to acquire and release OpenCL memory objects that have been created from
+OpenCL objects:
+
+.List of supported event command types
+[width="100%",cols="2,3",options="header"]
+|====
+| *Events Created By*
+| *Event Command Type*
+
+| {clEnqueueAcquireGLObjects}
+| {CL_COMMAND_ACQUIRE_GL_OBJECTS_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_ACQUIRE_GL_OBJECTS.asciidoc[]
+
+| {clEnqueueReleaseGLObjects}
+| {CL_COMMAND_RELEASE_GL_OBJECTS_anchor}
+
+include::{generated}/api/version-notes/CL_COMMAND_RELEASE_GL_OBJECTS.asciidoc[]
+
+|====

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -757,7 +757,7 @@ released, will result in undefined behavior.
 
 The following table describes the event command types for the OpenCL commands
 to acquire and release OpenCL memory objects that have been created from
-OpenCL objects:
+OpenGL objects:
 
 .List of supported event command types
 [width="100%",cols="2,3",options="header"]

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -127,7 +127,9 @@ if __name__ == "__main__":
     for enums in spec.findall('enums'):
         # Skip Vendor Extension Enums
         vendor = enums.get('vendor')
-        if not vendor or vendor == 'Khronos' or vendor == 'Multiple':
+        name = enums.get('name')    # special-case: enum block with KHR enums assigned to vendor
+        include_anyway = name == 'enums.4010'
+        if not vendor or vendor == 'Khronos' or vendor == 'Multiple' or include_anyway:
             for enum in enums.findall('enum'):
                 name = enum.get('name')
                 #print('found enum: ' + name)


### PR DESCRIPTION
Fixes #400.

This PR adds tables describing the event command types mapping for extensions that add new enqueue APIs.

