### PR TITLE
switch all OpenCL API and OpenCL C spec footnotes to asciidoctor syntax

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -24,6 +24,9 @@ include::config/attribs.txt[]
 // Formatting and links for API functions and enums.
 include::api/dictionary.asciidoc[]
 
+// External Footnotes
+include::api/footnotes.asciidoc[]
+
 <<<<
 
 include::copyrights.txt[]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -34,6 +34,9 @@ Khronos{R} OpenCL Working Group
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
 
+// External Footnotes
+include::c/footnotes.asciidoc[]
+
 <<<<
 
 include::copyrights.txt[]
@@ -220,7 +223,7 @@ The following table describes the list of built-in scalar data types.
 [cols=",",]
 |====
 | *Type*        | *Description*
-| `bool`^1^
+| `bool` footnote:[{fn-bool}]
     | A conditional data type which is either _true_ or _false_.
      The value _true_ expands to the integer constant 1 and the value
      _false_ expands to the integer constant 0.
@@ -236,15 +239,15 @@ The following table describes the list of built-in scalar data types.
     | A signed two's complement 32-bit integer.
 | `unsigned int`, `uint`
     | An unsigned 32-bit integer.
-| `long`^2x^
+| `long` footnote:long[{fn-long}]
     | A signed two's complement 64-bit integer.
-| `unsigned long`, `ulong`^2x^
+| `unsigned long`, `ulong` footnote:long[]
     | An unsigned 64-bit integer.
 | `float`
     | A 32-bit floating-point.
       The `float` data type must conform to the IEEE 754 single precision
       storage format.
-| `double`^2^
+| `double` footnote:[{fn-double}]
     | A 64-bit floating-point.
       The `double` data type must conform to the IEEE 754 double precision
       storage format.
@@ -252,17 +255,17 @@ The following table describes the list of built-in scalar data types.
     | A 16-bit floating-point.
       The `half` data type must conform to the IEEE 754-2008 half precision
       storage format.
-| `size_t`
-    | The unsigned integer type^3^ of the result of the `sizeof` operator.
-| `ptrdiff_t`
-    | A signed integer type^3^ that is the result of subtracting two
+| `size_t` footnote:size_t[{fn-size_t}]
+    | The unsigned integer type of the result of the `sizeof` operator.
+| `ptrdiff_t` footnote:size_t[]
+    | A signed integer type that is the result of subtracting two
       pointers.
-| `intptr_t`
-    | A signed integer type^3^ with the property that any valid pointer to
+| `intptr_t` footnote:size_t[]
+    | A signed integer type with the property that any valid pointer to
       `void` can be converted to this type, then converted back to pointer
       to `void`, and the result will compare equal to the original pointer.
-| `uintptr_t`
-    | An unsigned integer type^3^ with the property that any valid pointer
+| `uintptr_t` footnote:size_t[]
+    | An unsigned integer type with the property that any valid pointer
       to `void` can be converted to this type, then converted back to
       pointer to `void`, and the result will compare equal to the original
       pointer.
@@ -270,29 +273,6 @@ The following table describes the list of built-in scalar data types.
     | The `void` type comprises an empty set of values; it is an incomplete
       type that cannot be completed.
 |====
-
-[1] When any scalar value is converted to `bool`, the result is 0 if the
-value compares equal to 0; otherwise, the result is 1.
-
-// TODO: Renumber the footnotes from here onwards.
-[2x] The `long`, `unsigned long` and `ulong` scalar types are optional types
-for EMBEDDED profile devices that are supported if the value of the
-<<opencl-device-queries, `CL_DEVICE_EXTENSIONS` device query>>
-contains `+cles_khr_int64+`.
-An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature
-macro unconditionally for FULL profile devices, or for EMBEDDED profile
-devices that support these types.
-
-[2] The `double` scalar type is an optional type that is supported if the
-value of the <<opencl-device-queries, `CL_DEVICE_DOUBLE_FP_CONFIG` device
-query>> is not zero.
-If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_fp64+` feature macro.
-
-[3] These are 32-bit types if the value of the <<opencl-device-queries,
-`CL_DEVICE_ADDRESS_BITS` device query>> is 32-bits, and 64-bit types if the
-value of the query is 64-bits.
-
 
 Most built-in scalar data types are also declared as appropriate types in
 the OpenCL API (and header files) that can be used by an application.
@@ -391,25 +371,18 @@ write the `half` scalar or vector value to memory.
 
 
 [[built-in-vector-data-types]]
-=== Built-in Vector Data Types^4^
+=== Built-in Vector Data Types
 
 [open,refpage='vectorDataTypes',desc='Built-in Vector Data Types',type='freeform',spec='clang',anchor='built-in-vector-data-types',xrefs='alignmentOfDataTypes otherDataTypes reservedDataTypes scalarDataTypes']
 --
 
 The `char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned
 int`, `long`, `unsigned long`, and `float` vector data types are supported.
+footnote:[{fn-vector-types}]
 The vector data type is defined with the type name, i.e. `char`, `uchar`,
 `short`, `ushort`, `int`, `uint`, `long`, `ulong`, or `float`, followed by a
 literal value _n_ that defines the number of elements in the vector.
 Supported values of _n_ are 2, 3, 4, 8, and 16 for all vector data types.
-
-[4] Built-in vector data types are supported by the OpenCL implementation
-even if the underlying compute device does not support any or all of the
-vector data types.
-These are to be converted by the device compiler to appropriate instructions
-that use underlying built-in types supported natively by the compute device.
-Refer to Appendix B for a description of the order of the components of a
-vector type in memory.
 
 The following table describes the list of built-in vector data types.
 
@@ -430,30 +403,15 @@ The following table describes the list of built-in vector data types.
     | A vector of _n_ 32-bit signed two's complement integer values.
 | `uint__n__`
     | A vector of _n_ 32-bit unsigned integer values.
-| `long__n__`^5x^
+| `long__n__` footnote:long-vec[{fn-long-vec}]
     | A vector of _n_ 64-bit signed two's complement integer values.
-| `ulong__n__`^5x^
+| `ulong__n__` footnote:long-vec[]
     | A vector of _n_ 64-bit unsigned integer values.
 | `float__n__`
     | A vector of _n_ 32-bit floating-point values.
-| `double__n__`^5^
+| `double__n__` footnote:[{fn-double-vec}]
     | A vector of _n_ 64-bit floating-point values.
 |====
-
-// TODO include this footnote in the renumbering.
-[5x] The `long` and `ulong` vector types are optional types for
-EMBEDDED profile devices that are supported if the value of the
-<<opencl-device-queries, `CL_DEVICE_EXTENSIONS` device query>>
-contains `+cles_khr_int64+`.
-An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature
-macro unconditionally for FULL profile devices, or for EMBEDDED profile
-devices that support these types.
-
-[5] The `double` vector type is an optional type that is supported if the
-value of the <<opencl-device-queries, `CL_DEVICE_DOUBLE_FP_CONFIG` device
-query>> is not zero.
-If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_fp64+` feature macro.
 
 The built-in vector data types are also declared as appropriate types in the
 OpenCL API (and header files) that can be used by an application.
@@ -492,24 +450,24 @@ OpenCL.
 [cols=",",]
 |====
 | *Type* | *Description*
-| `image2d_t`
-    | A 2D image^6^.
-| `image3d_t`
-    | A 3D image^6^.
-| `image2d_array_t`
-    | A 2D image array^6^.
-| `image1d_t`
-    | A 1D image^6^.
-| `image1d_buffer_t`
-    | A 1D image created from a buffer object^6^.
-| `image1d_array_t`
-    | A 1D image array^6^.
-| `image2d_depth_t`
-    | A 2D depth image^6^.
-| `image2d_array_depth_t`
-    | A 2D depth image array^6^.
-| `sampler_t`
-    | A sampler type^6^.
+| `image2d_t` footnote:image-functions[{fn-image-functions}]
+    | A 2D image.
+| `image3d_t` footnote:image-functions[]
+    | A 3D image.
+| `image2d_array_t` footnote:image-functions[]
+    | A 2D image array.
+| `image1d_t` footnote:image-functions[]
+    | A 1D image.
+| `image1d_buffer_t` footnote:image-functions[]
+    | A 1D image created from a buffer object.
+| `image1d_array_t` footnote:image-functions[]
+    | A 1D image array.
+| `image2d_depth_t` footnote:image-functions[]
+    | A 2D depth image.
+| `image2d_array_depth_t` footnote:image-functions[]
+    | A 2D depth image array.
+| `sampler_t` footnote:image-functions[]
+    | A sampler type.
 | `queue_t`
     | A device command queue.
       This queue can only be used to enqueue commands from kernels executing
@@ -550,9 +508,6 @@ OpenCL.
       These flags are described in detail in the
       <<synchronization-functions, synchronization functions>> section.
 |====
-
-[6] Refer to the detailed description of the built-in
-<<image-read-and-write-functions,functions that use this type>>.
 
 [NOTE]
 ====
@@ -986,13 +941,9 @@ float2 *low = &vf.odd.lo;   // is illegal
 
 OpenCL C programs shall comply with the C99 type-based aliasing rules
 defined in <<C99-spec,section 6.5, item 7 of the C99 Specification>>.
-The OpenCL C built-in vector data types are considered aggregate^7^ types
-for the purpose of applying these aliasing rules.
-
-[7] That is, for the purpose of applying type-based aliasing rules, a
-built-in vector data type will be considered equivalent to the corresponding
-array type.
-
+The OpenCL C built-in vector data types are considered aggregate types
+footnote:[{fn-aggregate-types}] for the purpose of applying these
+aliasing rules.
 
 [[keywords]]
 === Keywords
@@ -1020,14 +971,13 @@ not be used otherwise.
 === Implicit Conversions
 
 Implicit conversions between scalar built-in types defined in
-<<table-builtin-scalar-types>> (except `void` and `half`^8^) are supported.
+<<table-builtin-scalar-types>> (except `void` and `half`
+footnote:[{fn-cl_khr_fp16}]) are supported.
 When an implicit conversion is done, it is not just a re-interpretation of
 the expression's value but a conversion of that value to an equivalent value
 in the new type.
 For example, the integer value 5 will be converted to the floating-point
 value 5.0.
-
-[8] Unless the *cl_khr_fp16* extension is supported and has been enabled.
 
 Implicit conversions from a scalar type to a vector type are allowed.
 In this case, the scalar may be subject to the usual arithmetic conversion
@@ -1045,7 +995,7 @@ Implicit conversions for pointer types follow the rules described in the
 
 Standard typecasts for built-in scalar data types defined in
 <<table-builtin-scalar-types>> will perform appropriate conversion (except
-`void` and `half`^9^).
+`void` and `half` footnote:[{fn-cl_khr_fp16}]).
 In the example below:
 
 [9] Unless the *cl_khr_fp16* extension is supported and has been enabled.
@@ -1213,17 +1163,10 @@ following table.
 |====
 
 By default, conversions to integer type use the `_rtz` (round toward zero)
-rounding mode and conversions to floating-point type^10^ use the default
-rounding mode.
+rounding mode and conversions to floating-point type
+footnote:[{fn-float-conversion-rounding}] use the default rounding mode.
 The only default floating-point rounding mode supported is round to nearest
 even i.e the default rounding mode will be `_rte` for floating-point types.
-
-[10] For conversions to floating-point format, when a finite source value
-exceeds the maximum representable finite floating-point destination value,
-the rounding mode will affect whether the result is the maximum finite
-floating-point value or infinity of same sign as the source value, per
-IEEE-754 rules for rounding.
-
 
 [[out-of-range-behavior]]
 ==== Out-of-Range Behavior and Saturated Conversions
@@ -1312,23 +1255,11 @@ data type in OpenCL.
 This is typically required when direct access to the bits in a
 floating-point type is needed, for example to mask off the sign bit or make
 use of the result of a vector <<operators-relational,relational operator>>
-on floating-point data^11^.
+on floating-point data footnote:[{fn-float-reinterpretation}].
 Several methods to achieve this (non-) conversion are frequently practiced
 in C, including pointer aliasing, unions and memcpy.
 Of these, only memcpy is strictly correct in C99.
 Since OpenCL does not provide *memcpy*, other methods are needed.
-
-[11] In addition, some other extensions to the C language designed to support
-particular vector ISA (e.g. AltiVec{trade}, CELL Broadband Engine{trade}
-Architecture) use such conversions in conjunction with swizzle operators to
-achieve type unconversion.
-So as to support legacy code of this type, *as_typen*() allows conversions
-between vectors of the same size but different numbers of elements, even
-though the behavior of this sort of conversion is not likely to be portable
-except to other OpenCL implementations for the same hardware architecture.
-AltiVec is a trademark of Motorola Inc.
-Cell Broadband Engine is a trademark of Sony Computer Entertainment, Inc.
-
 
 [[reinterpreting-types-using-unions]]
 ==== Reinterpreting Types Using Unions
@@ -1367,42 +1298,15 @@ u.d = 1.0;  // u.u contains 0x3ff00000 (big endian) or 0
 [open,refpage='as_typen',desc='Reinterpreting Types',type='freeform',spec='clang',anchor='reinterpreting-types-using-as_type-and-as_typen',xrefs='convert_T scalarDataTypes vectorDataTypes']
 --
 All data types described in <<table-builtin-scalar-types>> and
-<<table-builtin-vector-types>> (except `bool`, `half`^12^ and `void`) may be
-also reinterpreted as another data type of the same size using the
-*as_type*() operator for scalar data types and the *as_type__n__*()
-operator^13^ for vector data types.
+<<table-builtin-vector-types>> (except `bool`, `void`, and `half`
+footnote:[{fn-cl_khr_fp16}]) may be also reinterpreted as another data type of
+the same size using the *as_type*() operator for scalar data types and the
+*as_type__n__*() operator footnote:[{fn-reinterpret-vector-types}] for vector
+data types.
 When the operand and result type contain the same number of elements, the
 bits in the operand shall be returned directly without modification as the
 new type.
 The usual type promotion for function arguments shall not be performed.
-
-[12] Unless the *cl_khr_fp16* extension is supported and has been enabled.
-
-[13] While the union is intended to reflect the organization of data in
-memory, the *as_type*() and *as_type__n__*() constructs are intended to
-reflect the organization of data in register.
-The *as_type*() and *as_type__n__*() constructs are intended to compile to
-no instructions on devices that use a shared register file designed to
-operate on both the operand and result types.
-Note that while differences in memory organization are expected to largely
-be limited to those arising from endianness, the register based
-representation may also differ due to size of the element in register.
-(For example, an architecture may load a `char` into a 32-bit register, or a
-`char` vector into a SIMD vector register with fixed 32-bit element size.)
-If the element count does not match, then the implementation should pick a
-data representation that most closely matches what would happen if an
-appropriate result type operator was applied to a register containing data
-of the source type.
-If the number of elements matches, then the *as_type__n__*() should
-faithfully reproduce the behavior expected from a similar data type
-reinterpretation using memory/unions.
-So, for example if an implementation stores all single precision data as
-`double` in register, it should implement *as_int*(`float`) by first
-downconverting the `double` to single precision and then (if necessary)
-moving the single precision bits to a register suitable for operating on
-integer data.
-If data stored in different address spaces do not have the same endianness,
-then the "`dominant endianness`" of the device should prevail.
 
 For example, `*as_float*(0x3f800000)` returns `1.0f`, which is the value
 that the bit pattern `0x3f800000` has if viewed as an IEEE-754 single
@@ -1507,16 +1411,14 @@ For this purpose, the rank order defined as follows:
   . The rank of an integer type is greater than the rank of an integer type
     with less precision.
   . The rank of an unsigned integer type is *greater than* the rank of a
-    signed integer type with the same precision^14^.
+    signed integer type with the same precision
+    footnote:[{fn-integer-conversion-rank}].
   . The rank of the bool type is less than the rank of any other type.
   . The rank of an enumerated type shall equal the rank of the compatible
     integer type.
   . For all types, `T1`, `T2` and `T3`, if `T1` has greater rank than `T2`,
     and `T2` has greater rank than `T3`, then `T1` has greater rank than
     `T3`.
-
-[14] This is different from the standard integer conversion rank described in
-<<C99-spec,section 6.3.1.1 of the C99 Specification>>
 
 Otherwise, if all operands are scalar, the usual arithmetic conversions
 apply, per <<C99-spec,section 6.3.1.8 of the C99 Specification>>.
@@ -1621,7 +1523,7 @@ vector types.
 --
 The arithmetic post- and pre-increment and decrement operators (*--* and
 *++*) operate on built-in scalar and vector types except the built-in scalar
-and vector `float` types^15^.
+and vector `float` types footnote:[{fn-float-increment-decrement}].
 All unary operators work component-wise on their operands.
 These result with the same type they operated on.
 For post- and pre-increment and decrement, the expression must be one that
@@ -1633,16 +1535,6 @@ Post-increment and post-decrement expressions add or subtract 1 to the
 contents of the expression they operate on, but the resulting expression has
 the expression's value before the post-increment or post-decrement was
 executed.
-
-[15] The pre- and post- increment operators may have unexpected behavior on
-floating-point values and are therefore not supported for floating-point
-scalar and vector built-in types.
-For example, if variable _a_ has type `float` and holds the value
-`0x1.0p25f`, then `_a_{pp}` returns `0x1.0p25f`.
-Also, `(_a_{pp})--` is not guaranteed to return _a_, if _a_ has fractional
-value.
-In non-default rounding modes, `(_a_{pp})--` may produce the same result as
-`_a_{pp}` or `_a_--` for large _a_.
 --
 
 
