### PR TITLE
add subgroups and latest conformance version passed to appendices

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -444,7 +444,13 @@ versions and supported OpenCL C features:
   * {CL_DEVICE_OPENCL_C_FEATURES} to determine
     optional OpenCL C language features supported by a device.
 
-Finally, OpenCL 3.0 adds an event command type to identify events
+OpenCL 3.0 adds an event command type to identify events
 associated with the OpenCL 2.1 command {clEnqueueSVMMigrateMem}:
 
   * {CL_COMMAND_SVM_MIGRATE_MEM}
+
+OpenCL 3.0 adds a new query to determine the latest version of the conformance
+test suite that the device has fully passed in accordance with the official
+conformance process:
+
+  * {CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED}

--- a/ext/to_core_features.asciidoc
+++ b/ext/to_core_features.asciidoc
@@ -56,3 +56,7 @@
 //=== For OpenCL 2.2:
 //
 //* The OpenCL KHR extension *cl_khr_subgroup_named_barrier* has been added.
+
+=== For OpenCL 3.0:
+
+* The built-in functions described by *cl_khr_subgroups* are now supported in OpenCL C 3.0 when the `+__opencl_c_subgroups+` feature is supported.


### PR DESCRIPTION
This PR has two minor updates to the OpenCL 3.0 appendices:

1. Add `cl_khr_subgroups` to the list of "extensions promoted to core features", since OpenCL C 3.0 is the first core language that supports the subgroup built-in functions (fixes #456).
2. Add `CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED` to the list of API changes.