### PR TITLE
Unify the OpenCL C spec

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3005,12 +3005,6 @@ kernel void my_func(image2d_t img, global float *a)
 [open,refpage='restrictions',desc='Restrictions',type='freeform',spec='clang',anchor='restrictions']
 --
 
-[NOTE]
-====
-Items struckthrough are restrictions in a previous version of OpenCL C that
-are no longer present in OpenCL C 3.0.
-====
-
 [loweralpha]
   . The use of pointers is somewhat restricted.
     The following rules apply:
@@ -3021,10 +3015,11 @@ are no longer present in OpenCL C 3.0.
       assigned to a pointer declared with the `+__constant+` qualifier
       respectively.
     * Pointers to functions are not allowed.
-    * [line-through]#Arguments to kernel functions in a program cannot be
+    * Arguments to kernel functions in a program cannot be
       declared as a pointer to a pointer(s).
       Variables inside a function or arguments to non-kernel functions in a
-      program can be declared as a pointer to a pointer(s).#
+      program can be declared as a pointer to a pointer(s).
+      This restriction only applies to OpenCL C 1.2 or below.
   . An image type (`image2d_t`, `image3d_t`, `image2d_array_t`, `image1d_t`,
     `image1d_buffer_t` or `image1d_array_t`) can only be used as the type of
     a function argument.
@@ -3055,8 +3050,8 @@ address space qualifiers.
     with flexible (or unsized) arrays are not supported.
   . Variadic functions are not supported, with the exception of `printf` and
     `enqueue_kernel`.
-// Relaxed in OpenCL C 3.0.
-  . [line-through]#Variadic macros are not supported.#
+  . Variadic macros are not supported.
+    This restriction only applies to OpenCL C 2.0 or below.
   . If a list of parameters in a function declaration is empty, the function
     takes no arguments. This is due to the above restriction on variadic
     functions.
@@ -3068,7 +3063,8 @@ address space qualifiers.
     `wchar.h` and `wctype.h` are not available and cannot be included by a
     program.
   . The `auto` and `register` storage-class specifiers are not supported.
-  . [line-through]#Predefined identifiers are not supported.#
+  . Predefined identifiers are not supported.
+    This restriction only applies to OpenCL C 1.1 or below.
   . Recursion is not supported.
   . The return type of a kernel function must be `void`.
   . Arguments to kernel functions in a program cannot be declared with the
@@ -3084,36 +3080,37 @@ address space qualifiers.
     floating-point arithmetic can be performed.
   . Whether or not irreducible control flow is illegal is implementation
     defined.
-// Relaxed in OpenCL C 1.1, or the cl_khr_byte_addressable_store extension.
-//  . [line-through]#Built-in types that are less than 32-bits in size, i.e.
-//    `char`, `uchar`, `char2`, `uchar2`, `short`, `ushort`, and `half`, have
-//    the following restriction:#
-//+
-//    * [line-through]#Writes to a pointer (or arrays) of type `char`,
-//      `uchar`, `char2`, `uchar2`, `short`, `ushort`, and `half` or to
-//      elements of a struct that are of type `char`, `uchar`, `char2`,
-//      `uchar2`, `short` and `ushort` are not supported.
-//      Refer to _section 9.9_ for additional information.#
-//+
-//[line-through]#The kernel example below shows what memory operations are not
-//supported on built-in types less than 32-bits in size.#
-//+
-//[source,c,role="line-through"]
-//----------
-//kernel void
-//do_proc (__global char *pA, short b,
-//         __global short *pB)
-//{
-//    char x[100];
-//    __private char *px = x;
-//    int id = (int)get_global_id(0);
-//    short f;
-//
-//    f = pB[id] + b; // is allowed
-//    px[1] = pA[1]; // error. px cannot be written.
-//    pB[id] = b; // error. pB cannot be written
-//}
-//----------
+  . The following restriction only applies to OpenCL C 1.0, also see the
+    *cl_khr_byte_addressable_store* extension.
+    Built-in types that are less than 32-bits in size, i.e.
+    `char`, `uchar`, `char2`, `uchar2`, `short`, `ushort`, and `half`, have
+    the following restriction:
++
+    * Writes to a pointer (or arrays) of type `char`,
+      `uchar`, `char2`, `uchar2`, `short`, `ushort`, and `half` or to
+      elements of a struct that are of type `char`, `uchar`, `char2`,
+      `uchar2`, `short` and `ushort` are not supported.
+      Refer to _section 9.9_ for additional information.
++
+The kernel example below shows what memory operations are not supported on
+built-in types less than 32-bits in size.
++
+[source,c]
+----------
+kernel void
+do_proc (__global char *pA, short b,
+         __global short *pB)
+{
+    char x[100];
+    __private char *px = x;
+    int id = (int)get_global_id(0);
+    short f;
+
+    f = pB[id] + b; // is allowed
+    px[1] = pA[1]; // error. px cannot be written.
+    pB[id] = b; // error. pB cannot be written
+}
+----------
   . The type qualifiers `const`, `restrict` and `volatile` as defined by the
     C99 specification are supported.
     These qualifiers cannot be used with `image2d_t`, `image3d_t`,
@@ -3216,6 +3213,12 @@ The following predefined macro names are available.
     language version supported by each device is used as the version of
     OpenCL C when compiling the program for each device.
     <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
+
+`+__ROUNDING_MODE__+` ::
+    Used to determine the current rounding mode and is set to rte.
+    Only affects the rounding mode of conversions to a float type.
+    <<unified-spec, Deprecated by>> OpenCL C 1.1, along with the
+    *cl_khr_select_fprounding_mode* extension.
 
 `+__ENDIAN_LITTLE__+` ::
     Used to determine if the OpenCL device is a little endian architecture
@@ -5990,6 +5993,67 @@ in a subgroup.
   <<atomic-restrictions,atomic restrictions section>>.
 
 |====
+
+
+[[legacy-mem-fence-functions]]
+=== Legacy Explicit Memory Fence Functions
+
+[open,refpage='legacyFenceFunctions',desc='Legacy Explicit Memory Fence Functions',type='freeform',spec='clang',anchor='legacy-mem-fence-functions',alias='mem_fence read_mem_fence write_mem_fence']
+--
+IMPORTANT: The memory fence functions described in this sub-section are
+<<unified-spec, deprecated by>> OpenCL C 2.0.
+
+The OpenCL C programming language implements the following explicit memory fence functions to provide ordering between memory operations of a work-item.
+
+[[table-builtin-explicit-memory-fences]]
+.Built-in Explicit Memory Fence Functions
+[cols="3,7",]
+|====
+| *Function* | *Description*
+
+| void *mem_fence*( +
+  cl_mem_fence_flags _flags_) +
+
+| Orders loads and stores of a work-item executing a kernel.  This means that
+  loads and stores preceding the *mem_fence* will be committed to memory
+  before any loads and stores following the *mem_fence*.
+
+  The _flags_ argument specifies the memory address space and can be set to a
+  combination of the following literal values:
+
+  `CLK_LOCAL_MEM_FENCE` +
+  `CLK_GLOBAL_MEM_FENCE`
+
+  The value of _flags_ must be the same for all work-items in the work-group.
+
+| void *read_mem_fence*( +
+  cl_mem_fence_flags _flags_) +
+
+| Read memory barrier that orders only loads.
+
+  The _flags_ argument specifies the memory address space and can be set to a
+  combination of the following literal values:
+
+  `CLK_LOCAL_MEM_FENCE` +
+  `CLK_GLOBAL_MEM_FENCE`
+
+  The value of _flags_ must be the same for all work-items in the work-group.
+
+| void *write_mem_fence*( +
+  cl_mem_fence_flags _flags_) +
+
+| Write memory barrier that orders only stores.
+
+  The _flags_ argument specifies the memory address space and can be set to a
+  combination of the following literal values:
+
+  `CLK_LOCAL_MEM_FENCE` +
+  `CLK_GLOBAL_MEM_FENCE`
+
+  The value of _flags_ must be the same for all work-items in the work-group.
+
+|====
+--
 
 
 [[address-space-qualifier-functions]]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -132,7 +132,7 @@ naming convention for the feature macros is `+__opencl_c_<name>+`.
 Feature macro identifiers are used as names of features in this document.
 
 [[table-optional-lang-features]]
-.Optional features in OpenCL C 3.0 and their predefined macros.
+.Optional features in OpenCL C 3.0 or newer and their predefined macros.
 [cols="1,1",options="header",]
 |====
 | *Feature Macro/Name*
@@ -532,26 +532,26 @@ OpenCL.
       This queue can only be used to enqueue commands from kernels executing
       on the device.
 
-      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature.
+      <<unifed-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_device_enqueue+` feature.
 | `ndrange_t`
     | The N-dimensional range over which a kernel executes.
 
-      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature.
+      <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_device_enqueue+` feature.
 | `clk_event_t`
     | A device side event that identifies a command enqueue to
       a device command queue.
 