@@ -1651,15 +1543,11 @@ In non-default rounding modes, `(_a_{pp})--` may produce the same result as
 
 [open,refpage='relationalOperators',desc='Relational Operators',type='freeform',spec='clang',anchor='operators-relational',xrefs='operators']
 --
-The relational operators^16^ greater than (*>*), less than (*<*), greater
-than or equal (*>=*), and less than or equal (*\<=*) operate on scalar and
-vector types.
+The relational operators greater than (*>*), less than (*<*), greater than or
+equal (*>=*), and less than or equal (*\<=*) operate on scalar and vector types
+footnote:[{fn-relational-any-all}].
 All relational operators result in an integer type.
 After operand type conversion, the following cases are valid:
-
-[16] To test whether any or all elements in the result of a vector relational
-operator test _true_, for example to use in the context in an *if ( )*
-statement, please see the <<relational-functions,*any* and *all* built-ins>>.
 
   * The two operands are scalars.
     In this case, the operation is applied, resulting in an `int` scalar.
@@ -1699,14 +1587,10 @@ The relational operators always return 0 if either argument is not a number
 
 [open,refpage='equalityOperators',desc='Equality Operators',type='freeform',spec='clang',anchor='operators-equality',xrefs='operators']
 --
-The equality operators^17^ equal (*==*) and not equal (*!=*) operate on
-built-in scalar and vector types.
+The equality operators equal (*==*) and not equal (*!=*) operate on
+built-in scalar and vector types footnote:[{fn-relational-any-all}].
 All equality operators result in an integer type.
 After operand type conversion, the following cases are valid:
-
-[17] To test whether any or all elements in the result of a vector equality
-operator test true, for example to use in the context in an *if ( )*
-statement, please see the <<relational-functions,*any* and *all* built-ins>>.
 
   * The two operands are scalars.
     In this case, the operation is applied, resulting in a scalar.
@@ -1867,15 +1751,12 @@ For the right-shift (*>>*), left-shift (*<<*) operators, the rightmost
 operand must be a scalar if the first operand is a scalar, and the rightmost
 operand can be a vector or scalar if the first operand is a vector.
 
-The result of `E1` *<<* `E2` is `E1` left-shifted by log~2~(N) least
-significant bits in `E2` viewed as an unsigned integer value, where N is the
-number of bits used to represent the data type of `E1` after integer
-promotion^18^, if `E1` is a scalar, or the number of bits used to represent
-the type of `E1` elements, if `E1` is a vector.
+The result of `E1` *<<* `E2` is `E1` left-shifted by log~2~(N) least significant
+bits in `E2` viewed as an unsigned integer value, where N is the number of bits
+used to represent the data type of `E1` after integer promotion
+footnote:[{fn-integer-promotion}], if `E1` is a scalar, or the number of bits
+used to represent the type of `E1` elements, if `E1` is a vector.
 The vacated bits are filled with zeros.
-
-[18] Integer promotion is described in <<C99-spec,section 6.3.1.1 of the C99
-Specification>>.
 
 The result of `E1` *>>* `E2` is `E1` right-shifted by log~2~(N) least
 significant bits in `E2` viewed as an unsigned integer value, where N is the
@@ -1899,12 +1780,10 @@ any <<alignment-of-types,padding bytes needed for alignment>>, which may be
 an expression or the parenthesized name of a type.
 The size is determined from the type of the operand.
 The result is of type `size_t`.
-If the type of the operand is a variable length array^19^ type, the operand
-is evaluated; otherwise, the operand is not evaluated and the result is an
-integer constant.
-
-[19] Variable length arrays are <<restrictions-variable-length,not supported
-in OpenCL C>>.
+If the type of the operand is a variable length array
+footnote:[{fn-variable-length-array-restriction}] type, the operand is
+evaluated; otherwise, the operand is not evaluated and the result is an integer
+constant.
 
 When applied to an operand that has type `char` or `uchar`, the result is 1.
 When applied to an operand that has type `short`, `ushort`, or `half` the
@@ -1913,8 +1792,8 @@ When applied to an operand that has type `int`, `uint` or `float`, the
 result is 4.
 When applied to an operand that has type `long`, `ulong` or `double`, the
 result is 8.
-When applied to an operand that is a vector type, the result^20^ is number of
-components times the size of each scalar component.
+When applied to an operand that is a vector type, the result is the number of
+components times the size of each scalar component footnote:[{fn-vec3-size}].
 When applied to an operand that has array type, the result is the total
 number of bytes in the array.
 When applied to an operand that has structure or union type, the result is
@@ -1922,13 +1801,8 @@ the total number of bytes in such an object, including internal and trailing
 padding.
 The `sizeof` operator shall not be applied to an expression that has
 function type or an incomplete type, to the parenthesized name of such a
-type, or to an expression that designates a bit-field struct member^21^.
-
-[20] Except for 3-component vectors whose size is defined as 4 times the size
-of each scalar component.
-
-[21] Bit-field struct members are <<restrictions-bitfield, not supported in
-OpenCL C>>.
+type, or to an expression that designates a bit-field struct member
+footnote:[{fn-bitfield-struct-restriction}].
 
 The behavior of applying the `sizeof` operator to the `bool`, `image2d_t`,
 `image3d_t`, `image2d_array_t`, `image1d_t`, `image1d_buffer_t`,
@@ -1959,15 +1833,8 @@ If the operand points to an object, the result is an l-value designating the
 object.
 If the operand has type "pointer to __type__", the result has type
 "__type__".
-If an invalid value has been assigned to the pointer, the behavior of the
-unary *+*+* operator is undefined^22^.
-
-[22] Among the invalid values for dereferencing a pointer by the unary *+*+*
-operator are a null pointer, an address inappropriately aligned for the type
-of object pointed to, and the address of an object after the end of its
-lifetime.
-If *+*P+* is an l-value and *T* is the name of an object pointer type, *+*(T)P+*
-is an l-value that has a type compatible with that to which *T* points.
+If an invalid value has been assigned to the pointer, the behavior of the unary
+*+*+* operator is undefined footnote:[{fn-pointer-invalid-value-indirection}].
 --
 
 
@@ -1988,12 +1855,7 @@ operator nor the unary *+*+* that is implied by the *[]* is evaluated and the
 result is as if the *&* operator were removed and the *[]* operator were
 changed to a *+* operator.
 Otherwise, the result is a pointer to the object designated by its
-operand^23^.
-
-[23] Thus, *&*E* is equivalent to *E* (even if *E* is a null pointer), and
-*&(E1[E2])* is equivalent to *\((E1) {plus} (E2))*.
-It is always true that if *E* is an l-value that is a valid operand of the
-unary *&* operator, *+*&E+* is an l-value equal to *E*.
+operand footnote:[{fn-address-operator-result}].
 --
 
 
@@ -2943,24 +2805,16 @@ qualifiers and shall not be used otherwise.
 The `+__kernel+` qualifier can be used with the keyword __attribute__ to
 declare additional information about the kernel function as described below.
 
-The optional `+__attribute__((vec_type_hint(<type>)))+`^24^ is a hint to the
-compiler and is intended to be a representation of the computational _width_
-of the `+__kernel+`, and should serve as the basis for calculating processor
-bandwidth utilization when the compiler is looking to autovectorize the
-code.
+The optional `+__attribute__((vec_type_hint(<type>)))+`
+footnote:[{fn-vec-type-hint}] is a hint to the compiler and is intended to be a
+representation of the computational _width_ of the `+__kernel+`, and should
+serve as the basis for calculating processor bandwidth utilization when the
+compiler is looking to autovectorize the code.
 In the `+__attribute__((vec_type_hint(<type>)))+` qualifier <type> is one of
 the built-in vector types listed in <<table-builtin-vector-types>> or the
 constituent scalar element types.
 If `vec_type_hint (<type>)` is not specified, the kernel is assumed to have
 the `+__attribute__((vec_type_hint(int)))+` qualifier.
-
-[24] Implicit in autovectorization is the assumption that any libraries
-called from the `+__kernel+` must be recompilable at run time to handle
-cases where the compiler decides to merge or separate workitems.
-This probably means that such libraries can never be hard coded binaries or
-that hard coded binaries must be accompanied either by source or some
-retargetable intermediate representation.
-This may be a code security question for some.
 
 For example, where the developer specified a width of `float4`, the compiler
 should assume that the computation usually uses up to 4 lanes of a `float`
@@ -3173,9 +3027,9 @@ address space qualifiers.
     addition can also be different for the OpenCL device and the host
     processor making it difficult to allocate buffer objects to be passed as
     arguments to a kernel declared as pointer to these types.
-  . `half` is not supported as `half` can be used as a storage format^25^
-    only and is not a data type on which floating-point arithmetic can be
-    performed.
+  . `half` is not supported as `half` can be used as a storage format
+    footnote:[{fn-cl_khr_fp16}] only and is not a data type on which
+    floating-point arithmetic can be performed.
   . Whether or not irreducible control flow is illegal is implementation
     defined.
 // Relaxed in OpenCL C 1.1, or the cl_khr_byte_addressable_store extension.
@@ -3228,8 +3082,6 @@ address space qualifiers.
     are a pointer to a type declared to point to a named address space.
   . A function in an OpenCL program cannot be called `main`.
   . Implicit function declaration is not supported.
-
-[25] Unless the *cl_khr_fp16* extension is supported and has been enabled.
 --
 
 
@@ -3834,20 +3686,14 @@ information provided is in some sense correct.
 NOTE: The functionality described in this section requires support for
 OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature.
 
-This section describes the clang block syntax^26^.
+This section describes the clang block syntax
+footnote:[{fn-clang-block-syntax}].
 
 Like function types, the Block type is a pair consisting of a result value
 type and a list of parameter types very similar to a function type.
 Blocks are intended to be used much like functions with the key distinction
 being that in addition to executable code they also contain various variable
 bindings to automatic (stack) or `global` memory.
-
-[26] This syntax is already part of the clang source tree on which most
-vendors have based their OpenCL implementations.
-Additionally, blocks based closures are supported by the clang open source C
-compiler as well as Mac OS X's C and Objective C compilers.
-Specifically, Mac OS X's Grand Central Dispatch allows applications to queue
-tasks as a block.
 --
 
 
@@ -4029,17 +3875,9 @@ The following Blocks features are currently not supported in OpenCL C.
 
 Block literals are assumed to allocate memory at the point of definition and
 to be destroyed at the end of the same scope.
-To support these behaviors, additional restrictions^27^ in addition to the
-above feature restrictions are:
-
-[27] OpenCL C <<restrictions,does not allow function pointers>> primarily
-because it is difficult or expensive to implement generic indirections to
-executable code in many hardware architectures that OpenCL targets.
-OpenCL C's design of Blocks is intended to respect that same condition,
-yielding the restrictions listed here.
-As such, Blocks allow a form of dynamically enqueued function scheduling
-without providing a form of runtime synchronous dynamic dispatch analogous
-to function pointers.
+To support these behaviors, additional restrictions
+footnote:[{fn-clang-block-function-pointers}] in addition to the above feature
+restrictions are:
 
   * Block variables must be defined and used in a way that allows them to be
     statically determinable at build or "`link to executable`" time.
@@ -4229,9 +4067,10 @@ identifier of each work-item when this kernel is being executed on a device.
       argument to *clEnqueueNDRangeKernel* if _local_work_size_ is not
       `NULL`; otherwise the OpenCL implementation chooses an appropriate
       _local_work_size_ value which is returned by this function.
-      If the kernel is executed with a non-uniform work-group size^28^, calls
-      to this built-in from some work-groups may return different values
-      than calls to this built-in from other work-groups.
+      If the kernel is executed with a non-uniform work-group size
+      footnote:[{fn-non-uniform-work-groups}], calls to this built-in from some
+      work-groups may return different values than calls to this built-in from
+      other work-groups.
 
       Valid values of _dimindx_ are 0 to *get_work_dim*() - 1.
       For other values of _dimindx_, *get_local_size*() returns 1.
@@ -4307,9 +4146,6 @@ identifier of each work-item when this kernel is being executed on a device.
       (*get_local_id*(2) * *get_local_size*(1) * *get_local_size*(0)) {plus}
       (*get_local_id*(1) * *get_local_size*(0)) {plus} *get_local_id*(0).
 |====
-
-[28] I.e. the _global_work_size_ values specified to *clEnqueueNDRangeKernel*
-are not evenly divisible by the _local_work_size_ values for each dimension.
 
 NOTE: The functionality described in the following table requires support for
 the `+__opencl_c_subgroups+` feature.
@@ -4392,21 +4228,18 @@ if called with the round to nearest even rounding mode.
 
 The <<table-builtin-math, following table>> describes the list of built-in
 math functions that can take scalar or vector arguments.
