### PR TITLE
Correct `atomic_flag_test_and_set_explicit` `__local` Overload

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7312,7 +7312,7 @@ bool atomic_flag_test_and_set_explicit(
     memory_order order,
     memory_scope scope)
 bool atomic_flag_test_and_set_explicit(
-    volatile __global atomic_flag *object,
+    volatile __local atomic_flag *object,
     memory_order order,
     memory_scope scope)
 


### PR DESCRIPTION
* Use `__local` rather than `__global` in the second overload of the
`atomic_flag_test_and_set_explicit`. Currently both declarations use
`__global` and are identical.