### PR TITLE
fix two issues with the asciidoctor attributes

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8086,7 +8086,7 @@ To support non-uniform work-groups:
 . The program object associated with _kernel_ must support non-uniform work-groups.
 Specifically, this means:
 .. If the program was created with {clCreateProgramWithSource}, the program must be compiled or built using the `-cl-std=CL2.0` or `-cl-std=CL3.0` build option and without the `-cl-uniform-work-group-size` build option.
-.. If the program was created with {clCreateProgramWithIL} or {clCreateProgramWithBinaries}, the program must be compiled or built without the `-cl-uniform-work-group-size` build options.
+.. If the program was created with {clCreateProgramWithIL} or {clCreateProgramWithBinary}, the program must be compiled or built without the `-cl-uniform-work-group-size` build options.
 .. If the program was created using {clLinkProgram}, all input programs must support non-uniform work-groups.
 
 If non-uniform work-groups are supported, any single dimension

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -101,6 +101,7 @@ server's OpenCL/api-docs repository.
         <type category="define" requires="stdint">typedef <type>int32_t</type>  <name>cl_int</name> __attribute__((aligned(4)));</type>
         <type category="define" requires="stdint">typedef <type>int64_t</type>  <name>cl_long</name> __attribute__((aligned(8)));</type>
         <type category="define" requires="stdint">typedef <type>int8_t</type>   <name>cl_char</name>;</type>
+        <type category="define" requires="stdint">typedef <type>uint8_t</type>  <name>cl_uchar</name>;</type>
         <type category="define" requires="stdint">typedef <type>uint16_t</type> <name>cl_half</name> __attribute__((aligned(2)));</type>
         <type category="define" requires="stdint">typedef <type>uint16_t</type> <name>cl_ushort</name> __attribute__((aligned(2)));</type>
         <type category="define" requires="stdint">typedef <type>uint32_t</type> <name>cl_uint</name> __attribute__((aligned(4)));</type>


### PR DESCRIPTION
Fixes for two small asciidoctor attribute-related issues:

1. One of the links was to clCreateProgramWithBinaries, but the actual API name is clCreateProgramWithBinary.
2. The XML file was missing an entry for the cl_uchar type.