### PR TITLE
add a TYPE suffix to all asciidoctor type attributes

### DIFF
--- a/api/appendix_a.asciidoc
+++ b/api/appendix_a.asciidoc
@@ -53,15 +53,15 @@ being used by another command-queue are undefined.
 == Multiple Host Threads
 
 All OpenCL API calls are thread-safe footnote:[{fn-thread-safe}] except those
-that modify the state of {cl_kernel} objects: {clSetKernelArg},
+that modify the state of {cl_kernel_TYPE} objects: {clSetKernelArg},
 {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and {clCloneKernel}.
 {clSetKernelArg}, {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} and
 {clCloneKernel} are safe to call from any host thread, and safe to call
 re-entrantly so long as concurrent calls to any combination of these API
-calls operate on different {cl_kernel} objects.
-The state of the {cl_kernel} object is undefined if {clSetKernelArg},
+calls operate on different {cl_kernel_TYPE} objects.
+The state of the {cl_kernel_TYPE} object is undefined if {clSetKernelArg},
 {clSetKernelArgSVMPointer}, {clSetKernelExecInfo} or {clCloneKernel} are
-called from multiple host threads on the same {cl_kernel} object at the same
+called from multiple host threads on the same {cl_kernel_TYPE} object at the same
 time footnote:[{fn-race-condition}].
 Please note that there are additional limitations as to which OpenCL APIs
 may be called from <<event-objects,OpenCL callback functions>>.

--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -291,154 +291,154 @@ include::{generated}/api/version-notes/CL_CHAR_BIT.asciidoc[]
 | {CL_SCHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_SCHAR_MAX.asciidoc[]
-  | Maximum value of a type {cl_char}
+  | Maximum value of a type {cl_char_TYPE}
 | {CL_SCHAR_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_SCHAR_MIN.asciidoc[]
-  | Minimum value of a type {cl_char}
+  | Minimum value of a type {cl_char_TYPE}
 | {CL_CHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_CHAR_MAX.asciidoc[]
-  | Maximum value of a type {cl_char}
+  | Maximum value of a type {cl_char_TYPE}
 | {CL_CHAR_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_CHAR_MIN.asciidoc[]
-  | Minimum value of a type {cl_char}
+  | Minimum value of a type {cl_char_TYPE}
 | {CL_UCHAR_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_UCHAR_MAX.asciidoc[]
-  | Maximum value of a type {cl_uchar}
+  | Maximum value of a type {cl_uchar_TYPE}
 | {CL_SHRT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_SHRT_MAX.asciidoc[]
-  | Maximum value of a type {cl_short}
+  | Maximum value of a type {cl_short_TYPE}
 | {CL_SHRT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_SHRT_MIN.asciidoc[]
-  | Minimum value of a type {cl_short}
+  | Minimum value of a type {cl_short_TYPE}
 | {CL_USHRT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_USHRT_MAX.asciidoc[]
-  | Maximum value of a type {cl_ushort}
+  | Maximum value of a type {cl_ushort_TYPE}
 | {CL_INT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_INT_MAX.asciidoc[]
-  | Maximum value of a type {cl_int}
+  | Maximum value of a type {cl_int_TYPE}
 | {CL_INT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_INT_MIN.asciidoc[]
-  | Minimum value of a type {cl_int}
+  | Minimum value of a type {cl_int_TYPE}
 | {CL_UINT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_UINT_MAX.asciidoc[]
-  | Maximum value of a type {cl_uint}
+  | Maximum value of a type {cl_uint_TYPE}
 | {CL_LONG_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_LONG_MAX.asciidoc[]
-  | Maximum value of a type {cl_long}
+  | Maximum value of a type {cl_long_TYPE}
 | {CL_LONG_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_LONG_MIN.asciidoc[]
-  | Minimum value of a type {cl_long}
+  | Minimum value of a type {cl_long_TYPE}
 | {CL_ULONG_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_ULONG_MAX.asciidoc[]
-  | Maximum value of a type {cl_ulong}
+  | Maximum value of a type {cl_ulong_TYPE}
 | {CL_FLT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_DIG.asciidoc[]
-  | Number of decimal digits of precision for the type {cl_float}
+  | Number of decimal digits of precision for the type {cl_float_TYPE}
 | {CL_FLT_MANT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MANT_DIG.asciidoc[]
-  | Number of digits in the mantissa of type {cl_float}
+  | Number of digits in the mantissa of type {cl_float_TYPE}
 | {CL_FLT_MAX_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX_10_EXP.asciidoc[]
   | Maximum positive integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type {cl_float}
+    be represented as a normalized floating-point number of type {cl_float_TYPE}
 | {CL_FLT_MAX_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX_EXP.asciidoc[]
-  | Maximum exponent value of type {cl_float}
+  | Maximum exponent value of type {cl_float_TYPE}
 | {CL_FLT_MIN_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN_10_EXP.asciidoc[]
   | Minimum negative integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type {cl_float}
+    be represented as a normalized floating-point number of type {cl_float_TYPE}
 | {CL_FLT_MIN_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN_EXP.asciidoc[]
-  | Minimum exponent value of type {cl_float}
+  | Minimum exponent value of type {cl_float_TYPE}
 | {CL_FLT_RADIX_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_RADIX.asciidoc[]
-  | Base value of type {cl_float}
+  | Base value of type {cl_float_TYPE}
 | {CL_FLT_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MAX.asciidoc[]
-  | Maximum value of type {cl_float}
+  | Maximum value of type {cl_float_TYPE}
 | {CL_FLT_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_MIN.asciidoc[]
-  | Minimum value of type {cl_float}
+  | Minimum value of type {cl_float_TYPE}
 | {CL_FLT_EPSILON_anchor}
 
 include::{generated}/api/version-notes/CL_FLT_EPSILON.asciidoc[]
-  | Minimum positive floating-point number of type {cl_float} such that `1.0
+  | Minimum positive floating-point number of type {cl_float_TYPE} such that `1.0
     {plus} {CL_FLT_EPSILON} != 1` is true.
 | {CL_DBL_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_DIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Number of decimal digits of precision for the type {cl_double}
+  | Number of decimal digits of precision for the type {cl_double_TYPE}
 | {CL_DBL_MANT_DIG_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MANT_DIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Number of digits in the mantissa of type {cl_double}
+  | Number of digits in the mantissa of type {cl_double_TYPE}
 | {CL_DBL_MAX_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX_10_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
   | Maximum positive integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type {cl_double}
+    be represented as a normalized floating-point number of type {cl_double_TYPE}
 | {CL_DBL_MAX_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Maximum exponent value of type {cl_double}
+  | Maximum exponent value of type {cl_double_TYPE}
 | {CL_DBL_MIN_10_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN_10_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
   | Minimum negative integer such that 10 raised to this power minus one can
-    be represented as a normalized floating-point number of type {cl_double}
+    be represented as a normalized floating-point number of type {cl_double_TYPE}
 | {CL_DBL_MIN_EXP_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN_EXP.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum exponent value of type {cl_double}
+  | Minimum exponent value of type {cl_double_TYPE}
 | {CL_DBL_RADIX_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_RADIX.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Base value of type {cl_double}
+  | Base value of type {cl_double_TYPE}
 | {CL_DBL_MAX_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MAX.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Maximum value of type {cl_double}
+  | Maximum value of type {cl_double_TYPE}
 | {CL_DBL_MIN_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_MIN.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum value of type {cl_double}
+  | Minimum value of type {cl_double_TYPE}
 | {CL_DBL_EPSILON_anchor}
 
 include::{generated}/api/version-notes/CL_DBL_EPSILON.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | Minimum positive floating-point number of type {cl_double} such that
+  | Minimum positive floating-point number of type {cl_double_TYPE} such that
     `1.0 {plus} {CL_DBL_EPSILON} != 1` is true.
 | {CL_NAN_anchor}
 
@@ -447,15 +447,15 @@ include::{generated}/api/version-notes/CL_NAN.asciidoc[]
 | {CL_HUGE_VALF_anchor}
 
 include::{generated}/api/version-notes/CL_HUGE_VALF.asciidoc[]
-  | Largest representative value of type {cl_float}
+  | Largest representative value of type {cl_float_TYPE}
 | {CL_HUGE_VAL_anchor}
 
 include::{generated}/api/version-notes/CL_HUGE_VAL.asciidoc[]
-  | Largest representative value of type {cl_double}
+  | Largest representative value of type {cl_double_TYPE}
 | {CL_MAXFLOAT_anchor}
 
 include::{generated}/api/version-notes/CL_MAXFLOAT.asciidoc[]
-  | Maximum value of type {cl_float}
+  | Maximum value of type {cl_float_TYPE}
 | {CL_INFINITY_anchor}
 
 include::{generated}/api/version-notes/CL_INFINITY.asciidoc[]

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -116,18 +116,18 @@ runtime (_sections 4 and 5_):
 
   * Custom devices and built-in kernels are supported.
     {clCreateProgramWithBuiltInKernels} has been added to allow creation of
-    _cl_program_ using built-in kernels.
+    a {cl_program_TYPE} using built-in kernels.
   * Device partitioning that allows a device to be partitioned based on a
     number of partitioning schemes supported by the device.  This is done by
-    using {clCreateSubDevices} to create a new _cl_device_id_ based on a
+    using {clCreateSubDevices} to create a new {cl_device_id_TYPE} based on a
     partitioning.
   * {clCompileProgram} and {clLinkProgram} to allow handling these aspects
     {clBuildProgram} separately.
-  * Extend _cl_mem_flags_ to describe how the host accesses the data in a
-    {cl_mem} object.
+  * Extend {cl_mem_flags_TYPE} to describe how the host accesses the data in a
+    {cl_mem_TYPE} object.
   * {clEnqueueFillBuffer} and {clEnqueueFillImage} to support filling a
     buffer with a pattern or an image with a color.
-  * Add {CL_MAP_WRITE_INVALIDATE_REGION} to _cl_map_flags_.
+  * Add {CL_MAP_WRITE_INVALIDATE_REGION} to {cl_map_flags_TYPE}.
     Appropriate clarification to the behavior of {CL_MAP_WRITE} has been added
     to the spec.
   * New image types: 1D image, 1D image from a buffer object, 1D image array
@@ -145,7 +145,7 @@ runtime (_sections 4 and 5_):
     a kernel.
   * {clEnqueueMarkerWithWaitList} and {clEnqueueBarrierWithWaitList} APIs.
   * {clUnloadPlatformCompiler} to request that a single platform's compiler is
-    unloaded.  This is compatible with the `cl_khr_icd` extension if that is
+    unloaded.  This is compatible with the *cl_khr_icd* extension if that is
     supported, unlike {clUnloadCompiler}.
 
 The following features are added to the OpenCL C programming language
@@ -182,7 +182,7 @@ The following APIs in OpenCL 1.1 are deprecated (see glossary) in OpenCL
 // Bugzilla 5391 - cl_khr_icd specification
   * {clUnloadCompiler} and {clGetExtensionFunctionAddress} APIs are deprecated.
     The {clUnloadPlatformCompiler} and {clGetExtensionFunctionAddressForPlatform}
-    APIs provide equivalent functionality are compatible with the `cl_khr_icd`
+    APIs provide equivalent functionality are compatible with the *cl_khr_icd*
     extension.
 
 The following queries are deprecated (see glossary) in OpenCL 1.2:

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -155,73 +155,73 @@ Device Queries>> table.
 |====
 | Device Info | Return Type | Description
 | {CL_DEVICE_MAX_READ_IMAGE_ARGS}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         `read_only` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_WRITE_IMAGE_ARGS}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         `write_only` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         `write_only` or `read_write` qualifier.
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE2D_MAX_WIDTH}
-  | {size_t}
+  | {size_t_TYPE}
       | Max width of 2D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE2D_MAX_HEIGHT}
-  | {size_t}
+  | {size_t_TYPE}
       | Max height of 2D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_WIDTH}
-  | {size_t}
+  | {size_t_TYPE}
       | Max width of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_HEIGHT}
-  | {size_t}
+  | {size_t_TYPE}
       | Max height of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE3D_MAX_DEPTH}
-  | {size_t}
+  | {size_t_TYPE}
       | Max depth of 3D image in pixels.
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE}
-  | {size_t}
+  | {size_t_TYPE}
       | Max number of pixels for a 1D image created from a buffer object.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE}
-  | {size_t}
+  | {size_t_TYPE}
       | Max number of images in a 1D or 2D image array.
 
         The minimum value is 256 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_SAMPLERS}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Maximum number of samplers that can be used in a kernel.
 
         The minimum value is 8 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
         the value is 0 otherwise.
 | {CL_DEVICE_MAX_PARAMETER_SIZE}
-  | {size_t}
+  | {size_t_TYPE}
       | Max size in bytes of all arguments that can be passed to a kernel.
         The minimum value is 256 bytes for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_SINGLE_FP_CONFIG}
-  | {cl_device_fp_config}
+  | {cl_device_fp_config_TYPE}
       | Describes single precision floating-point capability of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -251,30 +251,30 @@ Device Queries>> table.
         {CL_FP_ROUND_TO_ZERO} or {CL_FP_ROUND_TO_NEAREST} for devices that are
         not of type {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE}
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Max size in bytes of a constant buffer allocation.
         The minimum value is 1 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 4 for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_LOCAL_MEM_SIZE}
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Size of local memory arena in bytes.
         The minimum value is 1 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_COMPILER_AVAILABLE}
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_FALSE} if the implementation does not have a compiler available
         to compile the program source.
 
         Is {CL_TRUE} if the compiler is available.
         This can be {CL_FALSE} for the embedded platform profile only.
 | {CL_DEVICE_LINKER_AVAILABLE}
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_FALSE} if the implementation does not have a linker available.
         Is {CL_TRUE} if the linker is available.
 
@@ -282,11 +282,11 @@ Device Queries>> table.
 
         This must be {CL_TRUE} if {CL_DEVICE_COMPILER_AVAILABLE} is {CL_TRUE}.
 | {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE}
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The max. size of the device queue in bytes.
         The minimum value is 64 KB for the embedded profile
 | {CL_DEVICE_PRINTF_BUFFER_SIZE}
-  | {size_t}
+  | {size_t_TYPE}
       | Maximum size in bytes of the internal buffer that holds the output
         of printf calls from a kernel.
         The minimum value for the EMBEDDED profile is 1 KB.

--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -104,7 +104,7 @@ All explicit conversion functions with specific rounding modes must still operat
 ]
 
 :fn-null-terminated-string: pass:n[ \
-A null terminated string is returned by OpenCL query function calls if the return type of the information being queried is a {char}[\]. \
+A null terminated string is returned by OpenCL query function calls if the return type of the information being queried is a {char_TYPE}[\]. \
 ]
 
 :fn-out-of-order-device-queue: pass:n[ \
@@ -121,7 +121,7 @@ If the platform profile returned is EMBEDDED_PROFILE, then devices that are only
 :fn-race-condition: pass:n[ \
 There is an inherent race condition in the design of OpenCL that occurs between setting a kernel argument and using the kernel with {clEnqueueNDRangeKernel}. \
 Another host thread might change the kernel arguments between when a host thread sets the kernel arguments and then enqueues the kernel, causing the wrong kernel arguments to be enqueued. \
-Rather than attempt to share {cl_kernel} objects among multiple host threads, applications are strongly encouraged to make additional {cl_kernel} objects for kernel functions for each host thread. \
+Rather than attempt to share {cl_kernel_TYPE} objects among multiple host threads, applications are strongly encouraged to make additional {cl_kernel_TYPE} objects for kernel functions for each host thread. \
 ]
 
 :fn-readimageh: pass:n[ \
@@ -147,10 +147,10 @@ This definition may be different from usage of the term in other contexts. \
 :fn-vendor-id: pass:n[ \
 OpenCL adopters must report a valid vendor ID for their implementation. \
 If there is no valid PCI vendor ID defined for the physical device, implementations must obtain a Khronos vendor ID. \
-This is a unique identifier greater than the largest PCI vendor ID (`0x10000`) and is representable by a {cl_uint}. \
+This is a unique identifier greater than the largest PCI vendor ID (`0x10000`) and is representable by a {cl_uint_TYPE}. \
 Khronos vendor IDs are synchronized across APIs by utilizing Vulkan's vk.xml as the central Khronos vendor ID registry. \
 An ID must be reserved here prior to use in OpenCL, regardless of whether a vendor implements Vulkan. \
 Only once the ID has been allotted may it be exposed to OpenCL by proposing a merge request against cl.xml, in the master branch of the OpenCL-Docs project. \
-The merge must define a new enumerant by adding an `<enum>` tag to the {cl_khronos_vendor_id} `<enums>` tag, with the `<value>` attribute set as the acquired Khronos vendor ID. \
+The merge must define a new enumerant by adding an `<enum>` tag to the {cl_khronos_vendor_id_TYPE} `<enums>` tag, with the `<value>` attribute set as the acquired Khronos vendor ID. \
 The `<name>` attribute must identify the vendor/adopter, and be of the form `CL_KHRONOS_VENDOR_ID_<vendor>`. \
 ]

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1328,7 +1328,7 @@ the same scope *P* such that:
   * *P* is *memory_scope_device* and *A* and *B* are executed by work-items
     on the same device when *A* and *B* apply to an SVM allocation or *A*
     and *B* are executed by work-items in the same kernel or one of its
-    children when *A* and *B* apply to a {cl_mem} buffer.
+    children when *A* and *B* apply to a {cl_mem_TYPE} buffer.
   * *P* is *memory_scope_all_svm_devices* if *A* and *B* are executed by
     host threads or by work-items on one or more devices that can share SVM
     memory with each other and the host process.
@@ -1962,12 +1962,12 @@ provide the necessary global-synchronizes-with relation.
 
 In this situation:
 
-  * access to shared locations or disjoint locations in a single {cl_mem}
+  * access to shared locations or disjoint locations in a single {cl_mem_TYPE}
     object when using atomic operations from different kernel instances
     enqueued from the host such that one or more of the atomic operations is
     a write is implementation-defined and correct behavior is not guaranteed
     except at synchronization points.
-  * access to shared locations or disjoint locations in a single {cl_mem}
+  * access to shared locations or disjoint locations in a single {cl_mem_TYPE}
     object when using atomic operations from different kernel instances
     consisting of a parent kernel and any number of child kernels enqueued
     by that kernel is guaranteed under the memory ordering rules described
@@ -2010,7 +2010,7 @@ Any values that were changed within this region by another kernel or host
 thread while the kernel synchronizing with the map operation was executing
 may be overwritten by the map operation.
 
-Access to non-SVM {cl_mem} buffers and coarse-grained SVM allocations is
+Access to non-SVM {cl_mem_TYPE} buffers and coarse-grained SVM allocations is
 ordered at synchronization points between host commands.
 In the presence of an out-of-order command queue or a set of command queues
 mapped to the same device, multiple kernel instances may execute
@@ -2129,7 +2129,7 @@ A version number comprises three logical fields:
   compatibility for any existing profiles.
 * The _patch_ version indicates bug fixes, clarifications and general improvements.
 
-Version numbers are represented using the {cl_version} type that is an alias for
+Version numbers are represented using the {cl_version_TYPE} type that is an alias for
 a 32-bit integer. The fields are packed as follows:
 
 * The _major_ version is a 10-bit integer packed into bits 31-22.
@@ -2141,10 +2141,10 @@ This enables versions to be ordered using standard C/C++ operators.
 A number of convenience macros are provided by the OpenCL Headers to make
 working with version numbers easier.
 
-`CL_VERSION_MAJOR` extracts the _major_ version from a packed {cl_version}. +
-`CL_VERSION_MINOR` extracts the _minor_ version from a packed {cl_version}. +
-`CL_VERSION_PATCH` extracts the _patch_ version from a packed {cl_version}. +
-`CL_MAKE_VERSION` returns a packed {cl_version} from a _major_, _minor_ and
+`CL_VERSION_MAJOR` extracts the _major_ version from a packed {cl_version_TYPE}. +
+`CL_VERSION_MINOR` extracts the _minor_ version from a packed {cl_version_TYPE}. +
+`CL_VERSION_PATCH` extracts the _patch_ version from a packed {cl_version_TYPE}. +
+`CL_MAKE_VERSION` returns a packed {cl_version_TYPE} from a _major_, _minor_ and
 _patch_ version.
 
 These are defined as follows:
@@ -2181,7 +2181,7 @@ typedef cl_uint cl_version;
 
 It is sometimes necessary to associate a version to an entity it applies to
 (e.g. extension or built-in kernel). This is done using a dedicated
-{cl_name_version} structure, defined as follows:
+{cl_name_version_TYPE} structure, defined as follows:
 
 include::{generated}/api/structs/cl_name_version.txt[]
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -20,11 +20,11 @@ The list of platforms available can be obtained with the function:
 include::{generated}/api/protos/clGetPlatformIDs.txt[]
 include::{generated}/api/version-notes/clGetPlatformIDs.asciidoc[]
 
-  * _num_entries_ is the number of {cl_platform_id} entries that can be added to
+  * _num_entries_ is the number of {cl_platform_id_TYPE} entries that can be added to
     _platforms_.
     If _platforms_ is not `NULL`, the _num_entries_ must be greater than zero.
   * _platforms_ returns a list of OpenCL platforms found.
-    The {cl_platform_id} values returned in _platforms_ can be used to identify a
+    The {cl_platform_id_TYPE} values returned in _platforms_ can be used to identify a
     specific OpenCL platform.
     If _platforms_ is `NULL`, this argument is ignored.
     The number of OpenCL platforms returned is the minimum of the value
@@ -82,7 +82,7 @@ in the <<platform-queries-table, Platform Queries>> table.
 | {CL_PLATFORM_PROFILE_anchor} footnote:[{fn-platform-profile}]
 
 include::{generated}/api/version-notes/CL_PLATFORM_PROFILE.asciidoc[]
-  | {char}[] footnote:[{fn-null-terminated-string}]
+  | {char_TYPE}[] footnote:[{fn-null-terminated-string}]
       | OpenCL profile string.
         Returns the profile name supported by the implementation.
         The profile name returned can be one of the following strings:
@@ -100,7 +100,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_PROFILE.asciidoc[]
 | {CL_PLATFORM_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_VERSION.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | OpenCL version string.
         Returns the OpenCL version supported by the implementation.
         This version string has the following format:
@@ -114,7 +114,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_VERSION.asciidoc[]
 | {CL_PLATFORM_NUMERIC_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_NUMERIC_VERSION.asciidoc[]
-  | {cl_version}
+  | {cl_version_TYPE}
       | Returns the detailed (major, minor, patch) version supported by the
         platform. The major and minor version numbers returned must match
         those returned via {CL_PLATFORM_VERSION}.
@@ -122,17 +122,17 @@ include::{generated}/api/version-notes/CL_PLATFORM_NUMERIC_VERSION.asciidoc[]
 | {CL_PLATFORM_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_NAME.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Platform name string.
 | {CL_PLATFORM_VENDOR_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_VENDOR.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Platform vendor string.
 | {CL_PLATFORM_EXTENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns a space separated list of extension names (the extension
         names themselves do not contain any spaces) supported by the
         platform.
@@ -141,7 +141,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS.asciidoc[]
 | {CL_PLATFORM_EXTENSIONS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS_WITH_VERSION.asciidoc[]
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of description (name and version) structures that lists
         all the extensions supported by the platform. The same extension name
         must not be reported more than once. The list of extensions reported
@@ -149,7 +149,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_EXTENSIONS_WITH_VERSION.ascii
 | {CL_PLATFORM_HOST_TIMER_RESOLUTION_anchor}
 
 include::{generated}/api/version-notes/CL_PLATFORM_HOST_TIMER_RESOLUTION.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Returns the resolution of the host timer in nanoseconds as used by
         {clGetDeviceAndHostTimer}.
 
@@ -195,11 +195,11 @@ include::{generated}/api/version-notes/clGetDeviceIDs.asciidoc[]
     devices available.
     The valid values for _device_type_ are specified in the
     <<device-types-table, Device Types>> table.
-  * _num_entries_ is the number of {cl_device_id} entries that can be added to
+  * _num_entries_ is the number of {cl_device_id_TYPE} entries that can be added to
     _devices_.
     If _devices_ is not `NULL`, the _num_entries_ must be greater than zero.
   * _devices_ returns a list of OpenCL devices found.
-    The {cl_device_id} values returned in _devices_ can be used to identify a
+    The {cl_device_id_TYPE} values returned in _devices_ can be used to identify a
     specific OpenCL device.
     If _devices_ is `NULL`, this argument is ignored.
     The number of OpenCL devices returned is the minimum of the value specified
@@ -338,7 +338,7 @@ device except for the following queries:
 | {CL_DEVICE_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_TYPE.asciidoc[]
-  | {cl_device_type}
+  | {cl_device_type_TYPE}
       | The type or types of the OpenCL device.
 
         Please see the <<device-types-table, Device Types>> table
@@ -347,25 +347,25 @@ include::{generated}/api/version-notes/CL_DEVICE_TYPE.asciidoc[]
 | {CL_DEVICE_VENDOR_ID_anchor} footnote:[{fn-vendor-id}]
 
 include::{generated}/api/version-notes/CL_DEVICE_VENDOR_ID.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | A unique device vendor identifier.
 
         If the vendor has a PCI vendor ID, the low 16 bits must contain that PCI
         vendor ID, and the remaining bits must be set to zero. Otherwise, the
         value returned must be a valid Khronos vendor ID represented by type
-        {cl_khronos_vendor_id}. Khronos vendor IDs are allocated starting at
+        {cl_khronos_vendor_id_TYPE}. Khronos vendor IDs are allocated starting at
         0x10000, to distinguish them from the PCI vendor ID namespace.
 | {CL_DEVICE_MAX_COMPUTE_UNITS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_COMPUTE_UNITS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The number of parallel compute units on the OpenCL device.
         A work-group executes on a single compute unit.
         The minimum value is 1.
 | {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Maximum dimensions that specify the global and local work-item IDs
         used by the data parallel execution model. (Refer to
         {clEnqueueNDRangeKernel}).
@@ -374,11 +374,11 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS.asciid
 | {CL_DEVICE_MAX_WORK_ITEM_SIZES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
-  | {size_t} []
+  | {size_t_TYPE}[]
       | Maximum number of work-items that can be specified in each dimension
         of the work-group to {clEnqueueNDRangeKernel}.
 
-        Returns _n_ {size_t} entries, where _n_ is the value returned by the
+        Returns _n_ {size_t_TYPE} entries, where _n_ is the value returned by the
         query for {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS}.
 
         The minimum value is (1, 1, 1) for devices that are not of type
@@ -386,7 +386,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
 | {CL_DEVICE_MAX_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Maximum number of work-items in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device. (Refer also to
@@ -408,7 +408,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
 // (all other entries were added in OpenCL 1.0).
   {CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF} is <<unified-spec, missing before>>
   version 1.1.
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Preferred native vector width size for built-in scalar types that
         can be put into vectors.
         The vector width is defined as the number of scalar elements that
@@ -430,7 +430,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
 // The CHAR annotation here is used to convey the same information for all
 // entries in this table row.
 include::{generated}/api/version-notes/CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the native ISA vector width.
         The vector width is defined as the number of scalar elements that
         can be stored in the vector.
@@ -443,7 +443,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR.asciid
 | {CL_DEVICE_MAX_CLOCK_FREQUENCY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CLOCK_FREQUENCY.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Clock frequency of the device in MHz.
         The meaning of this value is implementation-defined.
         For devices with multiple clock domains, the clock frequency for any
@@ -457,14 +457,14 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_CLOCK_FREQUENCY.asciidoc[]
 | {CL_DEVICE_ADDRESS_BITS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ADDRESS_BITS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The default compute device address space size of the global address
         space specified as an unsigned integer value in bits.
         Currently supported values are 32 or 64 bits.
 | {CL_DEVICE_MAX_MEM_ALLOC_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_MEM_ALLOC_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Max size of memory object allocation in bytes.
         The minimum value is max(min(1024 {times} 1024 {times} 1024, 1/4^th^
         of {CL_DEVICE_GLOBAL_MEM_SIZE}), 32 {times} 1024 {times} 1024) for
@@ -472,13 +472,13 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_MEM_ALLOC_SIZE.asciidoc[]
 | {CL_DEVICE_IMAGE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if images are supported by the OpenCL device and {CL_FALSE}
         otherwise.
 | {CL_DEVICE_MAX_READ_IMAGE_ARGS_anchor} footnote:[{fn-max-read-image-args}]
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_IMAGE_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         read_only qualifier.
         The minimum value is 128 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}, the
@@ -486,7 +486,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_IMAGE_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_WRITE_IMAGE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WRITE_IMAGE_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         write_only qualifier.
         The minimum value is 64 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}, the
@@ -494,7 +494,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WRITE_IMAGE_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of image objects arguments of a kernel declared with the
         write_only or read_write qualifier.
 
@@ -507,7 +507,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.ascii
 
 include::{generated}/api/version-notes/CL_DEVICE_IL_VERSION.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | {char}[]
+  | {char_TYPE}[]
       | The intermediate languages that can be supported by
         {clCreateProgramWithIL} for this device.
         Returns a space-separated list of IL version strings of the form
@@ -522,7 +522,7 @@ Also see extension *cl_khr_il_program*.
 
 include::{generated}/api/version-notes/CL_DEVICE_ILS_WITH_VERSION.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of descriptions (name and version) for all supported
         Intermediate Languages. Intermediate Languages with the same name may be
         reported more than once but each name and major/minor version
@@ -536,7 +536,7 @@ Also see extension *cl_khr_il_program*.
 | {CL_DEVICE_IMAGE2D_MAX_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_WIDTH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max width of 2D image or 1D image not created from a buffer object
         in pixels.
 
@@ -545,7 +545,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_WIDTH.asciidoc[]
 | {CL_DEVICE_IMAGE2D_MAX_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_HEIGHT.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max height of 2D image in pixels.
 
         The minimum value is 16384 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -553,7 +553,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE2D_MAX_HEIGHT.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_WIDTH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max width of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -561,7 +561,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_WIDTH.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_HEIGHT.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max height of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -569,7 +569,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_HEIGHT.asciidoc[]
 | {CL_DEVICE_IMAGE3D_MAX_DEPTH_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_DEPTH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max depth of 3D image in pixels.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -577,7 +577,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE3D_MAX_DEPTH.asciidoc[]
 | {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_BUFFER_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max number of pixels for a 1D image created from a buffer object.
 
         The minimum value is 65536 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -585,7 +585,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_BUFFER_SIZE.asciidoc[
 | {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max number of images in a 1D or 2D image array.
 
         The minimum value is 2048 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -593,7 +593,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_MAX_ARRAY_SIZE.asciidoc[]
 | {CL_DEVICE_MAX_SAMPLERS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_SAMPLERS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Maximum number of samplers that can be used in a kernel.
 
         The minimum value is 16 if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE},
@@ -601,7 +601,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_SAMPLERS.asciidoc[]
 | {CL_DEVICE_IMAGE_PITCH_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_PITCH_ALIGNMENT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The row pitch alignment size in pixels for 2D Images Created From a
         Buffer.
         The value returned must be a power of 2.
@@ -613,7 +613,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_PITCH_ALIGNMENT.asciidoc[
 | {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | This query specifies the minimum alignment in pixels of the host_ptr
         specified to {clCreateBuffer} or {clCreateBufferWithProperties} when a 2D Image
         is Created From a Buffer which was created using {CL_MEM_USE_HOST_PTR}.
@@ -626,7 +626,7 @@ include::{generated}/api/version-notes/CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT.as
 | {CL_DEVICE_MAX_PIPE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PIPE_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum number of pipe objects that can be passed as arguments
         to a kernel.
         The minimum value is 16 for devices supporting Pipes, and must be
@@ -634,7 +634,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PIPE_ARGS.asciidoc[]
 | {CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum number of reservations that can be active for a pipe per
         work-item in a kernel.
         A work-group reservation is counted as one reservation per
@@ -644,7 +644,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.as
 | {CL_DEVICE_PIPE_MAX_PACKET_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_PACKET_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum size of pipe packet in bytes.
 
         Support for Pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -653,7 +653,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_PACKET_SIZE.asciidoc[]
 | {CL_DEVICE_MAX_PARAMETER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Max size in bytes of all arguments that can be passed to a kernel.
 
         The minimum value is 1024 for devices that are not of type
@@ -663,7 +663,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
 | {CL_DEVICE_MEM_BASE_ADDR_ALIGN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Alignment requirement (in bits) for sub-buffer offsets.
         The minimum value is the size (in bits) of the largest OpenCL
         built-in data type supported by the device (long16 in FULL profile,
@@ -672,14 +672,14 @@ include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]
 | {CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The minimum value is the size (in bytes) of the largest OpenCL data
         type supported by the device (`long16` in FULL profile, `long16` or
         `int16` in EMBEDDED profile).
 | {CL_DEVICE_SINGLE_FP_CONFIG_anchor} footnote:native-rounding-modes[{fn-native-rounding-modes}]
 
 include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
-  | {cl_device_fp_config}
+  | {cl_device_fp_config_TYPE}
       | Describes single precision floating-point capability of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -715,7 +715,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
 
 include::{generated}/api/version-notes/CL_DEVICE_DOUBLE_FP_CONFIG.asciidoc[]
 Also see extension *cl_khr_fp64*.
-  | {cl_device_fp_config}
+  | {cl_device_fp_config_TYPE}
       | Describes double precision floating-point capability of the OpenCL
         device.
         This is a bit-field that describes one or more of the following
@@ -750,36 +750,36 @@ Also see extension *cl_khr_fp64*.
 | {CL_DEVICE_GLOBAL_MEM_CACHE_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHE_TYPE.asciidoc[]
-  | {cl_device_mem_cache_type}
+  | {cl_device_mem_cache_type_TYPE}
       | Type of global memory cache supported.
         Valid values are: {CL_NONE}, {CL_READ_ONLY_CACHE_anchor}, and
         {CL_READ_WRITE_CACHE_anchor}.
 | {CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Size of global memory cache line in bytes.
 | {CL_DEVICE_GLOBAL_MEM_CACHE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_CACHE_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Size of global memory cache in bytes.
 | {CL_DEVICE_GLOBAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Size of global device memory in bytes.
 | {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Max size in bytes of a constant buffer allocation.
         The minimum value is 64 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_MAX_CONSTANT_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
         The minimum value is 8 for devices that are not of type
@@ -787,7 +787,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_ARGS.asciidoc[]
 | {CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | The maximum number of bytes of storage that may be allocated for any
         single variable in program scope or inside a function in an OpenCL
         kernel language declared in the global address space.
@@ -800,7 +800,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciid
 | {CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Maximum preferred total size, in bytes, of all program variables in
         the global address space.
         This is a performance hint.
@@ -811,7 +811,7 @@ include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL
 | {CL_DEVICE_LOCAL_MEM_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_TYPE.asciidoc[]
-  | {cl_device_local_mem_type}
+  | {cl_device_local_mem_type_TYPE}
       | Type of local memory supported.
         This can be set to {CL_LOCAL_anchor} implying dedicated local memory storage
         such as SRAM , or {CL_GLOBAL_anchor}.
@@ -821,47 +821,47 @@ include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_TYPE.asciidoc[]
 | {CL_DEVICE_LOCAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Size of local memory region in bytes.
         The minimum value is 32 KB for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
 | {CL_DEVICE_ERROR_CORRECTION_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ERROR_CORRECTION_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device implements error correction for all
         accesses to compute device memory (global and constant).
         Is {CL_FALSE} if the device does not implement such error correction.
 | {CL_DEVICE_HOST_UNIFIED_MEMORY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_HOST_UNIFIED_MEMORY.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device and the host have a unified memory subsystem
         and is {CL_FALSE} otherwise.
 | {CL_DEVICE_PROFILING_TIMER_RESOLUTION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PROFILING_TIMER_RESOLUTION.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Describes the resolution of device timer.
         This is measured in nanoseconds.
         Refer to <<profiling-operations, Profiling Operations>> for details.
 | {CL_DEVICE_ENDIAN_LITTLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ENDIAN_LITTLE.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the OpenCL device is a little endian device and
         {CL_FALSE} otherwise
 | {CL_DEVICE_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_AVAILABLE.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device is available and {CL_FALSE} otherwise.
         A device is considered to be available if the device can be expected
         to successfully execute commands enqueued to the device.
 | {CL_DEVICE_COMPILER_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_COMPILER_AVAILABLE.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_FALSE} if the implementation does not have a compiler available
         to compile the program source.
 
@@ -870,7 +870,7 @@ include::{generated}/api/version-notes/CL_DEVICE_COMPILER_AVAILABLE.asciidoc[]
 | {CL_DEVICE_LINKER_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LINKER_AVAILABLE.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_FALSE} if the implementation does not have a linker available.
         Is {CL_TRUE} if the linker is available.
 
@@ -880,7 +880,7 @@ include::{generated}/api/version-notes/CL_DEVICE_LINKER_AVAILABLE.asciidoc[]
 | {CL_DEVICE_EXECUTION_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXECUTION_CAPABILITIES.asciidoc[]
-  | {cl_device_exec_capabilities}
+  | {cl_device_exec_capabilities_TYPE}
       | Describes the execution capabilities of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -894,13 +894,13 @@ include::{generated}/api/version-notes/CL_DEVICE_EXECUTION_CAPABILITIES.asciidoc
 | {CL_DEVICE_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_PROPERTIES.asciidoc[]
-  | {cl_command_queue_properties}
+  | {cl_command_queue_properties_TYPE}
       | See description of {CL_DEVICE_QUEUE_ON_HOST_PROPERTIES}.
 | {CL_DEVICE_QUEUE_ON_HOST_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_HOST_PROPERTIES.asciidoc[]
 
-  | {cl_command_queue_properties}
+  | {cl_command_queue_properties_TYPE}
       | Describes the on host command-queue properties supported by the
         device.
         This is a bit-field that describes one or more of the following
@@ -916,7 +916,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_HOST_PROPERTIES.asciid
 | {CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES.asciidoc[]
-  | {cl_command_queue_properties}
+  | {cl_command_queue_properties_TYPE}
       | Describes the on device command-queue properties supported by the
         device.
         This is a bit-field that describes one or more of the following
@@ -938,7 +938,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES.asci
 | {CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The preferred size of the device queue, in bytes.
         Applications should use this size for the device queue to ensure
         good performance.
@@ -948,7 +948,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.
 | {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum size of the device queue in bytes.
 
         The minimum value is 256 KB for the full profile and 64 KB for the
@@ -957,7 +957,7 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciid
 | {CL_DEVICE_MAX_ON_DEVICE_QUEUES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum number of device queues that can be created for this
         device in a single context.
 
@@ -966,7 +966,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
 | {CL_DEVICE_MAX_ON_DEVICE_EVENTS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | The maximum number of events in use by a device queue.
         These refer to events returned by the `enqueue_` built-in functions
         to a device queue or user events returned by the `create_user_event`
@@ -977,7 +977,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
 | {CL_DEVICE_BUILT_IN_KERNELS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | A semi-colon separated list of built-in kernels supported by the
         device.
         An empty string is returned if no built-in kernels are supported by
@@ -986,7 +986,7 @@ include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS.asciidoc[]
 | {CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION.asciidoc[]
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of descriptions for the built-in kernels supported by
         the device. Each built-in kernel may only be reported once. The list of
         reported kernels must match the list returned via
@@ -995,28 +995,28 @@ include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION.a
 | {CL_DEVICE_PLATFORM_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PLATFORM.asciidoc[]
-  | {cl_platform_id}
+  | {cl_platform_id_TYPE}
       | The platform associated with this device.
 | {CL_DEVICE_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NAME.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Device name string.
 | {CL_DEVICE_VENDOR_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_VENDOR.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Vendor name string.
 | {CL_DRIVER_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DRIVER_VERSION.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | OpenCL software driver version string.
         Follows a vendor-specific format.
 | {CL_DEVICE_PROFILE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PROFILE.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | OpenCL profile string.
         Returns the profile name supported by the device.
         The profile name returned can be one of the following strings:
@@ -1030,7 +1030,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PROFILE.asciidoc[]
 | {CL_DEVICE_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_VERSION.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | OpenCL version string.
         Returns the OpenCL version supported by the device. This version
         string has the following format:
@@ -1043,7 +1043,7 @@ include::{generated}/api/version-notes/CL_DEVICE_VERSION.asciidoc[]
 | {CL_DEVICE_NUMERIC_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NUMERIC_VERSION.asciidoc[]
-  | {cl_version}
+  | {cl_version_TYPE}
       | Returns the detailed (major, minor, patch) version supported by the
         device. The major and minor version numbers returned must match
         those returned via {CL_DEVICE_VERSION}.
@@ -1051,7 +1051,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NUMERIC_VERSION.asciidoc[]
 | {CL_DEVICE_OPENCL_C_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_VERSION.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns the highest fully backwards compatible OpenCL C version 
         supported by the compiler for the device.
         For devices supporting compilation from OpenCL C source, this will
@@ -1089,7 +1089,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_VERSION.asciidoc[]
 | {CL_DEVICE_OPENCL_C_ALL_VERSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_ALL_VERSIONS.asciidoc[]
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of name, version descriptions listing all the versions
         of OpenCL C supported by the compiler for the device.
         In each returned description structure, the name field is required to be
@@ -1123,7 +1123,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_ALL_VERSIONS.asciidoc[
 | {CL_DEVICE_OPENCL_C_FEATURES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_FEATURES.asciidoc[]
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of optional OpenCL C features supported by the
         compiler for the device alongside the OpenCL C version that introduced
         the feature macro.
@@ -1137,7 +1137,7 @@ include::{generated}/api/version-notes/CL_DEVICE_OPENCL_C_FEATURES.asciidoc[]
 | {CL_DEVICE_EXTENSIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns a space separated list of extension names (the extension
         names themselves do not contain any spaces) supported by the device.
         The list of extension names may include Khronos approved extension
@@ -1173,7 +1173,7 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS.asciidoc[]
 | {CL_DEVICE_EXTENSIONS_WITH_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS_WITH_VERSION.asciidoc[]
-  | {cl_name_version}[]
+  | {cl_name_version_TYPE}[]
       | Returns an array of description (name and version) structures. The same
         extension name must not be reported more than once. The list of
         extensions reported must match the list reported via
@@ -1185,14 +1185,14 @@ include::{generated}/api/version-notes/CL_DEVICE_EXTENSIONS_WITH_VERSION.asciido
 | {CL_DEVICE_PRINTF_BUFFER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PRINTF_BUFFER_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Maximum size in bytes of the internal buffer that holds the output
         of printf calls from a kernel.
         The minimum value for the FULL profile is 1 MB.
 | {CL_DEVICE_PREFERRED_INTEROP_USER_SYNC_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_INTEROP_USER_SYNC.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the devices preference is for the user to be
         responsible for synchronization, when sharing memory objects between
         OpenCL and other APIs such as DirectX, {CL_FALSE} if the device /
@@ -1202,14 +1202,14 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_INTEROP_USER_SYNC.asc
 | {CL_DEVICE_PARENT_DEVICE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARENT_DEVICE.asciidoc[]
-  | {cl_device_id}
-      | Returns the {cl_device_id} of the parent device to which this
+  | {cl_device_id_TYPE}
+      | Returns the {cl_device_id_TYPE} of the parent device to which this
         sub-device belongs.
         If _device_ is a root-level device, a `NULL` value is returned.
 | {CL_DEVICE_PARTITION_MAX_SUB_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_MAX_SUB_DEVICES.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the maximum number of sub-devices that can be created when a
         device is partitioned.
 
@@ -1217,9 +1217,9 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_MAX_SUB_DEVICES.ascii
 | {CL_DEVICE_PARTITION_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_PROPERTIES.asciidoc[]
-  | {cl_device_partition_property}[]
+  | {cl_device_partition_property_TYPE}[]
       | Returns the list of partition types supported by _device_.
-        This is an array of {cl_device_partition_property} values drawn from
+        This is an array of {cl_device_partition_property_TYPE} values drawn from
         the following list:
 
         {CL_DEVICE_PARTITION_EQUALLY} +
@@ -1232,7 +1232,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_PROPERTIES.asciidoc[]
 | {CL_DEVICE_PARTITION_AFFINITY_DOMAIN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_AFFINITY_DOMAIN.asciidoc[]
-  | {cl_device_affinity_domain}
+  | {cl_device_affinity_domain_TYPE}
       | Returns the list of supported affinity domains for partitioning the
         device using {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN}.
         This is a bit-field that describes one or more of the following
@@ -1250,7 +1250,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_AFFINITY_DOMAIN.ascii
 | {CL_DEVICE_PARTITION_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_TYPE.asciidoc[]
-  | {cl_device_partition_property}[]
+  | {cl_device_partition_property_TYPE}[]
       | Returns the properties argument specified in {clCreateSubDevices} if
         device is a sub-device.
         In the case where the properties argument to {clCreateSubDevices} is
@@ -1273,14 +1273,14 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_TYPE.asciidoc[]
 | {CL_DEVICE_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_DEVICE_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the _device_ reference count.
         If the device is a root-level device, a reference count of one is
         returned.
 | {CL_DEVICE_SVM_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_SVM_CAPABILITIES.asciidoc[]
-  | {cl_device_svm_capabilities}
+  | {cl_device_svm_capabilities_TYPE}
       | Describes the various shared virtual memory (SVM) memory
         allocation types the device supports.
         This is a bit-field that describes a combination of the following
@@ -1312,7 +1312,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SVM_CAPABILITIES.asciidoc[]
 | {CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 fine-grained SVM atomic types.
         This query can return 0 which indicates that the preferred alignment
@@ -1320,7 +1320,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGN
 | {CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 atomic types to global memory.
         This query can return 0 which indicates that the preferred alignment
@@ -1328,7 +1328,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNME
 | {CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Returns the value representing the preferred alignment in bytes for
         OpenCL 2.0 atomic types to local memory.
         This query can return 0 which indicates that the preferred alignment
@@ -1337,7 +1337,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMEN
 
 // Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Maximum number of sub-groups in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device.
@@ -1351,7 +1351,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
 
 // Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if this device supports independent forward progress of
         sub-groups, {CL_FALSE} otherwise.
 
@@ -1362,7 +1362,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_P
 | {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asciidoc[]
-  | {cl_device_atomic_capabilities}
+  | {cl_device_atomic_capabilities_TYPE}
       | Describes the various memory orders and scopes that the device supports for atomic memory operations.
         This is a bit-field that describes a combination of the following
         values:
@@ -1397,7 +1397,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
 | {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_FENCE_CAPABILITIES.asciidoc[]
-  | {cl_device_atomic_capabilities}
+  | {cl_device_atomic_capabilities_TYPE}
       | Describes the various memory orders and scopes that the device supports for atomic fence operations.
         This is a bit-field that has the same set of possible values as described for {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES}.
 
@@ -1410,7 +1410,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_FENCE_CAPABILITIES.ascii
 | {CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device supports non-uniform work groups, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for non-uniform work groups is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1418,7 +1418,7 @@ include::{generated}/api/version-notes/CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT.
 | {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device supports work group collective functions e.g. `work_group_broadcast`, `work_group_reduce`, and `work_group_scan`, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for work group collective functions is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1426,7 +1426,7 @@ include::{generated}/api/version-notes/CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS
 | {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device supports the generic address space and its associated built-in functions, and {CL_FALSE} otherwise.
 // This query didn't exist pre-OpenCL 3.0, but:
 //Support for the generic address space is required for an OpenCL 2.0, 2.1, or 2.2 device.
@@ -1434,7 +1434,7 @@ include::{generated}/api/version-notes/CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT.a
 | {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asciidoc[]
-  | {cl_device_device_enqueue_capabilities}
+  | {cl_device_device_enqueue_capabilities_TYPE}
       | Describes device-side enqueue capabilities of the device.
         This is a bit-field that describes one or more of the following
         values:
@@ -1453,7 +1453,7 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
 | {CL_DEVICE_PIPE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_SUPPORT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Is {CL_TRUE} if the device supports Pipes, and {CL_FALSE} otherwise.
 
       Devices that return {CL_TRUE} for {CL_DEVICE_PIPE_SUPPORT} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}.
@@ -1463,7 +1463,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_SUPPORT.asciidoc[]
 | {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Returns the preferred multiple of work-group size for the given device.
         This is a performance hint intended as a guide when specifying the local work size argument to {clEnqueueNDRangeKernel}.
 
@@ -1473,7 +1473,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTI
 | {CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns the latest version of the conformance test suite that this device
         has fully passed in accordance with the official conformance process.
 
@@ -1607,7 +1607,7 @@ include::{generated}/api/version-notes/clCreateSubDevices.asciidoc[]
     Only one of the listed partitioning schemes can be specified in
     _properties_.
   * _num_devices_ is the size of memory pointed to by _out_devices_ specified as
-    the number of {cl_device_id} entries.
+    the number of {cl_device_id_TYPE} entries.
   * _out_devices_ is the buffer where the OpenCL sub-devices will be returned.
     If _out_devices_ is `NULL`, this argument is ignored.
     If _out_devices_ is not `NULL`, _num_devices_ must be greater than or equal
@@ -1635,7 +1635,7 @@ on the queue are executed only on the sub-device.
 | {CL_DEVICE_PARTITION_EQUALLY_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_EQUALLY.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Split the aggregate device into as many smaller aggregate devices as
         can be created, each containing _n_ compute units.
         The value _n_ is passed as the value accompanying this property.
@@ -1645,7 +1645,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_EQUALLY.asciidoc[]
 | {CL_DEVICE_PARTITION_BY_COUNTS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_COUNTS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | This property is followed by a list of compute unit counts
         terminated with 0 or {CL_DEVICE_PARTITION_BY_COUNTS_LIST_END_anchor}.
         For each non-zero count _m_ in the list, a sub-device is created
@@ -1659,7 +1659,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_COUNTS.asciidoc[]
 | {CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN.asciidoc[]
-  | {cl_device_affinity_domain}
+  | {cl_device_affinity_domain_TYPE}
       | Split the device into smaller aggregate devices containing one or
         more compute units that all share part of a cache hierarchy.
         The value accompanying this property may be drawn from the following
@@ -1766,7 +1766,7 @@ include::{generated}/api/version-notes/clRetainDevice.asciidoc[]
 
 {clRetainDevice} increments the _device_ reference count if _device_ is a
 valid sub-device created by a call to {clCreateSubDevices}.
-If _device_ is a root level device i.e. a {cl_device_id} returned by
+If _device_ is a root level device i.e. a {cl_device_id_TYPE} returned by
 {clGetDeviceIDs}, the _device_ reference count remains unchanged.
 
 // refError
@@ -1793,7 +1793,7 @@ include::{generated}/api/version-notes/clReleaseDevice.asciidoc[]
 
 {clReleaseDevice} decrements the _device_ reference count if device is a
 valid sub-device created by a call to {clCreateSubDevices}.
-If _device_ is a root level device i.e. a {cl_device_id} returned by
+If _device_ is a root level device i.e. a {cl_device_id_TYPE} returned by
 {clGetDeviceIDs}, the _device_ reference count remains unchanged.
 
 // refError
@@ -1874,12 +1874,12 @@ on one or more devices specified in the context.
 | {CL_CONTEXT_PLATFORM_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_PLATFORM.asciidoc[]
-  | {cl_platform_id}
+  | {cl_platform_id_TYPE}
       | Specifies the platform to use.
 | {CL_CONTEXT_INTEROP_USER_SYNC_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_INTEROP_USER_SYNC.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Specifies whether the user is responsible for synchronization
         between OpenCL and other APIs.
         Please refer to the specific sections in the OpenCL Extension
@@ -2085,22 +2085,22 @@ _param_value_ by {clGetContextInfo} is described in the
 | {CL_CONTEXT_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_CONTEXT_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the _context_ reference count.
 | {CL_CONTEXT_NUM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_NUM_DEVICES.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the number of devices in _context_.
 | {CL_CONTEXT_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_DEVICES.asciidoc[]
-  | {cl_device_id}[]
+  | {cl_device_id_TYPE}[]
       | Return the list of devices and sub-devices in _context_.
 | {CL_CONTEXT_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_CONTEXT_PROPERTIES.asciidoc[]
-  | {cl_context_properties}[]
+  | {cl_context_properties_TYPE}[]
       | Return the properties argument specified in {clCreateContext} or
         {clCreateContextFromType}.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -62,7 +62,7 @@ Also see extension *cl_khr_create_command_queue*.
 | {CL_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
-  | {cl_command_queue_properties}
+  | {cl_command_queue_properties_TYPE}
       | This is a bitfield and can be set to a combination of the following
         values:
 
@@ -97,7 +97,7 @@ include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE_DEFAULT.asciidoc[]
 | {CL_QUEUE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Specifies the size of the device queue in bytes.
 
         This can only be specified if {CL_QUEUE_ON_DEVICE} is set in
@@ -328,22 +328,22 @@ _param_value_ by {clGetCommandQueueInfo} is described in the
 | {CL_QUEUE_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return the context specified when the command-queue is created.
 | {CL_QUEUE_DEVICE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE.asciidoc[]
-  | {cl_device_id}
+  | {cl_device_id_TYPE}
       | Return the device specified when the command-queue is created.
 | {CL_QUEUE_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_QUEUE_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the command-queue reference count.
 | {CL_QUEUE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
-  | {cl_command_queue_properties}
+  | {cl_command_queue_properties_TYPE}
       | Return the currently specified properties for the command-queue.
         These properties are specified by the value associated with the
         {CL_QUEUE_PROPERTIES} passed in _properties_ argument in
@@ -353,7 +353,7 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
 | {CL_QUEUE_PROPERTIES_ARRAY_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
-  | {cl_queue_properties}[]
+  | {cl_queue_properties_TYPE}[]
       | Return the properties argument specified in
         {clCreateCommandQueueWithProperties}.
 
@@ -371,7 +371,7 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
 | {CL_QUEUE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the size of the device command-queue.
         To be considered valid for this query, _command_queue_ must be a
         device command-queue.
@@ -379,7 +379,7 @@ include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
 | {CL_QUEUE_DEVICE_DEFAULT_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE_DEFAULT.asciidoc[]
-  | {cl_command_queue}
+  | {cl_command_queue_TYPE}
       | Return the current default command queue for the underlying device.
 |====
 
@@ -604,7 +604,7 @@ include::{generated}/api/version-notes/CL_MEM_COPY_HOST_PTR.asciidoc[]
     {CL_MEM_COPY_HOST_PTR} and {CL_MEM_USE_HOST_PTR} are mutually exclusive.
 
     {CL_MEM_COPY_HOST_PTR} can be used with {CL_MEM_ALLOC_HOST_PTR} to
-    initialize the contents of the {cl_mem} object allocated using
+    initialize the contents of the {cl_mem_TYPE} object allocated using
     host-accessible (e.g. PCIe) memory.
 | {CL_MEM_HOST_WRITE_ONLY_anchor}
 
@@ -682,7 +682,7 @@ include::{generated}/api/version-notes/clCreateSubBuffer.asciidoc[]
 include::{generated}/api/version-notes/CL_BUFFER_CREATE_TYPE_REGION.asciidoc[]
   | Create a buffer object that represents a specific region in _buffer_.
 
-    _buffer_create_info_ is a pointer to a {cl_buffer_region} structure
+    _buffer_create_info_ is a pointer to a {cl_buffer_region_TYPE} structure
     specifying a region of the buffer.
 
     If _buffer_ is created with {CL_MEM_USE_HOST_PTR}, the _host_ptr_
@@ -723,13 +723,13 @@ Otherwise, it returns one of the following errors in _errcode_ret_:
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 // These errors are specific to the {CL_BUFFER_CREATE_TYPE_REGION} parameter
-  * {CL_INVALID_VALUE} if the region specified by the {cl_buffer_region}
+  * {CL_INVALID_VALUE} if the region specified by the {cl_buffer_region_TYPE}
     structure passed in _buffer_create_info_ is out of bounds in _buffer_.
-  * {CL_INVALID_BUFFER_SIZE} if the _size_ field of the {cl_buffer_region}
+  * {CL_INVALID_BUFFER_SIZE} if the _size_ field of the {cl_buffer_region_TYPE}
     structure passed in _buffer_create_info_ is 0.
   * {CL_MISALIGNED_SUB_BUFFER_OFFSET} if there are no devices in _context_
     associated with _buffer_ for which the _origin_ field of the
-    {cl_buffer_region} structure passed in _buffer_create_info_ is
+    {cl_buffer_region_TYPE} structure passed in _buffer_create_info_ is
     aligned to the {CL_DEVICE_MEM_BASE_ADDR_ALIGN} value.
 
 [NOTE]
@@ -745,7 +745,7 @@ from multiple overlapping sub-buffer objects is defined.
 
 [open,refpage='cl_buffer_region',desc='',type='structs',xrefs='clCreateSubBuffer']
 --
-The {cl_buffer_region} structure specifies a region of a buffer object:
+The {cl_buffer_region_TYPE} structure specifies a region of a buffer object:
 
 include::{generated}/api/structs/cl_buffer_region.txt[]
 
@@ -1367,7 +1367,7 @@ include::{generated}/api/version-notes/clEnqueueFillBuffer.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
-or written by a kernel and/or the host and is given by the {cl_mem_flags}
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
 argument value specified when _buffer_ is created is ignored by
 {clEnqueueFillBuffer}.
 
@@ -1919,7 +1919,7 @@ returned in _errcode_ret_:
 
 [open,refpage='cl_image_format',desc='The image format descriptor structure is defined as:',type='structs',xrefs='clCreateImage']
 --
-The {cl_image_format} image format descriptor structure describes an image
+The {cl_image_format_TYPE} image format descriptor structure describes an image
 format, and is defined as:
 
 include::{generated}/api/structs/cl_image_format.txt[]
@@ -2145,7 +2145,7 @@ then the call to {clCreateImage}, {clCreateImageWithProperties},
 
 [open,refpage='cl_image_desc',desc='The image descriptor structure describes the type and dimensions of the image or image array and is defined as:',type='structs',xrefs='clCreateImage']
 --
-The {cl_image_desc} image descriptor structure describes the image type
+The {cl_image_desc_TYPE} image descriptor structure describes the image type
 and dimensions of an image or image array when creating an image using
 {clCreateImage} or {clCreateImageWithProperties}, and is defined as:
 
@@ -2331,7 +2331,7 @@ include::{generated}/api/version-notes/clGetSupportedImageFormats.asciidoc[]
     memory location given by _image_formats_.
   * _image_formats_ is a pointer to a memory location where the list of
     supported image formats are returned.
-    Each entry describes a {cl_image_format} structure supported by the OpenCL
+    Each entry describes a {cl_image_format_TYPE} structure supported by the OpenCL
     implementation.
     If _image_formats_ is `NULL`, it is ignored.
   * _num_image_formats_ is the actual number of supported image formats for a
@@ -2808,7 +2808,7 @@ include::{generated}/api/version-notes/clEnqueueCopyImage.asciidoc[]
 
 It is currently a requirement that the _src_image_ and _dst_image_ image
 memory objects for {clEnqueueCopyImage} must have the exact same image
-format (i.e. the {cl_image_format} descriptor specified when _src_image_ and
+format (i.e. the {cl_image_format_TYPE} descriptor specified when _src_image_ and
 _dst_image_ are created must match).
 
 // refError
@@ -2929,7 +2929,7 @@ include::{generated}/api/version-notes/clEnqueueFillImage.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 The usage information which indicates whether the memory object can be read
-or written by a kernel and/or the host and is given by the {cl_mem_flags}
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
 argument value specified when _image_ is created is ignored by
 {clEnqueueFillImage}.
 
@@ -3405,26 +3405,26 @@ include::{generated}/api/version-notes/clGetImageInfo.asciidoc[]
 | {CL_IMAGE_FORMAT_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_FORMAT.asciidoc[]
-  | {cl_image_format}
+  | {cl_image_format_TYPE}
       | Return the image format descriptor specified when _image_ is created
         with {clCreateImage}, {clCreateImageWithProperties},
         {clCreateImage2D} or {clCreateImage3D}.
 | {CL_IMAGE_ELEMENT_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ELEMENT_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return size of each element of the image memory object given by
         _image_ in bytes.
 | {CL_IMAGE_ROW_PITCH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ROW_PITCH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return calculated row pitch in bytes of a row of elements of the
         image object given by _image_.
 | {CL_IMAGE_SLICE_PITCH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_SLICE_PITCH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return calculated slice pitch in bytes of a 2D slice for the 3D
         image object or size of each image in a 1D or 2D image array given
         by _image_.
@@ -3432,42 +3432,42 @@ include::{generated}/api/version-notes/CL_IMAGE_SLICE_PITCH.asciidoc[]
 | {CL_IMAGE_WIDTH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_WIDTH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return width of the image in pixels.
 | {CL_IMAGE_HEIGHT_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_HEIGHT.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return height of the image in pixels.
         For a 1D image, 1D image buffer and 1D image array object, height =
         0.
 | {CL_IMAGE_DEPTH_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_DEPTH.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return depth of the image in pixels.
         For a 1D image, 1D image buffer, 2D image or 1D and 2D image array
         object, depth = 0.
 | {CL_IMAGE_ARRAY_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_ARRAY_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return number of images in the image array.
         If _image_ is not an image array, 0 is returned.
 | {CL_IMAGE_BUFFER_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_BUFFER.asciidoc[]
-  | {cl_mem}
+  | {cl_mem_TYPE}
       | Return buffer object associated with _image_.
 | {CL_IMAGE_NUM_MIP_LEVELS_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_NUM_MIP_LEVELS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return `num_mip_levels` associated with _image_.
 | {CL_IMAGE_NUM_SAMPLES_anchor}
 
 include::{generated}/api/version-notes/CL_IMAGE_NUM_SAMPLES.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return `num_samples` associated with _image_.
 |====
 
@@ -3619,20 +3619,20 @@ Otherwise, it returns one of the following errors:
 | {CL_PIPE_PACKET_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_PACKET_SIZE.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return pipe packet size specified when _pipe_ is created with
         {clCreatePipe}.
 | {CL_PIPE_MAX_PACKETS_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_MAX_PACKETS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return max. number of packets specified when _pipe_ is created with
         {clCreatePipe}.
 
 | {CL_PIPE_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_PIPE_PROPERTIES.asciidoc[]
-  | {cl_pipe_properties}[]
+  | {cl_pipe_properties_TYPE}[]
       | Return the properties argument specified in {clCreatePipe}.
 
         If the _properties_ argument specified in {clCreatePipe} used to
@@ -4100,7 +4100,7 @@ include::{generated}/api/version-notes/clGetMemObjectInfo.asciidoc[]
 | {CL_MEM_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_TYPE.asciidoc[]
-  | {cl_mem_object_type}
+  | {cl_mem_object_type_TYPE}
       | Returns one of the following values:
 
         {CL_MEM_OBJECT_BUFFER_anchor} if _memobj_ is created with {clCreateBuffer},
@@ -4117,7 +4117,7 @@ include::{generated}/api/version-notes/CL_MEM_TYPE.asciidoc[]
 | {CL_MEM_FLAGS_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_FLAGS.asciidoc[]
-  | {cl_mem_flags}
+  | {cl_mem_flags_TYPE}
       | Return the flags argument value specified when _memobj_ is created
         with {clCreateBuffer}, +
         {clCreateBufferWithProperties}, +
@@ -4133,13 +4133,13 @@ include::{generated}/api/version-notes/CL_MEM_FLAGS.asciidoc[]
 | {CL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return actual size of the data store associated with _memobj_ in
         bytes.
 | {CL_MEM_HOST_PTR_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
-  | {void} *
+  | {void_TYPE} *
       | If _memobj_ is created with {clCreateBuffer}, {clCreateBufferWithProperties},
         {clCreateImage}, {clCreateImageWithProperties}, {clCreateImage2D}, or
         {clCreateImage3D}, and {CL_MEM_USE_HOST_PTR} is specified in mem_flags,
@@ -4156,17 +4156,17 @@ include::{generated}/api/version-notes/CL_MEM_HOST_PTR.asciidoc[]
 | {CL_MEM_MAP_COUNT_anchor} footnote:[{fn-map-count-usage}]
 
 include::{generated}/api/version-notes/CL_MEM_MAP_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Map count.
 | {CL_MEM_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_MEM_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return _memobj_ reference count.
 | {CL_MEM_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return context specified when memory object is created.
         If _memobj_ is created using {clCreateSubBuffer}, the context
         associated with the memory object specified as the _buffer_ argument
@@ -4174,7 +4174,7 @@ include::{generated}/api/version-notes/CL_MEM_CONTEXT.asciidoc[]
 | {CL_MEM_ASSOCIATED_MEMOBJECT_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_ASSOCIATED_MEMOBJECT.asciidoc[]
-  | {cl_mem}
+  | {cl_mem_TYPE}
       | Return memory object from which _memobj_ is created.
 
         This returns the memory object specified as buffer argument to
@@ -4189,7 +4189,7 @@ include::{generated}/api/version-notes/CL_MEM_ASSOCIATED_MEMOBJECT.asciidoc[]
 | {CL_MEM_OFFSET_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_OFFSET.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Return offset if _memobj_ is a sub-buffer object created using
         {clCreateSubBuffer}.
 
@@ -4197,7 +4197,7 @@ include::{generated}/api/version-notes/CL_MEM_OFFSET.asciidoc[]
 | {CL_MEM_USES_SVM_POINTER_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_USES_SVM_POINTER.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Return {CL_TRUE} if _memobj_ is a buffer object that was created with
         {CL_MEM_USE_HOST_PTR} or is a sub-buffer object of a buffer object
         that was created with {CL_MEM_USE_HOST_PTR} and the _host_ptr_
@@ -4206,7 +4206,7 @@ include::{generated}/api/version-notes/CL_MEM_USES_SVM_POINTER.asciidoc[]
 | {CL_MEM_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_PROPERTIES.asciidoc[]
-  | {cl_mem_properties}[]
+  | {cl_mem_properties_TYPE}[]
       | Return the properties argument specified in
         {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
 
@@ -4272,7 +4272,7 @@ We call this fine-grained sharing.
     {clSVMAlloc}.
     Memory consistency is guaranteed at synchronization points and the host
     can use calls to {clEnqueueSVMMap} and {clEnqueueSVMUnmap} or create a
-    {cl_mem} buffer object using the SVM pointer and use OpenCL's existing host
+    {cl_mem_TYPE} buffer object using the SVM pointer and use OpenCL's existing host
     API functions {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} to
     update regions of the buffer.
     What coarse-grain buffer SVM adds to OpenCL's earlier buffer support are
@@ -4301,7 +4301,7 @@ We call this fine-grained sharing.
      consistency provided at synchronization points.
      There is no need for explicit calls to {clEnqueueSVMMap} and
      {clEnqueueSVMUnmap} or {clEnqueueMapBuffer} and
-     {clEnqueueUnmapMemObject} on a {cl_mem} buffer object created using the
+     {clEnqueueUnmapMemObject} on a {cl_mem_TYPE} buffer object created using the
      SVM pointer.
   ** If SVM atomic operations are not supported, the host and devices can
      concurrently read the same memory locations and can concurrently update
@@ -4309,7 +4309,7 @@ We call this fine-grained sharing.
      locations are undefined.
      Memory consistency is guaranteed at synchronization points without the
      need for explicit calls to {clEnqueueSVMMap} and {clEnqueueSVMUnmap}
-     or {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} on a {cl_mem}
+     or {clEnqueueMapBuffer} and {clEnqueueUnmapMemObject} on a {cl_mem_TYPE}
      buffer object created using the SVM pointer.
   * There are two kinds of fine-grain sharing support.
     Devices may support either fine-grain buffer sharing or fine-grain
@@ -4871,13 +4871,13 @@ Otherwise, it returns one of the following errors:
 If a coarse-grained SVM buffer is currently mapped for writing, the
 application must ensure that the SVM buffer is unmapped before any enqueued
 kernels or commands that read from or write to this SVM buffer or any of its
-associated {cl_mem} buffer objects begin execution; otherwise the behavior is
+associated {cl_mem_TYPE} buffer objects begin execution; otherwise the behavior is
 undefined.
 
 If a coarse-grained SVM buffer is currently mapped for reading, the
 application must ensure that the SVM buffer is unmapped before any enqueued
 kernels or commands that write to this memory object or any of its
-associated {cl_mem} buffer objects begin execution; otherwise the behavior is
+associated {cl_mem_TYPE} buffer objects begin execution; otherwise the behavior is
 undefined.
 
 A SVM buffer is considered as mapped if there are one or more active
@@ -4986,7 +4986,7 @@ In addition, sub-buffers can also be used to ensure that each device gets a
 consistent view of a SVM buffers memory when it is shared by multiple
 devices.
 For example, assume that two devices share a SVM pointer.
-The host can create a {cl_mem} buffer object using {clCreateBuffer} or
+The host can create a {cl_mem_TYPE} buffer object using {clCreateBuffer} or
 {clCreateBufferWithProperties} with {CL_MEM_USE_HOST_PTR} and _host_ptr_ set
 to the SVM pointer and then create two disjoint sub-buffers with starting
 virtual addresses _sb1_ptr_ and _sb2_ptr_.
@@ -5048,7 +5048,7 @@ include::{generated}/api/version-notes/clCreateSamplerWithProperties.asciidoc[]
 | {CL_SAMPLER_NORMALIZED_COORDS_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | A boolean value that specifies whether the image coordinates
         specified are normalized or not.
 
@@ -5057,7 +5057,7 @@ include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
 | {CL_SAMPLER_ADDRESSING_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
-  | {cl_addressing_mode}
+  | {cl_addressing_mode_TYPE}
       | Specifies how out-of-range image coordinates are handled when
         reading from an image.
         Valid values are:
@@ -5083,7 +5083,7 @@ include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
 | {CL_SAMPLER_FILTER_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_FILTER_MODE.asciidoc[]
-  | {cl_filter_mode}
+  | {cl_filter_mode_TYPE}
       | Specifies the type of filter that is applied when reading an
         image.
         Valid values are:
@@ -5250,33 +5250,33 @@ include::{generated}/api/version-notes/clGetSamplerInfo.asciidoc[]
 | {CL_SAMPLER_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_SAMPLER_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the _sampler_ reference count.
 | {CL_SAMPLER_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return the context specified when the sampler is created.
 | {CL_SAMPLER_NORMALIZED_COORDS_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_NORMALIZED_COORDS.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | Return the normalized coords value associated with _sampler_.
 | {CL_SAMPLER_ADDRESSING_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
-  | {cl_addressing_mode}
+  | {cl_addressing_mode_TYPE}
       | Return the addressing mode value associated with _sampler_.
 | {CL_SAMPLER_FILTER_MODE_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_FILTER_MODE.asciidoc[]
-  | {cl_filter_mode}
+  | {cl_filter_mode_TYPE}
       | Return the filter mode value associated with _sampler_.
 
 | {CL_SAMPLER_PROPERTIES_anchor}
 
 include::{generated}/api/version-notes/CL_SAMPLER_PROPERTIES.asciidoc[]
-  | {cl_sampler_properties}[]
+  | {cl_sampler_properties_TYPE}[]
       | Return the properties argument specified in
         {clCreateSamplerWithProperties}.
 
@@ -5691,7 +5691,7 @@ include::{generated}/api/version-notes/clSetProgramSpecializationConstant.asciid
     {clBuildProgram} until another call to {clSetProgramSpecializationConstant}
     changes it.
     If a specialization constant is a boolean constant, _spec_value_ should be a
-    pointer to a {cl_uchar} value.
+    pointer to a {cl_uchar_TYPE} value.
     A value of zero will set the specialization constant to false; any other
     value will set it to true.
 
@@ -6566,22 +6566,22 @@ include::{generated}/api/version-notes/clGetProgramInfo.asciidoc[]
 | {CL_PROGRAM_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_PROGRAM_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the _program_ reference count.
 | {CL_PROGRAM_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return the context specified when the program object is created
 | {CL_PROGRAM_NUM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_NUM_DEVICES.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the number of devices associated with _program_.
 | {CL_PROGRAM_DEVICES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_DEVICES.asciidoc[]
-  | {cl_device_id}[]
+  | {cl_device_id_TYPE}[]
       | Return the list of devices associated with the program object.
         This can be the devices associated with context on which the program
         object has been created or can be a subset of devices that are
@@ -6590,7 +6590,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_DEVICES.asciidoc[]
 | {CL_PROGRAM_SOURCE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SOURCE.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Return the program source code specified by
         {clCreateProgramWithSource}.
         The source string returned is a concatenation of all source strings
@@ -6610,7 +6610,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_SOURCE.asciidoc[]
 
 include::{generated}/api/version-notes/CL_PROGRAM_IL.asciidoc[]
 Also see extension *cl_khr_il_program*.
-  | {char}[]
+  | {char_TYPE}[]
       | Returns the program IL for programs created with
         {clCreateProgramWithIL}.
 
@@ -6621,7 +6621,7 @@ Also see extension *cl_khr_il_program*.
 | {CL_PROGRAM_BINARY_SIZES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARY_SIZES.asciidoc[]
-  | {size_t}[]
+  | {size_t_TYPE}[]
       | Returns an array that contains the size in bytes of the program
         binary (could be an executable binary, compiled binary or library
         binary) for each device associated with program.
@@ -6636,7 +6636,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARY_SIZES.asciidoc[]
 | {CL_PROGRAM_BINARIES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARIES.asciidoc[]
-  | {unsigned_char} *[]
+  | {unsigned_char_TYPE} *[]
       | Return the program binaries (could be an executable binary, compiled
         binary or library binary) for all devices associated with program.
         For each device in program, the binary returned can be the binary
@@ -6669,7 +6669,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARIES.asciidoc[]
 | {CL_PROGRAM_NUM_KERNELS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_NUM_KERNELS.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Returns the number of kernels declared in _program_ that can be
         created with {clCreateKernel}.
         This information is only available after a successful program
@@ -6678,7 +6678,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_NUM_KERNELS.asciidoc[]
 | {CL_PROGRAM_KERNEL_NAMES_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_KERNEL_NAMES.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns a semi-colon separated list of kernel names in _program_
         that can be created with {clCreateKernel}.
         This information is only available after a successful program
@@ -6687,7 +6687,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_KERNEL_NAMES.asciidoc[]
 | {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | This indicates that the _program_ object contains non-trivial
         constructor(s) that will be executed by runtime before any kernel
         from the program is executed.
@@ -6700,7 +6700,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asc
 | {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | This indicates that the program object contains non-trivial
         destructor(s) that will be executed by runtime when _program_ is
         destroyed.
@@ -6767,7 +6767,7 @@ include::{generated}/api/version-notes/clGetProgramBuildInfo.asciidoc[]
 | {CL_PROGRAM_BUILD_STATUS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_STATUS.asciidoc[]
-  | {cl_build_status}
+  | {cl_build_status_TYPE}
       | Returns the build, compile or link status, whichever was performed
         last on the specified _program_ object for _device_.
 
@@ -6792,7 +6792,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_STATUS.asciidoc[]
 | {CL_PROGRAM_BUILD_OPTIONS_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_OPTIONS.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Return the build, compile or link options specified by the options
         argument in {clBuildProgram}, {clCompileProgram} or {clLinkProgram},
         whichever was performed last on the specified _program_ object for
@@ -6803,7 +6803,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_OPTIONS.asciidoc[]
 | {CL_PROGRAM_BUILD_LOG_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_LOG.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Return the build, compile or link log for {clBuildProgram},
         {clCompileProgram} or {clLinkProgram}, whichever was performed last
         on program for device.
@@ -6813,7 +6813,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BUILD_LOG.asciidoc[]
 | {CL_PROGRAM_BINARY_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BINARY_TYPE.asciidoc[]
-  | {cl_program_binary_type}
+  | {cl_program_binary_type_TYPE}
       | Return the program binary type for device.
         This can be one of the following values:
 
@@ -6840,7 +6840,7 @@ include::{generated}/api/version-notes/CL_PROGRAM_BINARY_TYPE.asciidoc[]
 | {CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | The total amount of storage, in bytes, used by program variables in
         the global address space.
 |====
@@ -6935,7 +6935,7 @@ include::{generated}/api/version-notes/clCreateKernelsInProgram.asciidoc[]
 
   * _program_ is a program object with a successfully built executable.
   * _num_kernels_ is the size of memory pointed to by _kernels_ specified as the
-    number of {cl_kernel} entries.
+    number of {cl_kernel_TYPE} entries.
   * _kernels_ is the buffer where the kernel objects for kernels in _program_
     will be returned.
     If _kernels_ is `NULL`, it is ignored.
@@ -7059,14 +7059,14 @@ include::{generated}/api/version-notes/clSetKernelArg.asciidoc[]
     declared by a kernel (see below).
   * _arg_size_ specifies the size of the argument value.
     If the argument is a memory object, the _arg_size_ value must be equal to 
-    `sizeof({cl_mem})`.
+    `sizeof({cl_mem_TYPE})`.
     For arguments declared with the `local` qualifier, the size specified will
     be the size in bytes of the buffer that must be allocated for the `local`
     argument.
     If the argument is of type _sampler_t_, the _arg_size_ value must be equal
-    to `sizeof({cl_sampler})`.
+    to `sizeof({cl_sampler_TYPE})`.
     If the argument is of type _queue_t_, the _arg_size_ value must be equal to
-    `sizeof({cl_command_queue})`.
+    `sizeof({cl_command_queue_TYPE})`.
     For all other arguments, the size will be the size of argument type.
   * _arg_value_ is a pointer to data that should be used as the argument value
     for argument specified by _arg_index_.
@@ -7151,13 +7151,13 @@ memory or sampler objects specified as argument values by {clSetKernelArg}.
 Users may not rely on a kernel object to retain objects specified as
 argument values to the kernel.
 
-Implementations shall not allow {cl_kernel} objects to hold reference
-counts to {cl_kernel} arguments, because no mechanism is provided for the
+Implementations shall not allow {cl_kernel_TYPE} objects to hold reference
+counts to {cl_kernel_TYPE} arguments, because no mechanism is provided for the
 user to tell the kernel to release that ownership right.
 If the kernel holds ownership rights on kernel args, that would make it
 impossible for the user to tell with certainty when he may safely
 release user allocated resources associated with OpenCL objects such as
-the {cl_mem} backing store used with {CL_MEM_USE_HOST_PTR}.
+the {cl_mem_TYPE} backing store used with {CL_MEM_USE_HOST_PTR}.
 ====
 
 // refError
@@ -7178,9 +7178,9 @@ Otherwise, it returns one of the following errors:
     This error code is <<unified-spec, missing before>> version 2.0.
   * {CL_INVALID_ARG_SIZE} if _arg_size_ does not match the size of the data
     type for an argument that is not a memory object or if the argument is a
-    memory object and _arg_size_ != `sizeof({cl_mem})` or if _arg_size_ is
+    memory object and _arg_size_ != `sizeof({cl_mem_TYPE})` or if _arg_size_ is
     zero and the argument is declared with the local qualifier or if the
-    argument is a sampler and _arg_size_ != `sizeof({cl_sampler})`.
+    argument is a sampler and _arg_size_ != `sizeof({cl_sampler_TYPE})`.
   * {CL_MAX_SIZE_RESTRICTION_EXCEEDED} if the size in bytes of the memory
     object (if the argument is a memory object) or _arg_size_ (if the
     argument is declared with `local` qualifier) exceeds a language-
@@ -7266,7 +7266,7 @@ include::{generated}/api/version-notes/clSetKernelExecInfo.asciidoc[]
 | {CL_KERNEL_EXEC_INFO_SVM_PTRS_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_PTRS.asciidoc[]
-  | {void} *[]
+  | {void_TYPE} *[]
       | SVM pointers must reference locations contained entirely within
         buffers that are passed to kernel as arguments, or that are passed
         through the execution information.
@@ -7278,7 +7278,7 @@ include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_PTRS.asciidoc[]
 | {CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM.asciidoc[]
-  | {cl_bool}
+  | {cl_bool_TYPE}
       | This flag indicates whether the kernel uses pointers that are fine
         grain system SVM allocations.
         These fine grain system SVM pointers may be passed as arguments or
@@ -7378,7 +7378,7 @@ To clone a kernel object, call the function
 include::{generated}/api/protos/clCloneKernel.txt[]
 include::{generated}/api/version-notes/clCloneKernel.asciidoc[]
 
-  * _source_kernel_ is a valid {cl_kernel} object that will be copied.
+  * _source_kernel_ is a valid {cl_kernel_TYPE} object that will be copied.
     _source_kernel_ will not be modified in any way by this function.
   * _errcode_ret_ will be assigned an appropriate error code.
     If _errcode_ret_ is `NULL`, no error code is returned.
@@ -7460,32 +7460,32 @@ include::{generated}/api/version-notes/clGetKernelInfo.asciidoc[]
 | {CL_KERNEL_FUNCTION_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_FUNCTION_NAME.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Return the kernel function name.
 | {CL_KERNEL_NUM_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_NUM_ARGS.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the number of arguments to kernel.
 | {CL_KERNEL_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_KERNEL_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the _kernel_ reference count.
 | {CL_KERNEL_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return the context associated with _kernel_.
 | {CL_KERNEL_PROGRAM_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PROGRAM.asciidoc[]
-  | {cl_program}
+  | {cl_program_TYPE}
       | Return the program object associated with kernel.
 | {CL_KERNEL_ATTRIBUTES_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ATTRIBUTES.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns any attributes specified using the `+__attribute__+`
         OpenCL C qualifier (or using an OpenCL {cpp} qualifier syntax [[]] )
         with the kernel function declaration in the program source.
@@ -7559,7 +7559,7 @@ include::{generated}/api/version-notes/clGetKernelWorkGroupInfo.asciidoc[]
 | {CL_KERNEL_GLOBAL_WORK_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_GLOBAL_WORK_SIZE.asciidoc[]
-  | {size_t}[3]
+  | {size_t_TYPE}[3]
       | This provides a mechanism for the application to query the maximum
         global size that can be used to execute a kernel (i.e.
         _global_work_size_ argument to {clEnqueueNDRangeKernel}) on a custom
@@ -7572,7 +7572,7 @@ include::{generated}/api/version-notes/CL_KERNEL_GLOBAL_WORK_SIZE.asciidoc[]
 | {CL_KERNEL_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_WORK_GROUP_SIZE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | This provides a mechanism for the application to query the maximum
         work-group size that can be used to execute the kernel on a specific
         device given by device.
@@ -7588,7 +7588,7 @@ include::{generated}/api/version-notes/CL_KERNEL_WORK_GROUP_SIZE.asciidoc[]
 | {CL_KERNEL_COMPILE_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_COMPILE_WORK_GROUP_SIZE.asciidoc[]
-  | {size_t}[3]
+  | {size_t_TYPE}[3]
       | Returns the work-group size specified in the kernel source or IL.
 
         If the work-group size is not specified in the kernel source or IL,
@@ -7596,7 +7596,7 @@ include::{generated}/api/version-notes/CL_KERNEL_COMPILE_WORK_GROUP_SIZE.asciido
 | {CL_KERNEL_LOCAL_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_LOCAL_MEM_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Returns the amount of local memory in bytes being used by a kernel.
         This includes local memory that may be needed by an implementation
         to execute the kernel, variables declared inside the kernel with the
@@ -7610,7 +7610,7 @@ include::{generated}/api/version-notes/CL_KERNEL_LOCAL_MEM_SIZE.asciidoc[]
 | {CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE.asciidoc[]
-  | {size_t}
+  | {size_t_TYPE}
       | Returns the preferred multiple of work-group size for launch.
         This is a performance hint.
         Specifying a work-group size that is not a multiple of the value
@@ -7621,7 +7621,7 @@ include::{generated}/api/version-notes/CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTI
 | {CL_KERNEL_PRIVATE_MEM_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_PRIVATE_MEM_SIZE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | Returns the minimum amount of private memory, in bytes, used by each
         work-item in the kernel.
         This value may include any private memory needed by an
@@ -7697,14 +7697,14 @@ Also see extension *cl_khr_subgroups*.
 
 include::{generated}/api/version-notes/CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | {size_t} *
-      | {size_t}
+  | {size_t_TYPE} *
+      | {size_t_TYPE}
           | Returns the maximum sub-group size for this kernel.
             All sub-groups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.
 
-            The _input_value_ must be an array of {size_t} values
+            The _input_value_ must be an array of {size_t_TYPE} values
             corresponding to the local work size parameter of the intended
             dispatch.
             The number of dimensions in the ND-range will be inferred from
@@ -7713,15 +7713,15 @@ Also see extension *cl_khr_subgroups*.
 
 include::{generated}/api/version-notes/CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | {size_t} *
-      | {size_t}
+  | {size_t_TYPE} *
+      | {size_t_TYPE}
           | Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
             same number of sub-groups.
 
-            The _input_value_ must be an array of {size_t} values
+            The _input_value_ must be an array of {size_t_TYPE} values
             corresponding to the local work size parameter of the intended
             dispatch.
             The number of dimensions in the ND-range will be inferred from
@@ -7730,11 +7730,11 @@ Also see extension *cl_khr_subgroups*.
 
 include::{generated}/api/version-notes/CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT.asciidoc[]
 Also see extension *cl_khr_subgroups*.
-  | {size_t}
-      | {size_t}[]
+  | {size_t_TYPE}
+      | {size_t_TYPE}[]
           | Returns the local size that will generate the requested number
             of sub-groups for the kernel.
-            The output array must be an array of {size_t} values corresponding
+            The output array must be an array of {size_t_TYPE} values corresponding
             to the local size parameter.
             Any returned work-group will have one dimension.
             Other dimensions inferred from the value specified for
@@ -7751,7 +7751,7 @@ Also see extension *cl_khr_subgroups*.
 include::{generated}/api/version-notes/CL_KERNEL_MAX_NUM_SUB_GROUPS.asciidoc[]
 Also see extension *cl_khr_subgroups*.
   | ignored
-      | {size_t}
+      | {size_t_TYPE}
           | This provides a mechanism for the application to query the
             maximum number of sub-groups that may make up each work-group to
             execute a kernel on a specific device given by device.
@@ -7766,7 +7766,7 @@ Also see extension *cl_khr_subgroups*.
 include::{generated}/api/version-notes/CL_KERNEL_COMPILE_NUM_SUB_GROUPS.asciidoc[]
 Also see extension *cl_khr_subgroups*.
   | ignored
-      | {size_t}
+      | {size_t_TYPE}
           | Returns the number of sub-groups per work-group specified in the kernel
             source or IL. If the sub-group count is not specified then 0 is returned.
 |====
@@ -7835,7 +7835,7 @@ in options argument to {clBuildProgram} or {clCompileProgram}.
 | {CL_KERNEL_ARG_ADDRESS_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[]
-  | {cl_kernel_arg_address_qualifier}
+  | {cl_kernel_arg_address_qualifier_TYPE}
       | Returns the address qualifier specified for the argument given by
         _arg_index_.
         This can be one of the following values:
@@ -7850,7 +7850,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ADDRESS_QUALIFIER.asciidoc[
 | {CL_KERNEL_ARG_ACCESS_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
-  | {cl_kernel_arg_access_qualifier}
+  | {cl_kernel_arg_access_qualifier_TYPE}
       | Returns the access qualifier specified for the argument given by
         _arg_index_.
         This can be one of the following values:
@@ -7867,7 +7867,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_ACCESS_QUALIFIER.asciidoc[]
 | {CL_KERNEL_ARG_TYPE_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns the type name specified for the argument given by
         _arg_index_.
         The type name returned will be the argument type name as it was
@@ -7880,7 +7880,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
 | {CL_KERNEL_ARG_TYPE_QUALIFIER_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
-  | {cl_kernel_arg_type_qualifier}
+  | {cl_kernel_arg_type_qualifier_TYPE}
       | Returns a bitfield describing one or more type qualifiers specified
         for the argument given by _arg_index_.
         The returned values can be:
@@ -7898,7 +7898,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
 | {CL_KERNEL_ARG_NAME_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
-  | {char}[]
+  | {char_TYPE}[]
       | Returns the name specified for the argument given by _arg_index_.
 |====
 
@@ -8062,7 +8062,7 @@ Otherwise, it returns one of the following errors:
     deprecated by>> version 2.1.
   * {CL_INVALID_GLOBAL_WORK_SIZE} if any of the values specified in
     _global_work_size_[0], ... _global_work_size_[_work_dim_ - 1] exceed the
-    maximum value representable by {size_t} on the device on which the
+    maximum value representable by {size_t_TYPE} on the device on which the
     kernel-instance will be enqueued.
   * {CL_INVALID_GLOBAL_OFFSET} if the value specified in _global_work_size_
     {plus} the corresponding values in _global_work_offset_ for any
@@ -8246,10 +8246,10 @@ include::{generated}/api/version-notes/clEnqueueNativeKernel.asciidoc[]
   * _num_mem_objects_ is the number of buffer objects that are passed in _args_.
   * _mem_list_ is a list of valid buffer objects, if _num_mem_objects_ > 0.
     The buffer object values specified in _mem_list_ are memory object handles
-    (`{cl_mem}` values) returned by {clCreateBuffer} or {clCreateBufferWithProperties},
+    (`{cl_mem_TYPE}` values) returned by {clCreateBuffer} or {clCreateBufferWithProperties},
     or `NULL`.
   * _args_mem_loc_ is a pointer to appropriate locations that _args_ points to
-    where memory object handles ({cl_mem} values) are stored.
+    where memory object handles ({cl_mem_TYPE} values) are stored.
     Before the user function is executed, the memory object handles are replaced
     by pointers to global memory.
   * _event_wait_list_, _num_events_in_wait_list_ and _event_ are as described in
@@ -8257,7 +8257,7 @@ include::{generated}/api/version-notes/clEnqueueNativeKernel.asciidoc[]
 
 The data pointed to by _args_ and _cb_args_ bytes in size will be copied and
 a pointer to this copied region will be passed to _user_func_.
-The copy needs to be done because the memory objects ({cl_mem} values) that
+The copy needs to be done because the memory objects ({cl_mem_TYPE} values) that
 _args_ may contain need to be modified and replaced by appropriate pointers
 to global memory.
 When {clEnqueueNativeKernel} returns, the memory region pointed to by _args_
@@ -8550,25 +8550,25 @@ include::{generated}/api/version-notes/clGetEventInfo.asciidoc[]
 | {CL_EVENT_COMMAND_QUEUE_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_QUEUE.asciidoc[]
-  | {cl_command_queue}
+  | {cl_command_queue_TYPE}
       | Return the command-queue associated with _event_.
         For user event objects, a `NULL` value is returned.
 | {CL_EVENT_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_CONTEXT.asciidoc[]
-  | {cl_context}
+  | {cl_context_TYPE}
       | Return the context associated with _event_.
 | {CL_EVENT_COMMAND_TYPE_anchor}
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_TYPE.asciidoc[]
-  | {cl_command_type}
+  | {cl_command_type_TYPE}
       | Return the command type associated with _event_ as described in the
         <<event-command-type-table,Event Command Types>> table.
 
 | {CL_EVENT_COMMAND_EXECUTION_STATUS_anchor} footnote:[{fn-event-status-order}]
 
 include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciidoc[]
-  | {cl_int}
+  | {cl_int_TYPE}
       | Return the execution status of the command identified by event.
         Valid values are:
 
@@ -8590,7 +8590,7 @@ include::{generated}/api/version-notes/CL_EVENT_COMMAND_EXECUTION_STATUS.asciido
 | {CL_EVENT_REFERENCE_COUNT_anchor} footnote:[{fn-reference-count-usage}]
 
 include::{generated}/api/version-notes/CL_EVENT_REFERENCE_COUNT.asciidoc[]
-  | {cl_uint}
+  | {cl_uint_TYPE}
       | Return the _event_ reference count.
 |====
 
@@ -8920,7 +8920,7 @@ to the user event, it would be in principle no longer valid for the
 application to change the status of the event to unblock all the other
 machinery.
 As a result the waiting tasks will wait forever, and associated events,
-{cl_mem} objects, command queues and contexts are likely to leak.
+{cl_mem_TYPE} objects, command queues and contexts are likely to leak.
 In-order command queues caught up in this deadlock may cease to do any work.
 ====
 
@@ -9273,14 +9273,14 @@ include::{generated}/api/version-notes/clGetEventProfilingInfo.asciidoc[]
 | {CL_PROFILING_COMMAND_QUEUED_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_QUEUED.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event is enqueued in a
         command-queue by the host.
 | {CL_PROFILING_COMMAND_SUBMIT_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_SUBMIT.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event that has been
         enqueued is submitted by the host to the device associated with the
@@ -9288,21 +9288,21 @@ include::{generated}/api/version-notes/CL_PROFILING_COMMAND_SUBMIT.asciidoc[]
 | {CL_PROFILING_COMMAND_START_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_START.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event starts execution on
         the device.
 | {CL_PROFILING_COMMAND_END_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_END.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event has finished
         execution on the device.
 | {CL_PROFILING_COMMAND_COMPLETE_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_COMMAND_COMPLETE.asciidoc[]
-  | {cl_ulong}
+  | {cl_ulong_TYPE}
       | A 64-bit value that describes the current device time counter in
         nanoseconds when the command identified by event and any child
         commands enqueued by this command on the device have finished

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
 
     print('Found ' + str(numberOfEnums) + ' API enumerations.')
 
-    # Generate the API types dictionaries, only for structs (for now):
+    # Generate the API types dictionaries:
 
     numberOfTypes = 0
 
@@ -212,11 +212,15 @@ if __name__ == "__main__":
             # underscores for the attribute name.
             attribName = name.replace(" ", "_")
 
+            # Append the type suffix for disambiguation, since asciidoctor
+            # attributes are not case-sensitive (currently).
+            attribName = attribName + "_TYPE"
+
             # Example with link:
             #
             # // cl_image_desc
-            # :cl_image_desc_label: pass:q[`cl_image_desc`]
-            # :cl_image_desc: <<cl_image_desc,{cl_image_desc_label}>>
+            # :cl_image_desc_TYPE_label: pass:q[`cl_image_desc`]
+            # :cl_image_desc_TYPE: <<cl_image_desc,{cl_image_desc_TYPE_label}>>
             linkFile.write('// ' + name + '\n')
             if addLink:
                 linkFile.write('ifdef::backend-html5[]\n')
@@ -236,7 +240,7 @@ if __name__ == "__main__":
             linkFile.write('\n')
 
             # // cl_image_desc
-            # :cl_image_desc: pass:q[`cl_image_desc`]
+            # :cl_image_desc_TYPE: pass:q[`cl_image_desc`]
             nolinkFile.write('// ' + name + '\n')
             nolinkFile.write('ifdef::backend-html5[]\n')
             nolinkFile.write(':' + attribName + ': pass:q[`' + htmlName + '`]\n')


### PR DESCRIPTION
Fixes #443.

Because asciidoctor attributes are not currently case-sensitive, the TYPE suffix is needed to disambiguate between an API type and an enum with the same name.