### PR TITLE
add CL_KERNEL_COMPILE_NUM_SUB_GROUPS to Appendix H

### DIFF
--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -397,6 +397,10 @@ When Intermediate Language Programs are not supported:
 | {clSetProgramSpecializationConstant}
 | Returns {CL_INVALID_OPERATION} if no devices associated with _program_ support Intermediate Language Programs.
 
+| {clGetKernelSubGroupInfo}, passing +
+{CL_KERNEL_COMPILE_NUM_SUB_GROUPS}
+| Returns `0` if _device_ does not support Intermediate Language Programs, since there is currently no way to require a number of subgroups per work-group for programs created from source.
+
 |====
 
 == Subgroups


### PR DESCRIPTION
Fixes #445.

Since there is no way to specify this attribute for programs created from source, the query will always return zero if the device does not support intermediate language programs.