-We use the generic type name `gentype` to indicate that the function can
-take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`^d01^,
-`double2`, `double3`, `double4`, `double8` or `double16` as the type for the
-arguments.
+We use the generic type name `gentype` to indicate that the function can take
+`float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`
+footnote:double-precision-supported[{fn-double-precision-supported}], `double2`,
+`double3`, `double4`, `double8` or `double16` as the type for the arguments.
 We use the generic type name `gentypef` to indicate that the function can
 take `float`, `float2`, `float3`, `float4`, `float8`, or `float16` as the
 type for the arguments.
-We use the generic type name `gentyped`^d01^ to indicate that the function can
-take `double`, `double2`, `double3`, `double4`, `double8` or `double16` as
-the type for the arguments.
+We use the generic type name `gentyped` footnote:double-precision-supported[] to
+indicate that the function can take `double`, `double2`, `double3`, `double4`,
+`double8` or `double16` as the type for the arguments.
 For any specific use of a function, the actual type has to be the same for
 all arguments and the return type, unless otherwise specified.
-
-[d01] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-builtin-math]]
 .Built-in Scalar and Vector Argument Math Functions
@@ -4480,16 +4313,17 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
     | Returns _y_ if _x_ < _y_, otherwise it returns _x_.
       If one argument is a NaN, *fmax*() returns the other argument.
       If both arguments are NaNs, *fmax*() returns a NaN.
-| gentype *fmin*^29^(gentype _x_, gentype _y_) +
+| gentype *fmin*(gentype _x_, gentype _y_) +
   gentypef *fmin*(gentypef _x_, float _y_) +
   gentyped *fmin*(gentyped _x_, double _y_)
     | Returns _y_ if _y_ < _x_, otherwise it returns _x_.
       If one argument is a NaN, *fmin*() returns the other argument.
       If both arguments are NaNs, *fmin*() returns a NaN.
+      footnote:[{fn-fmin-fmax-nan}]
 | gentype *fmod*(gentype _x_, gentype _y_)
     | Modulus.
       Returns _x_ - _y_ * *trunc*(_x_/_y_).
-| gentype *fract*(gentype _x_, {global} gentype _*iptr_)^30^ +
+| gentype *fract*(gentype _x_, {global} gentype _*iptr_) +
   gentype *fract*(gentype _x_, {local} gentype _*iptr_) +
   gentype *fract*(gentype _x_, {private} gentype _*iptr_) +
 
@@ -4499,6 +4333,7 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
   gentype *fract*(gentype _x_, gentype _*iptr_)
     | Returns *fmin*(_x_ - *floor*(_x_), `0x1.fffffep-1f`).
       *floor*(x) is returned in _iptr_.
+      footnote:[{fn-fract-min}]
 | float__n__ **frexp**(float__n__ _x_, {global} int__n__ *exp) +
   float **frexp**(float _x_, {global} int *exp) +
 
@@ -4595,7 +4430,8 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
     The function may compute _a_ * _b_ + _c_ with reduced accuracy
     in the embedded profile.  See the OpenCL SPIR-V Environment Specification
     for details. On some hardware the mad instruction may provide better
-    performance than expanded computation of _a_ * _b_ + _c_.^31^
+    performance than expanded computation of _a_ * _b_ + _c_.
+    footnote:[{fn-mad-caution}]
 | gentype *maxmag*(gentype _x_, gentype _y_)
     | Returns _x_ if \|_x_\| > \|_y_\|, _y_ if \|_y_\| > \|_x_\|, otherwise
       *fmax*(_x_, _y_).
@@ -4730,10 +4566,6 @@ indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 | gentype *trunc*(gentype)
     | Round to integral value using the round to zero rounding mode.
 |====
-
-[29] *fmin* and *fmax* behave as defined by C99 and may not match the IEEE
-754-2008 definition for *minNum* and *maxNum* with regard to signaling NaNs.
-Specifically, signaling NaNs may behave as quiet NaNs.
 
 [30] The *min*() operator is there to prevent *fract*(-small) from returning
 1.0.
@@ -5080,11 +4912,12 @@ functions that take scalar or vector arguments.
 The vector versions of the integer functions operate component-wise.
 The description is per-component.
 
-We use the generic type name `gentype` to indicate that the function can
-take `char`, `char{2|3|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`,
-`short{2|3|4|8|16}`, `ushort`, `ushort{2|3|4|8|16}`, `int`,
-`int{2|3|4|8|16}`, `uint`, `uint{2|3|4|8|16}`, `long`, `long{2|3|4|8|16}
-ulong`^l00^, or `ulong{2|3|4|8|16}` as the type for the arguments.
+We use the generic type name `gentype` to indicate that the function can take
+`char`, `char{2|3|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`,
+`short{2|3|4|8|16}`, `ushort`, `ushort{2|3|4|8|16}`, `int`, `int{2|3|4|8|16}`,
+`uint`, `uint{2|3|4|8|16}`, `long` footnote:[{fn-int64-supported}],
+`long{2|3|4|8|16}`, `ulong`, or `ulong{2|3|4|8|16}` as the type for the
+arguments.
 We use the generic type name `ugentype` to refer to unsigned versions of
 `gentype`.
 For example, if `gentype` is `char4`, `ugentype` is `uchar4`.
@@ -5102,9 +4935,6 @@ described for <<operators-arithmetic,arithmetic operators>>.
 For any specific use of a function, the actual type has to be the same for
 all arguments and the return type unless otherwise specified.
 
-[l00] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
 [[table-builtin-functions]]
 .Built-in Scalar and Vector Integer Argument Functions
 [cols=",",]
@@ -5119,9 +4949,10 @@ indicated by the presence of the `+__opencl_c_int64+` feature macro.
 | gentype *hadd*(gentype _x_, gentype _y_)
     | Returns (_x_ + _y_) >> 1.
       The intermediate sum does not modulo overflow.
-| gentype *rhadd*(gentype _x_, gentype _y_)^32^
+| gentype *rhadd*(gentype _x_, gentype _y_)
     | Returns (_x_ + _y_ + 1) >> 1.
       The intermediate sum does not modulo overflow.
+      footnote:[{fn-rhadd-benefit}]
 | gentype *clamp*(gentype _x_, gentype _minval_, gentype _maxval_) +
   gentype *clamp*(gentype _x_, sgentype _minval_, sgentype _maxval_)
     | Returns *min*(*max*(_x_, _minval_), _maxval_).
@@ -5177,12 +5008,6 @@ indicated by the presence of the `+__opencl_c_int64+` feature macro.
 | gentype *popcount*(gentype _x_)
     | Returns the number of non-zero bits in _x_.
 |====
-
-[32] Frequently vector operations need n + 1 bits temporarily to calculate a
-result.
-The *rhadd* instruction gives you an extra bit without needing to upsample
-and downsample.
-This can be a profound performance win.
 
 The following table describes fast integer functions that can be used for
 optimizing performance of kernels.
@@ -5268,10 +5093,7 @@ the application.
 
 
 [[common-functions]]
-=== Common Functions^33^
-
-[33] The *mix* and *smoothstep* functions can be implemented using
-contractions such as *mad* or *fma*.
+=== Common Functions
 
 [open,refpage='commonFunctions',desc='Common Functions',type='freeform',spec='clang',anchor='common-functions',xrefs='integerFunctions',alias='commonClamp degrees commonMax commonMin mix radians sign smoothstep step']
 --
@@ -5279,10 +5101,10 @@ The <<table-builtin-common, following table>> describes the list of built-in
 common functions.
 These all operate component-wise.
 The description is per-component.
-We use the generic type name `gentype` to indicate that the function can
-take `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`^d02^,
-`double2`, `double3`, `double4`, `double8` or `double16` as the type for the
-arguments.
+We use the generic type name `gentype` to indicate that the function can take
+`float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`
+footnote:[{fn-double-precision-supported}], `double2`, `double3`, `double4`,
+`double8` or `double16` as the type for the arguments.
 We use the generic type name `gentypef` to indicate that the function can
 take `float`, `float2`, `float3`, `float4`, `float8`, or `float16` as the
 type for the arguments.
@@ -5290,11 +5112,10 @@ We use the generic type name `gentyped` to indicate that the function can
 take `double`, `double2`, `double3`, `double4`, `double8` or `double16` as
 the type for the arguments.
 
-[d02] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
-
 The built-in common functions are implemented using the round to nearest
 even rounding mode.
+The built-in common functions may be implemented using contractions such
+as *mad* or *fma*.
 
 [[table-builtin-common]]
 .Built-in Scalar and Vector Argument Common Functions
@@ -5354,6 +5175,7 @@ return t * t * (3 - 2 * t);
 
 Results are undefined if _edge0_ >= _edge1_ or if _x_, _edge0_ or _edge1_ is
 a NaN.
+
 | gentype *sign*(gentype _x_)
     | Returns 1.0 if _x_ > 0, -0.0 if _x_ = -0.0, +0.0 if _x_ = +0.0, or
       -1.0 if _x_ < 0.
@@ -5364,10 +5186,7 @@ a NaN.
 
 
 [[geometric-functions]]
-=== Geometric Functions^34^
-
-[34] The geometric functions can be implemented using contractions such as
-*mad* or *fma*.
+=== Geometric Functions
 
 [open,refpage='geometricFunctions',desc='Geometric Functions',type='freeform',spec='clang',anchor='geometric-functions',xrefs='integerFunctions',alias='cross dot distance length normalize fast_distance fast_length fast_normalize']
 --
@@ -5376,13 +5195,14 @@ The <<table-builtin-geometric, following table>> describes the list of built-in
 geometric functions.
 These all operate component-wise.
 The description is per-component.
-`float__n__` is `float`, `float2`, `float3`, or `float4` and `double__n__`
-is `double`^d03^, `double2`, `double3`, or `double4`.
+`float__n__` is `float`, `float2`, `float3`, or `float4` and `double__n__` is
+`double` footnote:[{fn-double-precision-supported}], `double2`, `double3`, or
+`double4`.
+
 The built-in geometric functions are implemented using the round to nearest
 even rounding mode.
-
-[d03] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
+The built-in geometric functions may be implemented using contractions such
+as *mad* or *fma*.
 
 [[table-builtin-geometric]]
 .Built-in Scalar and Vector Argument Geometric Functions
@@ -5458,32 +5278,22 @@ operators (*<*, *\<=*, *>*, *>=*, *!=*, *==*) can be used with scalar and
 vector built-in types and produce a scalar or vector signed integer result
 respectively.
 
-The functions^35^ described in the <<table-builtin-relational, following
-table>> can be used with built-in scalar or vector types as arguments and
-return a scalar or vector integer result.
+The functions described in the <<table-builtin-relational, following table>> can
+be used with built-in scalar or vector types as arguments and return a scalar or
+vector integer result footnote:[{fn-floating-point-exception-nans}].
 The argument type `gentype` refers to the following built-in types: `char`,
 `char__n__`, `uchar`, `uchar__n__`, `short`, `short__n__`, `ushort`,
-`ushort__n__`, `int`, `int__n__`, `uint`, `uint__n__`, `long`^l01^,
-`long__n__`, `ulong`, `ulong__n__`, `float`, `float__n__`, `double`^d04^, and
+`ushort__n__`, `int`, `int__n__`, `uint`, `uint__n__`, `long`
+footnote:[{fn-int64-supported}], `long__n__`, `ulong`, `ulong__n__`, `float`,
+`float__n__`, `double` footnote:[{fn-double-precision-supported}], and
 `double__n__`.
 The argument type `igentype` refers to the built-in signed integer types
 i.e. `char`, `char__n__`, `short`, `short__n__`, `int`, `int__n__`, `long`
 and `long__n__`.
 The argument type `ugentype` refers to the built-in unsigned integer types
 i.e. `uchar`, `uchar__n__`, `ushort`, `ushort__n__`, `uint`, `uint__n__`,
-`ulong`^l01^ and `ulong__n__`.
+`ulong` and `ulong__n__`.
 _n_ is 2, 3, 4, 8, or 16.
-
-[35] If an implementation extends this specification to support IEEE-754
-flags or exceptions, then all built-in functions defined in the following
-table shall proceed without raising the _invalid_ floating-point exception
-when one or more of the operands are NaNs.
-
-[l01] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[d04] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 The functions *isequal*, *isnotequal*, *isgreater*, *isgreaterequal*,
 *isless*, *islessequal*, *islessgreater*, *isfinite*, *isinf*, *isnan*,
@@ -5602,7 +5412,7 @@ Scalar inputs to *all* are deprecated by OpenCL C version 3.0.
    | Each bit of the result is the corresponding bit of _a_ if the
      corresponding bit of _c_ is 0.
      Otherwise it is the corresponding bit of _b_.
-| gentype **select**(gentype _a_, gentype _b_, igentype _c_)
+| gentype **select**(gentype _a_, gentype _b_, igentype _c_) +
   gentype **select**(gentype _a_, gentype _b_, ugentype _c_)
     | For each component of a vector type,
 
@@ -5611,12 +5421,8 @@ Scalar inputs to *all* are deprecated by OpenCL C version 3.0.
       For a scalar type, _result_ = _c_ ? _b_ : _a_.
 
       `igentype` and `ugentype` must have the same number of elements and
-      bits as `gentype`^36^.
+      bits as `gentype` footnote:[{fn-select-vs-ternary}].
 |====
-
-[36] The above definition means that the behavior of select and the ternary
-operator for vector and scalar types is dependent on different
-interpretations of the bit pattern of _c_.
 --
 
 
@@ -5630,26 +5436,18 @@ The <<table-vector-loadstore, following table>> describes the list of supported
 functions that allow you to read and write vector types from a pointer to
 memory.
 We use the generic type `gentype` to indicate the built-in data types
-`char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`^l02^, `ulong`,
-`float` or `double`^d05^.
+`char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long` footnote:[{fn-int64-supported}], `ulong`,
+`float` or `double` footnote:[{fn-double-precision-supported}].
 We use the generic type name `gentype__n__` to represent n-element vectors
 of `gentype` elements.
 We use the type name `half__n__` to represent n-element vectors of half
-elements^37^.
+elements.
 The suffix _n_ is also used in the function names (i.e. *vload__n__*,
-*vstore__n__* etc.), where _n_ = 2, 3, 4, 8 or 16.
-
-[l02] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[d05] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
-
-[37] The `half__n__` type is only defined by the *cl_khr_fp16* extension
-described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
+*vstore__n__* etc.), where _n_ = 2, 3 footnote:[{fn-vec3-vload-vstore}], 4, 8 or
+16.
 
 [[table-vector-loadstore]]
-.Built-in Vector Data Load and Store Functions^38^
+.Built-in Vector Data Load and Store Functions
 [cols="7,3",]
 |====
 | *Function* | *Description*
@@ -5951,19 +5749,6 @@ described in the <<opencl-extension-spec,OpenCL Extension Specification>>.
       The default rounding mode is round to nearest even.
 |====
 
-[38] *vload3* and *vload_half3* read (_x_,_y_,_z_) components from address
-`(_p_ + (_offset_ * 3))` into a 3-component vector.
-*vstore3* and *vstore_half3* write (_x_,_y_,_z_) components from a
-3-component vector to address `(_p_ + (_offset_ * 3))`. In addition,
-*vloada_half3* reads (_x_,_y_,_z_) components from address
-`(_p_ + (_offset_ * 4))` into a 3-component vector and *vstorea_half3*
-writes (_x_,_y_,_z_) components from a 3-component vector to address `(_p_
-{plus} (_offset_ * 4))`.  Whether *vloada_half3* and *vstorea_half3* read/write
-padding data between the third vector element and the next alignment boundary is
-implementation defined.  *vloada_* and *vstorea_* variants are provided to access
-data that is aligned to the size of the vector, and are intended to enable
-performance on hardware that can take advantage of the increased alignment.
-
 The results of vector data load and store functions are undefined if the
 address being read from or written to is not correctly aligned as described
 in <<table-vector-loadstore>>.
@@ -6010,7 +5795,7 @@ in a work-group.
 
   void *work_group_barrier*( +
   cl_mem_fence_flags _flags_, +
-  memory_scope _scope_^40^)
+  memory_scope _scope_)
 | For these functions, if any work-item in a work-group encounters a
   barrier, the barrier must be encountered by all work-items in the
   work-group before any are allowed to continue execution beyond the
@@ -6025,7 +5810,7 @@ in a work-group.
 
   The *barrier* and *work_group_barrier* functions can specify which
   memory operations become visible to the appropriate memory scope
-  identified by _scope_.
+  identified by _scope_ footnote:[{fn-memory-scope-restrictions}].
   The _flags_ argument specifies the memory address spaces.
   This is a bitfield and can be set to 0 or a combination of the
   following values OR'ed together.
@@ -6053,8 +5838,6 @@ in a work-group.
   The values of _flags_ and _scope_ must be the same for all work-items
   in the work-group.
 |====
-
-[40] Refer to the description and restrictions for <<memory-scope,`memory_scope`>>.
 --
 
 NOTE: The functionality described in the following table requires support for
@@ -6174,22 +5957,13 @@ The OpenCL C programming language implements the <<table-builtin-async-copy,
 following functions>> that provide asynchronous copies between `global` and
 local memory and a prefetch from `global` memory.
 
-We use the generic type name `gentype` to indicate the built-in data types
-char, `char{2|3^41^|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`,
-`short{2|3|4|8|16}`, `ushort`, `ushort{2|3|4|8|16}`, `int`,
-`int{2|3|4|8|16}`, `uint`, `uint{2|3|4|8|16}`, `long`^l03^, `long{2|3|4|8|16}`,
-`ulong`, `ulong{2|3|4|8|16}`, `float`, `float{2|3|4|8|16}`, or `double`^d06^,
-`double{2|3|4|8|16}` as the type for the arguments unless otherwise stated.
-
-[41] *async_work_group_copy* and *async_work_group_strided_copy* for
-3-component vector types behave as *async_work_group_copy* and
-*async_work_group_strided_copy* respectively for 4-component vector types.
-
-[l03] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[d06] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
+We use the generic type name `gentype` to indicate the built-in data types char,
+`char{2|3|4|8|16}`, `uchar`, `uchar{2|3|4|8|16}`, `short`, `short{2|3|4|8|16}`,
+`ushort`, `ushort{2|3|4|8|16}`, `int`, `int{2|3|4|8|16}`, `uint`,
+`uint{2|3|4|8|16}`, `long` footnote:[{fn-int64-supported}], `long{2|3|4|8|16}`,
+`ulong`, `ulong{2|3|4|8|16}`, `float`, `float{2|3|4|8|16}`, or `double`
+footnote:[{fn-double-precision-supported}], `double{2|3|4|8|16}` as the type for
+the arguments unless otherwise stated footnote:[{fn-vec3-async-copy}].
 
 [[table-builtin-async-copy]]
 .Built-in Async Copy and Prefetch Functions
@@ -6301,15 +6075,13 @@ These operations play a special role in making assignments in one work-item
 visible to another.
 A synchronization operation on one or more memory locations is either an
 acquire operation, a release operation, or both an acquire and release
-operation^42^.
+operation footnote:[{fn-atomic-no-consume}].
 A synchronization operation without an associated memory location is a fence
 and can be either an acquire fence, a release fence or both an acquire and
 release fence.
 In addition, there are relaxed atomic operations, which are not
 synchronization operations, and atomic read-modify-write operations which
 have special characteristics.
-
-[42] The <<C11-spec,C11>> consume operation is not supported.
 
 The types include
 
@@ -6602,33 +6374,14 @@ The list of supported atomic type names are:
 [none]
 * `atomic_int`
 * `atomic_uint`
-* `atomic_long`^45^
-* `atomic_ulong`
+* `atomic_long` footnote:atomic-int64-supported[{fn-atomic-int64-supported}]
+* `atomic_ulong` footnote:atomic-int64-supported[]
 * `atomic_float`
-* `atomic_double`^46^
-* `atomic_intptr_t`^47^
-* `atomic_uintptr_t`
-* `atomic_size_t`
-* `atomic_ptrdiff_t`
-
-[45] The atomic_long and atomic_ulong types are supported if the
-*cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions
-are supported and have been enabled.
-If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_int64+` feature.
-
-[46] The `atomic_double` type is only supported if double precision is
-supported and the *cl_khr_int64_base_atomics* and
-*cl_khr_int64_extended_atomics* extensions are supported and have been
-enabled.
-If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_fp64+` feature.
-
-[47] If the device address space is 64-bits, the data types
-`atomic_intptr_t`, `atomic_uintptr_t`, `atomic_size_t` and
-`atomic_ptrdiff_t` are supported if the *cl_khr_int64_base_atomics* and
-*cl_khr_int64_extended_atomics* extensions are supported and have been
-enabled.
+* `atomic_double` footnote:[{fn-atomic-double-supported}]
+* `atomic_intptr_t` footnote:atomic-size_t-supported[{fn-atomic-size_t-supported}]
+* `atomic_uintptr_t` footnote:atomic-size_t-supported[]
+* `atomic_size_t` footnote:atomic-size_t-supported[]
+* `atomic_ptrdiff_t` footnote:atomic-size_t-supported[]
 
 Arguments to a kernel can be declared to be a pointer to the above atomic
 types or the atomic_flag type.
@@ -7123,13 +6876,11 @@ else
 ----------
 ====
 
-The weak compare-and-exchange operations may fail spuriously^48^.
+The weak compare-and-exchange operations may fail spuriously
+footnote:[{fn-atomic-weak-rationale}].
 That is, even when the contents of memory referred to by `expected` and
 `object` are equal, it may return zero and store back to `expected` the same
 memory contents that were originally there.
-
-[48] This spurious failure enables implementation of compare-and-exchange on
-a broader class of machines, e.g. load-locked store-conditional machines.
 
 These generic functions return the result of the comparison.
 
@@ -7638,22 +7389,15 @@ semantics of the minimum requirements.
 
 The OpenCL C programming language implements the following additional
 built-in vector functions.
-We use the generic type name `gentype__n__` (or `gentype__m__`) to indicate
-the built-in data types `char{2|4|8|16}`, `uchar{2|4|8|16}`,
-`short{2|4|8|16}`, `ushort{2|4|8|16}`, `half{2|4|8|16}`^49^, `int{2|4|8|16}`,
-`uint{2|4|8|16}`, `long{2|4|8|16}`^l04^, `ulong{2|4|8|16}`, `float{2|4|8|16}`,
-or `double{2|4|8|16}`^50^ as the type for the arguments unless otherwise
-stated.
+We use the generic type name `gentype__n__` (or `gentype__m__`) to indicate the
+built-in data types `char{2|4|8|16}`, `uchar{2|4|8|16}`, `short{2|4|8|16}`,
+`ushort{2|4|8|16}`, `half{2|4|8|16}` footnote:[{fn-half-supported}],
+`int{2|4|8|16}`, `uint{2|4|8|16}`, `long{2|4|8|16}`
+footnote:[{fn-int64-supported}], `ulong{2|4|8|16}`, `float{2|4|8|16}`, or
+`double{2|4|8|16}` footnote:[{fn-double-precision-supported}] as the type for
+the arguments unless otherwise stated.
 We use the generic name `ugentype__n__` to indicate the built-in unsigned
 integer data types.
-
-[49] Only if the *cl_khr_fp16* extension is supported and has been enabled.
-
-[l04] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[50] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
 
 [[table-misc-vector]]
 .Built-in Miscellaneous Vector Functions
@@ -7812,7 +7556,8 @@ After the *%*, the following appear in sequence:
     If the converted value has fewer characters than the field width, it is
     padded with spaces (by default) on the left (or right, if the left
     adjustment flag, described later, has been given) to the field width.
-    The field width takes the form of a nonnegative decimal integer^51^.
+    The field width takes the form of a nonnegative decimal integer
+    footnote:[{fn-printf-field-width}].
   * An optional __precision__ that gives the minimum number of digits to
     appear for the *d*, *i*, *o*, *u*, *x*, and *X* conversions, the number
     of digits to appear after the decimal-point character for *a*, *A*, *e*,
@@ -7835,8 +7580,6 @@ After the *%*, the following appear in sequence:
   * A __conversion specifier__ character that specifies the type of
     conversion to be applied.
 
-[51] Note that *0* is taken as a flag, not as the beginning of a field width.
-
 The flag characters and their meanings are:
 
 *-* The result of the conversion is left-justified within the field.
@@ -7845,10 +7588,7 @@ The flag characters and their meanings are:
 *+* The result of a signed conversion always begins with a plus or minus
 sign.
 (It begins with a sign only when a negative value is converted if this flag
-is not specified.)^52^
-
-[52] The results of all floating conversions of a negative zero, and of
-negative values that round to zero, include a minus sign.
+is not specified.) footnote:[{fn-printf-minus-sign}]
 
 _space_ If the first character of a signed conversion is not a sign, or if a
 signed conversion results in no characters, a space is prefixed to the
@@ -7921,9 +7661,8 @@ will not be promoted).
 *h* Specifies that a following *d*, *i*, *o*, *u*, *x*, or *X* conversion
 specifier applies to a `short__n__` or `ushort__n__` argument (the argument
 will not be promoted); that a following *a*, *A*, *e*, *E*, *f*, *F*, *g*,
-or *G* conversion specifier applies to a `half__n__`^53^ argument.
-
-[53] Only if the cl_khr_fp16 extension is supported and has been enabled.
+or *G* conversion specifier applies to a `half__n__`
+footnote:[{fn-half-supported}] argument.
 
 *hl* This modifier can only be used with the vector specifier.
 Specifies that a following *d*, *i*, *o*, *u*, *x*, or *X* conversion
@@ -7990,11 +7729,7 @@ __[__**-**__]__**nan(**__n-char-sequence__**) **
 -- which style, and the meaning of any _n-char-sequence_, is
 implementation-defined.
 The *F* conversion specifier produces `INF`, `INFINITY`, or `NAN` instead of
-*inf*, *infinity*, or *nan*, respectively^54^.
-
-[54] When applied to infinite and NaN values, the *-*, *+*, and _space_ flag
-characters have their usual meaning; the *#* and *0* flag characters have no
-effect.
+*inf*, *infinity*, or *nan*, respectively footnote:[{fn-printf-infinity-nan}].
 
 **e,E** A `double`, `half__n__`, `float__n__` or `double__n__` argument
 representing a floating-point number is converted in the style
@@ -8036,10 +7771,11 @@ representing a floating-point number is converted in the style
 __[__**-**__]__**0x**__h__**.**__hhhh __**p{plusmn}**_d_, where there is one
 hexadecimal digit (which is nonzero if the argument is a normalized
 floating-point number and is otherwise unspecified) before the decimal-point
-character^55^ and the number of hexadecimal digits after it is equal to the
-precision; if the precision is missing, then the precision is sufficient for
-an exact representation of the value; if the precision is zero and the *#*
-flag is not specified, no decimal point character appears.
+character footnote:[{fn-printf-hex-float}] and the number of hexadecimal digits
+after it is equal to the precision; if the precision is missing, then the
+precision is sufficient for an exact representation of the value; if the
+precision is zero and the *#* flag is not specified, no decimal point character
+appears.
 The letters *abcdef* are used for *a* conversion and the letters *ABCDEF*
 for *A* conversion.
 The *A* conversion specifier produces a number with *X* and *P* instead of
@@ -8050,10 +7786,6 @@ If the value is zero, the exponent is zero.
 A `double`, `half__n__`, `float__n__` or `double__n__` argument representing
 an infinity or NaN is converted in the style of an *f* or *F* conversion
 specifier.
-
-[55] Binary implementations can choose the hexadecimal digit to the left of
-the decimal-point character so that subsequent digits align to nibble
-(4-bit) boundaries.
 
 [NOTE]
 ====
@@ -8068,16 +7800,13 @@ instead of a `double` and the `half` type will be converted to a `float`.
 *c* The `int` argument is converted to an `unsigned char`, and the resulting
 character is written.
 
-*s* The argument shall be a literal string^56^.
+*s* The argument shall be a literal string
+footnote:[{fn-printf-literal-string}].
 Characters from the literal string array are written up to (but not
 including) the terminating null character.
 If the precision is specified, no more than that many bytes are written.
 If the precision is not specified or is greater than the size of the array,
 the array shall contain a null character.
-
-[56] No special provisions are made for multibyte characters.
-The behavior of *printf* with the *s* conversion specifier is undefined if
-the argument value is not a pointer to a literal string.
 
 *p* The argument shall be a pointer to *void*.
 The pointer can refer to a memory region in the `global`, `constant`,
@@ -8315,8 +8044,8 @@ The sampler fields are described in the following table.
       `CLK_ADDRESS_CLAMP_TO_EDGE` - out-of-range image coordinates are
       clamped to the extent.
 
-      `CLK_ADDRESS_CLAMP`^57^ - out-of-range image coordinates will return a
-      border color.
+      `CLK_ADDRESS_CLAMP` - out-of-range image coordinates will return a
+      border color footnote:[{fn-CLK_ADDRESS_CLAMP}].
 
       `CLK_ADDRESS_NONE` - for this addressing mode the programmer
       guarantees that the image coordinates used to sample elements of the
@@ -8336,8 +8065,6 @@ The sampler fields are described in the following table.
       Refer to the <<addressing-and-filter-modes,detailed description of
       these filter modes>>.
 |====
-
-[57] This is similar to the `GL_ADDRESS_CLAMP_TO_BORDER` addressing mode.
 
 *Examples*:
 
@@ -8392,11 +8119,8 @@ The alpha component is returned as is.
 [open,refpage='imageReadFunctions',desc='Built-in Image Read Functions',type='freeform',spec='clang',anchor='built-in-image-read-functions',xrefs='imageQueryFunctions imageSamplerlessReadFunctions imageWriteFunctions',alias='read_imagef read_imagei read_imageui']
 --
 
-The following built-in function calls to read images with a sampler^58^ are
-supported.
-
-[58] The built-in function calls to read images with a sampler are not
-supported for `image1d_buffer_t` image types.
+The following built-in function calls to read images with a sampler are
+supported footnote:[{fn-read-image-with-sampler}].
 
 [[table-image-read]]
 .Built-in Image Read Functions
@@ -9638,16 +9362,9 @@ across a work-group.
 These built-in functions must be encountered by all work-items in a
 work-group executing the kernel.
 We use the generic type name `gentype` to indicate the built-in data types
-`half`^59^, `int`, `uint`, `long`^l05^, `ulong`, `float` or `double`^60^ as the
-type for the arguments.
-
-[59] Only if the *cl_khr_fp16* extension is supported and has been enabled.
-
-[l05] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[60] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
+`half` footnote:[{fn-half-supported}], `int`, `uint`, `long`
+footnote:[{fn-int64-supported}], `ulong`, `float` or `double`
+footnote:[{fn-double-precision-supported}] as the type for the arguments.
 
 [[table-builtin-work-group]]
 .Built-in Work-group Collective Functions
@@ -9815,16 +9532,11 @@ The macro `CLK_NULL_RESERVE_ID` refers to an invalid reservation ID.
 
 The OpenCL C programming language implements the following built-in
 functions that read from or write to a pipe.
-We use the generic type name `gentype` to indicate the built-in OpenCL C
-scalar or vector integer or floating-point data types^61^ or any user defined
-type built from these scalar and vector data types can be used as the type
-for the arguments to the pipe functions listed in the following table.
-
-[61] The `half` scalar and vector types can only be used if the *cl_khr_fp16*
-extension is supported and has been enabled.
-The `double` scalar and vector types can only be used if `double` precision
-is supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro
-is present.
+We use the generic type name `gentype` to indicate the built-in OpenCL C scalar
+or vector integer or floating-point data types
+footnote:[{fn-float-types-supported}] or any user defined type built from these
+scalar and vector data types can be used as the type for the arguments to the
+pipe functions listed in the following table.
 
 [[table-builtin-pipe]]
 .Built-in Pipe Functions
@@ -9890,10 +9602,11 @@ functions that operate at a work-group level.
 These built-in functions must be encountered by all work-items in a
 work-group executing the kernel with the same argument values; otherwise the
 behavior is undefined.
-We use the generic type name `gentype` to indicate the built-in OpenCL C
-scalar or vector integer or floating-point data types^62^ or any user defined
-type built from these scalar and vector data types can be used as the type
-for the arguments to the pipe functions listed in the following table.
+We use the generic type name `gentype` to indicate the built-in OpenCL C scalar
+or vector integer or floating-point data types
+footnote:[{fn-float-types-supported}] or any user defined type built from these
+scalar and vector data types can be used as the type for the arguments to the
+pipe functions listed in the following table.
 
 [62] The `half` scalar and vector types can only be used if the *cl_khr_fp16*
 extension is supported and has been enabled.
@@ -9966,16 +9679,11 @@ implementation defined.
 
 The OpenCL C programming language implements the following built-in query
 functions for a pipe.
-We use the generic type name `gentype` to indicate the built-in OpenCL C
-scalar or vector integer or floating-point data types^63^ or any user defined
-type built from these scalar and vector data types can be used as the type
-for the arguments to the pipe functions listed in the following table.
-
-[63] The `half` scalar and vector types can only be used if the *cl_khr_fp16*
-extension is supported and has been enabled.
-The `double` scalar and vector types can only be used if `double` precision
-is supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro is
-present.
+We use the generic type name `gentype` to indicate the built-in OpenCL C scalar
+or vector integer or floating-point data types
+footnote:[{fn-float-types-supported}] or any user defined type built from these
+scalar and vector data types can be used as the type for the arguments to the
+pipe functions listed in the following table.
 
 _aQual_ in the following table refers to one of the access qualifiers.
 For pipe query functions this may be `read_only` or `write_only`.
@@ -10349,13 +10057,10 @@ evaluate_dp_work_A(queue_t q,...)
 [[determining-when-a-child-kernel-begins-execution]]
 ==== Determining when a child kernel begins execution
 
-The `kernel_enqueue_flags_t`^64^ argument to enqueue_kernel built-in
-functions can be used to specify when the child kernel begins execution.
+The `kernel_enqueue_flags_t` footnote:[{fn-dse-kernel_enqueue_flags_t}] argument
+to the `enqueue_kernel` built-in functions can be used to specify when the child
+kernel begins execution.
 Supported values are described in the table below:
-
-[64] Implementations are not required to honor this flag.
-Implementations may not schedule kernel launch earlier than the point
-specified by this flag, however.
 
 [[table-kernel-enqueue-flags]]
 .Kernel Enqueue Flags
@@ -10367,19 +10072,13 @@ specified by this flag, however.
       kernel to finish execution before they begin execution.
 | `CLK_ENQUEUE_FLAGS_WAIT_KERNEL`
     | Indicates that all work-items of the parent kernel must finish
-      executing and all immediate^65^ side effects committed before the
-      enqueued child kernel may begin execution.
-| `CLK_ENQUEUE_FLAGS_WAIT_WORK_GROUP`^66^
+      executing and all immediate footnote:[{fn-dse-immediate-definition}] side
+      effects committed before the enqueued child kernel may begin execution.
+| `CLK_ENQUEUE_FLAGS_WAIT_WORK_GROUP`
     | Indicates that the enqueued kernels wait only for the workgroup that
       enqueued the kernels to finish before they begin execution.
+      footnote:[{fn-dse-CLK_ENQUEUE_FLAGS_WAIT_WORK_GROUP}]
 |====
-
-[65] Immediate meaning not side effects resulting from child kernels.
-The side effects would include stores to `global` memory and pipe reads and
-writes.
-
-[66] This acts as a memory synchronization point between work-items in a
-work-group and child kernels enqueued by work-items in the work-group.
 
 [NOTE]
 ====
@@ -10720,15 +10419,10 @@ NOTE: The functionality described in this section requires support for the `+__o
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
-For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `int`, `uint`, `long`^l06^, `ulong`, `float`, `double`^d07^, or `half`^h01^.
-
-[l06] Only if 64-bit integers are supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_int64+` feature macro.
-
-[d07] Only if double precision is supported.  In OpenCL C 3.0 this will be
-indicated by the presence of the `+__opencl_c_fp64+` feature macro.
-
-[h01] Only if the *cl_khr_fp16* extension is supported and has been enabled.
+For the functions below, the generic type name `gentype` may be the one of the
+supported built-in scalar data types `int`, `uint`, `long`
+footnote:[{fn-int64-supported}], `ulong`, `half` footnote:[{fn-half-supported}],
+`float`, and `double` footnote:[{fn-double-precision-supported}].
 
 .Built-in Subgroup Collective Functions
 [cols=",",options="header",]
@@ -10908,15 +10602,13 @@ IEEE 754 defines four possible rounding modes:
   * Round toward -{inf}
   * Round toward zero
 
-_Round to nearest_ _even_ is currently the only rounding mode required^67^ by
-the OpenCL specification for single precision and double precision
-operations and is therefore the default rounding mode.
+_Round to nearest_ _even_ is currently the only rounding mode required by the
+OpenCL specification for single precision and double precision operations and is
+therefore the default rounding mode
+footnote:[{fn-float-required-rounding-mode}].
 In addition, only static selection of rounding mode is supported.
 Dynamically reconfiguring the rounding modes as specified by the IEEE 754
 spec is unsupported.
-
-[67] Except for the embedded profile whether either round to zero or round to
-nearest rounding mode may be supported for single precision floating-point.
 
 
 [[inf-nan-and-denormalized-numbers]]
@@ -11000,19 +10692,17 @@ Currently hosted at
 https://hal.inria.fr/inria-00070503/document[https://hal.inria.fr/inria-00070503/document].
 ====
 
-The following table^68^ describes the minimum accuracy of single precision
+The following table describes the minimum accuracy of single precision
 floating-point arithmetic operations given as ULP values.
 The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
-
-[68] The ULP values for built-in math functions *lgamma* and *lgamma_r* is
-currently undefined.
+0 ulp is used for math functions that do not require rounding.
 
 [[table-ulp-float-math]]
 .ULP values for single precision built-in math functions
 [cols=",",]
 |====
-| *Function*            | *Min Accuracy - ULP values*^69^
+| *Function*            | *Min Accuracy - ULP values*
 | _x_ + _y_             | Correctly rounded
 | _x_ - _y_             | Correctly rounded
 | _x_ * _y_             | Correctly rounded
@@ -11078,6 +10768,8 @@ currently undefined.
 // = 2.75 + 0.5n
 | *length*              | {leq} 2.75 + 0.5n ulp, for gentype with vector width _n_
 | *ldexp*               | Correctly rounded
+| *lgamma*              | Undefined
+| *lgamma_r*            | Undefined
 | *log*                 | {leq} 3 ulp
 | *log2*                | {leq} 3 ulp
 | *log10*               | {leq} 3 ulp
@@ -11185,19 +10877,18 @@ currently undefined.
 | *native_tan*          | Implementation-defined
 |====
 
-[69] 0 ulp is used for math functions that do not require rounding.
-
 The following table describes the minimum accuracy of single precision
 floating-point arithmetic operations given as ULP values for the embedded
 profile.
 The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
+0 ulp is used for math functions that do not require rounding.
 
 [[table-ulp-embedded]]
 .ULP values for the embedded profile
 [cols=",",]
 |====
-| *Function*        | *Min Accuracy - ULP values*^70^
+| *Function*        | *Min Accuracy - ULP values*
 | _x_ + _y_         | Correctly rounded
 | _x_ - _y_         | Correctly rounded
 | _x_ * _y_         | Correctly rounded
@@ -11319,8 +11010,6 @@ is the infinitely precise result.
 | *native_tan*      | Implementation-defined
 |====
 
-[70] 0 ulp is used for math functions that do not require rounding.
-
 The following table describes the minimum accuracy of commonly used single
 precision floating-point arithmetic operations given as ULP values if the
 `-cl-unsafe-math-optimizations` compiler option is specified when compiling or
@@ -11333,12 +11022,13 @@ in <<table-ulp-float-math>> when operating in the full profile, and as
 defined in <<table-ulp-embedded>> when operating in the embedded profile.
 The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
+0 ulp is used for math functions that do not require rounding.
 
 [[table-float-ulp-relaxed]]
 .ULP values for single precision built-in math functions with unsafe math optimizations in the full and embedded profiles
 [cols=",",]
 |====
-| *Function* | *Min Accuracy - ULP values*^71^
+| *Function* | *Min Accuracy - ULP values*
 | *1.0 / _x_*
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
       profile, and {leq} 3 ulp for the embedded profile.
@@ -11381,7 +11071,7 @@ is the infinitely precise result.
 | *cosh*(_x_)
     | Defined for _x_ in the domain [-88,88] and implemented as 0.5f *
       (*exp*(_x_) + *exp*(-_x_)).
-      For non-derived implementations, the error is {leq} 8192 ULP.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 | *cospi*(_x_)
     | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
       2^-11^ and larger otherwise.
@@ -11419,9 +11109,10 @@ is the infinitely precise result.
       For _x_ > 0 or _x_ < 0 and even _y_, derived implementations implement
       this as *exp2*(_y_ * *log2*(*fabs*(_x_))).
       For _x_ < 0 and odd _y_, derived implementations implement this as
-      -*exp2*(_y_ * *log2*(*fabs*(_x_))^72^.
+      -*exp2*(_y_ * *log2*(*fabs*(_x_)).
       For _x_ == 0 and nonzero _y_, derived implementations return zero.
-      For non-derived implementations, the error is {leq} 8192 ULP
+      For non-derived implementations, the error is {leq} 8192 ulp.
+      footnote:[{fn-pow-performance}]
 | *pown*(_x_, _y_)
     | Defined only for integer values of y.
       Undefined for _x_ = 0 and _y_ = 0.
@@ -11442,7 +11133,7 @@ is the infinitely precise result.
       this case as -*exp2*(*log2*(-_x_) / _y_).
       Defined for _x_ = +/-0 when _y_ > 0, derived implementations will
       return +0 in this case.
-      For non-derived implementations, the error is {leq} 8192 ULP.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 | *sin*(_x_)
     | For _x_ in the domain [-{pi}, {pi}], the maximum absolute error is
       {leq} 2^-11^ and larger otherwise.
@@ -11453,7 +11144,7 @@ is the infinitely precise result.
       For _x_ in [-2^-10,2^-10], derived implementations implement as _x_.
       For _x_ outside of [-2^10,2^10], derived implement as *0.5f *
       (*exp*(_x_) - *exp*(-_x_)).
-      For non-derived implementations, the error is {leq} 8192 ULP.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 | *sinpi*(_x_)
     | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
       2^-11^ and larger otherwise.
@@ -11470,25 +11161,17 @@ is the infinitely precise result.
       an add both of which are correctly rounded.
 |====
 
-[71] 0 ulp is used for math functions that do not require rounding.
-
-[72] On some implementations, *powr*() or *pown*() may perform faster than
-*pow*().
-If _x_ is known to be >= 0, consider using *powr*() in place of *pow*(), or
-if _y_ is known to be an integer, consider using *pown*() in place of
-*pow*().
-
-
 The following table describes the minimum accuracy of double precision
 floating-point arithmetic operations given as ULP values.
 The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
+0 ulp is used for math functions that do not require rounding.
 
 [[table-ulp-double]]
 .ULP values for double precision built-in math functions
 [cols=",",]
 |====
-| *Function*        | *Min Accuracy - ULP values*^73^
+| *Function*        | *Min Accuracy - ULP values*
 | _x_ + _y_         | Correctly rounded
 | _x_ - _y_         | Correctly rounded
 | _x_ * _y_         | Correctly rounded
@@ -11615,8 +11298,6 @@ is the infinitely precise result.
 | *tgamma*          | {leq} 16 ulp
 | *trunc*           | Correctly rounded
 |====
-
-[73] 0 ulp is used for math functions that do not require rounding.
 
 
 [[edge-case-behavior]]
@@ -11805,11 +11486,8 @@ representable numbers in the range 0 < _x_ < `TYPE_MIN` and `-TYPE_MIN` <
 _x_ < -0.
 They do not include {plusmn}0.
 A non-zero number is said to be sub-normal before rounding if after
-normalization, its radix-2 exponent is less than (`TYPE_MIN_EXP` - 1)^74^.
-
-[74] Here `TYPE_MIN` and `TYPE_MIN_EXP` should be substituted by constants
-appropriate to the floating-point type under consideration, such as
-`FLT_MIN` and `FLT_MIN_EXP` for `float`.
+normalization, its radix-2 exponent is less than (`TYPE_MIN_EXP` - 1)
+footnote:[{fn-min-float-constants}].
 
 
 [[image-addressing-and-filtering]]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4230,12 +4230,12 @@ The <<table-builtin-math, following table>> describes the list of built-in
 math functions that can take scalar or vector arguments.
 We use the generic type name `gentype` to indicate that the function can take
 `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`
-footnote:double-precision-supported[{fn-double-precision-supported}], `double2`,
+footnote:double-supported[{fn-double-supported}], `double2`,
 `double3`, `double4`, `double8` or `double16` as the type for the arguments.
 We use the generic type name `gentypef` to indicate that the function can
 take `float`, `float2`, `float3`, `float4`, `float8`, or `float16` as the
 type for the arguments.
-We use the generic type name `gentyped` footnote:double-precision-supported[] to
+We use the generic type name `gentyped` footnote:double-supported[] to
 indicate that the function can take `double`, `double2`, `double3`, `double4`,
 `double8` or `double16` as the type for the arguments.
 For any specific use of a function, the actual type has to be the same for
@@ -4566,14 +4566,6 @@ all arguments and the return type, unless otherwise specified.
 | gentype *trunc*(gentype)
     | Round to integral value using the round to zero rounding mode.
 |====
-
-[30] The *min*() operator is there to prevent *fract*(-small) from returning
-1.0.
-It returns the largest positive floating-point number less than 1.0.
-
-[31] The user is cautioned that for some usages, e.g. *mad*(a, b, -a*b), the
-definition of *mad*() is loose enough in the embedded profile that almost any result is allowed from
-*mad*() for some values of a and b.
 
 The following table describes the following functions:
 
@@ -5103,7 +5095,7 @@ These all operate component-wise.
 The description is per-component.
 We use the generic type name `gentype` to indicate that the function can take
 `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `double`
-footnote:[{fn-double-precision-supported}], `double2`, `double3`, `double4`,
+footnote:[{fn-double-supported}], `double2`, `double3`, `double4`,
 `double8` or `double16` as the type for the arguments.
 We use the generic type name `gentypef` to indicate that the function can
 take `float`, `float2`, `float3`, `float4`, `float8`, or `float16` as the
@@ -5196,7 +5188,7 @@ geometric functions.
 These all operate component-wise.
 The description is per-component.
 `float__n__` is `float`, `float2`, `float3`, or `float4` and `double__n__` is
-`double` footnote:[{fn-double-precision-supported}], `double2`, `double3`, or
+`double` footnote:[{fn-double-supported}], `double2`, `double3`, or
 `double4`.
 
 The built-in geometric functions are implemented using the round to nearest
@@ -5285,7 +5277,7 @@ The argument type `gentype` refers to the following built-in types: `char`,
 `char__n__`, `uchar`, `uchar__n__`, `short`, `short__n__`, `ushort`,
 `ushort__n__`, `int`, `int__n__`, `uint`, `uint__n__`, `long`
 footnote:[{fn-int64-supported}], `long__n__`, `ulong`, `ulong__n__`, `float`,
-`float__n__`, `double` footnote:[{fn-double-precision-supported}], and
+`float__n__`, `double` footnote:[{fn-double-supported}], and
 `double__n__`.
 The argument type `igentype` refers to the built-in signed integer types
 i.e. `char`, `char__n__`, `short`, `short__n__`, `int`, `int__n__`, `long`
@@ -5437,7 +5429,7 @@ functions that allow you to read and write vector types from a pointer to
 memory.
 We use the generic type `gentype` to indicate the built-in data types
 `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long` footnote:[{fn-int64-supported}], `ulong`,
-`float` or `double` footnote:[{fn-double-precision-supported}].
+`float` or `double` footnote:[{fn-double-supported}].
 We use the generic type name `gentype__n__` to represent n-element vectors
 of `gentype` elements.
 We use the type name `half__n__` to represent n-element vectors of half
@@ -5962,7 +5954,7 @@ We use the generic type name `gentype` to indicate the built-in data types char,
 `ushort`, `ushort{2|3|4|8|16}`, `int`, `int{2|3|4|8|16}`, `uint`,
 `uint{2|3|4|8|16}`, `long` footnote:[{fn-int64-supported}], `long{2|3|4|8|16}`,
 `ulong`, `ulong{2|3|4|8|16}`, `float`, `float{2|3|4|8|16}`, or `double`
-footnote:[{fn-double-precision-supported}], `double{2|3|4|8|16}` as the type for
+footnote:[{fn-double-supported}], `double{2|3|4|8|16}` as the type for
 the arguments unless otherwise stated footnote:[{fn-vec3-async-copy}].
 
 [[table-builtin-async-copy]]
@@ -7394,7 +7386,7 @@ built-in data types `char{2|4|8|16}`, `uchar{2|4|8|16}`, `short{2|4|8|16}`,
 `ushort{2|4|8|16}`, `half{2|4|8|16}` footnote:[{fn-half-supported}],
 `int{2|4|8|16}`, `uint{2|4|8|16}`, `long{2|4|8|16}`
 footnote:[{fn-int64-supported}], `ulong{2|4|8|16}`, `float{2|4|8|16}`, or
-`double{2|4|8|16}` footnote:[{fn-double-precision-supported}] as the type for
+`double{2|4|8|16}` footnote:[{fn-double-supported}] as the type for
 the arguments unless otherwise stated.
 We use the generic name `ugentype__n__` to indicate the built-in unsigned
 integer data types.
@@ -9364,7 +9356,7 @@ work-group executing the kernel.
 We use the generic type name `gentype` to indicate the built-in data types
 `half` footnote:[{fn-half-supported}], `int`, `uint`, `long`
 footnote:[{fn-int64-supported}], `ulong`, `float` or `double`
-footnote:[{fn-double-precision-supported}] as the type for the arguments.
+footnote:[{fn-double-supported}] as the type for the arguments.
 
 [[table-builtin-work-group]]
 .Built-in Work-group Collective Functions
@@ -9607,12 +9599,6 @@ or vector integer or floating-point data types
 footnote:[{fn-float-types-supported}] or any user defined type built from these
 scalar and vector data types can be used as the type for the arguments to the
 pipe functions listed in the following table.
-
-[62] The `half` scalar and vector types can only be used if the *cl_khr_fp16*
-extension is supported and has been enabled.
-The `double` scalar and vector types can only be used if `double` precision
-is supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro is
-present.
 
 [[table-builtin-pipe-work-group]]
 .Built-in Pipe Work-group Functions
@@ -10422,7 +10408,7 @@ These built-in functions must be encountered by all work items in the subgroup e
 For the functions below, the generic type name `gentype` may be the one of the
 supported built-in scalar data types `int`, `uint`, `long`
 footnote:[{fn-int64-supported}], `ulong`, `half` footnote:[{fn-half-supported}],
-`float`, and `double` footnote:[{fn-double-precision-supported}].
+`float`, and `double` footnote:[{fn-double-supported}].
 
 .Built-in Subgroup Collective Functions
 [cols=",",options="header",]

--- a/api/appendix_a.asciidoc
+++ b/api/appendix_a.asciidoc
@@ -52,35 +52,19 @@ being used by another command-queue are undefined.
 
 == Multiple Host Threads
 
-All OpenCL API calls are thread-safe^1^ except those that modify the state
-of {cl_kernel} objects: {clSetKernelArg}, {clSetKernelArgSVMPointer},
-{clSetKernelExecInfo} and {clCloneKernel}.
-{clSetKernelArg} , {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and
+All OpenCL API calls are thread-safe footnote:[{fn-thread-safe}] except those
+that modify the state of {cl_kernel} objects: {clSetKernelArg},
+{clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and {clCloneKernel}.
+{clSetKernelArg}, {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and
 {clCloneKernel} are safe to call from any host thread, and safe to call
 re-entrantly so long as concurrent calls to any combination of these API
 calls operate on different {cl_kernel} objects.
 The state of the {cl_kernel} object is undefined if {clSetKernelArg},
 {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} or {clCloneKernel} are
 called from multiple host threads on the same {cl_kernel} object at the same
-time^2^.
+time footnote:[{fn-race-condition}].
 Please note that there are additional limitations as to which OpenCL APIs
 may be called from <<event-objects,OpenCL callback functions>>.
-
-1::
-    Please refer to the OpenCL glossary for the OpenCL definition of
-    thread-safe.
-    This definition may be different from usage of the term in other
-    contexts.
-2::
-    There is an inherent race condition in the design of OpenCL that occurs
-    between setting a kernel argument and using the kernel with
-    {clEnqueueNDRangeKernel}.
-    Another host thread might change the kernel arguments between when a
-    host thread sets the kernel arguments and then enqueues the kernel,
-    causing the wrong kernel arguments to be enqueued.
-    Rather than attempt to share {cl_kernel} objects among multiple host
-    threads, applications are strongly encouraged to make additional
-    {cl_kernel} objects for kernel functions for each host thread.
 
 The behavior of OpenCL APIs called from an interrupt or signal handler is
 implementation-defined

--- a/api/appendix_b.asciidoc
+++ b/api/appendix_b.asciidoc
@@ -100,16 +100,9 @@ little-endian data, regardless of how large each piece of data is in the
 vector.
 That is the transformation is equally valid whether that vector was a
 `uchar16` or a `ulong2`.
-Of course, as is well known, little-endian machines actually^1^ store their
-data in reverse byte order to compensate for the little-endian storage
-format of the array elements:
-
-1::
-    Note that we are talking about the programming model here.
-    In reality, little endian systems might choose to simply address their
-    bytes from "the right" or reverse the "order" of the bits in the byte.
-    Either of these choices would mean that no big swap would need to occur
-    in hardware.
+Of course, as is well known, little-endian machines
+actually footnote:[{fn-endianness}] store their data in reverse byte order to
+compensate for the little-endian storage format of the array elements:
 
 Memory (big-endian):
 

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -38,30 +38,19 @@ data type can be used in a kernel.
   . Image and image arrays created with an
     `image_channel_data_type` value of {CL_FLOAT} or {CL_HALF_FLOAT} can only be
     used with samplers that use a filter mode of {CL_FILTER_NEAREST}.
-    The values returned by *read_imagef* and *read_imageh*^1^ for 2D and 3D
+    The values returned by *read_imagef* footnote:[{fn-readimageh}] for 2D and 3D
     images if `image_channel_data_type` value is {CL_FLOAT} or {CL_HALF_FLOAT}
     and sampler with filter_mode = {CL_FILTER_LINEAR} are undefined.
-+
---
-1::
-    If *cl_khr_fp16* extension is supported.
---
 
 Furthermore, the OpenCL embedded profile has the following restrictions for all
 versions:
 
   . 64 bit integers i.e. long, ulong including the appropriate vector data
     types and operations on 64-bit integers are optional.
-    The *cles_khr_int64*^2^ extension string will be reported if the
-    embedded profile implementation supports 64-bit integers.
+    The *cles_khr_int64* footnote:[{fn-int64-performance}] extension string will
+    be reported if the embedded profile implementation supports 64-bit integers.
     If double precision is supported i.e. {CL_DEVICE_DOUBLE_FP_CONFIG} is not
     zero, then *cles_khr_int64* must also be supported.
-+
---
-2::
-    Note that the performance of 64-bit integer arithmetic can vary
-    significantly between embedded devices.
---
   . The mandated minimum single precision floating-point capability given by
     {CL_DEVICE_SINGLE_FP_CONFIG} is {CL_FP_ROUND_TO_ZERO} or
     {CL_FP_ROUND_TO_NEAREST}.

--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -1,0 +1,156 @@
+// Copyright 2017-2020 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Please keep footnotes in alphabetical order!
+
+// Note: Follows the suggested syntax from:
+// https://github.com/asciidoctor/asciidoctor-pdf/issues/1397
+
+:fn-compatible-image-channel-orders: pass:n[ \
+This allows creation of a sRGB view of the image from a linear RGB view or vice-versa, i.e. the pixels stored in the image can be accessed as linear RGB or sRGB values. \
+]
+
+:fn-create-context-all-or-subset: pass:n[ \
+{clCreateContextfromType} may may create a context for all or a subset of the actual physical devices present in the platform that match _device_type_. \
+]
+
+:fn-default-device-queue: pass:n[ \
+The application must create a default device queue if any kernels containing calls to `get_default_queue` are enqueued. \
+There can only be one default device queue for each device within a context. \
+If a default device queue has already been created, calling {clCreateCommandQueueWithProperties} with {CL_QUEUE_PROPERTIES} set to {CL_QUEUE_ON_DEVICE} and {CL_QUEUE_ON_DEVICE_DEFAULT} will return the default device queue that has already been created and increment its reference count by 1. \
+]
+
+:fn-depth-image-requirements: pass:n[ \
+Support for the {CL_DEPTH} image channel order is required only for 2D images and 2D image arrays. \
+]
+
+:fn-duplicate-devices: pass:n[ \
+Duplicate devices specified in _devices_ are ignored. \
+]
+
+:fn-endianness: pass:n[ \
+Note that we are talking about the programming model here. \
+In reality, little endian systems might choose to simply address their bytes from "the right" or reverse the "order" of the bits in the byte. \
+Either of these choices would mean that no big swap would need to occur in hardware. \
+]
+
+:fn-error-precedence: pass:n[ \
+The OpenCL specification does not describe the order of precedence for error codes returned by API calls. \
+]
+
+:fn-event-callback-complete: pass:n[ \
+The callback function registered for a _command_exec_callback_type_ value of {CL_COMPLETE} will be called when the command has completed successfully or is abnormally terminated. \
+]
+
+:fn-event-status-order: pass:n[ \
+The error code values are negative, and event state values are positive. \
+The event state values are ordered from the largest value {CL_QUEUED} for the first or initial state to the smallest value ({CL_COMPLETE} or negative integer value) for the last or complete state. \
+The value of {CL_COMPLETE} and {CL_SUCCESS} are the same. \
+]
+
+:fn-get-device-ids-all-or-subset: pass:n[ \
+{clGetDeviceIDs} may return all or a subset of the actual physical devices present in the platform and that match _device_type_. \
+]
+
+:fn-image-array-performance: pass:n[ \
+Note that reading and writing 2D image arrays from a kernel with `image_array_size` equal to one may perform worse than 2D images. \
+]
+
+:fn-image-from-buffer: pass:n[ \
+To create a 2D image from a buffer object that share the data store between the image and buffer object. \
+]
+
+:fn-image-from-image: pass:n[ \
+To create an image object from another image object that share the data store between these image objects. \
+]
+
+:fn-image-mem-fence: pass:n[ \
+This value for memory_scope can only be used with atomic_work_item_fence with flags set to CLK_IMAGE_MEM_FENCE. \
+]
+
+:fn-int64-performance: pass:n[ \
+Note that the performance of 64-bit integer arithmetic can vary significantly between embedded devices. \
+]
+
+:fn-kernel-arg-type-const-addr-space: pass:n[ \
+{CL_KERNEL_ARG_TYPE_CONST} is returned for {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is declared with the `constant` address space qualifier. \
+]
+
+:fn-kernel-arg-type-qualifier: pass:n[ \
+{CL_KERNEL_ARG_TYPE_CONST} is returned if the argument is a pointer and the referenced type is declared with the const qualifier. \
+For example, a kernel argument declared as `global int const *x` returns {CL_KERNEL_ARG_TYPE_CONST} but a kernel argument declared as `global int * const x` does not. + \
+Similarly, {CL_KERNEL_ARG_TYPE_RESTRICT} will be returned if the pointer type is marked `restrict`. \
+For example, `global int * restrict x` returns {CL_KERNEL_ARG_TYPE_RESTRICT}. + \
+{CL_KERNEL_ARG_TYPE_VOLATILE} is returned for {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is a pointer and the referenced type is declared with the volatile qualifier. \
+For example, a kernel argument declared as `global int volatile *x` returns {CL_KERNEL_ARG_TYPE_VOLATILE} but a kernel argument declared as `global int * volatile x` does not. \
+]
+
+:fn-map-count-usage: pass:n[ \
+The map count returned should be considered immediately stale. \
+It is unsuitable for general use in applications. \
+This feature is provided for debugging. \
+]
+
+:fn-max-read-image-args: pass:n[ \
+A kernel that uses an image argument with the write_only or read_write image qualifier may result in additional read_only images resources being created internally by an implementation. \
+The internally created read_only image resources will count against the max supported read image arguments given by {CL_DEVICE_MAX_READ_IMAGE_ARGS}. \
+Enqueuing a kernel that requires more images than the implementation can support will result in a {CL_OUT_OF_RESOURCES} error being returned. \
+]
+
+:fn-native-rounding-modes: pass:n[ \
+The optional rounding modes should be included as a device capability only if it is supported natively. \
+All explicit conversion functions with specific rounding modes must still operate correctly. \
+]
+
+:fn-null-terminated-string: pass:n[ \
+A null terminated string is returned by OpenCL query function calls if the return type of the information being queried is a {char}[\]. \
+]
+
+:fn-out-of-order-device-queue: pass:n[ \
+Only out-of-order device queues are supported. \
+]
+
+:fn-platform-profile: pass:n[ \
+The platform profile returns the profile that is implemented by the OpenCL framework. \
+If the platform profile returned is FULL_PROFILE, the OpenCL framework will support devices that are FULL_PROFILE and may also support devices that are EMBEDDED_PROFILE. \
+The compiler must be available for all devices i.e. {CL_DEVICE_COMPILER_AVAILABLE} is {CL_TRUE}. \
+If the platform profile returned is EMBEDDED_PROFILE, then devices that are only EMBEDDED_PROFILE are supported. \
+]
+
+:fn-race-condition: pass:n[ \
+There is an inherent race condition in the design of OpenCL that occurs between setting a kernel argument and using the kernel with {clEnqueueNDRangeKernel}. \
+Another host thread might change the kernel arguments between when a host thread sets the kernel arguments and then enqueues the kernel, causing the wrong kernel arguments to be enqueued. \
+Rather than attempt to share {cl_kernel} objects among multiple host threads, applications are strongly encouraged to make additional {cl_kernel} objects for kernel functions for each host thread. \
+]
+
+:fn-readimageh: pass:n[ \
+And *read_imageh*, if the *cl_khr_fp16* extension is supported. \
+]
+
+:fn-reference-count-usage: pass:n[ \
+The reference count returned should be considered immediately stale. \
+It is unsuitable for general use in applications. \
+This feature is provided for identifying memory leaks. \
+]
+
+:fn-srgb-image-requirements: pass:n[ \
+Support for reading from the {CL_sRGBA} image channel order is optional for 1D image buffers. \
+Support for writing to the {CL_sRGBA} image channel order is optional for all image types. \
+]
+
+:fn-thread-safe: pass:n[ \
+Please refer to the OpenCL glossary for the OpenCL definition of thread-safe. \
+This definition may be different from usage of the term in other contexts. \
+]
+
+:fn-vendor-id: pass:n[ \
+OpenCL adopters must report a valid vendor ID for their implementation. \
+If there is no valid PCI vendor ID defined for the physical device, implementations must obtain a Khronos vendor ID. \
+This is a unique identifier greater than the largest PCI vendor ID (`0x10000`) and is representable by a {cl_uint}. \
+Khronos vendor IDs are synchronized across APIs by utilizing Vulkan's vk.xml as the central Khronos vendor ID registry. \
+An ID must be reserved here prior to use in OpenCL, regardless of whether a vendor implements Vulkan. \
+Only once the ID has been allotted may it be exposed to OpenCL by proposing a merge request against cl.xml, in the master branch of the OpenCL-Docs project. \
+The merge must define a new enumerant by adding an `<enum>` tag to the {cl_khronos_vendor_id} `<enums>` tag, with the `<value>` attribute set as the acquired Khronos vendor ID. \
+The `<name>` attribute must identify the vendor/adopter, and be of the form `CL_KHRONOS_VENDOR_ID_<vendor>`. \
+]

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1175,13 +1175,7 @@ Distinct memory scopes are defined by the values of the memory_scope
 enumeration constant:
 
   * *memory_scope_work_item*: memory-ordering constraints only apply within
-    the work-item^1^.
-+
---
-1::
-    This value for memory_scope can only be used with atomic_work_item_fence
-    with flags set to CLK_IMAGE_MEM_FENCE.
---
+    the work-item footnote:[{fn-image-mem-fence}].
   * *memory_scope_sub_group*: memory-ordering constraints only apply within
     the sub-group.
   * *memory_scope_work_group*: memory-ordering constraints only apply to

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -676,7 +676,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE.asciid
       | The minimum value is the size (in bytes) of the largest OpenCL data
         type supported by the device (`long16` in FULL profile, `long16` or
         `int16` in EMBEDDED profile).
-| {CL_DEVICE_SINGLE_FP_CONFIG_anchor} footnote:[{fn-native-rounding-modes}]
+| {CL_DEVICE_SINGLE_FP_CONFIG_anchor} footnote:native-rounding-modes[{fn-native-rounding-modes}]
 
 include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
   | {cl_device_fp_config}
@@ -711,7 +711,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
         For the embedded profile, see the
         <<embedded-profile-single-fp-config-requirements, dedicated table>>.
 
-| {CL_DEVICE_DOUBLE_FP_CONFIG_anchor} footnote:[{fn-native-rounding-modes}]
+| {CL_DEVICE_DOUBLE_FP_CONFIG_anchor} footnote:native-rounding-modes[]
 
 include::{generated}/api/version-notes/CL_DEVICE_DOUBLE_FP_CONFIG.asciidoc[]
 Also see extension *cl_khr_fp64*.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -79,10 +79,10 @@ in the <<platform-queries-table, Platform Queries>> table.
 [width="100%",cols="<50%,<10%,<40%",options="header"]
 |====
 | Platform Info | Return Type | Description
-| {CL_PLATFORM_PROFILE_anchor}
+| {CL_PLATFORM_PROFILE_anchor} footnote:[{fn-platform-profile}]
 
 include::{generated}/api/version-notes/CL_PLATFORM_PROFILE.asciidoc[]
-  | {char}[]^1^
+  | {char}[] footnote:[{fn-null-terminated-string}]
       | OpenCL profile string.
         Returns the profile name supported by the implementation.
         The profile name returned can be one of the following strings:
@@ -163,7 +163,8 @@ include::{generated}/api/version-notes/CL_PLATFORM_HOST_TIMER_RESOLUTION.asciido
 
 {clGetPlatformInfo} returns {CL_SUCCESS} if the function is executed
 successfully.
-Otherwise, it returns one of the following errors^2^.
+Otherwise, it returns one of the following
+errors footnote:[{fn-error-precedence}].
 
   * {CL_INVALID_PLATFORM} if _platform_ is not a valid platform.
   * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values or
@@ -172,18 +173,7 @@ Otherwise, it returns one of the following errors^2^.
     Queries>> table, and _param_value_ is not a `NULL` value.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
-
-
-1::
-    A null terminated string is returned by OpenCL query function calls if
-    the return type of the information being queried is a {char}[].
-
-
-2::
-    The OpenCL specification does not describe the order of precedence for
-    error codes returned by API calls.
 --
-
 
 
 [[platform-querying-devices]]
@@ -192,7 +182,7 @@ Otherwise, it returns one of the following errors^2^.
 [open,refpage='clGetDeviceIDs',desc='Query devices available on a platform',type='protos']
 --
 The list of devices available on a platform can be obtained using the
-function^3^:
+function footnote:[{fn-get-device-ids-all-or-subset}]:
 
 include::{generated}/api/protos/clGetDeviceIDs.txt[]
 include::{generated}/api/version-notes/clGetDeviceIDs.asciidoc[]
@@ -218,10 +208,6 @@ include::{generated}/api/version-notes/clGetDeviceIDs.asciidoc[]
   * _num_devices_ returns the number of OpenCL devices available that match
     _device_type_.
     If _num_devices_ is `NULL`, this argument is ignored.
-
-3::
-    {clGetDeviceIDs} may return all or a subset of the actual physical
-    devices present in the platform and that match _device_type_.
 
 [[device-types-table]]
 .List of supported device_types by <<clGetDeviceIDs>>
@@ -358,7 +344,7 @@ include::{generated}/api/version-notes/CL_DEVICE_TYPE.asciidoc[]
         Please see the <<device-types-table, Device Types>> table
         for supported device types and device type combinations.
 
-| {CL_DEVICE_VENDOR_ID_anchor}^4^
+| {CL_DEVICE_VENDOR_ID_anchor} footnote:[{fn-vendor-id}]
 
 include::{generated}/api/version-notes/CL_DEVICE_VENDOR_ID.asciidoc[]
   | {cl_uint}
@@ -489,7 +475,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_SUPPORT.asciidoc[]
   | {cl_bool}
       | Is {CL_TRUE} if images are supported by the OpenCL device and {CL_FALSE}
         otherwise.
-| {CL_DEVICE_MAX_READ_IMAGE_ARGS_anchor}^5^
+| {CL_DEVICE_MAX_READ_IMAGE_ARGS_anchor} footnote:[{fn-max-read-image-args}]
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_IMAGE_ARGS.asciidoc[]
   | {cl_uint}
@@ -505,7 +491,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WRITE_IMAGE_ARGS.asciidoc[]
         write_only qualifier.
         The minimum value is 64 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}, the
         value is 0 otherwise.
-| {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS_anchor}^6^
+| {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.asciidoc[]
   | {cl_uint}
@@ -690,7 +676,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE.asciid
       | The minimum value is the size (in bytes) of the largest OpenCL data
         type supported by the device (`long16` in FULL profile, `long16` or
         `int16` in EMBEDDED profile).
-| {CL_DEVICE_SINGLE_FP_CONFIG_anchor}^7^
+| {CL_DEVICE_SINGLE_FP_CONFIG_anchor} footnote:[{fn-native-rounding-modes}]
 
 include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
   | {cl_device_fp_config}
@@ -725,7 +711,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
         For the embedded profile, see the
         <<embedded-profile-single-fp-config-requirements, dedicated table>>.
 
-| {CL_DEVICE_DOUBLE_FP_CONFIG_anchor}^8^
+| {CL_DEVICE_DOUBLE_FP_CONFIG_anchor} footnote:[{fn-native-rounding-modes}]
 
 include::{generated}/api/version-notes/CL_DEVICE_DOUBLE_FP_CONFIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
@@ -1027,7 +1013,7 @@ include::{generated}/api/version-notes/CL_DRIVER_VERSION.asciidoc[]
   | {char}[]
       | OpenCL software driver version string.
         Follows a vendor-specific format.
-| {CL_DEVICE_PROFILE_anchor}^9^
+| {CL_DEVICE_PROFILE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PROFILE.asciidoc[]
   | {char}[]
@@ -1284,7 +1270,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_TYPE.asciidoc[]
         associated with device or can return a property value of 0 (where 0
         is used to terminate the partition property list) in the memory that
         _param_value_ points to.
-| {CL_DEVICE_REFERENCE_COUNT_anchor}
+| {CL_DEVICE_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_DEVICE_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -1492,59 +1478,6 @@ include::{generated}/api/version-notes/CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASS
         has fully passed in accordance with the official conformance process.
 
 |====
-
-4::
-    OpenCL adopters must report a valid vendor ID for their implementation.
-    If there is no valid PCI vendor ID defined for the physical device,
-    implementations must obtain a Khronos vendor ID. This is a unique
-    identifier greater than the largest PCI vendor ID(0x10000) and is
-    representable by a {cl_uint}. Khronos vendor IDs are synchronized across
-    APIs by utilizing Vulkan's vk.xml as the central Khronos vendor ID registry.
-    An ID must be reserved here prior to use in OpenCL, regardless of whether a
-    vendor implements Vulkan. Only once the ID has been allotted may it be
-    exposed to OpenCL by proposing a merge request against cl.xml, in the master
-    branch of the OpenCL-Docs project. The merge must define a new enumerant by
-    adding an `<enum>` tag to the {cl_khronos_vendor_id} `<enums>` tag, with the
-    `<value>` attribute set as the acquired Khronos vendor ID. The `<name>`
-    attribute must identify the vendor/adopter, and be of the form
-    `CL_KHRONOS_VENDOR_ID_<vendor>`.
-
-5::
-    A kernel that uses an image argument with the write_only or read_write
-    image qualifier may result in additional read_only images resources being
-    created internally by an implementation.
-    The internally created read_only image resources will count against the max
-    supported read image arguments given by {CL_DEVICE_MAX_READ_IMAGE_ARGS}.
-    Enqueuing a kernel that requires more images than the implementation can
-    support will result in a {CL_OUT_OF_RESOURCES} error being returned.
-
-6::
-    NOTE: {CL_DEVICE_MAX_WRITE_IMAGE_ARGS} is only there for backward
-    compatibility.
-    {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS} should be used instead.
-
-7::
-    The optional rounding modes should be included as a device capability
-    only if it is supported natively.
-    All explicit conversion functions with specific rounding modes must
-    still operate correctly.
-
-8::
-    The optional rounding modes should be included as a device capability
-    only if it is supported natively.
-    All explicit conversion functions with specific rounding modes must
-    still operate correctly.
-
-9::
-    The platform profile returns the profile that is implemented by the
-    OpenCL framework.
-    If the platform profile returned is FULL_PROFILE, the OpenCL framework
-    will support devices that are FULL_PROFILE and may also support devices
-    that are EMBEDDED_PROFILE.
-    The compiler must be available for all devices i.e.
-    {CL_DEVICE_COMPILER_AVAILABLE} is {CL_TRUE}.
-    If the platform profile returned is EMBEDDED_PROFILE, then devices that
-    are only EMBEDDED_PROFILE are supported.
 
 // refError
 
@@ -1902,12 +1835,9 @@ include::{generated}/api/version-notes/clCreateContext.asciidoc[]
     _properties_ can be `NULL` in which case the platform that is selected is
     implementation-defined.
   * _num_devices_ is the number of devices specified in the _devices_ argument.
-  * _devices_ is a pointer to a list of unique devices^9^ returned by
+  * _devices_ is a pointer to a list of unique devices returned by
     {clGetDeviceIDs} or sub-devices created by {clCreateSubDevices} for a
-    platform.
-+
-9::
-    Duplicate devices specified in _devices_ are ignored.
+    platform. footnote:[{fn-duplicate-devices}]
   * _pfn_notify_ is a callback function that can be registered by the
     application.
     This callback function will be used by the OpenCL implementation to report
@@ -2008,8 +1938,8 @@ unavailable.
 
 [open,refpage='clCreateContextFromType',desc='Create an OpenCL context from a device type',type='protos']
 --
-To create an OpenCL context from a specific device type^10^, call the
-function:
+To create an OpenCL context from a specific device
+type footnote:[{fn-create-context-all-or-subset}], call the function:
 
 include::{generated}/api/protos/clCreateContextFromType.txt[]
 include::{generated}/api/version-notes/clCreateContextFromType.asciidoc[]
@@ -2032,10 +1962,6 @@ Only devices that are returned by {clGetDeviceIDs} for _device_type_ are
 used to create the context.
 The context does not reference any sub-devices that may have been created
 from these devices.
-
-10::
-    {clCreateContextfromType} may return all or a subset of the actual
-    physical devices present in the platform and that match device_type.
 
 // refError
 
@@ -2156,7 +2082,7 @@ _param_value_ by {clGetContextInfo} is described in the
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
 | Context Info | Return Type | Information returned in param_value
-| {CL_CONTEXT_REFERENCE_COUNT_anchor}^11^
+| {CL_CONTEXT_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_CONTEXT_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -2189,11 +2115,6 @@ include::{generated}/api/version-notes/CL_CONTEXT_PROPERTIES.asciidoc[]
         implementation must return _param_value_size_ret_ equal to 0,
         indicating that there are no properties to be returned.
 |====
-
-11::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -51,6 +51,8 @@ Also see extension *cl_khr_create_command_queue*.
     default value will be used.
     _properties_ can be `NULL` in which case the default values for supported
     command-queue properties will be used.
+  * _errcode_ret_ will return an appropriate error code.
+    If _errcode_ret_ is `NULL`, no error code is returned.
 
 [[queue-properties-table]]
 .List of supported queue creation properties by <<clCreateCommandQueueWithProperties>>
@@ -79,11 +81,14 @@ include::{generated}/api/version-notes/CL_QUEUE_PROFILING_ENABLE.asciidoc[]
 
         {CL_QUEUE_ON_DEVICE_anchor} - Indicates that this is a device queue.
         If {CL_QUEUE_ON_DEVICE} is set,
-        {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE}^1^ must also be set.
+        {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE}
+        footnote:[{fn-out-of-order-device-queue}]
+        must also be set.
 include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE.asciidoc[]
 
-        {CL_QUEUE_ON_DEVICE_DEFAULT_anchor}^2^ - indicates that this is the default
-        device queue.
+        {CL_QUEUE_ON_DEVICE_DEFAULT_anchor}
+        footnote:[{fn-default-device-queue}] -
+        indicates that this is the default device queue.
         This can only be used with {CL_QUEUE_ON_DEVICE}.
 include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE_DEFAULT.asciidoc[]
 
@@ -105,22 +110,6 @@ include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
         If {CL_QUEUE_SIZE} is not specified, the device queue is created with
         {CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE} as the size of the queue.
 |====
-
-1::
-    Only out-of-order device queues are supported.
-
-2::
-    The application must create the default device queue if any kernels
-    containing calls to get_default_queue are enqueued.
-    There can only be one default device queue for each device within a
-    context.
-    {clCreateCommandQueueWithProperties} with {CL_QUEUE_PROPERTIES} set to
-    {CL_QUEUE_ON_DEVICE} or {CL_QUEUE_ON_DEVICE_DEFAULT} will return the default
-    device queue that has already been created and increment its retain
-    count by 1.
-
-  * _errcode_ret_ will return an appropriate error code.
-    If _errcode_ret_ is `NULL`, no error code is returned.
 
 // refError
 
@@ -346,7 +335,7 @@ include::{generated}/api/version-notes/CL_QUEUE_CONTEXT.asciidoc[]
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE.asciidoc[]
   | {cl_device_id}
       | Return the device specified when the command-queue is created.
-| {CL_QUEUE_REFERENCE_COUNT_anchor}^3^
+| {CL_QUEUE_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_QUEUE_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -393,11 +382,6 @@ include::{generated}/api/version-notes/CL_QUEUE_DEVICE_DEFAULT.asciidoc[]
   | {cl_command_queue}
       | Return the current default command queue for the underlying device.
 |====
-
-3::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 
@@ -534,7 +518,8 @@ returned in _errcode_ret_:
     once.
   * {CL_INVALID_VALUE} if values specified in _flags_ are not valid as defined
     in the <<memory-flags-table,Memory Flags>> table.
-  * {CL_INVALID_BUFFER_SIZE} if _size_ is 0^4^.
+  * {CL_INVALID_BUFFER_SIZE} if _size_ is 0 or if _size_ is greater than
+    {CL_DEVICE_MAX_MEM_ALLOC_SIZE} for all devices in _context_.
   * {CL_INVALID_HOST_PTR} if _host_ptr_ is `NULL` and {CL_MEM_USE_HOST_PTR} or
     {CL_MEM_COPY_HOST_PTR} are set in _flags_ or if _host_ptr_ is not `NULL`
     but {CL_MEM_COPY_HOST_PTR} or {CL_MEM_USE_HOST_PTR} are not set in _flags_.
@@ -544,12 +529,6 @@ returned in _errcode_ret_:
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
-
-4::
-    Implementations may return {CL_INVALID_BUFFER_SIZE} if size is greater
-    than {CL_DEVICE_MAX_MEM_ALLOC_SIZE} value specified in the
-    <<device-queries-table,Device Queries>> table for all devices in
-    context.
 
 [[memory-flags-table]]
 .List of supported memory flag values
@@ -2194,13 +2173,11 @@ include::{generated}/api/structs/cl_image_desc.txt[]
   * `image_depth` is the depth of the image in pixels.
     This is only used if the image is a 3D image and must be a value {geq} 1 and
     {leq} {CL_DEVICE_IMAGE3D_MAX_DEPTH}.
-  * `image_array_size`^5^ is the number of images in the image array.
+  * `image_array_size` footnote:[{fn-image-array-performance}] is the number of
+    images in the image array.
     This is only used if the image is a 1D or 2D image array.
     The values for `image_array_size`, if specified, must be a value {geq} 1 and
     {leq} {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE}.
-5::
-    Note that reading and writing 2D image arrays from a kernel with
-    `image_array_size`=1 may be lower performance than 2D images.
   * `image_row_pitch` is the scan-line pitch in bytes.
     This must be 0 if _host_ptr_ is `NULL` and can be either 0 or {geq}
     `image_width` {times} size of element in bytes if _host_ptr_ is not `NULL`.
@@ -2226,22 +2203,15 @@ include::{generated}/api/structs/cl_image_desc.txt[]
   * `num_mip_levels` and `num_samples` must be 0.
   * `mem_object` may refer to a valid buffer or image memory object.
     `mem_object` can be a buffer memory object if `image_type` is
-    {CL_MEM_OBJECT_IMAGE1D_BUFFER} or {CL_MEM_OBJECT_IMAGE2D}^6^.
+    {CL_MEM_OBJECT_IMAGE1D_BUFFER} or
+    {CL_MEM_OBJECT_IMAGE2D} footnote:[{fn-image-from-buffer}].
     `mem_object` can be an image object if `image_type` is
-    {CL_MEM_OBJECT_IMAGE2D}^7^.
+    {CL_MEM_OBJECT_IMAGE2D} footnote:[{fn-image-from-image}].
     Otherwise it must be `NULL`.
     The image pixels are taken from the memory objects data store.
     When the contents of the specified memory objects data store are modified,
     those changes are reflected in the contents of the image object and
     vice-versa at corresponding synchronization points.
-
-6::
-    To create a 2D image from a buffer object that share the data store
-    between the image and buffer object.
-
-7::
-    To create an image object from another image object that share the data
-    store between these image objects.
 
 For a 1D image buffer created from a buffer object, the `image_width` {times}
 size of element in bytes must be {leq} size of the buffer object.
@@ -2283,7 +2253,8 @@ Restrictions are:
 
   * The image channel order specified in _image_format_ must be compatible
     with the image channel order associated with `mem_object`.
-    Compatible image channel orders ^8^ are:
+    Compatible image channel orders
+    footnote:[{fn-compatible-image-channel-orders}] are:
 +
 --
 [width="100%",cols="<50%,<50%",options="header"]
@@ -2310,11 +2281,6 @@ Restrictions are:
   | {CL_R}
 |====
 --
-
-8::
-    This allows creation of a sRGB view of the image from a linear
-    RGB view or vice-versa i.e. the pixels stored in the image can be
-    accessed as linear RGB or sRGB values.
 
 [NOTE]
 ====
@@ -2440,7 +2406,7 @@ is:
         {CL_HALF_FLOAT} +
         {CL_FLOAT}
 | 1
-  | {CL_DEPTH}^9^
+  | {CL_DEPTH} footnote:[{fn-depth-image-requirements}]
       | {CL_UNORM_INT16} +
         {CL_FLOAT}
 | 2
@@ -2475,19 +2441,9 @@ is:
   | {CL_BGRA}
       | {CL_UNORM_INT8}
 | 4
-  | {CL_sRGBA}^10^
+  | {CL_sRGBA} footnote:[{fn-srgb-image-requirements}]
       | {CL_UNORM_INT8}
 |====
-
-9::
-    Support for the {CL_DEPTH} image channel order is required only for 2D
-    images and 2D image arrays.
-
-10::
-    Support for reading from the {CL_sRGBA} image channel order is optional
-    for 1D image buffers.
-    Support for writing to the {CL_sRGBA} image channel order is optional
-    for all image types.
 
 For full profile devices supporting other OpenCL versions, such as OpenCL 1.2
 or OpenCL 3.0, the minimum list of supported image formats for either reading
@@ -4197,12 +4153,12 @@ include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
         created.
 
         Otherwise, returns `NULL`.
-| {CL_MEM_MAP_COUNT_anchor}^11^
+| {CL_MEM_MAP_COUNT_anchor} footnote:[{fn-map-count-usage}]
 
 include::{generated}/api/version-notes/CL_MEM_MAP_COUNT.asciidoc[]
   | {cl_uint}
       | Map count.
-| {CL_MEM_REFERENCE_COUNT_anchor}^12^
+| {CL_MEM_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_MEM_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -4268,16 +4224,6 @@ include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
         must return _param_value_size_ret_ equal to 0, indicating that
         there are no properties to be returned.
 |====
-
-11::
-    The map count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for debugging.
-
-12::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 
@@ -5301,7 +5247,7 @@ include::{generated}/api/version-notes/clGetSamplerInfo.asciidoc[]
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
 | Sampler Info | Return Type | Info. returned in _param_value_
-| {CL_SAMPLER_REFERENCE_COUNT_anchor}^13^
+| {CL_SAMPLER_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_SAMPLER_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -5344,11 +5290,6 @@ include::{generated}/api/version-notes/CL_SAMPLER_PROPERTIES.asciidoc[]
         implementation must return _param_value_size_ret_ equal to 0,
         indicating that there are no properties to be returned.
 |====
-
-13::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 
@@ -6622,7 +6563,7 @@ include::{generated}/api/version-notes/clGetProgramInfo.asciidoc[]
 [width="100%",cols="<34%,<33%,<33%",options="header"]
 |====
 | Program Info | Return Type | Info. returned in _param_value_
-| {CL_PROGRAM_REFERENCE_COUNT_anchor}^14^
+| {CL_PROGRAM_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_PROGRAM_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -6770,11 +6711,6 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asc
         Support for constructors and destructors for program scope global
         variables is required only for OpenCL 2.2 devices.
 |====
-
-14::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 
@@ -7531,7 +7467,7 @@ include::{generated}/api/version-notes/CL_KERNEL_FUNCTION_NAME.asciidoc[]
 include::{generated}/api/version-notes/CL_KERNEL_NUM_ARGS.asciidoc[]
   | {cl_uint}
       | Return the number of arguments to kernel.
-| {CL_KERNEL_REFERENCE_COUNT_anchor}^16^
+| {CL_KERNEL_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_KERNEL_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
@@ -7567,11 +7503,6 @@ include::{generated}/api/version-notes/CL_KERNEL_ATTRIBUTES.asciidoc[]
         {clCreateProgramWithSource} API call the string returned from this
         query will be empty.
 |====
-
-16::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 // refError
 
@@ -7954,9 +7885,11 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
         for the argument given by _arg_index_.
         The returned values can be:
         
-        {CL_KERNEL_ARG_TYPE_CONST_anchor}^17^ +
+        {CL_KERNEL_ARG_TYPE_CONST_anchor}
+        footnote:[{fn-kernel-arg-type-qualifier}]
+        footnote:[{fn-kernel-arg-type-const-addr-space}] +
         {CL_KERNEL_ARG_TYPE_RESTRICT_anchor} +
-        {CL_KERNEL_ARG_TYPE_VOLATILE_anchor}^18^ +
+        {CL_KERNEL_ARG_TYPE_VOLATILE_anchor} +
         {CL_KERNEL_ARG_TYPE_PIPE_anchor}, or +
         {CL_KERNEL_ARG_TYPE_NONE_anchor}
 
@@ -7968,29 +7901,6 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
   | {char}[]
       | Returns the name specified for the argument given by _arg_index_.
 |====
-
-17::
-    {CL_KERNEL_ARG_TYPE_CONST} is returned for
-    {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is declared with the
-    `constant` address space qualifier.
-
-18::
-    {CL_KERNEL_ARG_TYPE_VOLATILE} is returned for
-    {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is a pointer and the
-    referenced type is declared with the volatile qualifier.
-    For example, a kernel argument declared as `global int volatile *x`
-    returns {CL_KERNEL_ARG_TYPE_VOLATILE} but a kernel argument declared
-    as `global int * volatile x` does not.
-    Similarly, {CL_KERNEL_ARG_TYPE_CONST} is returned if the argument is a
-    pointer and the referenced type is declared with the restrict or
-    const qualifier.
-    For example, a kernel argument declared as `global int const *x`
-    returns {CL_KERNEL_ARG_TYPE_CONST} but a kernel argument declared as
-    `global int * const x` does not.
-    {CL_KERNEL_ARG_TYPE_RESTRICT} will be returned if the pointer type is
-    marked `restrict`.
-    For example, `global int * restrict x` returns
-    {CL_KERNEL_ARG_TYPE_RESTRICT}.
 
 {clGetKernelArgInfo} returns CL SUCCESS if the function is executed
 successfully.
@@ -8655,7 +8565,7 @@ include::{generated}/api/version-notes/CL_EVENT_COMMAND_TYPE.asciidoc[]
       | Return the command type associated with _event_ as described in the
         <<event-command-type-table,Event Command Types>> table.
 
-| {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor}^19^
+| {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor} footnote:[{fn-event-status-order}]
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciidoc[]
   | {cl_int}
@@ -8677,24 +8587,12 @@ include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciido
         These error codes come from the same set of error codes that are
         returned from the platform or runtime API calls as return values or
         errcode_ret values.
-| {CL_EVENT_REFERENCE_COUNT_anchor}^20^
+| {CL_EVENT_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_EVENT_REFERENCE_COUNT.asciidoc[]
   | {cl_uint}
       | Return the _event_ reference count.
 |====
-
-19::
-    The error code values are negative, and event state values are positive.
-    The event state values are ordered from the largest value {CL_QUEUED}
-    for the first or initial state to the smallest value ({CL_COMPLETE} or
-    negative integer value) for the last or complete state.
-    The value of {CL_COMPLETE} and {CL_SUCCESS} are the same.
-
-20::
-    The reference count returned should be considered immediately stale.
-    It is unsuitable for general use in applications.
-    This feature is provided for identifying memory leaks.
 
 [[event-command-type-table]]
 .List of supported event command types
@@ -8893,7 +8791,8 @@ include::{generated}/api/version-notes/clSetEventCallback.asciidoc[]
   * _command_exec_callback_type_ specifies the command execution status for
     which the callback is registered.
     The command execution callback values for which a callback can be registered
-    are: {CL_SUBMITTED}, {CL_RUNNING}, or {CL_COMPLETE}^21^.
+    are: {CL_SUBMITTED}, {CL_RUNNING}, or
+    {CL_COMPLETE} footnote:[{fn-event-callback-complete}].
     There is no guarantee that the callback functions registered for various
     execution status values for an event will be called in the exact order that
     the execution status of a command changes.
@@ -8922,11 +8821,6 @@ include::{generated}/api/version-notes/clSetEventCallback.asciidoc[]
   * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
     called.
     _user_data_ can be `NULL`.
-
-21::
-    The callback function registered for a _command_exec_callback_type_ value
-    of {CL_COMPLETE} will be called when the command has completed
-    successfully or is abnormally terminated.
 
 The registered callback function will be called when the execution status of
 command associated with _event_ changes to an execution status equal to or

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -1,0 +1,280 @@
+// Copyright 2017-2020 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Please keep footnotes in alphabetical order!
+
+// Note: Mostly follows the suggested syntax from:
+// https://github.com/asciidoctor/asciidoctor-pdf/issues/1397
+
+:fn-address-operator-result: pass:n[ \
+Thus, *&*E* is equivalent to *E* (even if *E* is a null pointer), and *&(E1[E2\])* is equivalent to *\((E1) {plus} (E2))*. \
+It is always true that if *E* is an l-value that is a valid operand of the unary *&* operator, *+*&E+* is an l-value equal to *E*. \
+]
+
+:fn-aggregate-types: pass:n[ \
+That is, for the purpose of applying type-based aliasing rules, a built-in vector data type will be considered equivalent to the corresponding array type. \
+]
+
+:fn-atomic-no-consume: pass:n[ \
+The <<C11-spec,C11>> consume operation is not supported. \
+]
+
+:fn-atomic-double-supported: pass:n[ \
+The `atomic_double` type is only supported if double precision is supported and the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled. \
+If this is the case then an OpenCL C 3.0 compiler must also define the `+__opencl_c_fp64+` feature. \
+]
+
+:fn-atomic-int64-supported: pass:n[ \
+The atomic_long and atomic_ulong types are supported if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled. \
+If this is the case then an OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature. \
+]
+
+:fn-atomic-size_t-supported: pass:n[ \
+If the device address space is 64-bits, the data types `atomic_intptr_t`, `atomic_uintptr_t`, `atomic_size_t` and `atomic_ptrdiff_t` are supported if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled. \
+]
+
+:fn-atomic-weak-rationale: pass:n[ \
+This spurious failure enables implementation of compare-and-exchange on a broader class of machines, e.g. load-locked store-conditional machines. \
+]
+
+:fn-bitfield-struct-restriction: pass:n[ \
+Bit-field struct members are <<restrictions-bitfield, not supported in OpenCL C>>. \
+]
+
+:fn-bool: pass:n[ \
+When any scalar value is converted to `bool`, the result is 0 if the value compares equal to 0; otherwise, the result is 1. \
+]
+
+:fn-cl_khr_fp16: pass:n[ \
+Unless the *cl_khr_fp16* extension is supported and has been enabled. \
+]
+
+:fn-clang-block-syntax: pass:n[ \
+This syntax is already part of the clang source tree on which most vendors have based their OpenCL implementations. \
+Additionally, blocks based closures are supported by the clang open source C compiler as well as Mac OS X's C and Objective C compilers. \
+Specifically, Mac OS X's Grand Central Dispatch allows applications to queue tasks as a block. \
+]
+
+:fn-clang-block-function-pointers: pass:n[ \
+OpenCL C <<restrictions,does not allow function pointers>> primarily because it is difficult or expensive to implement generic indirections to executable code in many hardware architectures that OpenCL targets. \
+OpenCL C's design of Blocks is intended to respect that same condition, yielding the restrictions listed here. \
+As such, Blocks allow a form of dynamically enqueued function scheduling without providing a form of runtime synchronous dynamic dispatch analogous to function pointers. \
+]
+
+:fn-CLK_ADDRESS_CLAMP: pass:n[ \
+This is similar to the `GL_ADDRESS_CLAMP_TO_BORDER` addressing mode. \
+]
+
+:fn-double: pass:n[ \
+The `double` scalar type is an optional type that is supported if the value of the `CL_DEVICE_DOUBLE_FP_CONFIG` device query is not zero. \
+If this is the case then an OpenCL C 3.0 compiler must also define the `+__opencl_c_fp64+` feature macro. \
+]
+
+:fn-double-precision-supported: pass:n[ \
+Only if double precision is supported. \
+In OpenCL C 3.0 this will be indicated by the presence of the `+__opencl_c_fp64+` feature macro. \
+]
+
+:fn-double-vec: pass:n[ \
+The `double__n__` vector type is an optional type that is supported if the value of the `CL_DEVICE_DOUBLE_FP_CONFIG` device query is not zero. \
+If this is the case then an OpenCL C 3.0 compiler must also define the `+__opencl_c_fp64+` feature macro. \
+]
+
+:fn-dse-CLK_ENQUEUE_FLAGS_WAIT_WORK_GROUP: pass:n[ \
+This acts as a memory synchronization point between work-items in a work-group and child kernels enqueued by work-items in the work-group. \
+]
+
+:fn-dse-immediate-definition: pass:n[ \
+Immediate meaning not side effects resulting from child kernels. \
+The side effects would include stores to `global` memory and pipe reads and writes. \
+]
+
+:fn-dse-kernel_enqueue_flags_t: pass:n[ \
+Implementations are not required to honor this flag. \
+Implementations may not schedule kernel launch earlier than the point specified by this flag, however. \
+]
+
+:fn-float-conversion-rounding: pass:n[ \
+For conversions to floating-point format, when a finite source value exceeds the maximum representable finite floating-point destination value, the rounding mode will affect whether the result is the maximum finite floating-point value or infinity of same sign as the source value, per IEEE-754 rules for rounding. \
+]
+
+:fn-float-increment-decrement: pass:n[ \
+The pre- and post- increment operators may have unexpected behavior on floating-point values and are therefore not supported for floating-point scalar and vector built-in types. \
+For example, if variable _a_ has type `float` and holds the value `0x1.0p25f`, then `_a_{pp}` returns `0x1.0p25f`. + \
+Also, `(_a_{pp})--` is not guaranteed to return _a_, if _a_ has fractional value. + \
+In non-default rounding modes, `(_a_{pp})--` may produce the same result as `_a_{pp}` or `_a_--` for large _a_. \
+]
+
+:fn-float-reinterpretation: pass:n[ \
+In addition, some other extensions to the C language designed to support a particular vector ISA (e.g. AltiVec{trade}, CELL Broadband Engine{trade} Architecture) use such conversions in conjunction with swizzle operators to achieve type un-conversion. \
+So as to support legacy code of this type, *as_typen*() allows conversions between vectors of the same size but different numbers of elements, even though the behavior of this sort of conversion is not likely to be portable except to other OpenCL implementations for the same hardware architecture. + \
+AltiVec is a trademark of Motorola Inc. + \
+Cell Broadband Engine is a trademark of Sony Computer Entertainment, Inc. \
+]
+
+:fn-float-required-rounding-mode: pass:n[ \
+Except for the embedded profile where either round to zero or round to nearest rounding mode may be supported for single precision floating-point. \
+]
+
+:fn-floating-point-exception-nans: pass:n[ \
+If an implementation extends this specification to support IEEE-754 flags or exceptions, then all built-in functions defined in the following table shall proceed without raising the _invalid_ floating-point exception when one or more of the operands are NaNs. \
+]
+
+:fn-float-types-supported: pass:n[ \
+The `half` scalar and vector types can only be used if the *cl_khr_fp16* extension is supported and has been enabled. \
+The `double` scalar and vector types can only be used if `double` precision is supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro is present. \
+]
+
+:fn-fmin-fmax-nan: pass:n[ \
+*fmin* and *fmax* behave as defined by C99 and may not match the IEEE 754-2008 definition for *minNum* and *maxNum* with regard to signaling NaNs. \
+Specifically, signaling NaNs may behave as quiet NaNs. \
+]
+
+:fn-fract-min: pass:n[ \
+The *min*() operator is there to prevent *fract*(-small) from returning 1.0. \
+It returns the largest positive floating-point number less than 1.0. \
+]
+
+:fn-half-supported: pass:n[ \
+Only if the *cl_khr_fp16* extension is supported and has been enabled. \
+]
+
+:fn-image-functions: pass:n[ \
+Refer to the detailed description of the built-in <<image-read-and-write-functions,Image Read and Write Functions>> that use this type. \
+]
+
+:fn-int64-supported: pass:n[ \
+Only if 64-bit integers are supported. \
+In OpenCL C 3.0 this will be indicated by the presence of the `+__opencl_c_int64+` feature macro. \
+]
+
+:fn-integer-conversion-rank: pass:n[ \
+This is different from the standard integer conversion rank described in <<C99-spec,section 6.3.1.1 of the C99 Specification>>. \
+]
+
+:fn-integer-promotion: pass:n[ \
+Integer promotion is described in <<C99-spec,section 6.3.1.1 of the C99 Specification>>. \
+]
+
+:fn-long: pass:n[ \
+The `long`, `unsigned long` and `ulong` scalar types are optional types for EMBEDDED profile devices that are supported if the value of the `CL_DEVICE_EXTENSIONS` device query contains *cles_khr_int64*. \
+An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature macro unconditionally for FULL profile devices, or for EMBEDDED profile devices that support these types. \
+]
+
+:fn-long-vec: pass:n[ \
+The `long__n__` and `ulong__n__` vector types are optional types for EMBEDDED profile devices that are supported if the value of the `CL_DEVICE_EXTENSIONS` device query contains *cles_khr_int64*. \
+An OpenCL C 3.0 compiler must also define the `+__opencl_c_int64+` feature macro unconditionally for FULL profile devices, or for EMBEDDED profile devices that support these types. \
+]
+
+:fn-mad-caution: pass:n[ \
+The user is cautioned that for some usages, e.g. *mad*(a, b, -a*b), the definition of *mad*() is loose enough in the embedded profile that almost any result is allowed from *mad*() for some values of a and b. \
+]
+
+:fn-memory-scope-restrictions: pass:n[ \
+Refer to the description and restrictions for <<memory-scope,`memory_scope`>>. \
+]
+
+:fn-min-float-constants: pass:n[ \
+Here `TYPE_MIN` and `TYPE_MIN_EXP` should be substituted by constants appropriate to the floating-point type under consideration, such as `FLT_MIN` and `FLT_MIN_EXP` for `float`. \
+]
+
+:fn-non-uniform-work-groups: pass:n[ \
+I.e. the _global_work_size_ values specified to *clEnqueueNDRangeKernel* are not evenly divisible by the _local_work_size_ values for each dimension. \
+]
+
+:fn-pointer-invalid-value-indirection: pass:n[ \
+Among the invalid values for dereferencing a pointer by the unary *+*+* operator are a null pointer, an address inappropriately aligned for the type of object pointed to, and the address of an object after the end of its lifetime. \
+If *+*P+* is an l-value and *T* is the name of an object pointer type, *+*(T)P+* is an l-value that has a type compatible with that to which *T* points. \
+]
+
+:fn-pow-performance: pass:n[ \
+On some implementations, *powr*() or *pown*() may perform faster than *pow*(). \
+If _x_ is known to be >= 0, consider using *powr*() in place of *pow*(), or if _y_ is known to be an integer, consider using *pown*() in place of *pow*(). \
+]
+
+:fn-printf-field-width: pass:n[ \
+Note that *0* is taken as a flag, not as the beginning of a field width. \
+]
+
+:fn-printf-hex-float: pass:n[ \
+Binary implementations can choose the hexadecimal digit to the left of the decimal-point character so that subsequent digits align to nibble (4-bit) boundaries. \
+]
+
+:fn-printf-infinity-nan: pass:n[ \
+When applied to infinite and NaN values, the *-*, *+*, and _space_ flag characters have their usual meaning; the *#* and *0* flag characters have no effect. \
+]
+
+:fn-printf-literal-string: pass:n[ \
+No special provisions are made for multibyte characters. \
+The behavior of *printf* with the *s* conversion specifier is undefined if the argument value is not a pointer to a literal string. \
+]
+
+:fn-printf-minus-sign: pass:n[ \
+The results of all floating conversions of a negative zero, and of negative values that round to zero, include a minus sign. \
+]
+
+:fn-read-image-with-sampler: pass:n[ \
+Note that the built-in function calls to read images with a sampler are not supported for `image1d_buffer_t` image types. \
+]
+
+:fn-reinterpret-vector-types: pass:n[ \
+While the union is intended to reflect the organization of data in memory, the *as_type*() and *as_type__n__*() constructs are intended to reflect the organization of data in register. \
+The *as_type*() and *as_type__n__*() constructs are intended to compile to no instructions on devices that use a shared register file designed to operate on both the operand and result types. \
+Note that while differences in memory organization are expected to largely be limited to those arising from endianness, the register based representation may also differ due to size of the element in register. \
+For example, an architecture may load a `char` into a 32-bit register, or a `char` vector into a SIMD vector register with fixed 32-bit element size. \
+If the element count does not match, then the implementation should pick a data representation that most closely matches what would happen if an appropriate result type operator was applied to a register containing data of the source type. \
+If the number of elements matches, then the *as_type__n__*() should faithfully reproduce the behavior expected from a similar data type reinterpretation using memory/unions. \
+So, for example if an implementation stores all single precision data as `double` in register, it should implement *as_int*(`float`) by first down-converting the `double` to single precision and then (if necessary) moving the single precision bits to a register suitable for operating on integer data. \
+If data stored in different address spaces do not have the same endianness, then the "`dominant endianness`" of the device should prevail. \
+]
+
+:fn-relational-any-all: pass:n[ \
+To test whether any or all elements in the result of a vector relational operator test _true_, for example to use in the context in an *if ( )* statement, please see the <<relational-functions,*any* and *all* built-ins>>. \
+]
+
+:fn-rhadd-benefit: pass:n[ \
+Frequently vector operations need n + 1 bits temporarily to calculate a result. \
+The *rhadd* instruction gives you an extra bit without needing to upsample and downsample. \
+This can be a profound performance win. \
+]
+
+:fn-select-vs-ternary: pass:n[ \
+This definition means that the behavior of select and the ternary operator for vector and scalar types is dependent on different interpretations of the bit pattern of _c_. \
+]
+
+:fn-size_t: pass:n[ \
+This is a 32-bit type if the value of the `CL_DEVICE_ADDRESS_BITS` device query is 32-bits, and a 64-bit type if the value of the query is 64-bits. \
+]
+
+:fn-variable-length-array-restriction: pass:n[ \
+Variable length arrays are <<restrictions-variable-length,not supported in OpenCL C>>. \
+]
+
+:fn-vec3-async-copy: pass:n[ \
+*async_work_group_copy* and *async_work_group_strided_copy* for 3-component vector types behave as *async_work_group_copy* and *async_work_group_strided_copy* respectively for 4-component vector types. \
+]
+
+:fn-vec3-size: pass:n[ \
+Except for 3-component vectors whose size is defined as 4 times the size of each scalar component. \
+]
+
+:fn-vec3-vload-vstore: pass:n[ \
+*vload3* and *vload_half3* read (_x_,_y_,_z_) components from address `(_p_ + (_offset_ * 3))` into a 3-component vector. \
+*vstore3* and *vstore_half3* write (_x_,_y_,_z_) components from a 3-component vector to address `(_p_ + (_offset_ * 3))`. \
+In addition, *vloada_half3* reads (_x_,_y_,_z_) components from address `(_p_ + (_offset_ * 4))` into a 3-component vector and *vstorea_half3* writes (_x_,_y_,_z_) components from a 3-component vector to address `(_p_ {plus} (_offset_ * 4))`. \
+Whether *vloada_half3* and *vstorea_half3* read/write padding data between the third vector element and the next alignment boundary is implementation defined. \
+The *vloada_* and *vstorea_* variants are provided to access data that is aligned to the size of the vector, and are intended to enable performance on hardware that can take advantage of the increased alignment. \
+]
+
+:fn-vec-type-hint: pass:n[ \
+Implicit in autovectorization is the assumption that any libraries called from the `+__kernel+` must be recompilable at run time to handle cases where the compiler decides to merge or separate workitems.  \
+This probably means that such libraries can never be hard coded binaries or that hard coded binaries must be accompanied either by source or some retargetable intermediate representation. \
+This may be a code security question for some. \
+]
+
+:fn-vector-types: pass:n[ \
+Built-in vector data types are supported by the OpenCL implementation even if the underlying compute device does not natively support any or all of the vector data types. \
+They are to be converted by the device compiler to appropriate instructions that use underlying built-in types supported natively by the compute device. \
+Refer to Appendix B in the OpenCL API specification for a description of the order of the components of a vector type in memory. \
+]

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -71,7 +71,7 @@ The `double` scalar type is an optional type that is supported if the value of t
 If this is the case then an OpenCL C 3.0 compiler must also define the `+__opencl_c_fp64+` feature macro. \
 ]
 
-:fn-double-precision-supported: pass:n[ \
+:fn-double-supported: pass:n[ \
 Only if double precision is supported. \
 In OpenCL C 3.0 this will be indicated by the presence of the `+__opencl_c_fp64+` feature macro. \
 ]

--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -211,6 +211,8 @@ class OpenCLConventions(ConventionsBase):
     def extra_refpage_headers(self):
         """Return any extra text to add to refpage headers."""
         return 'include::../config/attribs.txt[]\n' + \
+            'include::../api/footnotes.asciidoc[]\n' + \
+            'include::../c/footnotes.asciidoc[]\n' + \
             'include::{generated}/api/api-dictionary-no-links.asciidoc[]'
 
     @property


### PR DESCRIPTION
Fixes #386 

This change switches all OpenCL API and OpenCL C spec footnotes to use the asciidoctor footnote syntax.

See: https://asciidoctor.org/docs/user-manual/#user-footnotes

I decided to use a separate file with the text of all footnotes for each spec for easier reuse and less clutter where each of the footnotes is used - see the added "footnotes.asciidoc" files.  As mentioned in #386, in the PDF renderings the footnotes are placed at the end of each chapter, so they are more properly "endnotes" than "footnotes", but I still think this is preferable to our previous semi-inline footnote syntax, and using the asciidoctor footnote syntax will automatically renumber footnotes as needed.