### PR TITLE
add size constants to cl.xml for cl_khr_device_uuid

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -366,11 +366,17 @@ server's OpenCL/api-docs repository.
                 #endif
             </comment>
     </enums>
+
     <enums name="Constants.Versioning" vendor="Khronos" comment="Miscellaneous API constants, in cl.h">
         <enum value="10"                                 name="CL_VERSION_MAJOR_BITS"/>
         <enum value="10"                                 name="CL_VERSION_MINOR_BITS"/>
         <enum value="12"                                 name="CL_VERSION_PATCH_BITS"/>
         <enum value="64"                                 name="CL_NAME_VERSION_MAX_NAME_SIZE"/>
+    </enums>
+
+    <enums name="Constants.uuid" vendor="Khronos" comment="cl_khr_device_uuid size constants, in cl_ext.h">
+        <enum value="16"            name="CL_UUID_SIZE_KHR"/>
+        <enum value="8"             name="CL_LUID_SIZE_KHR"/>
     </enums>
 
     <enums start="0" end="-999" name="ErrorCodes.0" vendor="Khronos" comment="Error codes start at 0 and decrease">
@@ -3905,7 +3911,7 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_buffer_create_type"/>
         </require>
-	<require comment="Constants">
+        <require comment="Constants">
             <enum name="CL_NAN"/>
             <enum name="CL_HUGE_VALF"/>
             <enum name="CL_HUGE_VAL"/>
@@ -3991,7 +3997,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_kernel_arg_type_qualifier"/>
             <type name="cl_image_desc"/>
         </require>
-	<require comment="Constants">
+        <require comment="Constants">
             <enum name="CL_DBL_DIG"/>
             <enum name="CL_DBL_MANT_DIG"/>
             <enum name="CL_DBL_MAX_10_EXP"/>
@@ -5649,6 +5655,10 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_khr_device_uuid" supported="opencl">
+            <require comment="Size Constants">
+                <enum name="CL_UUID_SIZE_KHR"/>
+                <enum name="CL_LUID_SIZE_KHR"/>
+            </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_UUID_KHR"/>
                 <enum name="CL_DRIVER_UUID_KHR"/>


### PR DESCRIPTION
Adds the missing size constants for cl_khr_device_uuid to the XML file.

See: https://github.com/KhronosGroup/OpenCL-Docs/pull/421#pullrequestreview-479097124