### PR TITLE
fixes a few minor OpenCL C spec issues:

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -138,7 +138,7 @@ Feature macro identifiers are used as names of features in this document.
 
 [[table-optional-lang-features]]
 .Optional features in OpenCL C 3.0 and their predefined macros.
-[cols="1,3",options="header",]
+[cols="1,1",options="header",]
 |====
 | *Feature Macro/Name*
 | *Brief Description*
@@ -6249,7 +6249,7 @@ Examples:
 
 [source,c]
 ----------
-local atomic_int local_guide;
+local atomic_int guide;
 if (get_local_id(0) == 0)
     atomic_init(&guide, 42);
 work_group_barrier(CLK_LOCAL_MEM_FENCE);
@@ -6448,7 +6448,7 @@ void atomic_store(volatile __local A *object, C desired)
 // __opencl_c_atomic_order_seq_cst and __opencl_c_atomic_scope_device features.
 void atomic_store(volatile A *object, C desired)
 
-// Requires OpenCL C 3.0 and the __opencl_c_atomic_scope_device feature.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device feature.
 void atomic_store_explicit(volatile __global A *object,
                            C desired,
                            memory_order order)
@@ -6881,7 +6881,7 @@ bool atomic_compare_exchange_weak_explicit(
     memory_scope scope)
 ----------
 
-The _failure_ argument shall not be `memory_order_release` nor
+The `failure` argument shall not be `memory_order_release` nor
 `memory_order_acq_rel`.
 The `failure` argument shall be no stronger than the `success` argument.
 Atomically, compares the value pointed to by object for equality with that


### PR DESCRIPTION
This PR fixes a handful of minor OpenCL C bugs I've been collecting:

* adjusts column widths in the feature table to avoid wrapping
* fixes variable name in atomic_init example
* fixes version comment for atomic_store_explicit
* fixes misleading formatting for atomic_compare_exchange