### PR TITLE
Use gender-neutral language

### DIFF
--- a/api/appendix_b.asciidoc
+++ b/api/appendix_b.asciidoc
@@ -35,10 +35,9 @@ but very poorly on a GPU, for example.
 CPUs are designed in general to work well on latency sensitive algorithms on
 single threaded tasks, whereas common GPUs may encounter extremely long
 latencies, potentially orders of magnitude worse.
-A developer interested in writing portable code may find that it is
-necessary to test his design on a diversity of hardware designs to make sure
-that key algorithms are structured in a way that works well on a diversity
-of hardware.
+Developers interested in writing portable code may need to test their
+software on a diversity of hardware designs to make sure that key algorithms
+are structured in a way that works well on a diversity of hardware.
 We suggest favoring more work-items over fewer.
 It is anticipated that over the coming months and years experience will
 produce a set of best practices that will help foster a uniformly favorable

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7167,7 +7167,7 @@ Implementations shall not allow {cl_kernel_TYPE} objects to hold reference
 counts to {cl_kernel_TYPE} arguments, because no mechanism is provided for the
 user to tell the kernel to release that ownership right.
 If the kernel holds ownership rights on kernel args, that would make it
-impossible for the user to tell with certainty when he may safely
+impossible for users to tell with certainty when they may safely
 release user allocated resources associated with OpenCL objects such as
 the {cl_mem_TYPE} backing store used with {CL_MEM_USE_HOST_PTR}.
 ====


### PR DESCRIPTION
This PR changes a couple occurrences of "he" and "his" so as to be gender-neutral.