### PR TITLE
Address review feedback from Unifying OpenCL C specification

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -58,7 +58,7 @@ consistent with previous versions of the OpenCL and OpenCL C Programming
 Language specifications.
 --
 
-This section describes the OpenCL C 3.0 programming language.
+This section describes the OpenCL C programming language.
 The OpenCL C programming language may be used to write kernels that execute
 on an OpenCL device.
 
@@ -119,12 +119,12 @@ by the presence of special predefined macros.
 === Features
 
 IMPORTANT: Feature test macros <<unified-spec, require>> support for OpenCL C
-3.0.
+3.0 or newer.
 
 Optional language features are described in this document. They are optional
-from OpenCL C 3.0 and therefore are not supported by all implementations. When
-an OpenCL C 3.0 optional feature is supported, an associated __feature test
-macro__ will be predefined.
+from OpenCL C 3.0 onwards and therefore are not supported by all
+implementations. When an OpenCL C 3.0 optional feature is supported, an
+associated __feature test macro__ will be predefined.
 
 The following table describes OpenCL C 3.0 features and their meaning. The
 naming convention for the feature macros is `+__opencl_c_<name>+`.
@@ -215,8 +215,8 @@ operations across a work-group.
 
 |====
 
-In OpenCL C 3.0, feature macros must expand to the value `1` if the feature
-macro is defined by the OpenCL C compiler. A feature macro must not be
+In OpenCL C 3.0 or newer, feature macros must expand to the value `1` if the
+feature macro is defined by the OpenCL C compiler. A feature macro must not be
 defined if the feature is not supported by the OpenCL C compiler. A feature
 macro may expand to a different value in the future, but if this occurs the
 value of the feature macro must compare greater than the prior value of the
@@ -236,7 +236,8 @@ referred to as optional core features. Their presence could be
 indicated by the predefined extension macros. If any of the features has been
 an optional extension in earlier OpenCL versions it can still be used as an
 extension i.e. the same predefined extension macros are still valid in OpenCL C
-3.0. However, the use of feature macros is preferred whenever possible.
+3.0 or newer. However, the use of feature macros is preferred whenever
+possible.
 --
 
 [[supported-data-types]]
@@ -2056,9 +2057,10 @@ All function arguments shall be in the `+__private+` address space.
 
 Additionally, all function return values shall be in the `+__private+` address space.
 
-For OpenCL C 2.0 or with the `+__opencl_c_program_scope_global_variables+`
-feature, the address space for a variable at program scope or a `static`
-or `extern` variable inside a function may be either `+__constant+` or `+__global+`,
+For OpenCL C 2.0, or OpenCL 3.0 or newer with the
+`+__opencl_c_program_scope_global_variables+` feature, the address space for a
+variable at program scope or a `static` or `extern` variable inside a function
+may be either `+__constant+` or `+__global+`,
 and the address space defaults to `+__global+` if not specified.
 Otherwise, the address space for a variable at program scope or a `static` or `extern`
 variable inside a function must explicitly be `+__constant+`.
