### PR TITLE
memory_scope_all_devices is supported only for OpenCL C 3.0 or newer

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7602,9 +7602,11 @@ semantics of the minimum requirements.
   * Using `memory_scope_device` <<unified-spec, requires>> support for OpenCL
     C 2.0, or OpenCL C 3.0 or newer and the
     `+__opencl_c_atomic_scope_device+` feature.
-  * Using `memory_scope_all_svm_devices` or `memory_scope_all_devices`
-    <<unified-spec, requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
+  * Using `memory_scope_all_svm_devices` <<unified-spec, requires>>
+    support for OpenCL C 2.0, or OpenCL C 3.0 or
     newer and the `+__opencl_c_atomic_scope_all_devices+` feature.
+  * Using `memory_scope_all_devices` <<unified-spec, requires>> support for OpenCL
+    C 3.0 or newer and the `+__opencl_c_atomic_scope_all_devices+` feature.
 --
 
 


### PR DESCRIPTION
This is probably a fix. 

Generally  memory_scope_all_devices requires support for OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_all_devices feature. But here the spec says that memory_scope_all_devices can be supported for OpenCL C 2.0 which is erroneous.