### PR TITLE
Correct version that CL_DEPTH became core

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4092,13 +4092,6 @@ server's OpenCL/api-docs repository.
             <enum name="CL_MIGRATE_MEM_OBJECT_HOST"/>
             <enum name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED"/>
         </require>
-        <require comment="cl_channel_order">
-            <enum name="CL_DEPTH"/>
-            <enum name="CL_DEPTH_STENCIL"/>
-        </require>
-        <require comment="cl_channel_type">
-            <enum name="CL_UNORM_INT24"/>
-        </require>
         <require comment="cl_mem_object_type">
             <enum name="CL_MEM_OBJECT_IMAGE2D_ARRAY"/>
             <enum name="CL_MEM_OBJECT_IMAGE1D"/>
@@ -4242,6 +4235,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_MEM_KERNEL_READ_AND_WRITE"/>
         </require>
         <require comment="cl_channel_order">
+            <enum name="CL_DEPTH"/>
             <enum name="CL_sRGB"/>
             <enum name="CL_sRGBx"/>
             <enum name="CL_sRGBA"/>
@@ -5712,6 +5706,18 @@ server's OpenCL/api-docs repository.
         <extension name="cl_intel_mem_force_host_memory" supported="opencl">
             <require comment="cl_mem_flags">
                 <enum name="CL_MEM_FORCE_HOST_MEMORY_INTEL"/>
+            </require>
+        </extension>
+        <extension name="cl_khr_depth_images" supported="opencl">
+            <require>
+                <type name="CL/cl.h"/>
+            </require>
+            <require comment="cl_channel_order">
+                <enum name="CL_DEPTH"/>
+            </require>
+            <require comment="cl_channel_type">
+                <enum name="CL_UNORM_INT16"/>
+                <enum name="CL_FLOAT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Also correct other XML issues with cl_khr_depth_images and
cl_khr_gl_depth_images, but the other changes have no visible affect on the
specification.

Fixes #284