@@ -4411,8 +4413,8 @@ all arguments and the return type, unless otherwise specified.
   gentype *fract*(gentype _x_, {local} gentype _*iptr_) +
   gentype *fract*(gentype _x_, {private} gentype _*iptr_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   gentype *fract*(gentype _x_, gentype _*iptr_)
     | Returns *fmin*(_x_ - *floor*(_x_), `0x1.fffffep-1f`).
@@ -4427,8 +4429,8 @@ all arguments and the return type, unless otherwise specified.
   float__n__ **frexp**(float__n__ _x_, {private} int__n__ *exp) +
   float **frexp**(float _x_, {private} int *exp) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float__n__ **frexp**(float__n__ _x_, int__n__ *exp) +
   float **frexp**(float _x_, int *exp)
@@ -4445,8 +4447,8 @@ all arguments and the return type, unless otherwise specified.
   double__n__ **frexp**(double__n__ _x_, {private} int__n__ *exp) +
   double **frexp**(double _x_, {private} int *exp) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   double__n__ **frexp**(double__n__ _x_, int__n__ *exp) +
   double **frexp**(double _x_, int *exp)
@@ -4486,8 +4488,8 @@ all arguments and the return type, unless otherwise specified.
   double__n__ **lgamma_r**(double__n__ _x_, {private} int__n__ *_signp_) +
   double **lgamma_r**(double _x_, {private} int *_signp_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float__n__ **lgamma_r**(float__n__ _x_, int__n__ *_signp_) +
   float **lgamma_r**(float _x_, int *_signp_) +
@@ -4530,8 +4532,8 @@ all arguments and the return type, unless otherwise specified.
   gentype *modf*(gentype _x_, {local} gentype _*iptr_) +
   gentype *modf*(gentype _x_, {private} gentype _*iptr_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   gentype *modf*(gentype _x_, gentype _*iptr_)
     | Decompose a floating-point number.
@@ -4573,8 +4575,8 @@ all arguments and the return type, unless otherwise specified.
   float__n__ **remquo**(float__n__ _x_, float__n__ _y_, {private} int__n__ _*quo_) +
   float **remquo**(float _x_, float _y_, {private} int _*quo_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float__n__ **remquo**(float__n__ _x_, float__n__ _y_, int__n__ _*quo_) +
   float **remquo**(float _x_, float _y_, int _*quo_)
@@ -4596,8 +4598,8 @@ all arguments and the return type, unless otherwise specified.
   double__n__ **remquo**(double__n__ _x_, double__n__ _y_, {private} int__n__ _*quo_) +
   double **remquo**(double _x_, double _y_, {private} int _*quo_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   double__n__ **remquo**(double__n__ _x_, double__n__ _y_, int__n__ _*quo_) +
   double **remquo**(double _x_, double _y_, int _*quo_)
@@ -4630,8 +4632,8 @@ all arguments and the return type, unless otherwise specified.
   gentype *sincos*(gentype _x_, {local} gentype _*cosval_) +
   gentype *sincos*(gentype _x_, {private} gentype _*cosval_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   gentype *sincos*(gentype _x_, gentype _*cosval_)
     | Compute sine and cosine of x.
@@ -5550,8 +5552,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   gentype__n__ **vload__n__**(size_t _offset_, const {constant} gentype *_p_) +
   gentype__n__ **vload__n__**(size_t _offset_, const {private} gentype *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   gentype__n__ **vload__n__**(size_t _offset_, const gentype *_p_)
     | Return `sizeof(gentype__n__)` bytes of data, where the first `(__n__ *
@@ -5565,8 +5567,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {local} gentype *_p_) +
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, {private} gentype *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstore__n__**(gentype__n__ _data_, size_t _offset_, gentype *_p_)
     | Write `_n_ * sizeof(gentype)` bytes given by _data_ to the address
@@ -5580,8 +5582,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   float **vload_half**(size_t _offset_, const {constant} half *_p_) +
   float **vload_half**(size_t _offset_, const {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float **vload_half**(size_t _offset_, const half *_p_)
     | Read `sizeof(half)` bytes of data from the address computed as `(_p_
@@ -5595,8 +5597,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   float__n__ **vload_half__n__**(size_t _offset_, const {constant} half *_p_) +
   float__n__ **vload_half__n__**(size_t _offset_, const {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float__n__ **vload_half__n__**(size_t _offset_, const half *_p_)
     | Read `(_n_ * sizeof(half))` bytes of data from the address computed as
@@ -5623,8 +5625,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstore_half{rtp}**(float _data_, size_t _offset_, {private} half *_p_) +
   void **vstore_half{rtn}**(float _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstore_half**(float _data_, size_t _offset_, half *_p_) +
   void **vstore_half{rte}**(float _data_, size_t _offset_, half *_p_) +
@@ -5657,8 +5659,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstore_half__n__{rtp}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
   void **vstore_half__n__{rtn}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstore_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
   void **vstore_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
@@ -5692,8 +5694,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstore_half{rtp}**(double _data_, size_t _offset_, {private} half *_p_) +
   void **vstore_half{rtn}**(double _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstore_half**(double _data_, size_t _offset_, half *_p_) +
   void **vstore_half{rte}**(double _data_, size_t _offset_, half *_p_) +
@@ -5726,8 +5728,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstore_half__n__{rtp}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
   void **vstore_half__n__{rtn}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstore_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
   void **vstore_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
@@ -5747,8 +5749,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   float__n__ **vloada_half__n__**(size_t _offset_, const {constant} half *_p_) +
   float__n__ **vloada_half__n__**(size_t _offset_, const {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   float__n__ **vloada_half__n__**(size_t _offset_, const half *_p_)
     | For n = 2, 4, 8 and 16, read `sizeof(half__n__)` bytes of data from
@@ -5780,8 +5782,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstorea_half__n__{rtp}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
   void **vstorea_half__n__{rtn}**(float__n__ _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstorea_half__n__**(float__n__ _data_, size_t _offset_, half *_p_) +
   void **vstorea_half__n__{rte}**(float__n__ _data_, size_t _offset_, half *_p_) +
@@ -5819,8 +5821,8 @@ The suffix _n_ is also used in the function names (i.e. *vload__n__*,
   void **vstorea_half__n__{rtp}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
   void **vstorea_half__n__{rtn}**(double__n__ _data_, size_t _offset_, {private} half *_p_) +
 
-  For OpenCL C 2.0 or with the `+__opencl_c_generic_address_space+`
-  feature: +
+  For OpenCL C 2.0, or OpenCL C 3.0 or newer with the
+  `+__opencl_c_generic_address_space+` feature: +
 
   void **vstorea_half__n__**(double__n__ _data_, size_t _offset_, half *_p_) +
   void **vstorea_half__n__{rte}**(double__n__ _data_, size_t _offset_, half *_p_) +
@@ -8157,8 +8159,10 @@ from and/or write to specific locations in the image.
 
 Support for the image built-in functions is optional.
 If a device supports images then the value of the <<opencl-device-queries,
-`CL_DEVICE_IMAGE_SUPPORT` device query>>) is `CL_TRUE` and the OpenCL C 3.0
-compiler must define the `+__opencl_c_images+` feature macro.
+`CL_DEVICE_IMAGE_SUPPORT` device query>>) is `CL_TRUE` and the OpenCL C
+compiler for that device must define the `+__IMAGE_SUPPORT__+` macro.
+A compiler for OpenCL C 3.0 or newer for that device must also support the
+`+__opencl_c_images+` feature.
 
 Image memory objects that are being read by a kernel should be declared with
 the `read_only` qualifier.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -95,12 +95,12 @@ what versions of OpenCL C specify that feature.
     <<optional-functionality, optional>> in OpenCL C 3.0.
     Compilers for versions of OpenCL C 1.2 or below will not provide these
     features, compilers for OpenCL C 2.0 will provide these features,
-    compilers for OpenCL C 3.0 may provide these features.
+    compilers for OpenCL C 3.0 or newer may provide these features.
   * Requires support for OpenCL C 3.0 or newer and the
     `+__opencl_c_feature_name+` feature: <<optional-functionality,
     Optional>> features that were introduced in OpenCL C 3.0.
     Compilers for an earlier version of OpenCL C will not provide these
-    features, compilers for OpenCL C 3.0 may provide these features.
+    features, compilers for OpenCL C 3.0 or newer may provide these features.
   * Deprecated by OpenCL C _major.minor_: Features that were deprecated
     in version _major.minor_, see the definition of deprecation in the
     glossary of the main OpenCL specification.
@@ -126,8 +126,9 @@ from OpenCL C 3.0 onwards and therefore are not supported by all
 implementations. When an OpenCL C 3.0 optional feature is supported, an
 associated __feature test macro__ will be predefined.
 
-The following table describes OpenCL C 3.0 features and their meaning. The
-naming convention for the feature macros is `+__opencl_c_<name>+`.
+The following table describes OpenCL C 3.0 or newer features and their
+meaning. The naming convention for the feature macros is
+`+__opencl_c_<name>+`.
 
 Feature macro identifiers are used as names of features in this document.
 
@@ -576,8 +577,8 @@ The `image2d_t`, `image3d_t`, `image2d_array_t`, `image1d_t`,
 `image2d_array_depth_t` and `sampler_t` types are only defined if the device
 supports images, i.e. the value of the <<opencl-device-queries,
 `CL_DEVICE_IMAGE_SUPPORT` device query>>) is `CL_TRUE`.
-If this is the case then an OpenCL C 3.0 compiler must also define the
-`+__opencl_c_images+` feature macro.
+If this is the case then an OpenCL C 3.0 or newer compiler must also define
+the `+__opencl_c_images+` feature macro.
 ====
 
 The C99 derived types (arrays, structs, unions, functions, and pointers),
@@ -3265,8 +3266,8 @@ by OpenCL are reserved for future use.
 The predefined identifier `+__func__+` is available.
 <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 
-In OpenCL C 3.0 there are a number of optional predefined macros indicating
-optional language features. Such macros are listed in the
+In OpenCL C 3.0 or newer there are a number of optional predefined macros
+indicating optional language features. Such macros are listed in the
 <<table-optional-lang-features, optional features in OpenCL C 3.0 table>>.
 --
 
@@ -4801,9 +4802,9 @@ single precision floating-point number.
     | A constant expression of type `float` representing a quiet NaN.
 |====
 
-If double precision is supported by the device, e.g. for OpenCL C 3.0 the
-`+__opencl_c_fp64+` feature macro is present, the following symbolic constants
-will also be available:
+If double precision is supported by the device, e.g. for OpenCL C 3.0 or newer
+the `+__opencl_c_fp64+` feature macro is present, the following symbolic
+constants will also be available:
 
 [cols=",",]
 |====
@@ -4915,9 +4916,9 @@ They are of type `float` and are accurate within the precision of the
 | `M_SQRT1_2_F`   | Value of 1 / {sqrt}2
 |====
 
-If double precision is supported by the device, e.g. for OpenCL C 3.0 the
-`+__opencl_c_fp64+` feature macro is present, then the following macros and
-constants are also available:
+If double precision is supported by the device, e.g. for OpenCL C 3.0 or newer
+the `+__opencl_c_fp64+` feature macro is present, then the following macros
+and constants are also available:
 
 The `FP_FAST_FMA` macro indicates whether the *fma*() family of functions
 are fast compared with direct code for double precision floating-point.
@@ -7208,7 +7209,7 @@ The `atomic_flag` type provides the classic test-and-set functionality.
 It has two states, _set_ (value is non-zero) and _clear_ (value is 0).
 
 In OpenCL C 2.0 Operations on an object of type `atomic_flag` shall be
-lock-free, in OpenCL C 3.0 they may be lock-free.
+lock-free, in OpenCL C 3.0 or newer they may be lock-free.
 
 The macro `ATOMIC_FLAG_INIT` may be used to initialize an `atomic_flag` to the
 _clear_ state.
@@ -7573,7 +7574,8 @@ semantics of the minimum requirements.
     supported by OpenCL C.
   * OpenCL C 2.0 requires that the built-in atomic functions on atomic types
     are lock-free.
-    In OpenCL C 3.0 built-in atomic functions on atomic types may be lock-free.
+    In OpenCL C 3.0 or newer, built-in atomic functions on atomic types may be
+    lock-free.
   * The `+_Atomic+` type specifier and `+_Atomic+` type qualifier are not supported
     by OpenCL C.
   * The behavior of atomic operations where pointer arguments to the atomic
@@ -8022,8 +8024,8 @@ specifier.
 ====
 The conversion specifiers *e,E,g,G,a,A* convert a `float` or `half` argument
 that is a scalar type to a `double` only if the `double` data type is
-supported, e.g. for OpenCL C 3.0 the `+__opencl_c_fp64+` feature macro is
-present.
+supported, e.g. for OpenCL C 3.0 or newer the `+__opencl_c_fp64+` feature
+macro is present.
 If the `double` data type is not supported, the argument will be a `float`
 instead of a `double` and the `half` type will be converted to a `float`.
 ====


### PR DESCRIPTION
The original feedback was

> The "Features" chapter intro still talks about OpenCL C 3.0 specifically. Not a big issue, but everywhere else uses "OpenCL C 3.0 or newer" consistently.
>
> A few functions have existing text saying "For OpenCL C 2.0 or with the `__opencl_c_generic_address_space feature`" and could be updated for consistency.
>
> There is a line about "and the OpenCL C 3.0 compiler must define the `__opencl_c_images` feature macro" that would be worth taking another look at, especially since the optional support was indicated by `__IMAGE_SUPPORT__` pre-OpenCL C 3.0.