### PR TITLE
Clarify Required Atomic Capability Nesting

### DIFF
--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -7,6 +7,10 @@
 // Note: Follows the suggested syntax from:
 // https://github.com/asciidoctor/asciidoctor-pdf/issues/1397
 
+:fn-atomic-scope-work-item: pass:n[ \
+Note that this flag does not provide meaning for atomic memory operations, but only for atomic fence operations in certain circumstances, refer to the Memory Scope section of the OpenCL C specification. \
+]
+
 :fn-compatible-image-channel-orders: pass:n[ \
 This allows creation of a sRGB view of the image from a linear RGB view or vice-versa, i.e. the pixels stored in the image can be accessed as linear RGB or sRGB values. \
 ]

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -885,8 +885,7 @@ include::{generated}/api/version-notes/CL_DEVICE_EXECUTION_CAPABILITIES.asciidoc
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_EXEC_KERNEL_anchor} - The OpenCL device can execute OpenCL kernels.
-
+        {CL_EXEC_KERNEL_anchor} - The OpenCL device can execute OpenCL kernels. +
         {CL_EXEC_NATIVE_KERNEL_anchor} - The OpenCL device can execute native
         kernels.
 
@@ -1290,17 +1289,14 @@ include::{generated}/api/version-notes/CL_DEVICE_SVM_CAPABILITIES.asciidoc[]
         sharing using {clSVMAlloc}.
         Memory consistency is guaranteed at synchronization points and the
         host must use calls to {clEnqueueMapBuffer} and
-        {clEnqueueUnmapMemObject}.
-
+        {clEnqueueUnmapMemObject}. +
         {CL_DEVICE_SVM_FINE_GRAIN_BUFFER_anchor} - Support for fine-grain buffer
         sharing using {clSVMAlloc}.
         Memory consistency is guaranteed at synchronization points without
-        need for {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject}.
-
+        need for {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject}. +
         {CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_anchor} - Support for sharing the host's
         entire virtual memory including memory allocated using *malloc*.
-        Memory consistency is guaranteed at synchronization points.
-
+        Memory consistency is guaranteed at synchronization points. +
         {CL_DEVICE_SVM_ATOMICS_anchor} - Support for the OpenCL 2.0 atomic
         operations that provide memory consistency across the host and all
         OpenCL devices supporting fine-grain SVM allocations.
@@ -1367,27 +1363,19 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
         This is a bit-field that describes a combination of the following
         values:
 
-        {CL_DEVICE_ATOMIC_ORDER_RELAXED_anchor} - Support for relaxed memory ordering.
-        E.g the use of `memory_order_relaxed` in OpenCL C.
+        {CL_DEVICE_ATOMIC_ORDER_RELAXED_anchor} - Support for *relaxed* semantics. +
+        {CL_DEVICE_ATOMIC_ORDER_ACQ_REL_anchor} - Support for *acquire*, *release*, and *acquire-release* semantics. +
+        {CL_DEVICE_ATOMIC_ORDER_SEQ_CST_anchor} - Support for *sequentially consistent* semantics.
 
-        {CL_DEVICE_ATOMIC_ORDER_ACQ_REL_anchor} - Support for acquire and release memory orderings.
-        E.g the use of `memory_order_acquire`, `memory_order_release`, or `memory_order_acq_rel` in OpenCL C.
-
-        {CL_DEVICE_ATOMIC_ORDER_SEQ_CST_anchor} - Support for sequentially consistent memory ordering.
-        E.g the use of `memory_order_seq_cst` in OpenCL C.
+        Because atomic memory orders are hierarchical, a device that supports strong memory ordering semantics must also support all weaker memory semantics.
 
         {CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM_anchor} - Support for memory ordering constraints that apply to a single work item.