-      Requires support for OpenCL C 2.0 or the `+__opencl_c_device_enqueue+`
-      feature.
+      <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_device_enqueue+` feature.
 | `reserve_id_t`
     | A reservation ID.
       This opaque type is used to identify the reservation for
       <<pipe-functions,reading and writing a pipe>>.
 
-      Requires support for OpenCL C 2.0 or the `+__opencl_c_pipes+`
-      feature.
+      <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_pipes+` feature.
 | `event_t`
     | An event.
       This can be used to identify <<async-copies,async copies>> from
@@ -2190,7 +2190,7 @@ Examples:
 
 [source,c]
 ----------
-// Note: these examples assume OpenCL C 2.0 or the
+// Note: these examples assume OpenCL C 2.0, or OpenCL C 3.0 or newer and the
 // __opencl_c_program_scope_global_variables feature.
 
 global int foo;         // OK.
@@ -2350,8 +2350,9 @@ arguments are in the `+__private+` or `private` address space.
 [open,refpage='genericAddressSpace',desc='The Generic Address Space',type='freeform',spec='clang',anchor='the-generic-address-space',xrefs='addressSpaceQualifiers constant global local private']
 --
 
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+`+__opencl_c_generic_address_space+` feature.
 
 The following rules apply when using pointers that point to the generic
 address space:
@@ -3756,8 +3757,9 @@ information provided is in some sense correct.
 
 [open,refpage='blocks',desc='Blocks',type='freeform',spec='clang',anchor='blocks']
 --
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+`+__opencl_c_device_enqueue+` feature.
 
 This section describes the clang block syntax
 footnote:[{fn-clang-block-syntax}].
@@ -4229,7 +4231,8 @@ identifier of each work-item when this kernel is being executed on a device.
 |====
 
 NOTE: The functionality described in the following table <<unified-spec,
-requires>> support for OpenCL C 3.0 and the `+__opencl_c_subgroups+` feature.
+requires>> support for OpenCL C 3.0 or newer and the `+__opencl_c_subgroups+`
+feature.
 
 The following table describes the list of built-in work-item functions that
 can be used to query the size of a subgroup, number of subgroups per work group,
@@ -5931,7 +5934,8 @@ in a work-group.
 --
 
 NOTE: The functionality described in the following table <<unified-spec,
-requires>> support for OpenCL 3.0 and the `+__opencl_c_subgroups+` feature.
+requires>> support for OpenCL 3.0 or newer and the `+__opencl_c_subgroups+`
+feature.
 
 The following table describes built-in functions to synchronize the work-items
 in a subgroup.
@@ -6062,8 +6066,9 @@ The OpenCL C programming language implements the following explicit memory fence
 [open,refpage='addressSpaceQualifierFuncs',desc='Address Space Qualifier Functions',type='freeform',spec='clang',anchor='address-space-qualifier-functions',xrefs='qualifiers',alias='get_fence to_global to_local to_private']
 --
 
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_generic_address_space+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+`+__opencl_c_generic_address_space+` feature.
 
 This section describes built-in functions to safely convert from pointers
 to the generic address space to pointers to named address spaces, and to
@@ -6367,7 +6372,8 @@ pointed to by obj to the value value.
 void atomic_init(volatile __global A *obj, C value)
 void atomic_init(volatile __local A *obj, C value)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 void atomic_init(volatile A *obj, C value)
 ----------
 
@@ -6382,8 +6388,9 @@ work_group_barrier(CLK_LOCAL_MEM_FENCE);
 ----------
 
 NOTE: The function variant that uses the generic address space, i.e. no
-explicit address space is listed, requires OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, requires>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -6405,19 +6412,22 @@ The following table lists the enumeration constants:
 |====
 | *Memory Order* | *Additional Notes*
 | `memory_order_relaxed`
-    |
+    | <<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
 | `memory_order_acquire`
-    | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, but in OpenCL C 3.0
+      or newer some uses require the `+__opencl_c_atomic_order_acq_rel+`
+      feature.
 | `memory_order_release`
-    | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, but in OpenCL C 3.0
+      or newer some uses require the `+__opencl_c_atomic_order_acq_rel+`
+      feature.
 | `memory_order_acq_rel`
-    | Always present but some uses require support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_order_acq_rel+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, but in OpenCL C 3.0
+      or newer some uses require the `+__opencl_c_atomic_order_acq_rel+`
+      feature.
 | `memory_order_seq_cst`
-    | Requires support for OpenCL C 2.0, or the
-      `+__opencl_c_atomic_order_seq_cst+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_atomic_order_seq_cst+` feature.
 |====
 
 The `memory_order` can be used when performing atomic operations to `global`
@@ -6445,19 +6455,22 @@ The following table lists the enumeration constants:
 | `memory_scope_work_item`
     | `memory_scope_work_item` can only be used with `atomic_work_item_fence`
       with flags set to `CLK_IMAGE_MEM_FENCE`.
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
 | `memory_scope_sub_group`
-    | Requires support for the `+__opencl_c_subgroups+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 3.0 or newer and the
+      `+__opencl_c_subgroups+` feature.
 | `memory_scope_work_group`
-    |
+    | <<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
 | `memory_scope_device`
-    | Requires support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_scope_device+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_atomic_scope_device+` feature.
 | `memory_scope_all_svm_devices`
