### PR TITLE
Allow use of CL_DEVICE_COMPILER_AVAILABLE for IL

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5716,6 +5716,10 @@ Otherwise, it returns one of the following errors:
     language does not support specialization constants.
   * {CL_INVALID_OPERATION} if no devices associated with _program_ support
     Intermediate Language Programs.
+  * {CL_COMPILER_NOT_AVAILABLE} if _program_ is created with
+    {clCreateProgramWithIL} and a compiler is not
+    available, i.e. {CL_DEVICE_COMPILER_AVAILABLE} specified in the
+    <<device-queries-table,Device Queries>> table is set to {CL_FALSE}.
   * {CL_INVALID_SPEC_ID} if _spec_id_ is not a valid specialization constant
     identifier.
   * {CL_INVALID_VALUE} if _spec_size_ does not match the size of the
@@ -5816,8 +5820,8 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_BUILD_OPTIONS} if the build options specified by _options_ are
     invalid.
   * {CL_COMPILER_NOT_AVAILABLE} if _program_ is created with
-    {clCreateProgramWithSource} and a compiler is not available i.e.
-    {CL_DEVICE_COMPILER_AVAILABLE} specified in the
+    {clCreateProgramWithSource} or {clCreateProgramWithIL} and a compiler is
+    not available, i.e. {CL_DEVICE_COMPILER_AVAILABLE} specified in the
     <<device-queries-table,Device Queries>> table is set to {CL_FALSE}.
   * {CL_BUILD_PROGRAM_FAILURE} if there is a failure to build the program
     executable.
@@ -5992,7 +5996,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_OPERATION} if the compilation or build of a program executable
     for any of the devices listed in _device_list_ by a previous call to
     {clCompileProgram} or {clBuildProgram} for _program_ has not completed.
-  * {CL_COMPILER_NOT_AVAILABLE} if a compiler is not available i.e.
+  * {CL_COMPILER_NOT_AVAILABLE} if a compiler is not available, i.e.
     {CL_DEVICE_COMPILER_AVAILABLE} specified in the
     <<device-queries-table,Device Queries>> table is set to {CL_FALSE}.
   * {CL_COMPILE_PROGRAM_FAILURE} if there is a failure to compile the program
@@ -6130,7 +6134,7 @@ The list of errors that can be returned are:
   * {CL_INVALID_OPERATION} if the rules for devices containing compiled
     binaries or libraries as described in _input_programs_ argument above
     are not followed.
-  * {CL_LINKER_NOT_AVAILABLE} if a linker is not available i.e.
+  * {CL_LINKER_NOT_AVAILABLE} if a linker is not available, i.e.
     {CL_DEVICE_LINKER_AVAILABLE} specified in the
     <<device-queries-table,Device Queries>> table is set to {CL_FALSE}.
   * {CL_LINK_PROGRAM_FAILURE} if there is a failure to link the compiled


### PR DESCRIPTION
Currently how the use of IL programs should behave when
`CL_DEVICE_COMPILER_AVAILABLE` is `CL_FALSE` is underspecified.  This change
allows `CL_DEVICE_COMPILER_AVAILABLE` to be returned by entry points that
require use of a compiler.

`clBuildProgram` could already return `CL_DEVICE_COMPILER_AVAILABLE` for OpenCL
source, so extend that to IL.  `clCompileProgram` can already return
`CL_DEVICE_COMPILER_AVAILABLE` for any input type.

I've also added the `CL_DEVICE_COMPILER_AVAILABLE` to
`clSetProgramSpecializationConstant` because for it to be able to check the
validity of the provided `spec_id` it must be able to parse the IL program.

Fixes #438