### PR TITLE
Add API types to the attribute dictionary and use them in the spec

### DIFF
--- a/api/appendix_a.asciidoc
+++ b/api/appendix_a.asciidoc
@@ -53,15 +53,15 @@ being used by another command-queue are undefined.
 == Multiple Host Threads
 
 All OpenCL API calls are thread-safe^1^ except those that modify the state
-of cl_kernel objects: {clSetKernelArg}, {clSetKernelArgSVMPointer},
+of {cl_kernel} objects: {clSetKernelArg}, {clSetKernelArgSVMPointer},
 {clSetKernelExecInfo} and {clCloneKernel}.
 {clSetKernelArg} , {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and
 {clCloneKernel} are safe to call from any host thread, and safe to call
 re-entrantly so long as concurrent calls to any combination of these API
-calls operate on different cl_kernel objects.
-The state of the cl_kernel object is undefined if {clSetKernelArg},
+calls operate on different {cl_kernel} objects.
+The state of the {cl_kernel} object is undefined if {clSetKernelArg},
 {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} or {clCloneKernel} are
-called from multiple host threads on the same cl_kernel object at the same
+called from multiple host threads on the same {cl_kernel} object at the same
 time^2^.
 Please note that there are additional limitations as to which OpenCL APIs
 may be called from <<event-objects,OpenCL callback functions>>.
@@ -78,9 +78,9 @@ may be called from <<event-objects,OpenCL callback functions>>.
     Another host thread might change the kernel arguments between when a
     host thread sets the kernel arguments and then enqueues the kernel,
     causing the wrong kernel arguments to be enqueued.
-    Rather than attempt to share cl_kernel objects among multiple host
+    Rather than attempt to share {cl_kernel} objects among multiple host
     threads, applications are strongly encouraged to make additional
-    cl_kernel objects for kernel functions for each host thread.
+    {cl_kernel} objects for kernel functions for each host thread.
 
 The behavior of OpenCL APIs called from an interrupt or signal handler is
 implementation-defined

--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -307,7 +307,7 @@ include::{generated}/api/version-notes/CL_CHAR_MIN.asciidoc[]
 | {CL_UCHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_UCHAR_MAX.asciidoc[]
-  | Maximum value of a type `cl_uchar`
+  | Maximum value of a type {cl_uchar}
 | {CL_SHRT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_SHRT_MAX.asciidoc[]

--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -291,19 +291,19 @@ include::{generated}/api/version-notes/CL_CHAR_BIT.asciidoc[]
 | {CL_SCHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_SCHAR_MAX.asciidoc[]
-  | Maximum value of a type `cl_char`
+  | Maximum value of a type {cl_char}
 | {CL_SCHAR_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_SCHAR_MIN.asciidoc[]
-  | Minimum value of a type `cl_char`
+  | Minimum value of a type {cl_char}
 | {CL_CHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_CHAR_MAX.asciidoc[]
-  | Maximum value of a type `cl_char`
+  | Maximum value of a type {cl_char}
 | {CL_CHAR_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_CHAR_MIN.asciidoc[]
-  | Minimum value of a type `cl_char`
+  | Minimum value of a type {cl_char}
 | {CL_UCHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_UCHAR_MAX.asciidoc[]
@@ -311,134 +311,134 @@ include::{generated}/api/version-notes/CL_UCHAR_MAX.asciidoc[]
 | {CL_SHRT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_SHRT_MAX.asciidoc[]
-  | Maximum value of a type `cl_short`
+  | Maximum value of a type {cl_short}
 | {CL_SHRT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_SHRT_MIN.asciidoc[]
-  | Minimum value of a type `cl_short`
+  | Minimum value of a type {cl_short}
 | {CL_USHRT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_USHRT_MAX.asciidoc[]
-  | Maximum value of a type `cl_ushort`
+  | Maximum value of a type {cl_ushort}
 | {CL_INT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_INT_MAX.asciidoc[]
-  | Maximum value of a type `cl_int`
+  | Maximum value of a type {cl_int}
 | {CL_INT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_INT_MIN.asciidoc[]
-  | Minimum value of a type `cl_int`
+  | Minimum value of a type {cl_int}
 | {CL_UINT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_UINT_MAX.asciidoc[]
-  | Maximum value of a type `cl_uint`
+  | Maximum value of a type {cl_uint}
 | {CL_LONG_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_LONG_MAX.asciidoc[]
-  | Maximum value of a type `cl_long`
+  | Maximum value of a type {cl_long}
 | {CL_LONG_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_LONG_MIN.asciidoc[]
-  | Minimum value of a type `cl_long`
+  | Minimum value of a type {cl_long}
 | {CL_ULONG_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_ULONG_MAX.asciidoc[]
-  | Maximum value of a type `cl_ulong`
+  | Maximum value of a type {cl_ulong}
 | {CL_FLT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_DIG.asciidoc[]
-  | Number of decimal digits of precision for the type `cl_float`
+  | Number of decimal digits of precision for the type {cl_float}
 | {CL_FLT_MANT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MANT_DIG.asciidoc[]
-  | Number of digits in the mantissa of type `cl_float`
+  | Number of digits in the mantissa of type {cl_float}
 | {CL_FLT_MAX_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX_10_EXP.asciidoc[]
   | Maximum positive integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type `cl_float`
+    be represented as a normalized floating-point number of type {cl_float}
 | {CL_FLT_MAX_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX_EXP.asciidoc[]
-  | Maximum exponent value of type `cl_float`
+  | Maximum exponent value of type {cl_float}
 | {CL_FLT_MIN_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN_10_EXP.asciidoc[]
   | Minimum negative integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type `cl_float`
+    be represented as a normalized floating-point number of type {cl_float}
 | {CL_FLT_MIN_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN_EXP.asciidoc[]
-  | Minimum exponent value of type `cl_float`
+  | Minimum exponent value of type {cl_float}
 | {CL_FLT_RADIX_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_RADIX.asciidoc[]
-  | Base value of type `cl_float`
+  | Base value of type {cl_float}
 | {CL_FLT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX.asciidoc[]
-  | Maximum value of type `cl_float`
+  | Maximum value of type {cl_float}
 | {CL_FLT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN.asciidoc[]
-  | Minimum value of type `cl_float`
+  | Minimum value of type {cl_float}
 | {CL_FLT_EPSILON_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_EPSILON.asciidoc[]
-  | Minimum positive floating-point number of type `cl_float` such that `1.0
+  | Minimum positive floating-point number of type {cl_float} such that `1.0
     {plus} {CL_FLT_EPSILON} != 1` is true.
 | {CL_DBL_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_DIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Number of decimal digits of precision for the type `cl_double`
+  | Number of decimal digits of precision for the type {cl_double}
 | {CL_DBL_MANT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MANT_DIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Number of digits in the mantissa of type `cl_double`
+  | Number of digits in the mantissa of type {cl_double}
 | {CL_DBL_MAX_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX_10_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
   | Maximum positive integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type `cl_double`
+    be represented as a normalized floating-point number of type {cl_double}
 | {CL_DBL_MAX_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Maximum exponent value of type `cl_double`
+  | Maximum exponent value of type {cl_double}
 | {CL_DBL_MIN_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN_10_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
   | Minimum negative integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type `cl_double`
+    be represented as a normalized floating-point number of type {cl_double}
 | {CL_DBL_MIN_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum exponent value of type `cl_double`
+  | Minimum exponent value of type {cl_double}
 | {CL_DBL_RADIX_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_RADIX.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Base value of type `cl_double`
+  | Base value of type {cl_double}
 | {CL_DBL_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Maximum value of type `cl_double`
+  | Maximum value of type {cl_double}
 | {CL_DBL_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum value of type `cl_double`
+  | Minimum value of type {cl_double}
 | {CL_DBL_EPSILON_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_EPSILON.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum positive floating-point number of type `cl_double` such that
+  | Minimum positive floating-point number of type {cl_double} such that
     `1.0 {plus} {CL_DBL_EPSILON} != 1` is true.
 | {CL_NAN_anchor}
 
@@ -447,15 +447,15 @@ include::{generated}/api/version-notes/CL_NAN.asciidoc[]
 | {CL_HUGE_VALF_anchor}
 
 include::{generated}/api/version-notes/CL_HUGE_VALF.asciidoc[]
-  | Largest representative value of type `cl_float`
+  | Largest representative value of type {cl_float}
 | {CL_HUGE_VAL_anchor}
 
 include::{generated}/api/version-notes/CL_HUGE_VAL.asciidoc[]
-  | Largest representative value of type `cl_double`
+  | Largest representative value of type {cl_double}
 | {CL_MAXFLOAT_anchor}
 
 include::{generated}/api/version-notes/CL_MAXFLOAT.asciidoc[]
-  | Maximum value of type `cl_float`
+  | Maximum value of type {cl_float}
 | {CL_INFINITY_anchor}
 
 include::{generated}/api/version-notes/CL_INFINITY.asciidoc[]

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -124,7 +124,7 @@ runtime (_sections 4 and 5_):
   * {clCompileProgram} and {clLinkProgram} to allow handling these aspects
     {clBuildProgram} separately.
   * Extend _cl_mem_flags_ to describe how the host accesses the data in a
-    cl_mem object.
+    {cl_mem} object.
   * {clEnqueueFillBuffer} and {clEnqueueFillImage} to support filling a
     buffer with a pattern or an image with a color.
   * Add {CL_MAP_WRITE_INVALIDATE_REGION} to _cl_map_flags_.

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -164,75 +164,75 @@ Device Queries>> table.
 .List of supported param_names by <<clGetDeviceInfo>> for embedded profile
 [options="header"]
 |====
-| *cl_device_info* | Return Type | Description
+| Device Info | Return Type | Description
 | {CL_DEVICE_MAX_READ_IMAGE_ARGS}
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         `read_only` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_WRITE_IMAGE_ARGS}
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         `write_only` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS}
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         `write_only` or `read_write` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE2D_MAX_WIDTH}
-  | size_t
+  | {size_t}
       | Max width of 2D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE2D_MAX_HEIGHT}
-  | size_t
+  | {size_t}
       | Max height of 2D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_WIDTH}
-  | size_t
+  | {size_t}
       | Max width of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_HEIGHT}
-  | size_t
+  | {size_t}
       | Max height of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_DEPTH}
-  | size_t
+  | {size_t}
       | Max depth of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE}
-  | size_t
+  | {size_t}
       | Max number of pixels for a 1D image created from a buffer object.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE}
-  | size_t
+  | {size_t}
       | Max number of images in a 1D or 2D image array.
 
         The minimum value is 256 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_SAMPLERS}
-  | cl_uint
+  | {cl_uint}
       | Maximum number of samplers that can be used in a kernel.
 
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_PARAMETER_SIZE}
-  | size_t
+  | {size_t}
       | Max size in bytes of all arguments that can be passed to a kernel.
         The minimum value is 256 bytes for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_SINGLE_FP_CONFIG}
-  | cl_device_fp_config
+  | {cl_device_fp_config}
       | Describes single precision floating-point capability of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -262,30 +262,30 @@ Device Queries>> table.
         {CL_FP_ROUND_TO_ZERO} or {CL_FP_ROUND_TO_NEAREST} for devices that are
         not of type {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE}
-  | cl_ulong
+  | {cl_ulong}
       | Max size in bytes of a constant buffer allocation.
         The minimum value is 1 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS}
-  | cl_uint
+  | {cl_uint}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 4 for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_LOCAL_MEM_SIZE}
-  | cl_ulong
+  | {cl_ulong}
       | Size of local memory arena in bytes.
         The minimum value is 1 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_COMPILER_AVAILABLE}
-  | cl_bool
+  | {cl_bool}
       | Is {CL_FALSE} if the implementation does not have a compiler available
         to compile the program source.
 
         Is {CL_TRUE} if the compiler is available.
         This can be {CL_FALSE} for the embedded platform profile only.
 | {CL_DEVICE_LINKER_AVAILABLE}
-  | cl_bool
+  | {cl_bool}
       | Is {CL_FALSE} if the implementation does not have a linker available.
         Is {CL_TRUE} if the linker is available.
 
@@ -293,11 +293,11 @@ Device Queries>> table.
 
         This must be {CL_TRUE} if {CL_DEVICE_COMPILER_AVAILABLE} is {CL_TRUE}.
 | {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE}
-  | cl_uint
+  | {cl_uint}
       | The max. size of the device queue in bytes.
         The minimum value is 64 KB for the embedded profile
 | {CL_DEVICE_PRINTF_BUFFER_SIZE}
-  | size_t
+  | {size_t}
       | Maximum size in bytes of the internal buffer that holds the output
         of printf calls from a kernel.
         The minimum value for the EMBEDDED profile is 1 KB.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1334,7 +1334,7 @@ the same scope *P* such that:
   * *P* is *memory_scope_device* and *A* and *B* are executed by work-items
     on the same device when *A* and *B* apply to an SVM allocation or *A*
     and *B* are executed by work-items in the same kernel or one of its
-    children when *A* and *B* apply to a cl_mem buffer.
+    children when *A* and *B* apply to a {cl_mem} buffer.
   * *P* is *memory_scope_all_svm_devices* if *A* and *B* are executed by
     host threads or by work-items on one or more devices that can share SVM
     memory with each other and the host process.
@@ -1968,12 +1968,12 @@ provide the necessary global-synchronizes-with relation.
 
 In this situation:
 
-  * access to shared locations or disjoint locations in a single cl_mem
+  * access to shared locations or disjoint locations in a single {cl_mem}
     object when using atomic operations from different kernel instances
     enqueued from the host such that one or more of the atomic operations is
     a write is implementation-defined and correct behavior is not guaranteed
     except at synchronization points.
-  * access to shared locations or disjoint locations in a single cl_mem
+  * access to shared locations or disjoint locations in a single {cl_mem}
     object when using atomic operations from different kernel instances
     consisting of a parent kernel and any number of child kernels enqueued
     by that kernel is guaranteed under the memory ordering rules described
@@ -2016,7 +2016,7 @@ Any values that were changed within this region by another kernel or host
 thread while the kernel synchronizing with the map operation was executing
 may be overwritten by the map operation.
 
-Access to non-SVM cl_mem buffers and coarse-grained SVM allocations is
+Access to non-SVM {cl_mem} buffers and coarse-grained SVM allocations is
 ordered at synchronization points between host commands.
 In the presence of an out-of-order command queue or a set of command queues
 mapped to the same device, multiple kernel instances may execute
@@ -2135,7 +2135,7 @@ A version number comprises three logical fields:
   compatibility for any existing profiles.
 * The _patch_ version indicates bug fixes, clarifications and general improvements.
 
-Version numbers are represented using the `cl_version` type that is an alias for
+Version numbers are represented using the {cl_version} type that is an alias for
 a 32-bit integer. The fields are packed as follows:
 
 * The _major_ version is a 10-bit integer packed into bits 31-22.
@@ -2147,10 +2147,10 @@ This enables versions to be ordered using standard C/C++ operators.
 A number of convenience macros are provided by the OpenCL Headers to make
 working with version numbers easier.
 
-`CL_VERSION_MAJOR` extracts the _major_ version from a packed `cl_version`. +
-`CL_VERSION_MINOR` extracts the _minor_ version from a packed `cl_version`. +
-`CL_VERSION_PATCH` extracts the _patch_ version from a packed `cl_version`. +
-`CL_MAKE_VERSION` returns a packed `cl_version` from a _major_, _minor_ and
+`CL_VERSION_MAJOR` extracts the _major_ version from a packed {cl_version}. +
+`CL_VERSION_MINOR` extracts the _minor_ version from a packed {cl_version}. +
+`CL_VERSION_PATCH` extracts the _patch_ version from a packed {cl_version}. +
+`CL_MAKE_VERSION` returns a packed {cl_version} from a _major_, _minor_ and
 _patch_ version.
 
 These are defined as follows:

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1246,7 +1246,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_PROPERTIES.asciidoc[]
 | {CL_DEVICE_PARTITION_AFFINITY_DOMAIN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_AFFINITY_DOMAIN.asciidoc[]
-  | cl_device_affinity_ domain
+  | {cl_device_affinity_domain}
       | Returns the list of supported affinity domains for partitioning the
         device using {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN}.
         This is a bit-field that describes one or more of the following
@@ -1726,7 +1726,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_COUNTS.asciidoc[]
 | {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.asciidoc[]
-  | cl_device_affinity_ domain
+  | {cl_device_affinity_domain}
       | Split the device into smaller aggregate devices containing one or
         more compute units that all share part of a cache hierarchy.
         The value accompanying this property may be drawn from the following

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -20,11 +20,11 @@ The list of platforms available can be obtained with the function:
 include::{generated}/api/protos/clGetPlatformIDs.txt[]
 include::{generated}/api/version-notes/clGetPlatformIDs.asciidoc[]
 
-  * _num_entries_ is the number of cl_platform_id entries that can be added to
+  * _num_entries_ is the number of {cl_platform_id} entries that can be added to
     _platforms_.
     If _platforms_ is not `NULL`, the _num_entries_ must be greater than zero.
   * _platforms_ returns a list of OpenCL platforms found.
-    The cl_platform_id values returned in _platforms_ can be used to identify a
+    The {cl_platform_id} values returned in _platforms_ can be used to identify a
     specific OpenCL platform.
     If _platforms_ is `NULL`, this argument is ignored.
     The number of OpenCL platforms returned is the minimum of the value
@@ -78,11 +78,11 @@ in the <<platform-queries-table, Platform Queries>> table.
 .List of supported param_names by <<clGetPlatformInfo>>
 [width="100%",cols="<50%,<10%,<40%",options="header"]
 |====
-| *cl_platform_info* | Return Type | Description
+| Platform Info | Return Type | Description
 | {CL_PLATFORM_PROFILE_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_PROFILE.asciidoc[]
-  | char[]^1^
+  | {char}[]^1^
       | OpenCL profile string.
         Returns the profile name supported by the implementation.
         The profile name returned can be one of the following strings:
@@ -100,7 +100,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_PROFILE.asciidoc[]
 | {CL_PLATFORM_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_VERSION.asciidoc[]
-  | char[]
+  | {char}[]
       | OpenCL version string.
         Returns the OpenCL version supported by the implementation.
         This version string has the following format:
@@ -114,7 +114,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_VERSION.asciidoc[]
 | {CL_PLATFORM_NUMERIC_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_NUMERIC_VERSION.asciidoc[]
-  | cl_version
+  | {cl_version}
       | Returns the detailed (major, minor, patch) version supported by the
         platform. The major and minor version numbers returned must match
         those returned via {CL_PLATFORM_VERSION}.
@@ -122,17 +122,17 @@ include::{generated}/api/version-notes/CL_PLATFORM_NUMERIC_VERSION.asciidoc[]
 | {CL_PLATFORM_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_NAME.asciidoc[]
-  | char[]
+  | {char}[]
       | Platform name string.
 | {CL_PLATFORM_VENDOR_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_VENDOR.asciidoc[]
-  | char[]
+  | {char}[]
       | Platform vendor string.
 | {CL_PLATFORM_EXTENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns a space separated list of extension names (the extension
         names themselves do not contain any spaces) supported by the
         platform.
@@ -141,7 +141,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS.asciidoc[]
 | {CL_PLATFORM_EXTENSIONS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS_WITH_VERSION.asciidoc[]
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of description (name and version) structures that lists
         all the extensions supported by the platform. The same extension name
         must not be reported more than once. The list of extensions reported
@@ -149,7 +149,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS_WITH_VERSION.ascii
 | {CL_PLATFORM_HOST_TIMER_RESOLUTION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_HOST_TIMER_RESOLUTION.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Returns the resolution of the host timer in nanoseconds as used by
         {clGetDeviceAndHostTimer}.
 
@@ -176,7 +176,7 @@ Otherwise, it returns one of the following errors^2^.
 
 1::
     A null terminated string is returned by OpenCL query function calls if
-    the return type of the information being queried is a char[].
+    the return type of the information being queried is a {char}[].
 
 
 2::
@@ -205,11 +205,11 @@ include::{generated}/api/version-notes/clGetDeviceIDs.asciidoc[]
     devices available.
     The valid values for _device_type_ are specified in the
     <<device-types-table, Device Types>> table.
-  * _num_entries_ is the number of cl_device_id entries that can be added to
+  * _num_entries_ is the number of {cl_device_id} entries that can be added to
     _devices_.
     If _devices_ is not `NULL`, the _num_entries_ must be greater than zero.
   * _devices_ returns a list of OpenCL devices found.
-    The cl_device_id values returned in _devices_ can be used to identify a
+    The {cl_device_id} values returned in _devices_ can be used to identify a
     specific OpenCL device.
     If _devices_ is `NULL`, this argument is ignored.
     The number of OpenCL devices returned is the minimum of the value specified
@@ -227,7 +227,7 @@ include::{generated}/api/version-notes/clGetDeviceIDs.asciidoc[]
 .List of supported device_types by <<clGetDeviceIDs>>
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_device_type* | Description
+| Device Type | Description
 | {CL_DEVICE_TYPE_CPU_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_TYPE_CPU.asciidoc[]
@@ -348,11 +348,11 @@ device except for the following queries:
 .List of supported param_names by <<clGetDeviceInfo>>
 [width="100%",cols="<30%,<20%,<50%",options="header"]
 |====
-| *cl_device_info* | Return Type | Description
+| Device Info | Return Type | Description
 | {CL_DEVICE_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_TYPE.asciidoc[]
-  | cl_device_type
+  | {cl_device_type}
       | The type or types of the OpenCL device.
 
         Please see the <<device-types-table, Device Types>> table
@@ -361,25 +361,25 @@ include::{generated}/api/version-notes/CL_DEVICE_TYPE.asciidoc[]
 | {CL_DEVICE_VENDOR_ID_anchor}^4^
 
 include::{generated}/api/version-notes/CL_DEVICE_VENDOR_ID.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | A unique device vendor identifier.
 
         If the vendor has a PCI vendor ID, the low 16 bits must contain that PCI
         vendor ID, and the remaining bits must be set to zero. Otherwise, the
         value returned must be a valid Khronos vendor ID represented by type
-        `cl_khronos_vendor_id`. Khronos vendor IDs are allocated starting at
+        {cl_khronos_vendor_id}. Khronos vendor IDs are allocated starting at
         0x10000, to distinguish them from the PCI vendor ID namespace.
 | {CL_DEVICE_MAX_COMPUTE_UNITS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_COMPUTE_UNITS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The number of parallel compute units on the OpenCL device.
         A work-group executes on a single compute unit.
         The minimum value is 1.
 | {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Maximum dimensions that specify the global and local work-item IDs
         used by the data parallel execution model. (Refer to
         {clEnqueueNDRangeKernel}).
@@ -388,11 +388,11 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS.asciid
 | {CL_DEVICE_MAX_WORK_ITEM_SIZES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
-  | size_t []
+  | {size_t} []
       | Maximum number of work-items that can be specified in each dimension
         of the work-group to {clEnqueueNDRangeKernel}.
 
-        Returns _n_ size_t entries, where _n_ is the value returned by the
+        Returns _n_ {size_t} entries, where _n_ is the value returned by the
         query for {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS}.
 
         The minimum value is (1, 1, 1) for devices that are not of type
@@ -400,7 +400,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
 | {CL_DEVICE_MAX_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Maximum number of work-items in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device. (Refer also to
@@ -422,7 +422,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
 // (all other entries were added in OpenCL 1.0).
   {CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF} is <<unified-spec, missing before>>
   version 1.1.
-  | cl_uint
+  | {cl_uint}
       | Preferred native vector width size for built-in scalar types that
         can be put into vectors.
         The vector width is defined as the number of scalar elements that
@@ -444,7 +444,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
 // The CHAR annotation here is used to convey the same information for all
 // entries in this table row.
 include::{generated}/api/version-notes/CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the native ISA vector width.
         The vector width is defined as the number of scalar elements that
         can be stored in the vector.
@@ -457,7 +457,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR.asciid
 | {CL_DEVICE_MAX_CLOCK_FREQUENCY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CLOCK_FREQUENCY.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Clock frequency of the device in MHz.
         The meaning of this value is implementation-defined.
         For devices with multiple clock domains, the clock frequency for any
@@ -471,14 +471,14 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_CLOCK_FREQUENCY.asciidoc[]
 | {CL_DEVICE_ADDRESS_BITS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ADDRESS_BITS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The default compute device address space size of the global address
         space specified as an unsigned integer value in bits.
         Currently supported values are 32 or 64 bits.
 | {CL_DEVICE_MAX_MEM_ALLOC_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_MEM_ALLOC_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Max size of memory object allocation in bytes.
         The minimum value is max(min(1024 {times} 1024 {times} 1024, 1/4^th^
         of {CL_DEVICE_GLOBAL_MEM_SIZE}), 32 {times} 1024 {times} 1024) for
@@ -486,13 +486,13 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_MEM_ALLOC_SIZE.asciidoc[]
 | {CL_DEVICE_IMAGE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if images are supported by the OpenCL device and {CL_FALSE}
         otherwise.
 | {CL_DEVICE_MAX_READ_IMAGE_ARGS_anchor}^5^
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_IMAGE_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         read_only qualifier.
         The minimum value is 128 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}, the
@@ -500,7 +500,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_IMAGE_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_WRITE_IMAGE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WRITE_IMAGE_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         write_only qualifier.
         The minimum value is 64 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}, the
@@ -508,7 +508,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WRITE_IMAGE_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS_anchor}^6^
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Max number of image objects arguments of a kernel declared with the
         write_only or read_write qualifier.
 
@@ -521,7 +521,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.ascii
 
 include::{generated}/api/version-notes/CL_DEVICE_IL_VERSION.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | char[]
+  | {char}[]
       | The intermediate languages that can be supported by
         {clCreateProgramWithIL} for this device.
         Returns a space-separated list of IL version strings of the form
@@ -536,7 +536,7 @@ Also see extension *cl_khr_il_program*.
 
 include::{generated}/api/version-notes/CL_DEVICE_ILS_WITH_VERSION.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of descriptions (name and version) for all supported
         Intermediate Languages. Intermediate Languages with the same name may be
         reported more than once but each name and major/minor version
@@ -550,7 +550,7 @@ Also see extension *cl_khr_il_program*.
 | {CL_DEVICE_IMAGE2D_MAX_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_WIDTH.asciidoc[]
-  | size_t
+  | {size_t}
       | Max width of 2D image or 1D image not created from a buffer object
         in pixels.
 
@@ -559,7 +559,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_WIDTH.asciidoc[]
 | {CL_DEVICE_IMAGE2D_MAX_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_HEIGHT.asciidoc[]
-  | size_t
+  | {size_t}
       | Max height of 2D image in pixels.
 
         The minimum value is 16384 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -567,7 +567,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_HEIGHT.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_WIDTH.asciidoc[]
-  | size_t
+  | {size_t}
       | Max width of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -575,7 +575,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_WIDTH.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_HEIGHT.asciidoc[]
-  | size_t
+  | {size_t}
       | Max height of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -583,7 +583,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_HEIGHT.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_DEPTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_DEPTH.asciidoc[]
-  | size_t
+  | {size_t}
       | Max depth of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -591,7 +591,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_DEPTH.asciidoc[]
 | {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_BUFFER_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Max number of pixels for a 1D image created from a buffer object.
 
         The minimum value is 65536 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -599,7 +599,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_BUFFER_SIZE.asciidoc[
 | {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Max number of images in a 1D or 2D image array.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -607,7 +607,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.asciidoc[]
 | {CL_DEVICE_MAX_SAMPLERS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_SAMPLERS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Maximum number of samplers that can be used in a kernel.
 
         The minimum value is 16 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -615,7 +615,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_SAMPLERS.asciidoc[]
 | {CL_DEVICE_IMAGE_PITCH_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_PITCH_ALIGNMENT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The row pitch alignment size in pixels for 2D Images Created From a
         Buffer.
         The value returned must be a power of 2.
@@ -627,7 +627,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_PITCH_ALIGNMENT.asciidoc[
 | {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | This query specifies the minimum alignment in pixels of the host_ptr
         specified to {clCreateBuffer} or {clCreateBufferWithProperties} when a 2D Image
         is Created From a Buffer which was created using {CL_MEM_USE_HOST_PTR}.
@@ -640,7 +640,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT.as
 | {CL_DEVICE_MAX_PIPE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PIPE_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum number of pipe objects that can be passed as arguments
         to a kernel.
         The minimum value is 16 for devices supporting Pipes, and must be
@@ -648,7 +648,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PIPE_ARGS.asciidoc[]
 | {CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum number of reservations that can be active for a pipe per
         work-item in a kernel.
         A work-group reservation is counted as one reservation per
@@ -658,7 +658,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.as
 | {CL_DEVICE_PIPE_MAX_PACKET_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_PACKET_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum size of pipe packet in bytes.
 
         Support for Pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -667,7 +667,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_PACKET_SIZE.asciidoc[]
 | {CL_DEVICE_MAX_PARAMETER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Max size in bytes of all arguments that can be passed to a kernel.
 
         The minimum value is 1024 for devices that are not of type
@@ -677,7 +677,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
 | {CL_DEVICE_MEM_BASE_ADDR_ALIGN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Alignment requirement (in bits) for sub-buffer offsets.
         The minimum value is the size (in bits) of the largest OpenCL
         built-in data type supported by the device (long16 in FULL profile,
@@ -686,14 +686,14 @@ include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]
 | {CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The minimum value is the size (in bytes) of the largest OpenCL data
         type supported by the device (`long16` in FULL profile, `long16` or
         `int16` in EMBEDDED profile).
 | {CL_DEVICE_SINGLE_FP_CONFIG_anchor}^7^
 
 include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
-  | cl_device_fp_config
+  | {cl_device_fp_config}
       | Describes single precision floating-point capability of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -729,7 +729,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
 
 include::{generated}/api/version-notes/CL_DEVICE_DOUBLE_FP_CONFIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | cl_device_fp_config
+  | {cl_device_fp_config}
       | Describes double precision floating-point capability of the OpenCL
         device.
         This is a bit-field that describes one or more of the following
@@ -764,36 +764,36 @@ Also see extension *cl_khr_fp64*.
 | {CL_DEVICE_GLOBAL_MEM_CACHE_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHE_TYPE.asciidoc[]
-  | cl_device_mem_cache_type
+  | {cl_device_mem_cache_type}
       | Type of global memory cache supported.
         Valid values are: {CL_NONE}, {CL_READ_ONLY_CACHE_anchor}, and
         {CL_READ_WRITE_CACHE_anchor}.
 | {CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Size of global memory cache line in bytes.
 | {CL_DEVICE_GLOBAL_MEM_CACHE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHE_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Size of global memory cache in bytes.
 | {CL_DEVICE_GLOBAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Size of global device memory in bytes.
 | {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Max size in bytes of a constant buffer allocation.
         The minimum value is 64 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 8 for devices that are not of type
@@ -801,7 +801,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | The maximum number of bytes of storage that may be allocated for any
         single variable in program scope or inside a function in an OpenCL
         kernel language declared in the global address space.
@@ -814,7 +814,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciid
 | {CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Maximum preferred total size, in bytes, of all program variables in
         the global address space.
         This is a performance hint.
@@ -825,7 +825,7 @@ include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL
 | {CL_DEVICE_LOCAL_MEM_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_TYPE.asciidoc[]
-  | cl_device_local_mem_type
+  | {cl_device_local_mem_type}
       | Type of local memory supported.
         This can be set to {CL_LOCAL_anchor} implying dedicated local memory storage
         such as SRAM , or {CL_GLOBAL_anchor}.
@@ -835,47 +835,47 @@ include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_TYPE.asciidoc[]
 | {CL_DEVICE_LOCAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Size of local memory region in bytes.
         The minimum value is 32 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_ERROR_CORRECTION_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ERROR_CORRECTION_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device implements error correction for all
         accesses to compute device memory (global and constant).
         Is {CL_FALSE} if the device does not implement such error correction.
 | {CL_DEVICE_HOST_UNIFIED_MEMORY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_HOST_UNIFIED_MEMORY.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device and the host have a unified memory subsystem
         and is {CL_FALSE} otherwise.
 | {CL_DEVICE_PROFILING_TIMER_RESOLUTION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PROFILING_TIMER_RESOLUTION.asciidoc[]
-  | size_t
+  | {size_t}
       | Describes the resolution of device timer.
         This is measured in nanoseconds.
         Refer to <<profiling-operations, Profiling Operations>> for details.
 | {CL_DEVICE_ENDIAN_LITTLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ENDIAN_LITTLE.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the OpenCL device is a little endian device and
         {CL_FALSE} otherwise
 | {CL_DEVICE_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_AVAILABLE.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device is available and {CL_FALSE} otherwise.
         A device is considered to be available if the device can be expected
         to successfully execute commands enqueued to the device.
 | {CL_DEVICE_COMPILER_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_COMPILER_AVAILABLE.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_FALSE} if the implementation does not have a compiler available
         to compile the program source.
 
@@ -884,7 +884,7 @@ include::{generated}/api/version-notes/CL_DEVICE_COMPILER_AVAILABLE.asciidoc[]
 | {CL_DEVICE_LINKER_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LINKER_AVAILABLE.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_FALSE} if the implementation does not have a linker available.
         Is {CL_TRUE} if the linker is available.
 
@@ -894,7 +894,7 @@ include::{generated}/api/version-notes/CL_DEVICE_LINKER_AVAILABLE.asciidoc[]
 | {CL_DEVICE_EXECUTION_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXECUTION_CAPABILITIES.asciidoc[]
-  | cl_device_exec_capabilities
+  | {cl_device_exec_capabilities}
       | Describes the execution capabilities of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -908,13 +908,13 @@ include::{generated}/api/version-notes/CL_DEVICE_EXECUTION_CAPABILITIES.asciidoc
 | {CL_DEVICE_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_PROPERTIES.asciidoc[]
-  | cl_command_queue_properties
+  | {cl_command_queue_properties}
       | See description of {CL_DEVICE_QUEUE_ON_HOST_PROPERTIES}.
 | {CL_DEVICE_QUEUE_ON_HOST_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_HOST_PROPERTIES.asciidoc[]
 
-  | cl_command_queue_properties
+  | {cl_command_queue_properties}
       | Describes the on host command-queue properties supported by the
         device.
         This is a bit-field that describes one or more of the following
@@ -930,7 +930,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_HOST_PROPERTIES.asciid
 | {CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES.asciidoc[]
-  | cl_command_queue_properties
+  | {cl_command_queue_properties}
       | Describes the on device command-queue properties supported by the
         device.
         This is a bit-field that describes one or more of the following
@@ -952,7 +952,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES.asci
 | {CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The preferred size of the device queue, in bytes.
         Applications should use this size for the device queue to ensure
         good performance.
@@ -962,7 +962,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.
 | {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum size of the device queue in bytes.
 
         The minimum value is 256 KB for the full profile and 64 KB for the
@@ -971,7 +971,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciid
 | {CL_DEVICE_MAX_ON_DEVICE_QUEUES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum number of device queues that can be created for this
         device in a single context.
 
@@ -980,7 +980,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
 | {CL_DEVICE_MAX_ON_DEVICE_EVENTS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | The maximum number of events in use by a device queue.
         These refer to events returned by the `enqueue_` built-in functions
         to a device queue or user events returned by the `create_user_event`
@@ -991,7 +991,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
 | {CL_DEVICE_BUILT_IN_KERNELS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS.asciidoc[]
-  | char[]
+  | {char}[]
       | A semi-colon separated list of built-in kernels supported by the
         device.
         An empty string is returned if no built-in kernels are supported by
@@ -1000,7 +1000,7 @@ include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS.asciidoc[]
 | {CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION.asciidoc[]
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of descriptions for the built-in kernels supported by
         the device. Each built-in kernel may only be reported once. The list of
         reported kernels must match the list returned via
@@ -1009,28 +1009,28 @@ include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION.a
 | {CL_DEVICE_PLATFORM_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PLATFORM.asciidoc[]
-  | cl_platform_id
+  | {cl_platform_id}
       | The platform associated with this device.
 | {CL_DEVICE_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NAME.asciidoc[]
-  | char[]
+  | {char}[]
       | Device name string.
 | {CL_DEVICE_VENDOR_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_VENDOR.asciidoc[]
-  | char[]
+  | {char}[]
       | Vendor name string.
 | {CL_DRIVER_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DRIVER_VERSION.asciidoc[]
-  | char[]
+  | {char}[]
       | OpenCL software driver version string.
         Follows a vendor-specific format.
 | {CL_DEVICE_PROFILE_anchor}^9^
 
 include::{generated}/api/version-notes/CL_DEVICE_PROFILE.asciidoc[]
-  | char[]
+  | {char}[]
       | OpenCL profile string.
         Returns the profile name supported by the device.
         The profile name returned can be one of the following strings:
@@ -1044,7 +1044,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PROFILE.asciidoc[]
 | {CL_DEVICE_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_VERSION.asciidoc[]
-  | char[]
+  | {char}[]
       | OpenCL version string.
         Returns the OpenCL version supported by the device. This version
         string has the following format:
@@ -1057,7 +1057,7 @@ include::{generated}/api/version-notes/CL_DEVICE_VERSION.asciidoc[]
 | {CL_DEVICE_NUMERIC_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NUMERIC_VERSION.asciidoc[]
-  | cl_version
+  | {cl_version}
       | Returns the detailed (major, minor, patch) version supported by the
         device. The major and minor version numbers returned must match
         those returned via {CL_DEVICE_VERSION}.
@@ -1065,7 +1065,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NUMERIC_VERSION.asciidoc[]
 | {CL_DEVICE_OPENCL_C_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_VERSION.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns the highest fully backwards compatible OpenCL C version 
         supported by the compiler for the device.
         For devices supporting compilation from OpenCL C source, this will
@@ -1103,7 +1103,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_VERSION.asciidoc[]
 | {CL_DEVICE_OPENCL_C_ALL_VERSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_ALL_VERSIONS.asciidoc[]
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of name, version descriptions listing all the versions
         of OpenCL C supported by the compiler for the device.
         In each returned description structure, the name field is required to be
@@ -1137,7 +1137,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_ALL_VERSIONS.asciidoc[
 | {CL_DEVICE_OPENCL_C_FEATURES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_FEATURES.asciidoc[]
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of optional OpenCL C features supported by the
         compiler for the device alongside the OpenCL C version that introduced
         the feature macro.
@@ -1151,7 +1151,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_FEATURES.asciidoc[]
 | {CL_DEVICE_EXTENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns a space separated list of extension names (the extension
         names themselves do not contain any spaces) supported by the device.
         The list of extension names may include Khronos approved extension
@@ -1187,7 +1187,7 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
 | {CL_DEVICE_EXTENSIONS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS_WITH_VERSION.asciidoc[]
-  | cl_name_version[]
+  | {cl_name_version}[]
       | Returns an array of description (name and version) structures. The same
         extension name must not be reported more than once. The list of
         extensions reported must match the list reported via
@@ -1199,14 +1199,14 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS_WITH_VERSION.asciido
 | {CL_DEVICE_PRINTF_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PRINTF_BUFFER_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Maximum size in bytes of the internal buffer that holds the output
         of printf calls from a kernel.
         The minimum value for the FULL profile is 1 MB.
 | {CL_DEVICE_PREFERRED_INTEROP_USER_SYNC_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_INTEROP_USER_SYNC.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the devices preference is for the user to be
         responsible for synchronization, when sharing memory objects between
         OpenCL and other APIs such as DirectX, {CL_FALSE} if the device /
@@ -1216,14 +1216,14 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_INTEROP_USER_SYNC.asc
 | {CL_DEVICE_PARENT_DEVICE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARENT_DEVICE.asciidoc[]
-  | cl_device_id
-      | Returns the cl_device_id of the parent device to which this
+  | {cl_device_id}
+      | Returns the {cl_device_id} of the parent device to which this
         sub-device belongs.
         If _device_ is a root-level device, a `NULL` value is returned.
 | {CL_DEVICE_PARTITION_MAX_SUB_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_MAX_SUB_DEVICES.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the maximum number of sub-devices that can be created when a
         device is partitioned.
 
@@ -1231,9 +1231,9 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_MAX_SUB_DEVICES.ascii
 | {CL_DEVICE_PARTITION_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_PROPERTIES.asciidoc[]
-  | cl_device_partition_ property[]
+  | {cl_device_partition_property}[]
       | Returns the list of partition types supported by _device_.
-        This is an array of cl_device_partition_property values drawn from
+        This is an array of {cl_device_partition_property} values drawn from
         the following list:
 
         {CL_DEVICE_PARTITION_EQUALLY} +
@@ -1264,7 +1264,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_AFFINITY_DOMAIN.ascii
 | {CL_DEVICE_PARTITION_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_TYPE.asciidoc[]
-  | cl_device_partition_property[]
+  | {cl_device_partition_property}[]
       | Returns the properties argument specified in {clCreateSubDevices} if
         device is a sub-device.
         In the case where the properties argument to {clCreateSubDevices} is
@@ -1287,14 +1287,14 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_TYPE.asciidoc[]
 | {CL_DEVICE_REFERENCE_COUNT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the _device_ reference count.
         If the device is a root-level device, a reference count of one is
         returned.
 | {CL_DEVICE_SVM_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_SVM_CAPABILITIES.asciidoc[]
-  | cl_device_svm_capabilities
+  | {cl_device_svm_capabilities}
       | Describes the various shared virtual memory (SVM) memory
         allocation types the device supports.
         This is a bit-field that describes a combination of the following
@@ -1326,7 +1326,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SVM_CAPABILITIES.asciidoc[]
 | {CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 fine-grained SVM atomic types.
         This query can return 0 which indicates that the preferred alignment
@@ -1334,7 +1334,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGN
 | {CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 atomic types to global memory.
         This query can return 0 which indicates that the preferred alignment
@@ -1342,7 +1342,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNME
 | {CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 atomic types to local memory.
         This query can return 0 which indicates that the preferred alignment
@@ -1351,7 +1351,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMEN
 
 // Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Maximum number of sub-groups in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device.
@@ -1365,7 +1365,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
 
 // Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if this device supports independent forward progress of
         sub-groups, {CL_FALSE} otherwise.
 
@@ -1376,7 +1376,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_P
 | {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asciidoc[]
-  | cl_device_atomic_capabilities
+  | {cl_device_atomic_capabilities}
       | Describes the various memory orders and scopes that the device supports for atomic memory operations.
         This is a bit-field that describes a combination of the following
         values:
@@ -1411,7 +1411,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
 | {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_FENCE_CAPABILITIES.asciidoc[]
-  | cl_device_atomic_capabilities
+  | {cl_device_atomic_capabilities}
       | Describes the various memory orders and scopes that the device supports for atomic fence operations.
         This is a bit-field that has the same set of possible values as described for {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES}.
 
@@ -1424,7 +1424,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_FENCE_CAPABILITIES.ascii
 | {CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device supports non-uniform work groups, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for non-uniform work groups is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1432,7 +1432,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT.
 | {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device supports work group collective functions e.g. `work_group_broadcast`, `work_group_reduce`, and `work_group_scan`, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for work group collective functions is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1440,7 +1440,7 @@ include::{generated}/api/version-notes/CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS
 | {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device supports the generic address space and its associated built-in functions, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for the generic address space is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1448,7 +1448,7 @@ include::{generated}/api/version-notes/CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.a
 | {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asciidoc[]
-  | cl_device_device_enqueue_capabilities
+  | {cl_device_device_enqueue_capabilities}
       | Describes device-side enqueue capabilities of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -1467,7 +1467,7 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
 | {CL_DEVICE_PIPE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_SUPPORT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Is {CL_TRUE} if the device supports Pipes, and {CL_FALSE} otherwise.
 
       Devices that return {CL_TRUE} for {CL_DEVICE_PIPE_SUPPORT} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}.
@@ -1477,7 +1477,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_SUPPORT.asciidoc[]
 | {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE.asciidoc[]
-  | size_t
+  | {size_t}
       | Returns the preferred multiple of work-group size for the given device.
         This is a performance hint intended as a guide when specifying the local work size argument to {clEnqueueNDRangeKernel}.
 
@@ -1487,7 +1487,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTI
 | {CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns the latest version of the conformance test suite that this device
         has fully passed in accordance with the official conformance process.
 
@@ -1498,13 +1498,13 @@ include::{generated}/api/version-notes/CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASS
     If there is no valid PCI vendor ID defined for the physical device,
     implementations must obtain a Khronos vendor ID. This is a unique
     identifier greater than the largest PCI vendor ID(0x10000) and is
-    representable by a `cl_uint`. Khronos vendor IDs are synchronized across
+    representable by a {cl_uint}. Khronos vendor IDs are synchronized across
     APIs by utilizing Vulkan's vk.xml as the central Khronos vendor ID registry.
     An ID must be reserved here prior to use in OpenCL, regardless of whether a
     vendor implements Vulkan. Only once the ID has been allotted may it be
     exposed to OpenCL by proposing a merge request against cl.xml, in the master
     branch of the OpenCL-Docs project. The merge must define a new enumerant by
-    adding an `<enum>` tag to the `cl_khronos_vendor_id` `<enums>` tag, with the
+    adding an `<enum>` tag to the {cl_khronos_vendor_id} `<enums>` tag, with the
     `<value>` attribute set as the acquired Khronos vendor ID. The `<name>`
     attribute must identify the vendor/adopter, and be of the form
     `CL_KHRONOS_VENDOR_ID_<vendor>`.
@@ -1674,7 +1674,7 @@ include::{generated}/api/version-notes/clCreateSubDevices.asciidoc[]
     Only one of the listed partitioning schemes can be specified in
     _properties_.
   * _num_devices_ is the size of memory pointed to by _out_devices_ specified as
-    the number of cl_device_id entries.
+    the number of {cl_device_id} entries.
   * _out_devices_ is the buffer where the OpenCL sub-devices will be returned.
     If _out_devices_ is `NULL`, this argument is ignored.
     If _out_devices_ is not `NULL`, _num_devices_ must be greater than or equal
@@ -1698,11 +1698,11 @@ on the queue are executed only on the sub-device.
 .List of supported partition schemes by <<clCreateSubDevices>>
 [width="100%",cols="<30%,<20%,<50%",options="header"]
 |====
-| *cl_device_partition_property enum* | Partition value | Description
+| Partition Property | Partition Value | Description
 | {CL_DEVICE_PARTITION_EQUALLY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_EQUALLY.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Split the aggregate device into as many smaller aggregate devices as
         can be created, each containing _n_ compute units.
         The value _n_ is passed as the value accompanying this property.
@@ -1712,7 +1712,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_EQUALLY.asciidoc[]
 | {CL_DEVICE_PARTITION_BY_COUNTS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_COUNTS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | This property is followed by a list of compute unit counts
         terminated with 0 or {CL_DEVICE_PARTITION_BY_COUNTS_LIST_END_anchor}.
         For each non-zero count _m_ in the list, a sub-device is created
@@ -1833,7 +1833,7 @@ include::{generated}/api/version-notes/clRetainDevice.asciidoc[]
 
 {clRetainDevice} increments the _device_ reference count if _device_ is a
 valid sub-device created by a call to {clCreateSubDevices}.
-If _device_ is a root level device i.e. a cl_device_id returned by
+If _device_ is a root level device i.e. a {cl_device_id} returned by
 {clGetDeviceIDs}, the _device_ reference count remains unchanged.
 
 // refError
@@ -1860,7 +1860,7 @@ include::{generated}/api/version-notes/clReleaseDevice.asciidoc[]
 
 {clReleaseDevice} decrements the _device_ reference count if device is a
 valid sub-device created by a call to {clCreateSubDevices}.
-If _device_ is a root level device i.e. a cl_device_id returned by
+If _device_ is a root level device i.e. a {cl_device_id} returned by
 {clGetDeviceIDs}, the _device_ reference count remains unchanged.
 
 // refError
@@ -1940,16 +1940,16 @@ on one or more devices specified in the context.
 .List of supported context creation properties by <<clCreateContext>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_context_properties enum* | Property value | Description
+| Context Property | Property Value | Description
 | {CL_CONTEXT_PLATFORM_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_PLATFORM.asciidoc[]
-  | cl_platform_id
+  | {cl_platform_id}
       | Specifies the platform to use.
 | {CL_CONTEXT_INTEROP_USER_SYNC_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_INTEROP_USER_SYNC.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Specifies whether the user is responsible for synchronization
         between OpenCL and other APIs.
         Please refer to the specific sections in the OpenCL Extension
@@ -2155,26 +2155,26 @@ _param_value_ by {clGetContextInfo} is described in the
 .List of supported param_names by <<clGetContextInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_context_info* | Return Type | Information returned in param_value
+| Context Info | Return Type | Information returned in param_value
 | {CL_CONTEXT_REFERENCE_COUNT_anchor}^11^
 
 include::{generated}/api/version-notes/CL_CONTEXT_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the _context_ reference count.
 | {CL_CONTEXT_NUM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_NUM_DEVICES.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the number of devices in _context_.
 | {CL_CONTEXT_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_DEVICES.asciidoc[]
-  | cl_device_id[]
+  | {cl_device_id}[]
       | Return the list of devices and sub-devices in _context_.
 | {CL_CONTEXT_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_PROPERTIES.asciidoc[]
-  | cl_context_properties[]
+  | {cl_context_properties}[]
       | Return the properties argument specified in {clCreateContext} or
         {clCreateContextFromType}.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -56,11 +56,11 @@ Also see extension *cl_khr_create_command_queue*.
 .List of supported queue creation properties by <<clCreateCommandQueueWithProperties>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *Queue Properties* | Property Value | Description
+| Queue Property | Property Value | Description
 | {CL_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
-  | cl_bitfield
+  | {cl_command_queue_properties}
       | This is a bitfield and can be set to a combination of the following
         values:
 
@@ -92,7 +92,7 @@ include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE_DEFAULT.asciidoc[]
 | {CL_QUEUE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Specifies the size of the device queue in bytes.
 
         This can only be specified if {CL_QUEUE_ON_DEVICE} is set in
@@ -335,26 +335,26 @@ _param_value_ by {clGetCommandQueueInfo} is described in the
 .List of supported param_names by <<clGetCommandQueueInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_command_queue_info* | Return Type | Information returned in param_value
+| Queue Info | Return Type | Information returned in param_value
 | {CL_QUEUE_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return the context specified when the command-queue is created.
 | {CL_QUEUE_DEVICE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE.asciidoc[]
-  | cl_device_id
+  | {cl_device_id}
       | Return the device specified when the command-queue is created.
 | {CL_QUEUE_REFERENCE_COUNT_anchor}^3^
 
 include::{generated}/api/version-notes/CL_QUEUE_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the command-queue reference count.
 | {CL_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
-  | cl_command_queue_properties
+  | {cl_command_queue_properties}
       | Return the currently specified properties for the command-queue.
         These properties are specified by the value associated with the
         {CL_QUEUE_PROPERTIES} passed in _properties_ argument in
@@ -364,7 +364,7 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
 | {CL_QUEUE_PROPERTIES_ARRAY_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
-  | cl_queue_properties[]
+  | {cl_queue_properties}[]
       | Return the properties argument specified in
         {clCreateCommandQueueWithProperties}.
 
@@ -382,7 +382,7 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
 | {CL_QUEUE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the size of the device command-queue.
         To be considered valid for this query, _command_queue_ must be a
         device command-queue.
@@ -390,7 +390,7 @@ include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
 | {CL_QUEUE_DEVICE_DEFAULT_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE_DEFAULT.asciidoc[]
-  | cl_command_queue
+  | {cl_command_queue}
       | Return the current default command queue for the underlying device.
 |====
 
@@ -555,7 +555,7 @@ returned in _errcode_ret_:
 .List of supported memory flag values
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_mem_flags* | Description
+| Memory Flags | Description
 | {CL_MEM_READ_WRITE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_READ_WRITE.asciidoc[]
@@ -625,7 +625,7 @@ include::{generated}/api/version-notes/CL_MEM_COPY_HOST_PTR.asciidoc[]
     {CL_MEM_COPY_HOST_PTR} and {CL_MEM_USE_HOST_PTR} are mutually exclusive.
 
     {CL_MEM_COPY_HOST_PTR} can be used with {CL_MEM_ALLOC_HOST_PTR} to
-    initialize the contents of the cl_mem object allocated using
+    initialize the contents of the {cl_mem} object allocated using
     host-accessible (e.g. PCIe) memory.
 | {CL_MEM_HOST_WRITE_ONLY_anchor}
 
@@ -697,7 +697,7 @@ include::{generated}/api/version-notes/clCreateSubBuffer.asciidoc[]
 .List of supported buffer creation types by <<clCreateSubBuffer>>
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_buffer_create_type* | Description
+| Buffer Creation Type | Description
 | {CL_BUFFER_CREATE_TYPE_REGION_anchor}
 
 include::{generated}/api/version-notes/CL_BUFFER_CREATE_TYPE_REGION.asciidoc[]
@@ -1388,7 +1388,7 @@ include::{generated}/api/version-notes/clEnqueueFillBuffer.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
-or written by a kernel and/or the host and is given by the cl_mem_flags
+or written by a kernel and/or the host and is given by the {cl_mem_flags}
 argument value specified when _buffer_ is created is ignored by
 {clEnqueueFillBuffer}.
 
@@ -1554,7 +1554,7 @@ Objects>>.
 .List of supported map flag values
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_map_flags* | Description
+| Map Flags | Description
 | {CL_MAP_READ_anchor}
 
 include::{generated}/api/version-notes/CL_MAP_READ.asciidoc[]
@@ -2574,7 +2574,7 @@ parameter and any other image parameter.
 .Mapping from format flags passed to <<clGetSupportedImageFormats>> to OpenCL kernel language image access qualifiers
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| Access Qualifier | cl_mem_flags
+| Access Qualifier | Memory Flags
 | `read_only`
   | {CL_MEM_READ_ONLY}, +
     {CL_MEM_READ_WRITE}, +
@@ -2970,7 +2970,7 @@ include::{generated}/api/version-notes/clEnqueueFillImage.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
-or written by a kernel and/or the host and is given by the cl_mem_flags
+or written by a kernel and/or the host and is given by the {cl_mem_flags}
 argument value specified when _image_ is created is ignored by
 {clEnqueueFillImage}.
 
@@ -3442,7 +3442,7 @@ include::{generated}/api/version-notes/clGetImageInfo.asciidoc[]
 .List of supported param_names by <<clGetImageInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_image_info* | Return type | Info. returned in _param_value_
+| Image Info | Return type | Info. returned in _param_value_
 | {CL_IMAGE_FORMAT_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_FORMAT.asciidoc[]
@@ -3453,19 +3453,19 @@ include::{generated}/api/version-notes/CL_IMAGE_FORMAT.asciidoc[]
 | {CL_IMAGE_ELEMENT_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ELEMENT_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Return size of each element of the image memory object given by
         _image_ in bytes.
 | {CL_IMAGE_ROW_PITCH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ROW_PITCH.asciidoc[]
-  | size_t
+  | {size_t}
       | Return calculated row pitch in bytes of a row of elements of the
         image object given by _image_.
 | {CL_IMAGE_SLICE_PITCH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_SLICE_PITCH.asciidoc[]
-  | size_t
+  | {size_t}
       | Return calculated slice pitch in bytes of a 2D slice for the 3D
         image object or size of each image in a 1D or 2D image array given
         by _image_.
@@ -3473,42 +3473,42 @@ include::{generated}/api/version-notes/CL_IMAGE_SLICE_PITCH.asciidoc[]
 | {CL_IMAGE_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_WIDTH.asciidoc[]
-  | size_t
+  | {size_t}
       | Return width of the image in pixels.
 | {CL_IMAGE_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_HEIGHT.asciidoc[]
-  | size_t
+  | {size_t}
       | Return height of the image in pixels.
         For a 1D image, 1D image buffer and 1D image array object, height =
         0.
 | {CL_IMAGE_DEPTH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_DEPTH.asciidoc[]
-  | size_t
+  | {size_t}
       | Return depth of the image in pixels.
         For a 1D image, 1D image buffer, 2D image or 1D and 2D image array
         object, depth = 0.
 | {CL_IMAGE_ARRAY_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ARRAY_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Return number of images in the image array.
         If _image_ is not an image array, 0 is returned.
 | {CL_IMAGE_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_BUFFER.asciidoc[]
-  | cl_mem
+  | {cl_mem}
       | Return buffer object associated with _image_.
 | {CL_IMAGE_NUM_MIP_LEVELS_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_NUM_MIP_LEVELS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return `num_mip_levels` associated with _image_.
 | {CL_IMAGE_NUM_SAMPLES_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_NUM_SAMPLES.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return `num_samples` associated with _image_.
 |====
 
@@ -3656,24 +3656,24 @@ Otherwise, it returns one of the following errors:
 .List of supported param_names by <<clGetPipeInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_pipe_info* | Return type | Info. returned in _param_value_
+| Pipe Info | Return type | Info. returned in _param_value_
 | {CL_PIPE_PACKET_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_PACKET_SIZE.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return pipe packet size specified when _pipe_ is created with
         {clCreatePipe}.
 | {CL_PIPE_MAX_PACKETS_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_MAX_PACKETS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return max. number of packets specified when _pipe_ is created with
         {clCreatePipe}.
 
 | {CL_PIPE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_PROPERTIES.asciidoc[]
-  | cl_pipe_properties[]
+  | {cl_pipe_properties}[]
       | Return the properties argument specified in {clCreatePipe}.
 
         If the _properties_ argument specified in {clCreatePipe} used to
@@ -4030,10 +4030,10 @@ include::{generated}/api/version-notes/clEnqueueMigrateMemObjects.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 [[migration-flags-table]]
-.Supported values for cl_mem_migration_flags
+.List of supported migration flags by <<clEnqueueMigrateMemObjects>>
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_mem_migration flags* | Description
+| Memory Migration Flags | Description
 | {CL_MIGRATE_MEM_OBJECT_HOST_anchor}
 
 include::{generated}/api/version-notes/CL_MIGRATE_MEM_OBJECT_HOST.asciidoc[]
@@ -4137,11 +4137,11 @@ include::{generated}/api/version-notes/clGetMemObjectInfo.asciidoc[]
 .List of supported param_names by <<clGetMemObjectInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_mem_info* | Return type | Info. returned in _param_value_
+| Memory Object Info | Return type | Info. returned in _param_value_
 | {CL_MEM_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_TYPE.asciidoc[]
-  | cl_mem_object_type
+  | {cl_mem_object_type}
       | Returns one of the following values:
 
         {CL_MEM_OBJECT_BUFFER_anchor} if _memobj_ is created with {clCreateBuffer},
@@ -4158,7 +4158,7 @@ include::{generated}/api/version-notes/CL_MEM_TYPE.asciidoc[]
 | {CL_MEM_FLAGS_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_FLAGS.asciidoc[]
-  | cl_mem_flags
+  | {cl_mem_flags}
       | Return the flags argument value specified when _memobj_ is created
         with {clCreateBuffer}, +
         {clCreateBufferWithProperties}, +
@@ -4174,13 +4174,13 @@ include::{generated}/api/version-notes/CL_MEM_FLAGS.asciidoc[]
 | {CL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | Return actual size of the data store associated with _memobj_ in
         bytes.
 | {CL_MEM_HOST_PTR_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
-  | void *
+  | {void} *
       | If _memobj_ is created with {clCreateBuffer}, {clCreateBufferWithProperties},
         {clCreateImage}, {clCreateImageWithProperties}, {clCreateImage2D}, or
         {clCreateImage3D}, and {CL_MEM_USE_HOST_PTR} is specified in mem_flags,
@@ -4197,17 +4197,17 @@ include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
 | {CL_MEM_MAP_COUNT_anchor}^11^
 
 include::{generated}/api/version-notes/CL_MEM_MAP_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Map count.
 | {CL_MEM_REFERENCE_COUNT_anchor}^12^
 
 include::{generated}/api/version-notes/CL_MEM_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return _memobj_ reference count.
 | {CL_MEM_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return context specified when memory object is created.
         If _memobj_ is created using {clCreateSubBuffer}, the context
         associated with the memory object specified as the _buffer_ argument
@@ -4215,7 +4215,7 @@ include::{generated}/api/version-notes/CL_MEM_CONTEXT.asciidoc[]
 | {CL_MEM_ASSOCIATED_MEMOBJECT_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_ASSOCIATED_MEMOBJECT.asciidoc[]
-  | cl_mem
+  | {cl_mem}
       | Return memory object from which _memobj_ is created.
 
         This returns the memory object specified as buffer argument to
@@ -4230,7 +4230,7 @@ include::{generated}/api/version-notes/CL_MEM_ASSOCIATED_MEMOBJECT.asciidoc[]
 | {CL_MEM_OFFSET_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_OFFSET.asciidoc[]
-  | size_t
+  | {size_t}
       | Return offset if _memobj_ is a sub-buffer object created using
         {clCreateSubBuffer}.
 
@@ -4238,7 +4238,7 @@ include::{generated}/api/version-notes/CL_MEM_OFFSET.asciidoc[]
 | {CL_MEM_USES_SVM_POINTER_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_USES_SVM_POINTER.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Return {CL_TRUE} if _memobj_ is a buffer object that was created with
         {CL_MEM_USE_HOST_PTR} or is a sub-buffer object of a buffer object
         that was created with {CL_MEM_USE_HOST_PTR} and the _host_ptr_
@@ -4247,7 +4247,7 @@ include::{generated}/api/version-notes/CL_MEM_USES_SVM_POINTER.asciidoc[]
 | {CL_MEM_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
-  | cl_mem_properties[]
+  | {cl_mem_properties}[]
       | Return the properties argument specified in
         {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
 
@@ -4323,7 +4323,7 @@ We call this fine-grained sharing.
     {clSVMAlloc}.
     Memory consistency is guaranteed at synchronization points and the host
     can use calls to {clEnqueueSVMMap} and {clEnqueueSVMUnmap} or create a
-    cl_mem buffer object using the SVM pointer and use OpenCL's existing host
+    {cl_mem} buffer object using the SVM pointer and use OpenCL's existing host
     API functions {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} to
     update regions of the buffer.
     What coarse-grain buffer SVM adds to OpenCL's earlier buffer support are
@@ -4352,7 +4352,7 @@ We call this fine-grained sharing.
      consistency provided at synchronization points.
      There is no need for explicit calls to {clEnqueueSVMMap} and
      {clEnqueueSVMUnmap} or {clEnqueueMapBuffer} and
-     {clEnqueueUnmapMemObject} on a cl_mem buffer object created using the
+     {clEnqueueUnmapMemObject} on a {cl_mem} buffer object created using the
      SVM pointer.
   ** If SVM atomic operations are not supported, the host and devices can
      concurrently read the same memory locations and can concurrently update
@@ -4360,7 +4360,7 @@ We call this fine-grained sharing.
      locations are undefined.
      Memory consistency is guaranteed at synchronization points without the
      need for explicit calls to {clEnqueueSVMMap} and {clEnqueueSVMUnmap}
-     or {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} on a cl_mem
+     or {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} on a {cl_mem}
      buffer object created using the SVM pointer.
   * There are two kinds of fine-grain sharing support.
     Devices may support either fine-grain buffer sharing or fine-grain
@@ -4419,7 +4419,7 @@ include::{generated}/api/version-notes/clSVMAlloc.asciidoc[]
 .List of supported SVM memory flag values
 [width="100%",cols="<50%,<50%",options="header"]
 |====
-| *cl_svm_mem_flags* | Description
+| SVM Memory Flags | Description
 | {CL_MEM_READ_WRITE}
   | This flag specifies that the SVM buffer will be read and written by a
     kernel.
@@ -4922,13 +4922,13 @@ Otherwise, it returns one of the following errors:
 If a coarse-grained SVM buffer is currently mapped for writing, the
 application must ensure that the SVM buffer is unmapped before any enqueued
 kernels or commands that read from or write to this SVM buffer or any of its
-associated cl_mem buffer objects begin execution; otherwise the behavior is
+associated {cl_mem} buffer objects begin execution; otherwise the behavior is
 undefined.
 
 If a coarse-grained SVM buffer is currently mapped for reading, the
 application must ensure that the SVM buffer is unmapped before any enqueued
 kernels or commands that write to this memory object or any of its
-associated cl_mem buffer objects begin execution; otherwise the behavior is
+associated {cl_mem} buffer objects begin execution; otherwise the behavior is
 undefined.
 
 A SVM buffer is considered as mapped if there are one or more active
@@ -5037,7 +5037,7 @@ In addition, sub-buffers can also be used to ensure that each device gets a
 consistent view of a SVM buffers memory when it is shared by multiple
 devices.
 For example, assume that two devices share a SVM pointer.
-The host can create a cl_mem buffer object using {clCreateBuffer} or
+The host can create a {cl_mem} buffer object using {clCreateBuffer} or
 {clCreateBufferWithProperties} with {CL_MEM_USE_HOST_PTR} and _host_ptr_ set
 to the SVM pointer and then create two disjoint sub-buffers with starting
 virtual addresses _sb1_ptr_ and _sb2_ptr_.
@@ -5095,11 +5095,11 @@ include::{generated}/api/version-notes/clCreateSamplerWithProperties.asciidoc[]
 .List of supported sampler creation properties by <<clCreateSamplerWithProperties>>
 [width="100%",cols="2,1,3",options="header"]
 |====
-| *cl_sampler_properties* enum | Property Value | Description
+| Sampler Property | Property Value | Description
 | {CL_SAMPLER_NORMALIZED_COORDS_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | A boolean value that specifies whether the image coordinates
         specified are normalized or not.
 
@@ -5108,7 +5108,7 @@ include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
 | {CL_SAMPLER_ADDRESSING_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
-  | cl_addressing_mode
+  | {cl_addressing_mode}
       | Specifies how out-of-range image coordinates are handled when
         reading from an image.
         Valid values are:
@@ -5134,7 +5134,7 @@ include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
 | {CL_SAMPLER_FILTER_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_FILTER_MODE.asciidoc[]
-  | cl_filter_mode
+  | {cl_filter_mode}
       | Specifies the type of filter that is applied when reading an
         image.
         Valid values are:
@@ -5297,37 +5297,37 @@ include::{generated}/api/version-notes/clGetSamplerInfo.asciidoc[]
 .List of supported param_names by <<clGetSamplerInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_sampler_info* | Return Type | Info. returned in _param_value_
+| Sampler Info | Return Type | Info. returned in _param_value_
 | {CL_SAMPLER_REFERENCE_COUNT_anchor}^13^
 
 include::{generated}/api/version-notes/CL_SAMPLER_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the _sampler_ reference count.
 | {CL_SAMPLER_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return the context specified when the sampler is created.
 | {CL_SAMPLER_NORMALIZED_COORDS_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | Return the normalized coords value associated with _sampler_.
 | {CL_SAMPLER_ADDRESSING_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
-  | cl_addressing_mode
+  | {cl_addressing_mode}
       | Return the addressing mode value associated with _sampler_.
 | {CL_SAMPLER_FILTER_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_FILTER_MODE.asciidoc[]
-  | cl_filter_mode
+  | {cl_filter_mode}
       | Return the filter mode value associated with _sampler_.
 
 | {CL_SAMPLER_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_PROPERTIES.asciidoc[]
-  | cl_sampler_properties[]
+  | {cl_sampler_properties}[]
       | Return the properties argument specified in
         {clCreateSamplerWithProperties}.
 
@@ -6614,26 +6614,26 @@ include::{generated}/api/version-notes/clGetProgramInfo.asciidoc[]
 .List of supported param_names by <<clGetProgramInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_program_info* | Return Type | Info. returned in _param_value_
+| Program Info | Return Type | Info. returned in _param_value_
 | {CL_PROGRAM_REFERENCE_COUNT_anchor}^14^
 
 include::{generated}/api/version-notes/CL_PROGRAM_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the _program_ reference count.
 | {CL_PROGRAM_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return the context specified when the program object is created
 | {CL_PROGRAM_NUM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_NUM_DEVICES.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the number of devices associated with _program_.
 | {CL_PROGRAM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_DEVICES.asciidoc[]
-  | cl_device_id[]
+  | {cl_device_id}[]
       | Return the list of devices associated with the program object.
         This can be the devices associated with context on which the program
         object has been created or can be a subset of devices that are
@@ -6642,7 +6642,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_DEVICES.asciidoc[]
 | {CL_PROGRAM_SOURCE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SOURCE.asciidoc[]
-  | char[]
+  | {char}[]
       | Return the program source code specified by
         {clCreateProgramWithSource}.
         The source string returned is a concatenation of all source strings
@@ -6662,7 +6662,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_SOURCE.asciidoc[]
 
 include::{generated}/api/version-notes/CL_PROGRAM_IL.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | char[]
+  | {char}[]
       | Returns the program IL for programs created with
         {clCreateProgramWithIL}.
 
@@ -6673,7 +6673,7 @@ Also see extension *cl_khr_il_program*.
 | {CL_PROGRAM_BINARY_SIZES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARY_SIZES.asciidoc[]
-  | size_t[]
+  | {size_t}[]
       | Returns an array that contains the size in bytes of the program
         binary (could be an executable binary, compiled binary or library
         binary) for each device associated with program.
@@ -6688,7 +6688,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARY_SIZES.asciidoc[]
 | {CL_PROGRAM_BINARIES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARIES.asciidoc[]
-  | unsigned char *[]
+  | {unsigned_char} *[]
       | Return the program binaries (could be an executable binary, compiled
         binary or library binary) for all devices associated with program.
         For each device in program, the binary returned can be the binary
@@ -6721,7 +6721,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARIES.asciidoc[]
 | {CL_PROGRAM_NUM_KERNELS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_NUM_KERNELS.asciidoc[]
-  | size_t
+  | {size_t}
       | Returns the number of kernels declared in _program_ that can be
         created with {clCreateKernel}.
         This information is only available after a successful program
@@ -6730,7 +6730,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_NUM_KERNELS.asciidoc[]
 | {CL_PROGRAM_KERNEL_NAMES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_KERNEL_NAMES.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns a semi-colon separated list of kernel names in _program_
         that can be created with {clCreateKernel}.
         This information is only available after a successful program
@@ -6739,7 +6739,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_KERNEL_NAMES.asciidoc[]
 | {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | This indicates that the _program_ object contains non-trivial
         constructor(s) that will be executed by runtime before any kernel
         from the program is executed.
@@ -6752,7 +6752,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asc
 | {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | This indicates that the program object contains non-trivial
         destructor(s) that will be executed by runtime when _program_ is
         destroyed.
@@ -6820,11 +6820,11 @@ include::{generated}/api/version-notes/clGetProgramBuildInfo.asciidoc[]
 .List of supported param_names by <<clGetProgramBuildInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_program_build_info* | Return Type | Info. returned in _param_value_
+| Program Build Info | Return Type | Info. returned in _param_value_
 | {CL_PROGRAM_BUILD_STATUS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_STATUS.asciidoc[]
-  | cl_build_status
+  | {cl_build_status}
       | Returns the build, compile or link status, whichever was performed
         last on the specified _program_ object for _device_.
 
@@ -6849,7 +6849,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_STATUS.asciidoc[]
 | {CL_PROGRAM_BUILD_OPTIONS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_OPTIONS.asciidoc[]
-  | char[]
+  | {char}[]
       | Return the build, compile or link options specified by the options
         argument in {clBuildProgram}, {clCompileProgram} or {clLinkProgram},
         whichever was performed last on the specified _program_ object for
@@ -6860,7 +6860,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_OPTIONS.asciidoc[]
 | {CL_PROGRAM_BUILD_LOG_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_LOG.asciidoc[]
-  | char[]
+  | {char}[]
       | Return the build, compile or link log for {clBuildProgram},
         {clCompileProgram} or {clLinkProgram}, whichever was performed last
         on program for device.
@@ -6870,7 +6870,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_LOG.asciidoc[]
 | {CL_PROGRAM_BINARY_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARY_TYPE.asciidoc[]
-  | cl_program_binary_type
+  | {cl_program_binary_type}
       | Return the program binary type for device.
         This can be one of the following values:
 
@@ -6897,7 +6897,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARY_TYPE.asciidoc[]
 | {CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | The total amount of storage, in bytes, used by program variables in
         the global address space.
 |====
@@ -6992,7 +6992,7 @@ include::{generated}/api/version-notes/clCreateKernelsInProgram.asciidoc[]
 
   * _program_ is a program object with a successfully built executable.
   * _num_kernels_ is the size of memory pointed to by _kernels_ specified as the
-    number of cl_kernel entries.
+    number of {cl_kernel} entries.
   * _kernels_ is the buffer where the kernel objects for kernels in _program_
     will be returned.
     If _kernels_ is `NULL`, it is ignored.
@@ -7116,14 +7116,14 @@ include::{generated}/api/version-notes/clSetKernelArg.asciidoc[]
     declared by a kernel (see below).
   * _arg_size_ specifies the size of the argument value.
     If the argument is a memory object, the _arg_size_ value must be equal to 
-    `sizeof(cl_mem)`.
+    `sizeof({cl_mem})`.
     For arguments declared with the `local` qualifier, the size specified will
     be the size in bytes of the buffer that must be allocated for the `local`
     argument.
     If the argument is of type _sampler_t_, the _arg_size_ value must be equal
-    to `sizeof(cl_sampler)`.
+    to `sizeof({cl_sampler})`.
     If the argument is of type _queue_t_, the _arg_size_ value must be equal to
-    `sizeof(cl_command_queue)`.
+    `sizeof({cl_command_queue})`.
     For all other arguments, the size will be the size of argument type.
   * _arg_value_ is a pointer to data that should be used as the argument value
     for argument specified by _arg_index_.
@@ -7208,13 +7208,13 @@ memory or sampler objects specified as argument values by {clSetKernelArg}.
 Users may not rely on a kernel object to retain objects specified as
 argument values to the kernel.
 
-Implementations shall not allow cl_kernel objects to hold reference
-counts to cl_kernel arguments, because no mechanism is provided for the
+Implementations shall not allow {cl_kernel} objects to hold reference
+counts to {cl_kernel} arguments, because no mechanism is provided for the
 user to tell the kernel to release that ownership right.
 If the kernel holds ownership rights on kernel args, that would make it
 impossible for the user to tell with certainty when he may safely
 release user allocated resources associated with OpenCL objects such as
-the cl_mem backing store used with {CL_MEM_USE_HOST_PTR}.
+the {cl_mem} backing store used with {CL_MEM_USE_HOST_PTR}.
 ====
 
 // refError
@@ -7235,9 +7235,9 @@ Otherwise, it returns one of the following errors:
     This error code is <<unified-spec, missing before>> version 2.0.
   * {CL_INVALID_ARG_SIZE} if _arg_size_ does not match the size of the data
     type for an argument that is not a memory object or if the argument is a
-    memory object and _arg_size_ != `sizeof(cl_mem)` or if _arg_size_ is
+    memory object and _arg_size_ != `sizeof({cl_mem})` or if _arg_size_ is
     zero and the argument is declared with the local qualifier or if the
-    argument is a sampler and _arg_size_ != `sizeof(cl_sampler)`.
+    argument is a sampler and _arg_size_ != `sizeof({cl_sampler})`.
   * {CL_MAX_SIZE_RESTRICTION_EXCEEDED} if the size in bytes of the memory
     object (if the argument is a memory object) or _arg_size_ (if the
     argument is declared with `local` qualifier) exceeds a language-
@@ -7319,11 +7319,11 @@ include::{generated}/api/version-notes/clSetKernelExecInfo.asciidoc[]
 .List of supported param_names by <<clSetKernelExecInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_kernel_exec_info* | Type | Description
+| Kernel Exec Info | Type | Description
 | {CL_KERNEL_EXEC_INFO_SVM_PTRS_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_PTRS.asciidoc[]
-  | void *[]
+  | {void} *[]
       | SVM pointers must reference locations contained entirely within
         buffers that are passed to kernel as arguments, or that are passed
         through the execution information.
@@ -7335,7 +7335,7 @@ include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_PTRS.asciidoc[]
 | {CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM.asciidoc[]
-  | cl_bool
+  | {cl_bool}
       | This flag indicates whether the kernel uses pointers that are fine
         grain system SVM allocations.
         These fine grain system SVM pointers may be passed as arguments or
@@ -7435,7 +7435,7 @@ To clone a kernel object, call the function
 include::{generated}/api/protos/clCloneKernel.txt[]
 include::{generated}/api/version-notes/clCloneKernel.asciidoc[]
 
-  * _source_kernel_ is a valid cl_kernel object that will be copied.
+  * _source_kernel_ is a valid {cl_kernel} object that will be copied.
     _source_kernel_ will not be modified in any way by this function.
   * _errcode_ret_ will be assigned an appropriate error code.
     If _errcode_ret_ is `NULL`, no error code is returned.
@@ -7513,36 +7513,36 @@ include::{generated}/api/version-notes/clGetKernelInfo.asciidoc[]
 .List of supported param_names by <<clGetKernelInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_kernel_info* | Return Type | Info. returned in _param_value_
+| Kernel Info | Return Type | Info. returned in _param_value_
 | {CL_KERNEL_FUNCTION_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_FUNCTION_NAME.asciidoc[]
-  | char[]
+  | {char}[]
       | Return the kernel function name.
 | {CL_KERNEL_NUM_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_NUM_ARGS.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the number of arguments to kernel.
 | {CL_KERNEL_REFERENCE_COUNT_anchor}^16^
 
 include::{generated}/api/version-notes/CL_KERNEL_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the _kernel_ reference count.
 | {CL_KERNEL_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return the context associated with _kernel_.
 | {CL_KERNEL_PROGRAM_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PROGRAM.asciidoc[]
-  | cl_program
+  | {cl_program}
       | Return the program object associated with kernel.
 | {CL_KERNEL_ATTRIBUTES_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ATTRIBUTES.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns any attributes specified using the `+__attribute__+`
         OpenCL C qualifier (or using an OpenCL {cpp} qualifier syntax [[]] )
         with the kernel function declaration in the program source.
@@ -7617,11 +7617,11 @@ include::{generated}/api/version-notes/clGetKernelWorkGroupInfo.asciidoc[]
 .List of supported param_names by <<clGetKernelWorkGroupInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_kernel_work_group_info* | Return Type | Info. returned in _param_value_
+| Kernel Work Group Info | Return Type | Info. returned in _param_value_
 | {CL_KERNEL_GLOBAL_WORK_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_GLOBAL_WORK_SIZE.asciidoc[]
-  | size_t[3]
+  | {size_t}[3]
       | This provides a mechanism for the application to query the maximum
         global size that can be used to execute a kernel (i.e.
         _global_work_size_ argument to {clEnqueueNDRangeKernel}) on a custom
@@ -7634,7 +7634,7 @@ include::{generated}/api/version-notes/CL_KERNEL_GLOBAL_WORK_SIZE.asciidoc[]
 | {CL_KERNEL_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_WORK_GROUP_SIZE.asciidoc[]
-  | size_t
+  | {size_t}
       | This provides a mechanism for the application to query the maximum
         workgroup size that can be used to execute the kernel on a specific
         device given by device.
@@ -7650,7 +7650,7 @@ include::{generated}/api/version-notes/CL_KERNEL_WORK_GROUP_SIZE.asciidoc[]
 | {CL_KERNEL_COMPILE_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_COMPILE_WORK_GROUP_SIZE.asciidoc[]
-  | size_t[3]
+  | {size_t}[3]
       | Returns the work-group size specified in the kernel source or IL.
 
         If the work-group size is not specified in the kernel source or IL,
@@ -7658,7 +7658,7 @@ include::{generated}/api/version-notes/CL_KERNEL_COMPILE_WORK_GROUP_SIZE.asciido
 | {CL_KERNEL_LOCAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_LOCAL_MEM_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Returns the amount of local memory in bytes being used by a kernel.
         This includes local memory that may be needed by an implementation
         to execute the kernel, variables declared inside the kernel with the
@@ -7672,7 +7672,7 @@ include::{generated}/api/version-notes/CL_KERNEL_LOCAL_MEM_SIZE.asciidoc[]
 | {CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE.asciidoc[]
-  | size_t
+  | {size_t}
       | Returns the preferred multiple of work-group size for launch.
         This is a performance hint.
         Specifying a work-group size that is not a multiple of the value
@@ -7683,7 +7683,7 @@ include::{generated}/api/version-notes/CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTI
 | {CL_KERNEL_PRIVATE_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PRIVATE_MEM_SIZE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | Returns the minimum amount of private memory, in bytes, used by each
         work-item in the kernel.
         This value may include any private memory needed by an
@@ -7754,19 +7754,19 @@ Also see extension *cl_khr_subgroups*.
 .List of supported param_names by <<clGetKernelSubGroupInfo>>
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
-| *cl_kernel_sub_group_info* | Input Type | Return Type | Info. returned in _param_value_
+| Kernel Subgroup Info | Input Type | Return Type | Info. returned in _param_value_
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | size_t *
-      | size_t
+  | {size_t} *
+      | {size_t}
           | Returns the maximum sub-group size for this kernel.
             All sub-groups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.
 
-            The _input_value_ must be an array of size_t values
+            The _input_value_ must be an array of {size_t} values
             corresponding to the local work size parameter of the intended
             dispatch.
             The number of dimensions in the ND-range will be inferred from
@@ -7775,15 +7775,15 @@ Also see extension *cl_khr_subgroups*.
 
 include::{generated}/api/version-notes/CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | size_t *
-      | size_t
+  | {size_t} *
+      | {size_t}
           | Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
             same number of sub-groups.
 
-            The _input_value_ must be an array of size_t values
+            The _input_value_ must be an array of {size_t} values
             corresponding to the local work size parameter of the intended
             dispatch.
             The number of dimensions in the ND-range will be inferred from
@@ -7792,11 +7792,11 @@ Also see extension *cl_khr_subgroups*.
 
 include::{generated}/api/version-notes/CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | size_t
-      | size_t[]
+  | {size_t}
+      | {size_t}[]
           | Returns the local size that will generate the requested number
             of sub-groups for the kernel.
-            The output array must be an array of size_t values corresponding
+            The output array must be an array of {size_t} values corresponding
             to the local size parameter.
             Any returned work-group will have one dimension.
             Other dimensions inferred from the value specified for
@@ -7813,7 +7813,7 @@ Also see extension *cl_khr_subgroups*.
 include::{generated}/api/version-notes/CL_KERNEL_MAX_NUM_SUB_GROUPS.asciidoc[]
 Also see extension *cl_khr_subgroups*.
   | ignored
-      | size_t
+      | {size_t}
           | This provides a mechanism for the application to query the
             maximum number of sub-groups that may make up each work-group to
             execute a kernel on a specific device given by device.
@@ -7828,7 +7828,7 @@ Also see extension *cl_khr_subgroups*.
 include::{generated}/api/version-notes/CL_KERNEL_COMPILE_NUM_SUB_GROUPS.asciidoc[]
 Also see extension *cl_khr_subgroups*.
   | ignored
-      | size_t
+      | {size_t}
           | Returns the number of sub-groups per work-group specified in the kernel
             source or IL. If the sub-group count is not specified then 0 is returned.
 |====
@@ -7893,11 +7893,11 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
 .List of supported param_names by <<clGetKernelArgInfo>>
 [width="100%",cols="2,1,3",options="header"]
 |====
-| *cl_kernel_arg_info* | Return Type | Info. returned in _param_value_
+| Kernel Arg Info | Return Type | Info. returned in _param_value_
 | {CL_KERNEL_ARG_ADDRESS_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[]
-  | cl_kernel_arg_address_qualifier
+  | {cl_kernel_arg_address_qualifier}
       | Returns the address qualifier specified for the argument given by
         _arg_index_.
         This can be one of the following values:
@@ -7912,7 +7912,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[
 | {CL_KERNEL_ARG_ACCESS_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
-  | cl_kernel_arg_access_qualifier
+  | {cl_kernel_arg_access_qualifier}
       | Returns the access qualifier specified for the argument given by
         _arg_index_.
         This can be one of the following values:
@@ -7929,7 +7929,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
 | {CL_KERNEL_ARG_TYPE_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns the type name specified for the argument given by
         _arg_index_.
         The type name returned will be the argument type name as it was
@@ -7942,7 +7942,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
 | {CL_KERNEL_ARG_TYPE_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
-  | cl_kernel_arg_type_qualifier
+  | {cl_kernel_arg_type_qualifier}
       | Returns a bitfield describing one or more type qualifiers specified
         for the argument given by _arg_index_.
         The returned values can be:
@@ -7958,7 +7958,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
 | {CL_KERNEL_ARG_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
-  | char[]
+  | {char}[]
       | Returns the name specified for the argument given by _arg_index_.
 |====
 
@@ -8145,7 +8145,7 @@ Otherwise, it returns one of the following errors:
     deprecated by>> version 2.1.
   * {CL_INVALID_GLOBAL_WORK_SIZE} if any of the values specified in
     _global_work_size_[0], ... _global_work_size_[_work_dim_ - 1] exceed the
-    maximum value representable by size_t on the device on which the
+    maximum value representable by {size_t} on the device on which the
     kernel-instance will be enqueued.
   * {CL_INVALID_GLOBAL_OFFSET} if the value specified in _global_work_size_
     {plus} the corresponding values in _global_work_offset_ for any
@@ -8329,10 +8329,10 @@ include::{generated}/api/version-notes/clEnqueueNativeKernel.asciidoc[]
   * _num_mem_objects_ is the number of buffer objects that are passed in _args_.
   * _mem_list_ is a list of valid buffer objects, if _num_mem_objects_ > 0.
     The buffer object values specified in _mem_list_ are memory object handles
-    (`cl_mem` values) returned by {clCreateBuffer} or {clCreateBufferWithProperties},
+    (`{cl_mem}` values) returned by {clCreateBuffer} or {clCreateBufferWithProperties},
     or `NULL`.
   * _args_mem_loc_ is a pointer to appropriate locations that _args_ points to
-    where memory object handles (cl_mem values) are stored.
+    where memory object handles ({cl_mem} values) are stored.
     Before the user function is executed, the memory object handles are replaced
     by pointers to global memory.
   * _event_wait_list_, _num_events_in_wait_list_ and _event_ are as described in
@@ -8340,7 +8340,7 @@ include::{generated}/api/version-notes/clEnqueueNativeKernel.asciidoc[]
 
 The data pointed to by _args_ and _cb_args_ bytes in size will be copied and
 a pointer to this copied region will be passed to _user_func_.
-The copy needs to be done because the memory objects (cl_mem values) that
+The copy needs to be done because the memory objects ({cl_mem} values) that
 _args_ may contain need to be modified and replaced by appropriate pointers
 to global memory.
 When {clEnqueueNativeKernel} returns, the memory region pointed to by _args_
@@ -8629,29 +8629,29 @@ include::{generated}/api/version-notes/clGetEventInfo.asciidoc[]
 .List of supported param_names by <<clGetEventInfo>>
 [width="100%",cols="<30%,<33%,<37%",options="header"]
 |====
-| *cl_event_info* | Return Type | Info. returned in _param_value_
+| Event Info | Return Type | Info. returned in _param_value_
 | {CL_EVENT_COMMAND_QUEUE_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_QUEUE.asciidoc[]
-  | cl_command_queue
+  | {cl_command_queue}
       | Return the command-queue associated with _event_.
         For user event objects, a `NULL` value is returned.
 | {CL_EVENT_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_CONTEXT.asciidoc[]
-  | cl_context
+  | {cl_context}
       | Return the context associated with _event_.
 | {CL_EVENT_COMMAND_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_TYPE.asciidoc[]
-  | cl_command_type
+  | {cl_command_type}
       | Return the command type associated with _event_ as described in the
         <<event-command-type-table,Event Command Types>> table.
 
 | {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor}^19^
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciidoc[]
-  | cl_int
+  | {cl_int}
       | Return the execution status of the command identified by event.
         Valid values are:
 
@@ -8673,7 +8673,7 @@ include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciido
 | {CL_EVENT_REFERENCE_COUNT_anchor}^20^
 
 include::{generated}/api/version-notes/CL_EVENT_REFERENCE_COUNT.asciidoc[]
-  | cl_uint
+  | {cl_uint}
       | Return the _event_ reference count.
 |====
 
@@ -9029,7 +9029,7 @@ to the user event, it would be in principle no longer valid for the
 application to change the status of the event to unblock all the other
 machinery.
 As a result the waiting tasks will wait forever, and associated events,
-cl_mem objects, command queues and contexts are likely to leak.
+{cl_mem} objects, command queues and contexts are likely to leak.
 In-order command queues caught up in this deadlock may cease to do any work.
 ====
 
@@ -9378,18 +9378,18 @@ include::{generated}/api/version-notes/clGetEventProfilingInfo.asciidoc[]
 .List of supported param_names by <<clGetEventProfilingInfo>>
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
-| *cl_profiling_info* | Return Type | Info. returned in _param_value_
+| Event Profiling Info | Return Type | Info. returned in _param_value_
 | {CL_PROFILING_COMMAND_QUEUED_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_QUEUED.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event is enqueued in a
         command-queue by the host.
 | {CL_PROFILING_COMMAND_SUBMIT_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_SUBMIT.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event that has been
         enqueued is submitted by the host to the device associated with the
@@ -9397,21 +9397,21 @@ include::{generated}/api/version-notes/CL_PROFILING_COMMAND_SUBMIT.asciidoc[]
 | {CL_PROFILING_COMMAND_START_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_START.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event starts execution on
         the device.
 | {CL_PROFILING_COMMAND_END_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_END.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event has finished
         execution on the device.
 | {CL_PROFILING_COMMAND_COMPLETE_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_COMPLETE.asciidoc[]
-  | cl_ulong
+  | {cl_ulong}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event and any child
         commands enqueued by this command on the device have finished

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5745,7 +5745,7 @@ include::{generated}/api/version-notes/clSetProgramSpecializationConstant.asciid
     {clBuildProgram} until another call to {clSetProgramSpecializationConstant}
     changes it.
     If a specialization constant is a boolean constant, _spec_value_ should be a
-    pointer to a `cl_uchar` value.
+    pointer to a {cl_uchar} value.
     A value of zero will set the specialization constant to false; any other
     value will set it to true.
 

--- a/scripts/checklinks.py
+++ b/scripts/checklinks.py
@@ -64,12 +64,16 @@ if __name__ == "__main__":
             #   / = proto include
             fileunlinkedapi = sorted(list(set(re.findall(r"[^{\w<'/](cl[A-Z]\w+)\b[^'](?!.')", sourcetext))))
             fileunlinkedenums = sorted(list(set(re.findall("r[^{\w<](CL_\w+)", sourcetext))))
+            fileunlinkedtypes = sorted(list(set(re.findall("r[^{\w<](cl_\w+)", sourcetext))))
 
             if len(fileunlinkedapi) != 0:
                 print("unlinked APIs in " + filename + ":\n\t" + '\n\t'.join(fileunlinkedapi))
 
             if len(fileunlinkedenums) != 0:
                 print("unlinked enums in " + filename + ":\n\t" + '\n\t'.join(fileunlinkedenums))
+
+            if len(fileunlinkedtypes) != 0:
+                print("unlinked types in " + filename + ":\n\t" + '\n\t'.join(fileunlinkedtypes))
 
     linkswithoutanchors = sorted(list(links - anchors))
     anchorswithoutlinks = sorted(list(anchors - links))

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -135,8 +135,8 @@ if __name__ == "__main__":
                 # Create a variant of the name that precedes underscores with
                 # "zero width" spaces.  This causes some long names to be
                 # broken at more intuitive places.
-                htmlName = name.replace("_", "_<wbr>")
-                otherName = name.replace("_", "_&#8203;")
+                htmlName = name[:3] + name[3:].replace("_", "_<wbr>")
+                otherName = name[:3] + name[3:].replace("_", "_&#8203;")
 
                 # Example with link:
                 #
@@ -180,28 +180,73 @@ if __name__ == "__main__":
 
     for types in spec.findall('types'):
         for type in types.findall('type'):
+            addLink = False
+            name = ""
             category = type.get('category')
-            if category == 'struct':
+            if category == 'basetype':
                 name = type.get('name')
-                #print('found type: ' +name)
+            elif category == 'struct':
+                addLink = True
+                name = type.get('name')
+            elif category == 'define':
+                name = type.find('name').text
+            else:
+                continue
 
-                # Example without link:
-                #
-                # // clEnqueueNDRangeKernel
-                # :clEnqueueNDRangeKernel_label: pass:q[*clEnqueueNDRangeKernel*]
-                # :clEnqueueNDRangeKernel: <<clEnqueueNDRangeKernel,{clEnqueueNDRangeKernel_label}>>
-                linkFile.write('// ' + name + '\n')
-                linkFile.write(':' + name + '_label: pass:q[*' + name + '*]\n')
-                linkFile.write(':' + name + ': <<' + name + ',{' + name + '_label}>>\n')
-                linkFile.write('\n')
+            #print('found type: ' +name)
 
-                nolinkFile.write('// ' + name + '\n')
-                nolinkFile.write(':' + name + ': pass:q[`' + name + '`]\n')
-                nolinkFile.write('\n')
+            # Create a variant of the name that precedes underscores with
+            # "zero width" spaces.  This causes some long names to be
+            # broken at more intuitive places.
+            if name.endswith('_t'):
+                htmlName = name
+                otherName = name
+            else:
+                htmlName = name[:3] + name[3:].replace("_", "_<wbr>")
+                otherName = name[:3] + name[3:].replace("_", "_&#8203;")
 
-                numberOfTypes = numberOfTypes + 1
+            # Some types can have spaces in the name (such as unsigned char),
+            # but Asciidoctor attributes cannot.  So, replace spaces with
+            # underscores for the attribute name.
+            attribName = name.replace(" ", "_")
 
-    print('Found ' + str(numberOfTypes) + ' API struct types.')
+            # Example with link:
+            #
+            # // cl_image_desc
+            # :cl_image_desc_label: pass:q[`cl_image_desc`]
+            # :cl_image_desc: <<cl_image_desc,{cl_image_desc_label}>>
+            linkFile.write('// ' + name + '\n')
+            if addLink:
+                linkFile.write('ifdef::backend-html5[]\n')
+                linkFile.write(':' + attribName + '_label: pass:q[`' + htmlName + '`]\n')
+                linkFile.write('endif::[]\n')
+                linkFile.write('ifndef::backend-html5[]\n')
+                linkFile.write(':' + attribName + '_label: pass:q[`' + otherName + '`]\n')
+                linkFile.write('endif::[]\n')
+                linkFile.write(':' + attribName + ': <<' + name + ',{' + attribName + '_label}>>\n')
+            else:
+                linkFile.write('ifdef::backend-html5[]\n')
+                linkFile.write(':' + attribName + ': pass:q[`' + htmlName + '`]\n')
+                linkFile.write('endif::[]\n')
+                linkFile.write('ifndef::backend-html5[]\n')
+                linkFile.write(':' + attribName + ': pass:q[`' + otherName + '`]\n')
+                linkFile.write('endif::[]\n')
+            linkFile.write('\n')
+
+            # // cl_image_desc
+            # :cl_image_desc: pass:q[`cl_image_desc`]
+            nolinkFile.write('// ' + name + '\n')
+            nolinkFile.write('ifdef::backend-html5[]\n')
+            nolinkFile.write(':' + attribName + ': pass:q[`' + htmlName + '`]\n')
+            nolinkFile.write('endif::[]\n')
+            nolinkFile.write('ifndef::backend-html5[]\n')
+            nolinkFile.write(':' + attribName + ': pass:q[`' + otherName + '`]\n')
+            nolinkFile.write('endif::[]\n')
+            nolinkFile.write('\n')
+
+            numberOfTypes = numberOfTypes + 1
+
+    print('Found ' + str(numberOfTypes) + ' API types.')
 
     linkFile.write( GetFooter() )
     linkFile.close()


### PR DESCRIPTION
This change should be purely cosmetic.  It adds all API types to the attribute dictionary and uses them throughout the spec.  This provides two key benefits:

1. The API type formatting is consistent throughout the spec.
2. Long API types names, such as `cl_device_svm_capabilities`, wrap much more nicely in table cells via "zero width spaces" similar to long API enums.

This change is low priority but it would be nice to include it in the OpenCL 3.0 specs.