### PR TITLE
fix unnecessary capitalization of optional OpenCL 3.0 features

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -417,9 +417,9 @@ when creating buffers, images, pipes, samplers, and command queues:
   * {CL_QUEUE_PROPERTIES_ARRAY}
 
 // GitHub issue #348
-Program Initialization and Clean-Up kernels are not supported in OpenCL
+Program initialization and clean-up kernels are not supported in OpenCL
 3.0 due to implementation complexity and lack of demand.
-The following APIs and queries for Program Initialization and Clean-Up
+The following APIs and queries for program initialization and clean-up
 kernels are deprecated in OpenCL 3.0:
 
   * {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT}

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -128,8 +128,8 @@ minimum will define some or all of following feature macros as appropriate:
 
 == Device-Side Enqueue
 
-Device-Side Enqueue and On-Device Queues are optional for devices supporting OpenCL 3.0.
-When Device-Side Enqueue is not supported:
+Device-side enqueue and on-device queues are optional for devices supporting OpenCL 3.0.
+When device-side enqueue is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -138,18 +138,18 @@ When Device-Side Enqueue is not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES}
-| May return `0`, indicating that _device_ does not support Device-Side Enqueue and On-Device Queues.
+| May return `0`, indicating that _device_ does not support device-side enqueue and on-device queues.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES}
-| Returns `0` if _device_ does not support Device-Side Enqueue and On-Device Queues.
+| Returns `0` if _device_ does not support device-side enqueue and on-device queues.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE}, +
 {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE}, +
 {CL_DEVICE_MAX_ON_DEVICE_QUEUES}, or +
 {CL_DEVICE_MAX_ON_DEVICE_EVENTS}
-| Returns `0` if _device_ does not support Device-Side Enqueue and On-Device Queues.
+| Returns `0` if _device_ does not support device-side enqueue and on-device queues.
 
 | {clGetCommandQueueInfo}, passing +
 {CL_QUEUE_SIZE}
@@ -157,18 +157,18 @@ When Device-Side Enqueue is not supported:
 
 | {clGetCommandQueueInfo}, passing +
 {CL_QUEUE_DEVICE_DEFAULT}
-| Returns `NULL` if the device associated with _command_queue_ does not support On-Device Queues.
+| Returns `NULL` if the device associated with _command_queue_ does not support on-device queues.
 
 | {clGetEventProfilingInfo}, passing +
 {CL_PROFILING_COMMAND_COMPLETE}
-| Returns a value equivalent to passing {CL_PROFILING_COMMAND_END} if the device associated with _event_ does not support On-Device Enqueue.
+| Returns a value equivalent to passing {CL_PROFILING_COMMAND_END} if the device associated with _event_ does not support device-side enqueue.
 
 | {clSetDefaultDeviceCommandQueue}
-| Returns {CL_INVALID_OPERATION} if _device_ does not support On-Device Queues.
+| Returns {CL_INVALID_OPERATION} if _device_ does not support on-device queues.
 
 |====
 
-When Device-Side Enqueue is supported but a replaceable default On-Device Queue is not supported:
+When device-side enqueue is supported but a replaceable default on-device queue is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -177,20 +177,20 @@ When Device-Side Enqueue is supported but a replaceable default On-Device Queue 
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES}
-| May omit {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT}, indicating that _device_ does not support a replaceable default On-Device Queue.
+| May omit {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT}, indicating that _device_ does not support a replaceable default on-device queue.
 
 | {clSetDefaultDeviceCommandQueue}
-| Returns {CL_INVALID_OPERATION} if _device_ does not support a replaceable default On-Device Queue.
+| Returns {CL_INVALID_OPERATION} if _device_ does not support a replaceable default on-device queue.
 
 |====
 
-OpenCL C compilers supporting Device-Side Enqueue and On-Device Queues will define the feature macro `+__opencl_c_device_enqueue+`.
-OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for Device-Side Enqueue accept pointers to the generic address space.
+OpenCL C compilers supporting device-side enqueue and on-device queues will define the feature macro `+__opencl_c_device_enqueue+`.
+OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for device-side Enqueue accept pointers to the generic address space.
 
 == Pipes
 
 Pipe memory objects are optional for devices supporting OpenCL 3.0.
