### PR TITLE
fix the calculation in "mapping work-items onto an NDRange"

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -368,7 +368,7 @@ work-group (S~x~,S~y~) and the local ID (s~x~, s~y~) inside the work-group
 such that
 
 [none]
-* (g~x~ , g~y~) = (w~x~ S~x~ + s~x~ + F~x~, w~y~ S~y~ + s~y~ + F~y~)
+* (g~x~, g~y~) = (w~x~ {times} S~x~ + s~x~ + F~x~, w~y~ {times} S~y~ + s~y~ + F~y~)
 
 The number of work-groups can be computed as:
 
@@ -379,7 +379,7 @@ Given a global ID and the work-group size, the work-group ID for a work-item
 is computed as:
 
 [none]
-* (w~x~, w~y~) = ( (g~x~ s~x~ F~x~) / S~x~, (g~y~ s~y~ F~y~) / S~y~ )
+* (w~x~, w~y~) = ( (g~x~ - s~x~ - F~x~) / S~x~, (g~y~ - s~y~ - F~y~) / S~y~ )
 
 [[index-space-image]]
 image::images/index_space.jpg[align="center", title="An example of an NDRange index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global NDRange size (i.e. all work-groups have the same size) and that the offset is equal to zero."]


### PR DESCRIPTION
Fixes #475

It looks like several symbols were omitted from the calculations in "Mapping work-items onto an NDRange".  This PR fixes the calculations so they are consistent with the OpenCL 1.2 specs.