-    | Requires support for OpenCL C 2.0 or the
-      `+__opencl_c_atomic_scope_all_devices+` feature.
+    | <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_atomic_scope_all_devices+` feature.
 | `memory_scope_all_devices`
     | An alias for `memory_scope_all_svm_devices`.
-      Requires support for the `+__opencl_c_atomic_scope_all_devices+` feature.
+      <<unified-spec, Requires>> support for OpenCL C 3.0 or newer and the
+      `+__opencl_c_atomic_scope_all_devices+` feature.
 |====
 
 // This is no longer correct given `memory_scope_sub_group`.
@@ -6570,11 +6583,13 @@ This section specifies each general kind.
 void atomic_store(volatile __global A *object, C desired)
 void atomic_store(volatile __local A *object, C desired)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 void atomic_store(volatile A *object, C desired)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 void atomic_store_explicit(volatile __global A *object,
                            C desired,
                            memory_order order)
@@ -6582,8 +6597,9 @@ void atomic_store_explicit(volatile __local A *object,
                            C desired,
                            memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// features.
 void atomic_store_explicit(volatile A *object,
                            C desired,
                            memory_order order)
@@ -6598,7 +6614,8 @@ void atomic_store_explicit(volatile __local A *object,
                            memory_order order,
                            memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 void atomic_store_explicit(volatile A *object,
                            C desired,
                            memory_order order,
@@ -6611,15 +6628,17 @@ Atomically replace the value pointed to by _object_ with the value of
 _desired_.
 Memory is affected according to the value of _order_.
 
-NOTE: The non-explicit `atomic_store` function requires OpenCL C 2.0, or both
-the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_store` function <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -6635,18 +6654,21 @@ explicit address space is listed, require OpenCL C 2.0 or the
 C atomic_load(volatile __global A *object)
 C atomic_load(volatile __local A *object)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 C atomic_load(volatile A *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 C atomic_load_explicit(volatile __global A *object,
                        memory_order order)
 C atomic_load_explicit(volatile __local A *object,
                        memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// features.
 C atomic_load_explicit(volatile A *object,
                        memory_order order)
 
@@ -6658,7 +6680,8 @@ C atomic_load_explicit(volatile __local A *object,
                        memory_order order,
                        memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 C atomic_load_explicit(volatile A *object,
                        memory_order order,
                        memory_scope scope)
@@ -6669,15 +6692,17 @@ The _order_ argument shall not be `memory_order_release` nor
 Memory is affected according to the value of _order_.
 Atomically returns the value pointed to by _object_.
 
-NOTE: The non-explicit `atomic_load` function requires OpenCL C 2.0, or both
-the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_load` function <<unified-spec, requires>>
+support for OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -6693,11 +6718,13 @@ explicit address space is listed, require OpenCL C 2.0 or the
 C atomic_exchange(volatile __global A *object, C desired)
 C atomic_exchange(volatile __local A *object, C desired)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 C atomic_exchange(volatile A *object, C desired)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 C atomic_exchange_explicit(volatile __global A *object,
                            C desired,
                            memory_order order)
@@ -6705,8 +6732,9 @@ C atomic_exchange_explicit(volatile __local A *object,
                            C desired,
                            memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// feature.
 C atomic_exchange_explicit(volatile A *object,
                            C desired,
                            memory_order order)
@@ -6721,7 +6749,8 @@ C atomic_exchange_explicit(volatile __local A *object,
                            memory_order order,
                            memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 C atomic_exchange_explicit(volatile A *object,
                            C desired,
                            memory_order order,
@@ -6735,15 +6764,17 @@ These operations are read-modify-write operations (as defined by
 Atomically returns the value pointed to by object immediately before the
 effects.
 
-NOTE: The non-explicit `atomic_exchange` function requires OpenCL C 2.0, or
-both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_exchange` function <<unified-spec, requires>>
+support for OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -6775,8 +6806,9 @@ bool atomic_compare_exchange_strong(
     volatile __local A *object,
     __private C *expected, C desired)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_strong(
     volatile A *object,
     C *expected, C desired)
@@ -6819,7 +6851,8 @@ bool atomic_compare_exchange_strong_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_strong_explicit(
     volatile A *object,
     C *expected,
@@ -6871,7 +6904,8 @@ bool atomic_compare_exchange_strong_explicit(
     memory_order failure,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_strong_explicit(
     volatile A *object,
     C *expected,
@@ -6901,8 +6935,9 @@ bool atomic_compare_exchange_weak(
     volatile __local A *object,
     __private C *expected, C desired)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_weak(
     volatile A *object,
     C *expected, C desired)
@@ -6945,7 +6980,8 @@ bool atomic_compare_exchange_weak_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_weak_explicit(
     volatile A *object,
     C *expected,
@@ -6997,7 +7033,8 @@ bool atomic_compare_exchange_weak_explicit(
     memory_order failure,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 bool atomic_compare_exchange_weak_explicit(
     volatile A *object,
     C *expected,
@@ -7043,15 +7080,17 @@ memory contents that were originally there.
 These generic functions return the result of the comparison.
 
 NOTE: The non-explicit `atomic_compare_exchange_strong` and
-`atomic_compare_exchange_weak` functions requires OpenCL C 2.0, or both the
+`atomic_compare_exchange_weak` functions <<unified-spec, requires>> support
+for OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
 `+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
 features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -7105,8 +7144,9 @@ C atomic_fetch_key_explicit(volatile __local A *object,
                             M operand,
                             memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// features.
 C atomic_fetch_key_explicit(volatile A *object,
                             M operand,
                             memory_order order)
@@ -7121,7 +7161,8 @@ C atomic_fetch_key_explicit(volatile __local A *object,
                             memory_order order,
                             memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 C atomic_fetch_key_explicit(volatile A *object,
                             M operand,
                             memory_order order,
@@ -7142,15 +7183,17 @@ operations otherwise have no undefined behavior.
 Returns atomically the value pointed to by `object` immediately before the
 effects.
 
-NOTE: The non-explicit `atomic_fetch_key` functions require OpenCL C 2.0, or
-both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_fetch_key` functions <<unified-spec, require>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -7196,12 +7239,14 @@ bool atomic_flag_test_and_set(
 bool atomic_flag_test_and_set(
     volatile __local atomic_flag *object)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 bool atomic_flag_test_and_set(
     volatile atomic_flag *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 bool atomic_flag_test_and_set_explicit(
     volatile __global atomic_flag *object,
     memory_order order)
@@ -7209,8 +7254,9 @@ bool atomic_flag_test_and_set_explicit(
     volatile __local atomic_flag *object,
     memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0 or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// features.
 bool atomic_flag_test_and_set_explicit(
     volatile atomic_flag *object,
     memory_order order)
@@ -7225,7 +7271,8 @@ bool atomic_flag_test_and_set_explicit(
     memory_order order,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 bool atomic_flag_test_and_set_explicit(
     volatile atomic_flag *object,
     memory_order order,
@@ -7238,15 +7285,17 @@ These operations are atomic read-modify-write operations (as defined by
 <<C11-spec,section 5.1.2.4 of the C11 Specification>>).
 Returns atomically the value of the `object` immediately before the effects.
 
-NOTE: The non-explicit `atomic_flag_test_and_set` function requires OpenCL C
-2.0, or both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_flag_test_and_set` function <<unified-spec,
+requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 
@@ -7262,11 +7311,13 @@ explicit address space is listed, require OpenCL C 2.0 or the
 void atomic_flag_clear(volatile __global atomic_flag *object)
 void atomic_flag_clear(volatile __local atomic_flag *object)
 
-// Requires OpenCL C 2.0, or all of the __opencl_c_generic_address_space,
-// __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and all of the
+// __opencl_c_generic_address_space, __opencl_c_atomic_order_seq_cst and
+// __opencl_c_atomic_scope_device features.
 void atomic_flag_clear(volatile atomic_flag *object)
 
-// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 void atomic_flag_clear_explicit(
     volatile __global atomic_flag *object,
     memory_order order)
@@ -7274,8 +7325,9 @@ void atomic_flag_clear_explicit(
     volatile __local atomic_flag *object,
     memory_order order)
 
-// Requires OpenCL C 2.0 or both the __opencl_c_generic_address_space and
-// __opencl_c_atomic_scope_device features.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and __opencl_c_atomic_scope_device
+// features.
 void atomic_flag_clear_explicit(
     volatile atomic_flag *object,
     memory_order order)
@@ -7290,7 +7342,8 @@ void atomic_flag_clear_explicit(
     memory_order order,
     memory_scope scope)
 
-// Requires OpenCL C 2.0 or the __opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+// __opencl_c_generic_address_space feature.
 void atomic_flag_clear_explicit(
     volatile atomic_flag *object,
     memory_order order,
@@ -7302,15 +7355,17 @@ The `order` argument shall not be `memory_order_acquire` nor
 Atomically sets the value pointed to by object to false.
 Memory is affected according to the value of order.
 
-NOTE: The non-explicit `atomic_flag_clear` function requires OpenCL C 2.0, or
-both the `+__opencl_c_atomic_order_seq_cst+` and
-`+__opencl_c_atomic_scope_device+` features.
+NOTE: The non-explicit `atomic_flag_clear` function <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+`+__opencl_c_atomic_order_seq_cst+` and `+__opencl_c_atomic_scope_device+`
+features.
 For the explicit variants, memory order and scope enumerations must respect the
 <<atomic-restrictions,restrictions section below>>.
 
 NOTE: The function variants that use the generic address space, i.e. no
-explicit address space is listed, require OpenCL C 2.0 or the
-`+__opencl_c_generic_address_space+` feature.
+explicit address space is listed, <<unified-spec, require>> support for OpenCL
+C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_generic_address_space+`
+feature.
 --
 
 [[atomic-legacy]]
@@ -7523,22 +7578,29 @@ semantics of the minimum requirements.
     functions refers to an atomic type in the `private` address space is
     undefined.
   * Using `memory_order_acquire` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature.
+    `atomic_work_item_fence` <<unified-spec, requires>> support for OpenCL C
+    2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_atomic_order_acq_rel+`
+    feature.
   * Using `memory_order_release` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature.
+    `atomic_work_item_fence` <<unified-spec, requires>> support for OpenCL C
+    2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_atomic_order_acq_rel+`
+    feature.
   * Using `memory_order_acq_rel` with any built-in atomic function except
-    `atomic_work_item_fence` requires OpenCL C 2.0 or the
-    `+__opencl_c_atomic_order_acq_rel+` feature.
-  * Using `memory_order_seq_cst` with any built-in atomic function requires
-    OpenCL C 2.0 or the `+__opencl_c_atomic_order_seq_cst+` feature.
-  * Using `memory_scope_sub_group` with any built-in atomic function requires
-    the `+__opencl_c_subgroups+` feature.
-  * Using `memory_scope_device` requires OpenCL C 2.0 or the
+    `atomic_work_item_fence` <<unified-spec, requires>> support for OpenCL C
+    2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_atomic_order_acq_rel+`
+    feature.
+  * Using `memory_order_seq_cst` with any built-in atomic function
+    <<unified-spec, requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+    newer and the `+__opencl_c_atomic_order_seq_cst+` feature.
+  * Using `memory_scope_sub_group` with any built-in atomic function
+    <<unified-spec, requires>> support for OpenCL C 3.0 or newer and the
+    `+__opencl_c_subgroups+` feature.
+  * Using `memory_scope_device` <<unified-spec, requires>> support for OpenCL
+    C 2.0, or OpenCL C 3.0 or newer and the
     `+__opencl_c_atomic_scope_device+` feature.
-  * Using `memory_scope_all_svm_devices` or `memory_scope_all_devices` requires
-    OpenCL C 2.0 or the `+__opencl_c_atomic_scope_all_devices+` feature.
+  * Using `memory_scope_all_svm_devices` or `memory_scope_all_devices`
+    <<unified-spec, requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+    newer and the `+__opencl_c_atomic_scope_all_devices+` feature.
 --
 
 
@@ -9337,8 +9399,9 @@ For write functions this may be `write_only` or `read_write`.
       are not in the range [0, image width-1], [0, image height-1], and [0,
       image depth-1], respectively, is undefined.
 
-      Requires support for OpenCL C 2.0, the `+__opencl_c_3d_image_writes+`
-      feature, or the `cl_khr_3d_image_writes` extension.
+      <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+      newer and the `+__opencl_c_3d_image_writes+` feature, or the
+      `cl_khr_3d_image_writes` extension.
 |====
 --
 
@@ -9606,8 +9669,9 @@ support will result in a `CL_OUT_OF_RESOURCES` error being returned.
 [open,refpage='workGroupFunctions',desc='Work-group Collective Functions',type='freeform',spec='clang',anchor='work-group-functions',xrefs='',alias='work_group_all work_group_any work_group_broadcast work_group_reduce work_group_scan_exclusive work_group_scan_inclusive']
 --
 
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_work_group_collective_functions+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+`+__opencl_c_work_group_collective_functions+` feature.
 
 This section decribes built-in functions that perform collective options
 across a work-group.
@@ -9716,8 +9780,8 @@ given work-group.
 [[pipe-functions]]
 === Pipe Functions
 
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_pipes+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the `+__opencl_c_pipes+` feature.
 
 A pipe is identified by specifying the `pipe` keyword with a type.
 The data type specifies the size of each packet in the pipe.
@@ -9985,8 +10049,9 @@ The following behavior is undefined:
 
 [open,refpage='enqueue_kernel',desc='Enqueuing Kernels',type='freeform',spec='clang',anchor='enqueuing-kernels',xrefs='enqueue_marker']
 --
-NOTE: The functionality described in this section requires support for
-OpenCL C 2.0 or the `+__opencl_c_device_enqueue+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
+`+__opencl_c_device_enqueue+` feature.
 
 This section describes built-in functions that allow a kernel to
 enqueue additional work to the same device, without host interaction.
@@ -10661,7 +10726,8 @@ foo(queue_t q, ...)
 [open,refpage='subgroupFunctions',desc='Subgroup Functions',type='freeform',spec='clang',anchor='subgroup-functions',xrefs='',alias='sub_group_all sub_group_any sub_group_broadcast sub_group_reduce sub_group_scan_exclusive sub_group_scan_inclusive sub_group_reserve_read_pipe sub_gorup_reserve_write_pipe sub_group_commit_read_pipe sub_group_commit_write_pipe get_kernel_sub_group_count_for_ndrange get_kernel_max_sub_group_size_for_ndrange']
 --
 
-NOTE: The functionality described in this section requires support for the `+__opencl_c_subgroups+` feature.
+NOTE: The functionality described in this section <<unified-spec, requires>>
+support for OpenCL C 3.0 or newer and the `+__opencl_c_subgroups+` feature.
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
@@ -10737,7 +10803,9 @@ The order of floating-point operations is not guaranteed for the *sub_group_redu
 The order of these floating-point operations is also non-deterministic for a given sub-group.
 ====
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_pipes+` features.
+NOTE: The functionality described in the following table <<unified-spec,
+requires>> support for OpenCL C 3.0 or newer and the `+__opencl_c_subgroups+`
+and `+__opencl_c_pipes+` features.
 
 The following table describes built-in pipe functions that operate at a
 subgroup level.
@@ -10788,7 +10856,9 @@ can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
 groups is implementation defined.
 
-NOTE: The functionality described in the following table requires support for the `+__opencl_c_subgroups+` and `+__opencl_c_device_enqueue+` features.
+NOTE: The functionality described in the following table <<unified-spec,
+requires>> support for OpenCL C 3.0 or newer and the `+__opencl_c_subgroups+`
+and `+__opencl_c_device_enqueue+` features.
 
 The following table describes built-in functions to query subgroup
 information for a block to be enqueued.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -118,6 +118,9 @@ by the presence of special predefined macros.
 [[features]]
 === Features
 
+IMPORTANT: Feature test macros <<unified-spec, require>> support for OpenCL C
+3.0.
+
 Optional language features are described in this document. They are optional
 from OpenCL C 3.0 and therefore are not supported by all implementations. When
 an OpenCL C 3.0 optional feature is supported, an associated __feature test
@@ -283,6 +286,9 @@ The following table describes the list of built-in scalar data types.
     | A 64-bit floating-point.
       The `double` data type must conform to the IEEE 754 double precision
       storage format.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
+      Also see extension *cl_khr_fp64*.
 | `half`
     | A 16-bit floating-point.
       The `half` data type must conform to the IEEE 754-2008 half precision
@@ -325,7 +331,7 @@ application:
 | `long`                     | `cl_long`
 | `unsigned long`, `ulong`   | `cl_ulong`
 | `float`                    | `cl_float`
-| `double`                   | `cl_double`
+| `double`                   | `cl_double` footnote:[{fn-cl_double}]
 | `half`                     | `cl_half`
 | `size_t`                   | n/a
 | `ptrdiff_t`                | n/a
@@ -408,13 +414,17 @@ write the `half` scalar or vector value to memory.
 [open,refpage='vectorDataTypes',desc='Built-in Vector Data Types',type='freeform',spec='clang',anchor='built-in-vector-data-types',xrefs='alignmentOfDataTypes otherDataTypes reservedDataTypes scalarDataTypes']
 --
 
-The `char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned
-int`, `long`, `unsigned long`, and `float` vector data types are supported.
+The `char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned int`,
+`long`, `unsigned long`, `float` and `double vector data types are supported.
 footnote:[{fn-vector-types}]
 The vector data type is defined with the type name, i.e. `char`, `uchar`,
-`short`, `ushort`, `int`, `uint`, `long`, `ulong`, or `float`, followed by a
-literal value _n_ that defines the number of elements in the vector.
+`short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, or `double`
+followed by a literal value _n_ that defines the number of elements in the
+vector.
 Supported values of _n_ are 2, 3, 4, 8, and 16 for all vector data types.
+
+NOTE: Vector types with three elements, i.e. where _n_ is 3, <<unified-spec,
+require>> support for OpenCL C 1.1 or newer.
 
 The following table describes the list of built-in vector data types.
 
@@ -443,6 +453,9 @@ The following table describes the list of built-in vector data types.
     | A vector of _n_ 32-bit floating-point values.
 | `double__n__` footnote:[{fn-double-vec}]
     | A vector of _n_ 64-bit floating-point values.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
+      Also see extension *cl_khr_fp64*.
 |====
 
 The built-in vector data types are also declared as appropriate types in the
@@ -488,16 +501,30 @@ OpenCL.
     | A 3D image.
 | `image2d_array_t` footnote:image-functions[]
     | A 2D image array.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | `image1d_t` footnote:image-functions[]
     | A 1D image.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | `image1d_buffer_t` footnote:image-functions[]
     | A 1D image created from a buffer object.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | `image1d_array_t` footnote:image-functions[]
     | A 1D image array.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | `image2d_depth_t` footnote:image-functions[]
     | A 2D depth image.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | `image2d_array_depth_t` footnote:image-functions[]
     | A 2D depth image array.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | `sampler_t` footnote:image-functions[]
     | A sampler type.
 | `queue_t`
@@ -2928,7 +2955,9 @@ can be 1, 2 or 3.
 [open,refpage='storageSpecifiers',desc='Storage-Class Specifiers',type='freeform',spec='clang',anchor='storage-class-specifiers',alias='typedef extern static']
 --
 
-The `typedef`, `extern` and `static` storage-class specifiers are supported.
+The `typedef` storage-class specifier is supported.
+The `extern` and `static` storage-class specifiers are supported but
+<<unified-spec, require>> support for OpenCL C 1.2 or newer.
 The `auto` and `register` storage-class specifiers are not supported.
 
 The `extern` storage-class specifier can only be used for functions (kernel
@@ -3161,29 +3190,32 @@ The following predefined macro names are available.
 
 `CL_VERSION_1_0` ::
     Substitutes the integer 100 reflecting the OpenCL 1.0 version.
+    <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 
 `CL_VERSION_1_1` ::
     Substitutes the integer 110 reflecting the OpenCL 1.1 version.
+    <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 
 `CL_VERSION_1_2` ::
     Substitutes the integer 120 reflecting the OpenCL 1.2 version.
+    <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 
 `CL_VERSION_2_0` ::
     Substitutes the integer 200 reflecting the OpenCL 2.0 version.
+    <<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
 
 `CL_VERSION_3_0` ::
     Substitutes the integer 300 reflecting the OpenCL 3.0 version.
+    <<unified-spec, Requires>> support for OpenCL C 3.0 or newer.
 
 `+__OPENCL_C_VERSION__+` ::
     Substitutes an integer reflecting the OpenCL C version specified by the
-    `-cl-std` build option the (see <<opencl-spec,OpenCL
-    Specification>>) to *clBuildProgram* or *clCompileProgram*.
+    `-cl-std` build option (see <<opencl-spec,OpenCL Specification>>) to
+    *clBuildProgram* or *clCompileProgram*.
     If the `-cl-std` build option is not specified, the highest OpenCL C 1.x
     language version supported by each device is used as the version of
     OpenCL C when compiling the program for each device.
-    The version of OpenCL C described in this document will have
-    `+__OPENCL_C_VERSION__+` substitute the integer 300 if `-cl-std=CL3.0`
-    is specified, and the integer 200 if `-cl-std=CL2.0` is specified.
+    <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 
 `+__ENDIAN_LITTLE__+` ::
     Used to determine if the OpenCL device is a little endian architecture
@@ -3219,11 +3251,13 @@ __kernel __attribute__((work_group_size_hint(X, 1, 1))) \
 The `NULL` macro expands to a null pointer constant.
 An integer constant expression with the value 0, or such an expression cast
 to type `void *` is called a _null pointer constant_.
+<<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
 
 The macro names defined by the C99 specification but not currently supported
 by OpenCL are reserved for future use.
 
 The predefined identifier `+__func__+` is available.
+<<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 
 In OpenCL C 3.0 there are a number of optional predefined macros indicating
 optional language features. Such macros are listed in the
@@ -3553,6 +3587,9 @@ pointer is assigned to another.
 `nosvm` ::
 The `nosvm` attribute can be used with a pointer variable to inform the
 compiler that the pointer does not refer to a shared virtual memory region.
+<<unified-spec, Requires>> support for OpenCL C 2.0 or newer.
+// __attribute__((nosvm)) was both added and deprecated in OpenCL C 2.0,
+// presumably it was a later revision that deprecated the attribute.
 
 [NOTE]
 ====
@@ -4125,6 +4162,8 @@ identifier of each work-item when this kernel is being executed on a device.
 
       Valid values of _dimindx_ are 0 to *get_work_dim*() - 1.
       For other values of _dimindx_, *get_enqueued_local_size*() returns 1.
+
+      <<unified-spec, Requires>> support for OpenCL 2.0 or newer.
 | size_t *get_local_id*(uint _dimindx_)
     | Returns the unique local work-item ID, i.e. a work-item within a
       specific work-group for dimension identified by _dimindx_.
@@ -4149,6 +4188,8 @@ identifier of each work-item when this kernel is being executed on a device.
 
       Valid values of _dimindx_ are 0 to *get_work_dim*() - 1.
       For other values, *get_global_offset*() returns 0.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | size_t *get_global_linear_id*()
     | Returns the work-items 1-dimensional global ID.
 
@@ -4163,6 +4204,8 @@ identifier of each work-item when this kernel is being executed on a device.
       *get_global_offset*(2)+)+ * *get_global_size*(1) * *get_global_size*(0)+)+
       {plus} +((+*get_global_id*(1) - *get_global_offset*(1)+)+ * *get_global_size*(0)+)+
       {plus} (*get_global_id*(0) - *get_global_offset*(0)+)+.
+
+      <<unified-spec, Requires>> support for OpenCL 2.0 or newer.
 | size_t *get_local_linear_id*()
     | Returns the work-items 1-dimensional local ID.
 
@@ -4178,10 +4221,12 @@ identifier of each work-item when this kernel is being executed on a device.
 
       (*get_local_id*(2) * *get_local_size*(1) * *get_local_size*(0)) {plus}
       (*get_local_id*(1) * *get_local_size*(0)) {plus} *get_local_id*(0).
+
+      <<unified-spec, Requires>> support for OpenCL 2.0 or newer.
 |====
 
-NOTE: The functionality described in the following table requires support for
-the `+__opencl_c_subgroups+` feature.
+NOTE: The functionality described in the following table <<unified-spec,
+requires>> support for OpenCL C 3.0 and the `+__opencl_c_subgroups+` feature.
 
 The following table describes the list of built-in work-item functions that
 can be used to query the size of a subgroup, number of subgroups per work group,
@@ -4468,9 +4513,13 @@ all arguments and the return type, unless otherwise specified.
 | gentype *maxmag*(gentype _x_, gentype _y_)
     | Returns _x_ if \|_x_\| > \|_y_\|, _y_ if \|_y_\| > \|_x_\|, otherwise
       *fmax*(_x_, _y_).
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | gentype *minmag*(gentype _x_, gentype _y_)
     | Returns _x_ if \|_x_\| < \|_y_\|, _y_ if \|_y_\| < \|_x_\|, otherwise
       *fmin*(_x_, _y_).
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | gentype *modf*(gentype _x_, {global} gentype _*iptr_) +
   gentype *modf*(gentype _x_, {local} gentype _*iptr_) +
   gentype *modf*(gentype _x_, {private} gentype _*iptr_) +
@@ -4982,6 +5031,8 @@ all arguments and the return type unless otherwise specified.
   gentype *clamp*(gentype _x_, sgentype _minval_, sgentype _maxval_)
     | Returns *min*(*max*(_x_, _minval_), _maxval_).
       Results are undefined if _minval_ > _maxval_.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | gentype *clz*(gentype _x_)
     | Returns the number of leading 0-bits in _x_, starting at the most
       significant bit position.
@@ -4991,14 +5042,22 @@ all arguments and the return type unless otherwise specified.
     | Returns the count of trailing 0-bits in _x_.
       If _x_ is 0, returns the size in bits of the type of _x_ or component
       type of _x_, if _x_ is a vector.
+
+      <<unified-spec, Requires>> support for OpenCL 2.0 or newer.
 | gentype *mad_hi*(gentype _a_, gentype _b_, gentype _c_)
     | Returns *mul_hi*(_a_, _b_) + _c_.
 | gentype *mad_sat*(gentype _a_, gentype _b_, gentype _c_)
     | Returns _a_ * _b_ + _c_ and saturates the result.
 | gentype *max*(gentype _x_, gentype _y_) +
+
+  For OpenCL C 1.1 or newer: +
+
   gentype *max*(gentype _x_, sgentype _y_)
     | Returns _y_ if _x_ < _y_, otherwise it returns _x_.
 | gentype *min*(gentype _x_, gentype _y_) +
+
+  For OpenCL C 1.1 or newer: +
+
   gentype *min*(gentype _x_, sgentype _y_)
     | Returns _y_ if _y_ < _x_, otherwise it returns _x_.
 | gentype *mul_hi*(gentype _x_, gentype _y_)
@@ -5031,7 +5090,9 @@ all arguments and the return type unless otherwise specified.
     | _result_[i] = ((long)_hi_[i] << 32) \| _lo_[i] +
       _result_[i] = ((ulong)_hi_[i] << 32) \| _lo_[i]
 | gentype *popcount*(gentype _x_)
-    | Returns the number of non-zero bits in _x_.
+    | Returns the number of non-zero bits in _x_. +
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 |====
 
 The following table describes fast integer functions that can be used for
@@ -5424,12 +5485,14 @@ not a number (NaN) and the argument type is a vector.
 | |
 | int *any*(igentype _x_)
 
-Scalar inputs to *any* are deprecated by OpenCL C version 3.0.
+Scalar inputs to *any* are <<unified-spec, deprecated by>> OpenCL C version
+3.0.
     | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
       any component of _x_ (for vector inputs) is set; otherwise returns 0.
 | int *all*(igentype _x_)
 
-Scalar inputs to *all* are deprecated by OpenCL C version 3.0.
+Scalar inputs to *all* are <<unified-spec, deprecated by>> OpenCL C version
+3.0.
     | Returns 1 if the most significant bit of _x_ (for scalar inputs) or
       all components of _x_ (for vector inputs) is set; otherwise returns 0.
 | |
@@ -5673,7 +5736,6 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
 
       *vstore_half__n__* uses the default rounding mode.
       The default rounding mode is round to nearest even.
-| |
 | float__n__ **vloada_half__n__**(size_t _offset_, const {global} half *_p_) +
   float__n__ **vloada_half__n__**(size_t _offset_, const {local} half *_p_) +
   float__n__ **vloada_half__n__**(size_t _offset_, const {constant} half *_p_) +
@@ -5795,7 +5857,7 @@ arguments which point to the generic address space are also supported.
 
 [open,refpage='syncFunctions',desc='Synchronization Functions',type='freeform',spec='clang',anchor='synchronization-functions',alias='barrier work_group_barrier']
 --
-The following table desribes built-in functions to synchronize the work-items
+The following table describes built-in functions to synchronize the work-items
 in a work-group.
 
 // Editors note: The table column widths are chosen so the description
@@ -5813,7 +5875,7 @@ in a work-group.
 | void *barrier*( +
   cl_mem_fence_flags _flags_) +
 
-  Added as an alias for *barrier* in OpenCL C 2.0 and newer: +
+  For OpenCL C 2.0 or newer, as an alias for *barrier*: +
 
   void *work_group_barrier*( +
   cl_mem_fence_flags _flags_) +
@@ -5865,10 +5927,10 @@ in a work-group.
 |====
 --
 
-NOTE: The functionality described in the following table requires support for
-the `+__opencl_c_subgroups+` feature.
+NOTE: The functionality described in the following table <<unified-spec,
+requires>> support for OpenCL 3.0 and the `+__opencl_c_subgroups+` feature.
 
-The following table desribes built-in functions to synchronize the work-items
+The following table describes built-in functions to synchronize the work-items
 in a subgroup.
 
 .Built-in Subgroup Synchronization Functions
@@ -6061,6 +6123,8 @@ the arguments unless otherwise stated footnote:[{fn-vec3-async-copy}].
       _src_stride_ or _dst_stride_ is 0, or if the _src_stride_ or
       _dst_stride_ values cause the _src_ or _dst_ pointers to exceed the
       upper bounds of the address space during the copy.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | |
 | void **wait_group_events**(int _num_events_, event_t *_event_list_)
     | Wait for events that identify the *async_work_group_copy* operations
@@ -6092,6 +6156,11 @@ is undefined.
 
 [[atomic-functions]]
 === Atomic Functions
+
+IMPORTANT: The C11 style atomic functions in this sub-section <<unified-spec,
+require>> support for OpenCL 2.0 or newer.  However, this statement does not
+apply to the <<atomic-legacy, "OpenCL C 1.x Legacy Atomics">> descriptions at
+the end of this sub-section.
 
 The OpenCL C programming language implements a subset of the C11 atomics
 (refer to <<C11-spec,section 7.17 of the C11 Specification>>) and
@@ -6433,7 +6502,7 @@ This section specifies each general kind.
 [source,c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
-// and __opencl_c_atomic_scope_device feature.
+// and __opencl_c_atomic_scope_device features.
 void atomic_store(volatile __global A *object, C desired)
 void atomic_store(volatile __local A *object, C desired)
 
@@ -7183,8 +7252,11 @@ explicit address space is listed, require OpenCL C 2.0 or the
 [[atomic-legacy]]
 ==== OpenCL C 1.x Legacy Atomics
 
-IMPORTANT: The atomic functions described in this sub-section are deprecated by
-OpenCL C version 2.0.
+IMPORTANT: The atomic functions described in this sub-section <<unified-spec,
+require>> support for OpenCL C 1.1 or newer, and are <<unified-spec,
+deprecated by>> OpenCL C 2.0.  Also see extensions
+`cl_khr_global_int32_base_atomics`, `cl_khr_global_int32_extended_atomics`,
+`cl_khr_local_int32_base_atomics`, and `cl_khr_local_int32_extended_atomics`.
 
 OpenCL C 1.x had support for relaxed atomic operations via built-in functions
 that could operate on any memory address in `+__global+` or `+__local+` spaces.
@@ -7453,6 +7525,8 @@ integer data types.
 
       *vec_step* may also take a pure type as an argument, e.g.
       *vec_step*(float2)
+
+      <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 | gentype__n__ *shuffle*(gentype__m__ _x_,
                           ugentype__n__ _mask_) +
   gentype__n__ *shuffle2*(gentype__m__ _x_,
@@ -7476,6 +7550,8 @@ For this purpose, the number of elements in a vector is given by
 *vec_step*(gentype__m__).
 The shuffle _mask_ operand specifies, for each element of the result vector,
 which element of the one or two input vectors the result element gets.
+
+<<unified-spec, Requires>> support for OpenCL C 1.1 or newer.
 
 Examples:
 
@@ -7518,6 +7594,8 @@ b = shuffle(a, mask); //  not valid
 
 [open,refpage='printfFunction',desc='printf Function',type='freeform',spec='clang',anchor='printf']
 --
+IMPORTANT: *printf* <<unified-spec, requires>> support for OpenCL C 1.2.
+
 The OpenCL C programming language implements the *printf* function.
 
 [[table-printf]]
@@ -8403,6 +8481,8 @@ supported footnote:[{fn-read-image-with-sampler}].
       Values returned by *read_imagef* for image objects with
       _image_channel_data_type_ values not specified in the description
       above are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
 | int4 *read_imagei*(read_only image1d_t _image_, sampler_t _sampler_,
   int _coord_) +
@@ -8448,6 +8528,8 @@ supported footnote:[{fn-read-image-with-sampler}].
       `CLK_NORMALIZED_COORDS_FALSE` and addressing mode set to
       `CLK_ADDRESS_CLAMP_TO_EDGE`, `CLK_ADDRESS_CLAMP` or
       `CLK_ADDRESS_NONE`; otherwise the values returned are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
 | float4 *read_imagef*(read_only image1d_array_t _image_,
   sampler_t _sampler_, int2 _coord_) +
@@ -8477,6 +8559,8 @@ supported footnote:[{fn-read-image-with-sampler}].
       Values returned by *read_imagef* for image objects with
       image_channel_data_type values not specified in the description above
       are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | int4 *read_imagei*(read_only image1d_array_t _image_, sampler_t _sampler_,
   int2 _coord_) +
   int4 *read_imagei*(read_only image1d_array_t _image_, sampler_t _sampler_,
@@ -8521,6 +8605,8 @@ supported footnote:[{fn-read-image-with-sampler}].
       `CLK_NORMALIZED_COORDS_FALSE` and addressing mode set to
       `CLK_ADDRESS_CLAMP_TO_EDGE`, `CLK_ADDRESS_CLAMP` or
       `CLK_ADDRESS_NONE`; otherwise the values returned are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
 | float *read_imagef*(read_only image2d_depth_t _image_,
   sampler_t _sampler_, int2 _coord_) +
@@ -8545,6 +8631,9 @@ supported footnote:[{fn-read-image-with-sampler}].
       Values returned by *read_imagef* for depth image objects with
       _image_channel_data_type_ values not specified in the description
       above are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 | float *read_imagef*(read_only image2d_array_depth_t _image_,
   sampler_t _sampler_, int4 _coord_) +
@@ -8569,6 +8658,9 @@ supported footnote:[{fn-read-image-with-sampler}].
       Values returned by *read_imagef* for image objects with
       _image_channel_data_type_ values not specified in the description
       above are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 |====
 --
@@ -8579,6 +8671,11 @@ supported footnote:[{fn-read-image-with-sampler}].
 
 [open,refpage='imageSamplerlessReadFunctions',desc='Built-in Image Sampler-less Read Functions',type='freeform',spec='clang',anchor='built-in-image-sampler-less-read-functions',xrefs='imageQueryFunctions imageReadFunctions imageWriteFunctions']
 --
+
+NOTE: Sampler-less image read functions <<unified-spec, require>> support for
+OpenCL C 1.2 or newer, with some functions requiring support for newer
+versions of OpenCL C as noted in the <<table-image-samplerless-read, table
+below>>.
 
 The sampler-less image read functions behave exactly as the corresponding
 <<built-in-image-read-functions,built-in image read functions>> that take
@@ -8864,6 +8961,9 @@ For samplerless read functions this may be `read_only` or `read_write`.
       Values returned by *read_imagef* for image objects with
       _image_channel_data_type_ values not specified in the description
       above are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 | float *read_imagef*(_aQual_ image2d_array_depth_t _image_, int4 _coord_)
     | Use _coord.xy_ to do an element lookup in the 2D image identified by
@@ -8879,6 +8979,9 @@ For samplerless read functions this may be `read_only` or `read_write`.
       Values returned by *read_imagef* for image objects with
       _image_channel_data_type_ values not specified in the description
       above are undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 |====
 --
@@ -9028,6 +9131,8 @@ For write functions this may be `write_only` or `read_write`.
       image objects created with _image_channel_data_type_ values not
       specified in the description above, or with a coordinate value that is
       not in the range [0, image width-1], is undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
 | void *write_imagef*(_aQual_ image1d_array_t _image_, int2 _coord_,
   float4 _color_) +
@@ -9070,6 +9175,8 @@ For write functions this may be `write_only` or `read_write`.
       specified in the description above or with (_x_, _y_) coordinate
       values that are not in the range [0, image width-1] and [0, image
       number of layers-1], respectively, is undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
 | void *write_imagef*(_aQual_ image2d_depth_t _image_, int2 _coord_,
   float _depth_)
@@ -9093,6 +9200,9 @@ For write functions this may be `write_only` or `read_write`.
       specified in the description above or with (_x_, _y_) coordinate
       values that are not in the range [0, image width-1] and [0, image
       height-1], respectively, is undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 | void *write_imagef*(_aQual_ image2d_array_depth_t _image_, int4 _coord_,
   float _depth_)
@@ -9117,6 +9227,9 @@ For write functions this may be `write_only` or `read_write`.
       specified in the description above or with (_x_, _y_, _z_) coordinate
       values that are not in the range [0, image width-1], [0, image
       height-1], [0, image number of layers-1], respectively, is undefined.
+
+      <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+      `cl_khr_depth_images` extension.
 | |
 | void *write_imagef*(_aQual_ image3d_t _image_, int4 _coord_,
   float4 _color_) +
@@ -9183,30 +9296,50 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
 [cols=",",]
 |====
 | *Function* | *Description*
-| int *get_image_width*(_aQual_ image1d_t _image_) +
-  int *get_image_width*(_aQual_ image1d_buffer_t _image_) +
-  int *get_image_width*(_aQual_ image2d_t _image_) +
+| int *get_image_width*(_aQual_ image2d_t _image_) +
   int *get_image_width*(_aQual_ image3d_t _image_) +
+
+  For OpenCL C 1.2 or newer: +
+
+  int *get_image_width*(_aQual_ image1d_t _image_) +
+  int *get_image_width*(_aQual_ image1d_buffer_t _image_) +
   int *get_image_width*(_aQual_ image1d_array_t _image_) +
   int *get_image_width*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   int *get_image_width*(_aQual_ image2d_depth_t _image_) +
   int *get_image_width*(_aQual_ image2d_array_depth_t _image_)
     | Return the image width in pixels.
 | int *get_image_height*(_aQual_ image2d_t _image_) +
   int *get_image_height*(_aQual_ image3d_t _image_) +
+
+  For OpenCL C 1.2 or newer: +
+
   int *get_image_height*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   int *get_image_height*(_aQual_ image2d_depth_t _image_) +
   int *get_image_height*(_aQual_ image2d_array_depth_t _image_)
     | Return the image height in pixels.
 | int *get_image_depth*(image3d_t _image_)
     | Return the image depth in pixels.
 | |
-| int *get_image_channel_data_type*(_aQual_ image1d_t _image_) +
+| int *get_image_channel_data_type*(_aQual_ image2d_t _image_) +
+  int *get_image_channel_data_type*(_aQual_ image3d_t _image_) +
+
+  For OpenCL C 1.2 or newer: +
+
+  int *get_image_channel_data_type*(_aQual_ image1d_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image1d_buffer_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image2d_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image3d_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image1d_array_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   int *get_image_channel_data_type*(_aQual_ image2d_depth_t _image_) +
   int *get_image_channel_data_type*(_aQual_ image2d_array_depth_t _image_)
     | Return the channel data type. Valid values are:
@@ -9218,7 +9351,6 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       `CLK_UNORM_SHORT_565` +
       `CLK_UNORM_SHORT_555` +
       `CLK_UNORM_INT_101010` +
-      `CLK_UNORM_INT_101010_2` +
       `CLK_SIGNED_INT8` +
       `CLK_SIGNED_INT16` +
       `CLK_SIGNED_INT32` +
@@ -9226,30 +9358,46 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       `CLK_UNSIGNED_INT16` +
       `CLK_UNSIGNED_INT32` +
       `CLK_HALF_FLOAT` +
-      `CLK_FLOAT`
-| int *get_image_channel_order*(_aQual_ image1d_t _image_) +
-  int *get_image_channel_order*(_aQual_ image1d_buffer_t _image_) +
-  int *get_image_channel_order*(_aQual_ image2d_t _image_) +
+      `CLK_FLOAT` +
+
+      Additionally, for OpenCL C 3.0 or newer: +
+
+      `CLK_UNORM_INT_101010_2` footnote:[{fn-CLK_UNORM_INT_101010_2}]
+| int *get_image_channel_order*(_aQual_ image2d_t _image_) +
   int *get_image_channel_order*(_aQual_ image3d_t _image_) +
+
+  For OpenCL C 1.2 or newer: +
+
+  int *get_image_channel_order*(_aQual_ image1d_t _image_) +
+  int *get_image_channel_order*(_aQual_ image1d_buffer_t _image_) +
   int *get_image_channel_order*(_aQual_ image1d_array_t _image_) +
   int *get_image_channel_order*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   int *get_image_channel_order*(_aQual_ image2d_depth_t _image_) +
   int *get_image_channel_order*(_aQual_ image2d_array_depth_t _image_)
     | Return the image channel order. Valid values are:
 
       `CLK_A` +
       `CLK_R` +
-      `CLK_Rx` +
       `CLK_RG` +
-      `CLK_RGx` +
       `CLK_RA` +
       `CLK_RGB` +
-      `CLK_RGBx` +
       `CLK_RGBA` +
       `CLK_ARGB` +
       `CLK_BGRA` +
       `CLK_INTENSITY` +
       `CLK_LUMINANCE` +
+
+      Additionally, for OpenCL C 1.1 or newer: +
+
+      `CLK_Rx` +
+      `CLK_RGx` +
+      `CLK_RGBx` +
+
+      Additionally, for OpenCL C 2.0 or newer: +
+
       `CLK_ABGR` +
       `CLK_DEPTH` +
       `CLK_sRGB` +
@@ -9258,7 +9406,13 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       `CLK_sBGRA`
 | |
 | int2 *get_image_dim*(_aQual_ image2d_t _image_) +
+
+  For OpenCL C 1.2 or newer: +
+
   int2 *get_image_dim*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   int2 *get_image_dim*(_aQual_ image2d_depth_t _image_) +
   int2 *get_image_dim*(_aQual_ image2d_array_depth_t _image_)
     | Return the 2D image width and height as an int2 type.
@@ -9269,10 +9423,17 @@ For query functions this may be `read_only`, `write_only` or `read_write`.
       The width is returned in the _x_ component, height in the _y_
       component, depth in the _z_ component and the _w_ component is 0.
 | |
-| size_t *get_image_array_size*(_aQual_ image2d_array_t _image_) +
+| For OpenCL C 1.2 or newer: +
+
+  size_t *get_image_array_size*(_aQual_ image2d_array_t _image_) +
+
+  For OpenCL C 2.0 or newer, also see `cl_khr_depth_images` extension: +
+
   size_t *get_image_array_size*(_aQual_ image2d_array_depth_t _image_)
     | Return the number of images in the 2D image array.
-| size_t *get_image_array_size*(_aQual_ image1d_array_t _image_)
+| For OpenCL C 1.2 or newer: +
+
+  size_t *get_image_array_size*(_aQual_ image1d_array_t _image_)
     | Return the number of images in the 1D image array.
 |====
 
@@ -9355,6 +9516,8 @@ and will be set to 1.0 for the alpha channel.
 
 For `CL_DEPTH` images, a scalar value is returned by *read_imagef* or
 supplied to *write_imagef*.
+<<unified-spec, Requires>> support for OpenCL C 2.0 or newer, also see
+`cl_khr_depth_images` extension.
 
 [NOTE]
 ====

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11192,10 +11192,10 @@ is the infinitely precise result.
 | *native_tan*      | Implementation-defined
 |====
 
-The following table describes the minimum accuracy of commonly used single
-precision floating-point arithmetic operations given as ULP values if the
-`-cl-unsafe-math-optimizations` compiler option is specified when compiling or
-building an OpenCL program.
+The <<table-float-ulp-relaxed,following table>> describes the minimum accuracy
+of commonly used single precision floating-point arithmetic operations given
+as ULP values if the `-cl-unsafe-math-optimizations` compiler option is
+specified when compiling or building an OpenCL program.
 For derived implementations, the operations used in the derivation may
 themselves be relaxed according to the following table.
 The minimum accuracy of math functions not defined in the following table
@@ -11205,6 +11205,10 @@ defined in <<table-ulp-embedded>> when operating in the embedded profile.
 The reference value used to compute the ULP value of an arithmetic operation
 is the infinitely precise result.
 0 ulp is used for math functions that do not require rounding.
+
+Defined minimum accuracy of single precision floating-point arithmetic
+operations and builtins with `-cl-unsafe-math-optimizations` <<unified-spec,
+requires>> support for OpenCL C 2.0 or newer.
 
 [[table-float-ulp-relaxed]]
 .ULP values for single precision built-in math functions with unsafe math optimizations in the full and embedded profiles

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -78,38 +78,30 @@ language grammar.
 [[unified-spec]]
 == Unified Specification
 
-[NOTE]
---
-The unification of this document is still in progress.  All notes on required
-version should be correct, but using this document as a description of OpenCL
-C 1.0, 1.1, 1.2, or 2.0 may be incomplete.  This document is a complete
-description of OpenCL C 3.0.
---
-
 This document specifies all versions of OpenCL C.
 
 There are several ways that an OpenCL C feature may be described in terms of
 what versions of OpenCL C specify that feature.
 
-  * Requires support for OpenCL C _major.minor_ or above: Features that were
+  * Requires support for OpenCL C _major.minor_ or newer: Features that were
     introduced in version _major.minor_.
     Compilers for an earlier version of OpenCL C will not provide these
     features.
-  ** In some instances the variation of "For OpenCL C _major.minor_ or above"
+  ** In some instances the variation of "For OpenCL C _major.minor_ or newer"
      is used, it has the identical meaning.
-  * Requires support for OpenCL C 2.0, or OpenCL C 3.0 and the
+  * Requires support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
     `+__opencl_c_feature_name+` feature:
     Features that were introduced in OpenCL C 2.0 as mandatory, but made
     <<optional-functionality, optional>> in OpenCL C 3.0.
     Compilers for versions of OpenCL C 1.2 or below will not provide these
     features, compilers for OpenCL C 2.0 will provide these features,
     compilers for OpenCL C 3.0 may provide these features.
-  * Requires support for OpenCL C 3.0 and the `+__opencl_c_feature_name+`
-    feature: <<optional-functionality, Optional>> features that were
-    introduced in OpenCL C 3.0.
+  * Requires support for OpenCL C 3.0 or newer and the
+    `+__opencl_c_feature_name+` feature: <<optional-functionality,
+    Optional>> features that were introduced in OpenCL C 3.0.
     Compilers for an earlier version of OpenCL C will not provide these
     features, compilers for OpenCL C 3.0 may provide these features.
-  * Deprecated by _major.minor_: Features that were deprecated
+  * Deprecated by OpenCL C _major.minor_: Features that were deprecated
     in version _major.minor_, see the definition of deprecation in the
     glossary of the main OpenCL specification.
   * Universal: Features that have no mention of what version they are missing

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The OpenCL^(TM)^ C 3.0 Specification
+= The OpenCL^(TM)^ C Specification
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -73,8 +73,8 @@ The following features are added to the OpenCL C programming language
   ** *clamp* integer function defined in _section 6.15.3_.
   ** (vector, scalar) variant of integer functions *min* and *max* in
      _section 6.12.3_.
-  ** *async_work_group_strided_copy* defined in section _6.15.10_.
-  ** *vec_step*, *shuffle* and *shuffle2* defined in section _6.15.12_.
+  ** *async_work_group_strided_copy* defined in section _6.15.11_.
+  ** *vec_step*, *shuffle* and *shuffle2* defined in section _6.15.13_.
   * *cl_khr_byte_addressable_store* extension is a core feature.
   * *cl_khr_global_int32_base_atomics*,
     *cl_khr_global_int32_extended_atomics*,
@@ -159,10 +159,10 @@ The following features are added to the OpenCL C programming language
     *image1d_array_t*, and *image2d_array_t*.
   * New built-in functions
   ** Functions to read from and write to a 1D image, 1D and 2D image arrays
-     described in _sections 6.15.14.2_, _6.15.14.3_ and _6.15.14.4_.
-  ** Sampler-less image read functions described in _section 6.15.14.3_.
+     described in _sections 6.15.15.2_, _6.15.15.3_ and _6.15.15.4_.
+  ** Sampler-less image read functions described in _section 6.15.15.3_.
   ** *popcount* integer function described in _section 6.15.3_.
-  ** *printf* function described in _section 6.15.13_.
+  ** *printf* function described in _section 6.15.14_.
   * Storage class specifiers extern and static as described in _section
     6.10_.
   * Macros `CL_VERSION_1_2` and `+__OPENCL_C_VERSION__+`.
@@ -234,7 +234,7 @@ The following features are added to the OpenCL C programming language
   * Program scope variables in global address space.
   * Generic address space.
   * C1x atomics.
-  * New built-in functions (sections 6.15.9, 6.15.11, and 6.15.15).
+  * New built-in functions (sections 6.15.10, 6.15.12, and 6.15.16).
   * Support images with the read_write qualifier.
   * 3D image writes are a core feature.
   * The `CL_VERSION_2_0` and `NULL` macros.
@@ -278,14 +278,14 @@ The following queries are deprecated (see glossary) in OpenCL 2.0:
      programming language.
      The *atomic_work_item_fence* function provides equivalent
      functionality.
-     The deprecated functions are still described in section 6.15.11.5 of this
+     The deprecated functions are still described in section 6.15.9 of this
      specification.
   ** The Atomic Functions defined in section 6.12.11 of the OpenCL 1.2
      specification have been deprecated to simplify the programming
      language.
      The *atomic_fetch* and modify functions provide equivalent
      functionality.
-     The deprecated functions are still described in section 6.15.11.8 of this
+     The deprecated functions are still described in section 6.15.12.8 of this
      specification.
 
 == Summary of changes from OpenCL 2.0 to OpenCL 2.1

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -55,8 +55,10 @@ The following modifications are made to the OpenCL 1.1 platform layer and
 runtime (_sections 4 and 5_):
 
   * Following queries in _table 4.3_
-  ** {CL_DEVICE_MAX_PARAMETER_SIZE} from 256 to 1024 bytes
-  ** {CL_DEVICE_LOCAL_MEM_SIZE} from 16 KB to 32 KB.
+  ** The minimum FULL_PROFILE value for {CL_DEVICE_MAX_PARAMETER_SIZE}
+     increased from 256 to 1024 bytes
+  ** The minimum FULL_PROFILE value for {CL_DEVICE_LOCAL_MEM_SIZE} increased
+     from 16 KB to 32 KB.
   * The _global_work_offset_ argument in {clEnqueueNDRangeKernel} can be a
     non-`NULL` value.
   * All API calls except {clSetKernelArg} are thread-safe.
@@ -153,8 +155,8 @@ The following features are added to the OpenCL C programming language
 
   * Double-precision is now an optional core feature instead of an
     extension.
-  * New built in image types: *image1d_t*, *image1d_array_t* and
-    *image2d_array_t* .
+  * New built in image types: *image1d_t*, *image1d_buffer_t*,
+    *image1d_array_t*, and *image2d_array_t*.
   * New built-in functions
   ** Functions to read from and write to a 1D image, 1D and 2D image arrays
      described in _sections 6.15.14.2_, _6.15.14.3_ and _6.15.14.4_.
@@ -235,7 +237,7 @@ The following features are added to the OpenCL C programming language
   * New built-in functions (sections 6.15.9, 6.15.11, and 6.15.15).
   * Support images with the read_write qualifier.
   * 3D image writes are a core feature.
-  * The `CL_VERSION_2_0` macro.
+  * The `CL_VERSION_2_0` and `NULL` macros.
 
 The following APIs are deprecated (see glossary) in OpenCL 2.0:
 

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -46,6 +46,11 @@ Bit-field struct members are <<restrictions-bitfield, not supported in OpenCL C>
 When any scalar value is converted to `bool`, the result is 0 if the value compares equal to 0; otherwise, the result is 1. \
 ]
 
+:fn-cl_double: pass:n[ \
+<<unified-spec, Requires>> support for OpenCL C 1.2 or above. \
+Also see extension *cl_khr_fp64*. \
+]
+
 :fn-cl_khr_fp16: pass:n[ \
 Unless the *cl_khr_fp16* extension is supported and has been enabled. \
 ]
@@ -64,6 +69,10 @@ As such, Blocks allow a form of dynamically enqueued function scheduling without
 
 :fn-CLK_ADDRESS_CLAMP: pass:n[ \
 This is similar to the `GL_ADDRESS_CLAMP_TO_BORDER` addressing mode. \
+]
+
+:fn-CLK_UNORM_INT_101010_2: pass:n[ \
+Although `CL_UNORM_INT_101010_2` was added in OpenCL 2.1, because there was no OpenCL C 2.1 this image channel order <<unified-spec, requires>> OpenCL 3.0. \
 ]
 
 :fn-double: pass:n[ \

--- a/man/toctail
+++ b/man/toctail
@@ -496,6 +496,14 @@
                                 </ul>
                             </li>
 
+                            <li><a href="legacyFenceFunctions.html" target="pagedisplay">Legacy Explicit Memory Fence Functions</a>
+                                <ul class="Level4">
+                                    <li><a href="mem_fence.html" target="pagedisplay">mem_fence</a></li>
+                                    <li><a href="read_mem_fence.html" target="pagedisplay">read_mem_fence</a></li>
+                                    <li><a href="write_mem_fence.html" target="pagedisplay">write_mem_fence</a></li>
+                                </ul>
+                            </li>
+
                             <li><a href="vectorDataLoadandStoreFunctions.html" target="pagedisplay">Vector Data Load and Store Functions</a>
                                 <ul class="Level4">
                                     <li><a href="vloadn.html" target="pagedisplay">vload<em>n</em></a></li>


### PR DESCRIPTION
* Note which version of OpenCL C is required for features added after 1.0.
* Re-adding descriptions of deprecated functionality.
  * A new 6.15.9 subsection describing `mem_fence`, `read_mem_fence`, `write_mem_fence`.
  * Restrictions that were crossed out have version annotations, the large of which is around byte addressable memory.
  * The `__ROUNDING_MODE__` macro.

Steps to take this PR out of draft:

  - [x] Rework "unified spec" introduction section. Moved to https://github.com/KhronosGroup/OpenCL-Docs/pull/457.
  - [x] Link existing use of "required" or "deprecated" to introduction where appropriate.
  - [x] Eliminate all TODO notes.
  - [x] Check the HTML and PDF rendering of all changes.
  - [x] Work through all the "2.0 or feature" and "feature alone" notes to add OpenCL 3.0 requirements as appropriate.

Fixes #315 #452