-When Pipes are not supported:
+When pipes are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -199,29 +199,29 @@ When Pipes are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_PIPE_SUPPORT}
-| May return {CL_FALSE}, indicating that _device_ does not support Pipes.
+| May return {CL_FALSE}, indicating that _device_ does not support pipes.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_MAX_PIPE_ARGS}, +
 {CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS}, or +
 {CL_DEVICE_PIPE_MAX_PACKET_SIZE}
-| Returns `0` if _device_ does not support Pipes.
+| Returns `0` if _device_ does not support pipes.
 
 | {clCreatePipe}
-| Returns {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
+| Returns {CL_INVALID_OPERATION} if no devices in _context_ support pipes.
 
 | {clGetPipeInfo}
 | Returns {CL_INVALID_MEM_OBJECT} since _pipe_ cannot be a valid pipe object.
 
 |====
 
-OpenCL C compilers supporting Pipes will define the feature macro `+__opencl_c_pipes+`.
-OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for Pipes accept pointers to the generic address space.
+OpenCL C compilers supporting pipes will define the feature macro `+__opencl_c_pipes+`.
+OpenCL C compilers that define the feature macro `+__opencl_c_pipes+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for pipes accept pointers to the generic address space.
 
 == Program Scope Global Variables
 
-Program Scope Global Variables are optional for devices supporting OpenCL 3.0.
-When Program Scope Global Variables are not supported:
+Program scope global variables are optional for devices supporting OpenCL 3.0.
+When program scope global variables are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -230,28 +230,28 @@ When Program Scope Global Variables are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE}
-| May return `0`, indicating that _device_ does not support Program Scope Global Variables.
+| May return `0`, indicating that _device_ does not support program scope global variables.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE}
-| Returns `0` if _device_ does not support Program Scope Global Variables.
+| Returns `0` if _device_ does not support program scope global variables.
 
 | {clGetProgramBuildInfo}, passing +
 {CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE}
-| Returns `0` if _device_ does not support Program Scope Global Variables.
+| Returns `0` if _device_ does not support program scope global variables.
 
 |====
 
-OpenCL C compilers supporting Program Scope Global Variables will define the feature macro `+__opencl_c_program_scope_global_variables+`.
+OpenCL C compilers supporting program scope global variables will define the feature macro `+__opencl_c_program_scope_global_variables+`.
 
-// TODO: There is no SPIR-V capability specific to Program Scope Global Variables.
-// May need to update the validation rules to disallow Program Scope Global Variables
+// TODO: There is no SPIR-V capability specific to program scope global variables.
+// May need to update the validation rules to disallow program scope global variables
 // for OpenCL 1.2 consumers regardless.
 
 == Non-Uniform Work Groups
 
-Support for Non-Uniform Work Groups is optional for devices supporting OpenCL 3.0.
-When Non-Uniform Work Groups are not supported:
+Support for non-uniform work groups is optional for devices supporting OpenCL 3.0.
+When non-uniform work groups are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -260,23 +260,23 @@ When Non-Uniform Work Groups are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT}
-| May return {CL_FALSE}, indicating that _device_ does not support Non-Uniform Work Groups.
+| May return {CL_FALSE}, indicating that _device_ does not support non-uniform work groups.
 
 | {clEnqueueNDRangeKernel}
-| Behaves as though Non-Uniform Work Groups were not enabled for _kernel_, if the device associated with _command_queue_ does not support Non-Uniform Work Groups.
+| Behaves as though non-uniform Work Groups were not enabled for _kernel_, if the device associated with _command_queue_ does not support non-uniform work groups.
 
 |====
 
-// Note, there are no language or SPIR-V changes for Non-Uniform Work Groups.
+// Note, there are no language or SPIR-V changes for non-uniform work groups.
 // The `get_enqueued_local_size` and `get_enqueued_num_sub_groups` built-in
 // functions, and the *EnqueuedWorkgroupSize* and *NumEnqueuedSubGroups*
 // *BuiltIn* decorations will be supported even if the device does not support
-// Non-Uniform Work Groups.
+// non-uniform Work Groups.
 
 == Read-Write Images
 
-Read-Write Images, that may be read from and written to in the same kernel, are optional for devices supporting OpenCL 3.0.
-When Read-Write Images are not supported:
+Read-write images, that may be read from and written to in the same kernel, are optional for devices supporting OpenCL 3.0.
+When read-write images are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -285,20 +285,20 @@ When Read-Write Images are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS}
-| May return `0`, indicating that _device_ does not support Read-Write Images.
+| May return `0`, indicating that _device_ does not support read-write images.
 
 | {clGetSupportedImageFormats}, passing +
 {CL_MEM_KERNEL_READ_AND_WRITE}
-| Returns an empty set (such as _num_image_formats_ equal to `0`), indicating that no image formats are supported for reading and writing in the same kernel, if no devices in _context_ support Read-Write Images.
+| Returns an empty set (such as _num_image_formats_ equal to `0`), indicating that no image formats are supported for reading and writing in the same kernel, if no devices in _context_ support read-write images.
 
 |====
 
-OpenCL C compilers supporting Read-Write Images will define the feature macro `+__opencl_c_read_write_images+`.
+OpenCL C compilers supporting read-write images will define the feature macro `+__opencl_c_read_write_images+`.
 
 == Creating 2D Images from Buffers
 
-Creating a 2D Image from a Buffer is optional for devices supporting OpenCL 3.0.
-When Creating a 2D Image from a Buffer is not supported:
+Creating a 2D image from a buffer is optional for devices supporting OpenCL 3.0.
+When creating a 2D image from a buffer is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -308,24 +308,24 @@ When Creating a 2D Image from a Buffer is not supported:
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_IMAGE_PITCH_ALIGNMENT} or +
 {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT}
-| May return `0`, indicating that _device_ does not support Creating a 2D Image from a Buffer.
+| May return `0`, indicating that _device_ does not support creating a 2D image from a Buffer.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_EXTENSIONS}
-| Will not describe support for the `cl_khr_image2d_from_buffer` extension if _device_ does not support Creating a 2D Image from a Buffer.
+| Will not describe support for the `cl_khr_image2d_from_buffer` extension if _device_ does not support creating a 2D image from a buffer.
 
 | {clCreateImage} or +
 {clCreateImageWithProperties}, passing +
 __image_type__ equal to {CL_MEM_OBJECT_IMAGE2D} and +
 __mem_object__ not equal to `NULL`
-| Returns {CL_INVALID_OPERATION} if no devices in _context_ support Creating a 2D Image from a Buffer.
+| Returns {CL_INVALID_OPERATION} if no devices in _context_ support creating a 2D image from a buffer.
 
 |====
 
 == sRGB Images
 
-All of the sRGB Image Channel Orders (such as {CL_sRGBA}) are optional for devices supporting OpenCL 3.0.
-When sRGB Images are not supported:
+All of the sRGB image channel orders (such as {CL_sRGBA}) are optional for devices supporting OpenCL 3.0.
+When sRGB images are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -333,14 +333,14 @@ When sRGB Images are not supported:
 |*Behavior*
 
 | {clGetSupportedImageFormats}
-| Will not return return any image formats with `image_channel_order` equal to an sRGB Image Channel Order if no devices in _context_ support sRGB Images.
+| Will not return return any image formats with `image_channel_order` equal to an sRGB image channel order if no devices in _context_ support sRGB images.
 
 |====
 
 == Depth Images
 
-The {CL_DEPTH} Image Channel Order is optional for devices supporting OpenCL 3.0.
-When Depth Images are not supported:
+The {CL_DEPTH} image channel order is optional for devices supporting OpenCL 3.0.
+When depth images are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -348,14 +348,14 @@ When Depth Images are not supported:
 |*Behavior*
 
 | {clGetSupportedImageFormats}
-| Will not return any image formats with `image_channel_order` equal to {CL_DEPTH} if no devices in _context_ support Depth Images.
+| Will not return any image formats with `image_channel_order` equal to {CL_DEPTH} if no devices in _context_ support depth images.
 
 |====
 
 == Device and Host Timer Synchronization
 
-Synchronizing the Device and Host Timers is optional for platforms supporting OpenCL 3.0.
-When Device and Host Timer Synchronization is not supported:
+Synchronizing the device and host timers is optional for platforms supporting OpenCL 3.0.
+When device and host timer synchronization is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -364,18 +364,18 @@ When Device and Host Timer Synchronization is not supported:
 
 | {clGetPlatformInfo}, passing +
 {CL_PLATFORM_HOST_TIMER_RESOLUTION}
-| May return `0`, indicating that _platform_ does not support Device and Host Timer Synchronization.
+| May return `0`, indicating that _platform_ does not support device and host timer synchronization.
 
 | {clGetDeviceAndHostTimer},
 {clGetHostTimer}
-| Returns {CL_INVALID_OPERATION} if the platform associated with _device_ does not support Device and Host Timer Synchronization.
+| Returns {CL_INVALID_OPERATION} if the platform associated with _device_ does not support device and host timer synchronization.
 
 |====
 
 == Intermediate Language Programs
 
-Creating Programs from an Intermediate Language (such as SPIR-V) is optional for devices supporting OpenCL 3.0.
-When Intermediate Language Programs are not supported:
+Creating programs from an intermediate language (such as SPIR-V) is optional for devices supporting OpenCL 3.0.
+When intermediate language programs are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -385,28 +385,28 @@ When Intermediate Language Programs are not supported:
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_IL_VERSION} or +
 {CL_DEVICE_ILS_WITH_VERSION}
-| May return an empty string and empty array, indicating that _device_ does not support Intermediate Language Programs.
+| May return an empty string and empty array, indicating that _device_ does not support intermediate language programs.
 
 | {clGetProgramInfo}, passing +
 {CL_PROGRAM_IL}
-| Returns an empty buffer (such as _param_value_size_ret_ equal to `0`) if no devices in the context associated with _program_ support Intermediate Language Programs.
+| Returns an empty buffer (such as _param_value_size_ret_ equal to `0`) if no devices in the context associated with _program_ support intermediate language programs.
 
 | {clCreateProgramWithIL}
-| Returns {CL_INVALID_OPERATION} if no devices in _context_ support Intermediate Language Programs.
+| Returns {CL_INVALID_OPERATION} if no devices in _context_ support intermediate language programs.
 
 | {clSetProgramSpecializationConstant}
-| Returns {CL_INVALID_OPERATION} if no devices associated with _program_ support Intermediate Language Programs.
+| Returns {CL_INVALID_OPERATION} if no devices associated with _program_ support intermediate language programs.
 
 | {clGetKernelSubGroupInfo}, passing +
 {CL_KERNEL_COMPILE_NUM_SUB_GROUPS}
-| Returns `0` if _device_ does not support Intermediate Language Programs, since there is currently no way to require a number of subgroups per work-group for programs created from source.
+| Returns `0` if _device_ does not support intermediate language programs, since there is currently no way to require a number of subgroups per work-group for programs created from source.
 
 |====
 
 == Subgroups
 
 Subgroups are optional for devices supporting OpenCL 3.0.
-When Subgroups are not supported:
+When subgroups are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -415,30 +415,30 @@ When Subgroups are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_MAX_NUM_SUB_GROUPS}
-| May return `0`, indicating that _device_ does not support Subgroups.
+| May return `0`, indicating that _device_ does not support subgroups.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS}
-| Returns {CL_FALSE} if _device_ does not support Subgroups.
+| Returns {CL_FALSE} if _device_ does not support subgroups.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_EXTENSIONS}
-| Will not describe support for the `cl_khr_subgroups` extension if _device_ does not support Subgroups.
+| Will not describe support for the `cl_khr_subgroups` extension if _device_ does not support subgroups.
 
 | {clGetKernelSubGroupInfo}
-| Returns {CL_INVALID_OPERATION} if _device_ does not support Subgroups.
+| Returns {CL_INVALID_OPERATION} if _device_ does not support subgroups.
 // Note: for {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE}, {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE},
 //       {CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT}, {CL_KERNEL_MAX_NUM_SUB_GROUPS},
 //       {CL_KERNEL_COMPILE_NUM_SUB_GROUPS}.
 
 |====
 
-OpenCL C compilers supporting Subgroups will define the feature macro `+__opencl_c_subgroups+`.
+OpenCL C compilers supporting subgroups will define the feature macro `+__opencl_c_subgroups+`.
 
 == Program Initialization and Clean-Up Kernels
 
-Program Initialization and Clean-Up Kernels are not supported in OpenCL 3.0, and the APIs and queries for Program Initialization and Clean-Up kernels are deprecated in OpenCL 3.0.
-When Program Initialization and Clean-Up Kernels are not supported:
+Program initialization and clean-up kernels are not supported in OpenCL 3.0, and the APIs and queries for program initialization and clean-up kernels are deprecated in OpenCL 3.0.
+When program initialization and clean-up kernels are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -448,17 +448,17 @@ When Program Initialization and Clean-Up Kernels are not supported:
 | {clGetProgramInfo}, passing +
 {CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT} or +
 {CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT}
-| Returns {CL_FALSE} if no devices in the context associated with _program_ support Program Initialization and Clean-Up Kernels.
+| Returns {CL_FALSE} if no devices in the context associated with _program_ support program initialization and clean-up kernels.
 
 | {clSetProgramReleaseCallback}
-| Returns {CL_INVALID_OPERATION} if no devices in the context associated with _program_ support Program Initialization and Clean-Up Kernels.
+| Returns {CL_INVALID_OPERATION} if no devices in the context associated with _program_ support program initialization and clean-up kernels.
 
 |====
 
 == 3D Image Writes
 
-Kernel built-in functions for Writing to 3D Image Objects are optional for devices supporting OpenCL 3.0.
-When Writing to 3D Image Objects is not supported:
+Kernel built-in functions for writing to 3D image objects are optional for devices supporting OpenCL 3.0.
+When writing to 3D image objects is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -467,23 +467,23 @@ When Writing to 3D Image Objects is not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_EXTENSIONS}
-| Will not describe support for the `cl_khr_3d_image_writes` extension if _device_ does not support Writing to 3D Image Objects.
+| Will not describe support for the `cl_khr_3d_image_writes` extension if _device_ does not support writing to 3D image objects.
 
 | {clGetSupportedImageFormats}, passing +
 {CL_MEM_OBJECT_IMAGE3D} and one of +
 {CL_MEM_WRITE_ONLY}, +
 {CL_MEM_READ_WRITE}, or +
 {CL_MEM_KERNEL_READ_AND_WRITE}
-| Returns an empty set (such as _num_image_formats_ equal to `0`), indicating that no image formats are supported for writing to 3D image objects, if no devices in _context_ support Writing to 3D Image Objects.
+| Returns an empty set (such as _num_image_formats_ equal to `0`), indicating that no image formats are supported for writing to 3D image objects, if no devices in _context_ support writing to 3D image objects.
 
 |====
 
-OpenCL C compilers supporting Writing to 3D Image Objects will define the feature macro `+__opencl_c_3d_image_writes+`.
+OpenCL C compilers supporting writing to 3D image objects will define the feature macro `+__opencl_c_3d_image_writes+`.
 
 == Work Group Collective Functions
 
-Work Group Collective Functions for broadcasts, scans, and reductions are optional for devices supporting OpenCL 3.0.
-When Work Group Collective Functions are not supported:
+Work group collective functions for broadcasts, scans, and reductions are optional for devices supporting OpenCL 3.0.
+When work group collective functions are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -492,16 +492,16 @@ When Work Group Collective Functions are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT}
-| May return {CL_FALSE}, indicating that _device_ does not support Work Group Collective Functions.
+| May return {CL_FALSE}, indicating that _device_ does not support work group collective functions.
 
 |====
 
-OpenCL C compilers supporting Work Group Collective Functions will define the feature macro `+__opencl_c_work_group_collective_functions+`.
+OpenCL C compilers supporting work group collective functions will define the feature macro `+__opencl_c_work_group_collective_functions+`.
 
 == Generic Address Space
 
-Support for the Generic Address Space is optional for devices supporting OpenCL 3.0.
-When the Generic Address Space is not supported:
+Support for the generic address space is optional for devices supporting OpenCL 3.0.
+When the generic address space is not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -510,11 +510,11 @@ When the Generic Address Space is not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}
-| May return {CL_FALSE}, indicating that _device_ does not support the Generic Address Space.
+| May return {CL_FALSE}, indicating that _device_ does not support the generic address space.
 
 |====
 
-OpenCL C compilers supporting the Generic Address Space will define the feature macro `+__opencl_c_generic_address_space+`.
+OpenCL C compilers supporting the generic address space will define the feature macro `+__opencl_c_generic_address_space+`.
 
 //== Required APIs
 //

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -153,10 +153,10 @@ include::{generated}/api/version-notes/CL_PLATFORM_HOST_TIMER_RESOLUTION.asciido
       | Returns the resolution of the host timer in nanoseconds as used by
         {clGetDeviceAndHostTimer}.
 
-        Support for Device and Host Timer Synchronization is required for
+        Support for device and host timer synchronization is required for
         platforms supporting OpenCL 2.1 or 2.2.
-        This value must be 0 for devices that do not support Device and
-        Host Timer Synchronization.
+        This value must be 0 for devices that do not support device and
+        host timer synchronization.
 |====
 
 // refError
@@ -498,11 +498,11 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS.ascii
       | Max number of image objects arguments of a kernel declared with the
         write_only or read_write qualifier.
 
-        Support for Read-Write Image arguments is required for an OpenCL 2.0, 2.1,
+        Support for read-write image arguments is required for an OpenCL 2.0, 2.1,
         or 2.2 device if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}.
 
-        The minimum value is 64 if the device supports Read-Write Images arguments,
-        and must be 0 for devices that do not support Read-Write Images.
+        The minimum value is 64 if the device supports read-write images arguments,
+        and must be 0 for devices that do not support read-write images.
 | {CL_DEVICE_IL_VERSION_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IL_VERSION.asciidoc[]
@@ -515,7 +515,7 @@ Also see extension *cl_khr_il_program*.
 
         For an OpenCL 2.1 or 2.2 device, SPIR-V is a required IL prefix.
 
-        If the device does not support Intermediate Language Programs, the
+        If the device does not support intermediate language programs, the
         value must be `""` (an empty string).
 
 | {CL_DEVICE_ILS_WITH_VERSION_anchor}
@@ -524,7 +524,7 @@ include::{generated}/api/version-notes/CL_DEVICE_ILS_WITH_VERSION.asciidoc[]
 Also see extension *cl_khr_il_program*.
   | {cl_name_version_TYPE}[]
       | Returns an array of descriptions (name and version) for all supported
-        Intermediate Languages. Intermediate Languages with the same name may be
+        intermediate languages. Intermediate languages with the same name may be
         reported more than once but each name and major/minor version
         combination may only be reported once. The list of intermediate
         languages reported must match the list reported via
@@ -602,35 +602,35 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_SAMPLERS.asciidoc[]
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_PITCH_ALIGNMENT.asciidoc[]
   | {cl_uint_TYPE}
-      | The row pitch alignment size in pixels for 2D Images Created From a
-        Buffer.
+      | The row pitch alignment size in pixels for 2D images created from a
+        buffer.
         The value returned must be a power of 2.
 
-        Support for 2D Images Created From a Buffer is required for an OpenCL 2.0, 2.1,
+        Support for 2D images created from a buffer is required for an OpenCL 2.0, 2.1,
         or 2.2 device if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}.
 
-        This value must be 0 for devices that do not support 2D Images Created from a Buffer.
+        This value must be 0 for devices that do not support 2D images created from a buffer.
 | {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT.asciidoc[]
   | {cl_uint_TYPE}
       | This query specifies the minimum alignment in pixels of the host_ptr
-        specified to {clCreateBuffer} or {clCreateBufferWithProperties} when a 2D Image
-        is Created From a Buffer which was created using {CL_MEM_USE_HOST_PTR}.
+        specified to {clCreateBuffer} or {clCreateBufferWithProperties} when a 2D image
+        is created from a buffer which was created using {CL_MEM_USE_HOST_PTR}.
         The value returned must be a power of 2.
 
-        Support for 2D Images Created From a Buffer is required for an OpenCL 2.0, 2.1,
+        Support for 2D images created from a buffer is required for an OpenCL 2.0, 2.1,
         or 2.2 device if {CL_DEVICE_IMAGE_SUPPORT} is {CL_TRUE}.
 
-        This value must be 0 for devices that do not support 2D Images Created from a Buffer.
+        This value must be 0 for devices that do not support 2D images created from a buffer.
 | {CL_DEVICE_MAX_PIPE_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PIPE_ARGS.asciidoc[]
   | {cl_uint_TYPE}
       | The maximum number of pipe objects that can be passed as arguments
         to a kernel.
-        The minimum value is 16 for devices supporting Pipes, and must be
-        0 for devices that do not support Pipes.
+        The minimum value is 16 for devices supporting pipes, and must be
+        0 for devices that do not support pipes.
 | {CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.asciidoc[]
@@ -639,17 +639,17 @@ include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS.as
         work-item in a kernel.
         A work-group reservation is counted as one reservation per
         work-item.
-        The minimum value is 1 for devices supporting Pipes, and must be
-        0 for devices that do not support Pipes.
+        The minimum value is 1 for devices supporting pipes, and must be
+        0 for devices that do not support pipes.
 | {CL_DEVICE_PIPE_MAX_PACKET_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_MAX_PACKET_SIZE.asciidoc[]
   | {cl_uint_TYPE}
       | The maximum size of pipe packet in bytes.
 
-        Support for Pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
-        The minimum value is 1024 bytes if the device supports Pipes, and must be
-        0 for devices that do not support Pipes.
+        Support for pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
+        The minimum value is 1024 bytes if the device supports pipes, and must be
+        0 for devices that do not support pipes.
 | {CL_DEVICE_MAX_PARAMETER_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
@@ -782,11 +782,11 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciid
         single variable in program scope or inside a function in an OpenCL
         kernel language declared in the global address space.
 
-        Support for Program Scope Global Variables is required for an OpenCL 2.0,
+        Support for program scope global variables is required for an OpenCL 2.0,
         2.1, or 2.2 device.
-        The minimum value is 64 KB if the device supports Program Scope Global
-        Variables, and must be 0 for devices that do not support Program Scope
-        Global Variables.
+        The minimum value is 64 KB if the device supports program scope global
+        variables, and must be 0 for devices that do not support program scope
+        global variables.
 | {CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE.asciidoc[]
@@ -917,13 +917,13 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES.asci
         These properties are described in the <<queue-properties-table,
         Queue Properties>> table.
 
-        Support for On-Device Queues is required for an OpenCL 2.0, 2.1, or 2.2 device.
-        When On-Device Queues are supported, the mandated minimum capability is:
+        Support for on-device queues is required for an OpenCL 2.0, 2.1, or 2.2 device.
+        When on-device queues are supported, the mandated minimum capability is:
 
         {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE} \| +
         {CL_QUEUE_PROFILING_ENABLE}.
 
-        Must be 0 for devices that do not support On-Device Queues.
+        Must be 0 for devices that do not support on-device queues.
 | {CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.asciidoc[]
@@ -932,8 +932,8 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE.
         Applications should use this size for the device queue to ensure
         good performance.
 
-        The minimum value is 16 KB for devices supporting On-Device Queues,
-        and must be 0 for devices that do not support On-Device Queues.
+        The minimum value is 16 KB for devices supporting on-device queues,
+        and must be 0 for devices that do not support on-device queues.
 | {CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciidoc[]
@@ -941,8 +941,8 @@ include::{generated}/api/version-notes/CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE.asciid
       | The maximum size of the device queue in bytes.
 
         The minimum value is 256 KB for the full profile and 64 KB for the
-        embedded profile for devices supporting On-Device Queues,
-        and must be 0 for devices that do not support On-Device Queues.
+        embedded profile for devices supporting on-device queues,
+        and must be 0 for devices that do not support on-device queues.
 | {CL_DEVICE_MAX_ON_DEVICE_QUEUES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
@@ -950,8 +950,8 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_QUEUES.asciidoc[]
       | The maximum number of device queues that can be created for this
         device in a single context.
 
-        The minimum value is 1 for devices supporting On-Device Queues,
-        and must be 0 for devices that do not support On-Device Queues.
+        The minimum value is 1 for devices supporting on-device queues,
+        and must be 0 for devices that do not support on-device queues.
 | {CL_DEVICE_MAX_ON_DEVICE_EVENTS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
@@ -961,8 +961,8 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_ON_DEVICE_EVENTS.asciidoc[]
         to a device queue or user events returned by the `create_user_event`
         built-in function that have not been released.
 
-        The minimum value is 1024 for devices supporting On-Device Queues,
-        and must be 0 for devices that do not support On-Device Queues.
+        The minimum value is 1024 for devices supporting on-device queues,
+        and must be 0 for devices that do not support on-device queues.
 | {CL_DEVICE_BUILT_IN_KERNELS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_BUILT_IN_KERNELS.asciidoc[]
@@ -1328,9 +1328,9 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device.
 
-        The minimum value is 1 if the device supports Subgroups, and must be
-        0 for devices that do not support Subgroups.
-        Support for Subgroups is required for an OpenCL 2.1 or 2.2 device.
+        The minimum value is 1 if the device supports subgroups, and must be
+        0 for devices that do not support subgroups.
+        Support for subgroups is required for an OpenCL 2.1 or 2.2 device.
 
         (Refer also to {clGetKernelSubGroupInfo}.)
 | {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS_anchor}
@@ -1343,7 +1343,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_P
 
         This query must return {CL_TRUE} for devices that support the
         *cl_khr_subgroups* extension, and must return {CL_FALSE} for
-        devices that do not support Subgroups.
+        devices that do not support subgroups.
 
 | {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES_anchor}
 
@@ -1416,8 +1416,8 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
         This is a bit-field that describes one or more of the following
         values:
 
-        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and On-Device queues. +
-        {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default On-Device queue.
+        {CL_DEVICE_QUEUE_SUPPORTED_anchor} - Device supports device-side enqueue and on-device queues. +
+        {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT_anchor} - Device supports a replaceable default on-device queue.
 
         If {CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT} is set, {CL_DEVICE_QUEUE_SUPPORTED} must also be set.
 
@@ -1430,11 +1430,11 @@ include::{generated}/api/version-notes/CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES.asc
 
 include::{generated}/api/version-notes/CL_DEVICE_PIPE_SUPPORT.asciidoc[]
   | {cl_bool_TYPE}
-      | Is {CL_TRUE} if the device supports Pipes, and {CL_FALSE} otherwise.
+      | Is {CL_TRUE} if the device supports pipes, and {CL_FALSE} otherwise.
 
       Devices that return {CL_TRUE} for {CL_DEVICE_PIPE_SUPPORT} must also return {CL_TRUE} for {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT}.
 // This query didn't exist pre-OpenCL 3.0, but:
-//Support for Pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
+//Support for pipes is required for an OpenCL 2.0, 2.1, or 2.2 device.
 
 | {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE_anchor}
 
@@ -1512,7 +1512,8 @@ _host_timestamp_ if provided.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_DEVICE} if _device_ is not a valid device.
-  * {CL_INVALID_OPERATION} if the platform associated with _device_ does not support Device and Host Timer Synchronization.
+  * {CL_INVALID_OPERATION} if the platform associated with _device_ does not
+    support device and host timer synchronization.
   * {CL_INVALID_VALUE} if _host_timestamp_ or _device_timestamp_ is `NULL`.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
@@ -1552,7 +1553,8 @@ _host_timestamp_ if provided.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_DEVICE} if _device_ is not a valid device.
-  * {CL_INVALID_OPERATION} if the platform associated with _device_ does not support Device and Host Timer Synchronization.
+  * {CL_INVALID_OPERATION} if the platform associated with _device_ does not
+    support device and host timer synchronization.
   * {CL_INVALID_VALUE} if _host_timestamp_ is `NULL`.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -217,7 +217,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
   * {CL_INVALID_DEVICE} if _device_ is not a valid device or is not associated
     with _context_.
-  * {CL_INVALID_OPERATION} if _device_ does not support a replaceable default On-Device Queue.
+  * {CL_INVALID_OPERATION} if _device_ does not support a replaceable default on-device queue.
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid command-queue
     for _device_.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
@@ -3544,7 +3544,7 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_OPERATION} if no devices in _context_ support Pipes.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support pipes.
   * {CL_INVALID_VALUE} if values specified in _flags_ are not as defined
     above.
   * {CL_INVALID_VALUE} if _properties_ is not `NULL`.
@@ -5409,8 +5409,8 @@ Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_OPERATION} if no devices in _context_ support Intermediate
-    Language Programs.
+  * {CL_INVALID_OPERATION} if no devices in _context_ support intermediate
+    language programs.
   * {CL_INVALID_VALUE} if _il_ is `NULL` or if _length_ is zero.
   * {CL_INVALID_VALUE} if the _length_-byte memory pointed to by _il_ does not
     contain well-formed intermediate language input that can be consumed by
@@ -5715,7 +5715,7 @@ Otherwise, it returns one of the following errors:
     from an intermediate language (e.g. SPIR-V), or if the intermediate
     language does not support specialization constants.
   * {CL_INVALID_OPERATION} if no devices associated with _program_ support
-    Intermediate Language Programs.
+    intermediate language programs.
   * {CL_COMPILER_NOT_AVAILABLE} if _program_ is created with
     {clCreateProgramWithIL} and a compiler is not
     available, i.e. {CL_DEVICE_COMPILER_AVAILABLE} specified in the
@@ -7792,7 +7792,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_DEVICE} if _device_ is not in the list of devices associated
     with _kernel_ or if _device_ is `NULL` but there is more than one device
     associated with _kernel_.
-  * {CL_INVALID_OPERATION} if _device_ does not support Subgroups.
+  * {CL_INVALID_OPERATION} if _device_ does not support subgroups.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table


### PR DESCRIPTION
This is a purely editorial change that fixes the unnecessary capitalization of many optional OpenCL 3.0 features.