-        E.g the use of `memory_scope_work_item` in OpenCL C.
-        Note that this flag does not provide meaning for atomic memory operations, but only for atomic fence operations in certain circumstances, refer to the Memory Scope section of the OpenCL C specification.
+        footnote:[Note that this flag does not provide meaning for atomic memory operations, but only for atomic fence operations in certain circumstances, refer to the Memory Scope section of the OpenCL C specification.] +
+        {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP_anchor} - Support for memory ordering constraints that apply to all work-items in a work-group. +
+        {CL_DEVICE_ATOMIC_SCOPE_DEVICE_anchor} - Support for memory ordering constraints that apply to all work-items executing on the device. +
+        {CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES_anchor} - Support for memory ordering constraints that apply to all work-items executing across all devices that can share SVM memory with each other and the host process.
 
-        {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP_anchor} - Support for memory ordering constraints that apply to all work items in a work-group.
-        E.g the use of `memory_scope_work_group` in OpenCL C.
-
-        {CL_DEVICE_ATOMIC_SCOPE_DEVICE_anchor} - Support for memory ordering constraints that apply to all work-items of a kernel(s) simultaneously executing on a device.
-        E.g the use of `memory_scope_device` in OpenCL C.
-
-        {CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES_anchor} - Support for memory ordering constraints that apply to all work-items of a kernel(s) executing across all devices that can share SVM memory with each other and the host process.
-        E.g the use of `memory_scope_all_svm_devices` in OpenCL C.
+        Because atomic scopes are hierarchical, a device that supports a wide scope must also support all narrower scopes, except for the work-item scope, which is a special case.
 
         The mandated minimum capability is:
 
@@ -1439,8 +1427,7 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues.
-
+        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues. +
         {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue.
 
         If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} must also be set.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -684,29 +684,24 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_FP_DENORM_anchor} - denorms are supported
-
-        {CL_FP_INF_NAN_anchor} - INF and quiet NaNs are supported.
-
+        {CL_FP_DENORM_anchor} - denorms are supported +
+        {CL_FP_INF_NAN_anchor} - INF and quiet NaNs are supported +
         {CL_FP_ROUND_TO_NEAREST_anchor}-- round to nearest even rounding mode
-        supported
-
-        {CL_FP_ROUND_TO_ZERO_anchor} - round to zero rounding mode supported
-
+        supported +
+        {CL_FP_ROUND_TO_ZERO_anchor} - round to zero rounding mode supported +
         {CL_FP_ROUND_TO_INF_anchor} - round to positive and negative infinity
-        rounding modes supported
-
-        {CL_FP_FMA_anchor} - IEEE754-2008 fused multiply-add is supported.
-
+        rounding modes supported +
+        {CL_FP_FMA_anchor} - IEEE754-2008 fused multiply-add is supported +
         {CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT_anchor} - divide and sqrt are correctly
-        rounded as defined by the IEEE754 specification.
-
+        rounded as defined by the IEEE754 specification +
         {CL_FP_SOFT_FLOAT_anchor} - Basic floating-point operations (such as
-        addition, subtraction, multiplication) are implemented in software.
+        addition, subtraction, multiplication) are implemented in software
 
         For the full profile, the mandated minimum floating-point capability
         for devices that are not of type {CL_DEVICE_TYPE_CUSTOM} is:
-        {CL_FP_ROUND_TO_NEAREST} \| {CL_FP_INF_NAN}.
+
+        {CL_FP_ROUND_TO_NEAREST} \| +
+        {CL_FP_INF_NAN}.
 
         For the embedded profile, see the
         <<embedded-profile-single-fp-config-requirements, dedicated table>>.
@@ -721,28 +716,23 @@ Also see extension *cl_khr_fp64*.
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_FP_DENORM} - denorms are supported
-
-        {CL_FP_INF_NAN} - INF and NaNs are supported.
-
+        {CL_FP_DENORM} - denorms are supported +
+        {CL_FP_INF_NAN} - INF and NaNs are supported +
         {CL_FP_ROUND_TO_NEAREST} - round to nearest even rounding mode
-        supported.
-
-        {CL_FP_ROUND_TO_ZERO} - round to zero rounding mode supported.
-
+        supported +
+        {CL_FP_ROUND_TO_ZERO} - round to zero rounding mode supported +
         {CL_FP_ROUND_TO_INF} - round to positive and negative infinity
