### PR TITLE
Program scope constructor/destructor queries require a built program

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6691,6 +6691,9 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT.asc
       | This indicates that the _program_ object contains non-trivial
         constructor(s) that will be executed by runtime before any kernel
         from the program is executed.
+        This information is only available after a successful program
+        executable has been built for at least one device in the list of
+        devices associated with _program_.
 
         Querying {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT} may unconditionally
         return {CL_FALSE} if no devices associated with _program_ support
@@ -6704,6 +6707,9 @@ include::{generated}/api/version-notes/CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT.asc
       | This indicates that the program object contains non-trivial
         destructor(s) that will be executed by runtime when _program_ is
         destroyed.
+        This information is only available after a successful program
+        executable has been built for at least one device in the list of
+        devices associated with _program_.
 
         Querying {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT} may unconditionally
         return {CL_FALSE} if no devices associated with _program_ support
@@ -6723,10 +6729,12 @@ Otherwise, it returns one of the following errors:
     the <<program-info-table,Program Object Queries>> table and
     _param_value_ is not `NULL`.
   * {CL_INVALID_PROGRAM} if _program_ is a not a valid program object.
-  * {CL_INVALID_PROGRAM_EXECUTABLE} if _param_name_ is {CL_PROGRAM_NUM_KERNELS}
-    or {CL_PROGRAM_KERNEL_NAMES} and a successful program executable has not
-    been built for at least one device in the list of devices associated
-    with _program_.
+  * {CL_INVALID_PROGRAM_EXECUTABLE} if _param_name_ is
+    {CL_PROGRAM_NUM_KERNELS}, {CL_PROGRAM_KERNEL_NAMES},
+    {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT}, or
+    {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT} and a successful program executable
+    has not been built for at least one device in the list of devices
+    associated with _program_.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources


### PR DESCRIPTION
It isn't possible to know what to return for
`CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT` or
`CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT` passed to `clGetProgramInfo` without
examining the program.   So require the program to be built first.

Fixes #436