### PR TITLE
Add an introductory section on Unified OpenCL C spec

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -75,6 +75,46 @@ in OpenCL C.
 Please refer to the C99 specification for a detailed description of the
 language grammar.
 
+[[unified-spec]]
+== Unified Specification
+
+[NOTE]
+--
+The unification of this document is still in progress.  All notes on required
+version should be correct, but using this document as a description of OpenCL
+C 1.0, 1.1, 1.2, or 2.0 may be incomplete.  This document is a complete
+description of OpenCL C 3.0.
+--
+
+This document specifies all versions of OpenCL C.
+
+There are several ways that an OpenCL C feature may be described in terms of
+what versions of OpenCL C specify that feature.
+
+  * Requires support for OpenCL C _major.minor_ or above: Features that were
+    introduced in version _major.minor_.
+    Compilers for an earlier version of OpenCL C will not provide these
+    features.
+  ** In some instances the variation of "For OpenCL C _major.minor_ or above"
+     is used, it has the identical meaning.
+  * Requires support for OpenCL C 2.0, or OpenCL C 3.0 and the
+    `+__opencl_c_feature_name+` feature:
+    Features that were introduced in OpenCL C 2.0 as mandatory, but made
+    <<optional-functionality, optional>> in OpenCL C 3.0.
+    Compilers for versions of OpenCL C 1.2 or below will not provide these
+    features, compilers for OpenCL C 2.0 will provide these features,
+    compilers for OpenCL C 3.0 may provide these features.
+  * Requires support for OpenCL C 3.0 and the `+__opencl_c_feature_name+`
+    feature: <<optional-functionality, Optional>> features that were
+    introduced in OpenCL C 3.0.
+    Compilers for an earlier version of OpenCL C will not provide these
+    features, compilers for OpenCL C 3.0 may provide these features.
+  * Deprecated by _major.minor_: Features that were deprecated
+    in version _major.minor_, see the definition of deprecation in the
+    glossary of the main OpenCL specification.
+  * Universal: Features that have no mention of what version they are missing
+    before or deprecated by are specified for all versions of OpenCL C.
+
 [[optional-functionality]]
 == Optional functionality
 

--- a/api/appendix_b.asciidoc
+++ b/api/appendix_b.asciidoc
@@ -199,7 +199,7 @@ different number of elements, then we get different results on different
 implementations depending on whether the system is big-endian, or
 little-endian or indeed has no vector unit at all.
 (Thus, the behavior of bitcasts to vectors of different numbers of elements
-is implementation-defined, see section 6.2.4 of OpenCL 2.0 C specification.)
+is implementation-defined, see section 6.4.4 of OpenCL C specification.)
 
 An example follows:
 
@@ -315,4 +315,4 @@ that are undefined in C99:
     as shift left by `33%32 = 1` bit.
   * A number of edge cases for math library functions are more rigorously
     defined than in C99.
-    Please see _section 7.5_ of the OpenCL 2.0 C specification.
+    Please see _section 7.5_ of the OpenCL C specification.

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -66,13 +66,13 @@ The following features are added to the OpenCL C programming language
 
   * 3-component vector data types.
   * New built-in functions
-  ** *get_global_offset* work-item function defined in section _6.12.1_.
-  ** *minmag*, *maxmag* math functions defined in section _6.12.2_.
-  ** *clamp* integer function defined in _section 6.12.3_.
+  ** *get_global_offset* work-item function defined in section _6.15.1_.
+  ** *minmag*, *maxmag* math functions defined in section _6.15.2_.
+  ** *clamp* integer function defined in _section 6.15.3_.
   ** (vector, scalar) variant of integer functions *min* and *max* in
      _section 6.12.3_.
-  ** *async_work_group_strided_copy* defined in section _6.12.10_.
-  ** *vec_step*, *shuffle* and *shuffle2* defined in section _6.12.12_.
+  ** *async_work_group_strided_copy* defined in section _6.15.10_.
+  ** *vec_step*, *shuffle* and *shuffle2* defined in section _6.15.12_.
   * *cl_khr_byte_addressable_store* extension is a core feature.
   * *cl_khr_global_int32_base_atomics*,
     *cl_khr_global_int32_extended_atomics*,
@@ -157,12 +157,12 @@ The following features are added to the OpenCL C programming language
     *image2d_array_t* .
   * New built-in functions
   ** Functions to read from and write to a 1D image, 1D and 2D image arrays
-     described in _sections 6.12.14.2_, _6.12.14.3_ and _6.12.14.4_.
-  ** Sampler-less image read functions described in _section 6.12.14.3_.
-  ** *popcount* integer function described in _section 6.12.3_.
-  ** *printf* function described in _section 6.12.13_.
+     described in _sections 6.15.14.2_, _6.15.14.3_ and _6.15.14.4_.
+  ** Sampler-less image read functions described in _section 6.15.14.3_.
+  ** *popcount* integer function described in _section 6.15.3_.
+  ** *printf* function described in _section 6.15.13_.
   * Storage class specifiers extern and static as described in _section
-    6.8_.
+    6.10_.
   * Macros `CL_VERSION_1_2` and `+__OPENCL_C_VERSION__+`.
 
 The following APIs in OpenCL 1.1 are deprecated (see glossary) in OpenCL
@@ -232,7 +232,7 @@ The following features are added to the OpenCL C programming language
   * Program scope variables in global address space.
   * Generic address space.
   * C1x atomics.
-  * New built-in functions (sections 6.13.9, 6.13.11, 6.13.15 and 6.14).
+  * New built-in functions (sections 6.15.9, 6.15.11, and 6.15.15).
   * Support images with the read_write qualifier.
   * 3D image writes are a core feature.
   * The `CL_VERSION_2_0` macro.
@@ -276,11 +276,15 @@ The following queries are deprecated (see glossary) in OpenCL 2.0:
      programming language.
      The *atomic_work_item_fence* function provides equivalent
      functionality.
+     The deprecated functions are still described in section 6.15.11.5 of this
+     specification.
   ** The Atomic Functions defined in section 6.12.11 of the OpenCL 1.2
      specification have been deprecated to simplify the programming
      language.
      The *atomic_fetch* and modify functions provide equivalent
      functionality.
+     The deprecated functions are still described in section 6.15.11.8 of this
+     specification.
 
 == Summary of changes from OpenCL 2.0 to OpenCL 2.1
 


### PR DESCRIPTION
Add this separately to get the section numbers in order.

Also renumber references to sections of OpenCL in the API specification,
mostly in the change descriptions.  Do not renumber references to older
versions of the specification when noting that a feature was deprecated.