-        rounding modes supported.
-
-        {CL_FP_FMA} - IEEE754-2008 fused multiply-add is supported.
-
+        rounding modes supported +
+        {CL_FP_FMA} - IEEE754-2008 fused multiply-add is supported +
         {CL_FP_SOFT_FLOAT} - Basic floating-point operations (such as
-        addition, subtraction, multiplication) are implemented in software.
+        addition, subtraction, multiplication) are implemented in software
 
         Double precision is an optional feature so the mandated minimum
         double precision floating-point capability is 0.
 
         If double precision is supported by the device, then the minimum
-        double precision floating-point capability must be: +
+        double precision floating-point capability is:
+
         {CL_FP_FMA} \| +
         {CL_FP_ROUND_TO_NEAREST} \| +
         {CL_FP_INF_NAN} \| +
@@ -1363,13 +1353,14 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
         This is a bit-field that describes a combination of the following
         values:
 
-        {CL_DEVICE_ATOMIC_ORDER_RELAXED_anchor} - Support for *relaxed* semantics. +
-        {CL_DEVICE_ATOMIC_ORDER_ACQ_REL_anchor} - Support for *acquire*, *release*, and *acquire-release* semantics. +
-        {CL_DEVICE_ATOMIC_ORDER_SEQ_CST_anchor} - Support for *sequentially consistent* semantics.
+        {CL_DEVICE_ATOMIC_ORDER_RELAXED_anchor} - Support for the *relaxed* memory order. +
+        {CL_DEVICE_ATOMIC_ORDER_ACQ_REL_anchor} - Support for the *acquire*, *release*, and *acquire-release* memory orders. +
+        {CL_DEVICE_ATOMIC_ORDER_SEQ_CST_anchor} - Support for the *sequentially consistent* memory order.
 
-        Because atomic memory orders are hierarchical, a device that supports strong memory ordering semantics must also support all weaker memory semantics.
+        Because atomic memory orders are hierarchical, a device that supports a strong memory order must also support all weaker memory orders.
 
         {CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM_anchor} - Support for memory ordering constraints that apply to a single work item.
+// TOOD: Move this to footnotes.asciidoc after #433 is merged!
         footnote:[Note that this flag does not provide meaning for atomic memory operations, but only for atomic fence operations in certain circumstances, refer to the Memory Scope section of the OpenCL C specification.] +
         {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP_anchor} - Support for memory ordering constraints that apply to all work-items in a work-group. +
         {CL_DEVICE_ATOMIC_SCOPE_DEVICE_anchor} - Support for memory ordering constraints that apply to all work-items executing on the device. +

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1359,9 +1359,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
 
         Because atomic memory orders are hierarchical, a device that supports a strong memory order must also support all weaker memory orders.
 
-        {CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM_anchor} - Support for memory ordering constraints that apply to a single work item.
-// TOOD: Move this to footnotes.asciidoc after #433 is merged!
-        footnote:[Note that this flag does not provide meaning for atomic memory operations, but only for atomic fence operations in certain circumstances, refer to the Memory Scope section of the OpenCL C specification.] +
+        {CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM_anchor} footnote:[{fn-atomic-scope-work-item}] - Support for memory ordering constraints that apply to a single work item. +
         {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP_anchor} - Support for memory ordering constraints that apply to all work-items in a work-group. +
         {CL_DEVICE_ATOMIC_SCOPE_DEVICE_anchor} - Support for memory ordering constraints that apply to all work-items executing on the device. +
         {CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES_anchor} - Support for memory ordering constraints that apply to all work-items executing across all devices that can share SVM memory with each other and the host process.


### PR DESCRIPTION
Fixes #404 

This change clarifies that when a device supports a strong atomic memory order or wide atomic scope it also must support the weaker atomic memory orders and narrower scopes, except for the work-item scope which is a special-case.

I've also updated a few of the device query descriptions to shorten the table cells, especially for the atomic capabilities, since they were too long and extended beyond a page in the PDF rendering.

Ideally we would merge #433 before this change since this change introduces a footnote.  If #433 is merged first, I will rebase and add the footnote into the separate footnotes file.