### PR TITLE
Clarify usage of feature test macros for pre-OpenCL C 3.0

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -119,7 +119,8 @@ by the presence of special predefined macros.
 === Features
 
 IMPORTANT: Feature test macros <<unified-spec, require>> support for OpenCL C
-3.0 or newer.
+3.0 or newer. This means that applications which target previous OpenCL C versions
+shouldn't rely on the presence of feature test macros.
 
 Optional language features are described in this document. They are optional
 from OpenCL C 3.0 onwards and therefore are not supported by all

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -119,8 +119,7 @@ by the presence of special predefined macros.
 === Features
 
 IMPORTANT: Feature test macros <<unified-spec, require>> support for OpenCL C
-3.0 or newer. This means that applications which target previous OpenCL C versions
-shouldn't rely on the presence of feature test macros.
+3.0 or newer.
 
 Optional language features are described in this document. They are optional
 from OpenCL C 3.0 onwards and therefore are not supported by all
@@ -223,6 +222,13 @@ defined if the feature is not supported by the OpenCL C compiler. A feature
 macro may expand to a different value in the future, but if this occurs the
 value of the feature macro must compare greater than the prior value of the
 feature macro.
+
+As specified in <<C99-spec,section 7.1.3 of the C99 Specification>> double
+underscore identifiers are reserved for any use and therefore compilers
+for earlier OpenCL C versions are allowed to define feature test macros
+but they are not required doing so. This means that applications which
+target earlier OpenCL C versions shouldn't rely on the presence of
+feature test macros unless compiler explicitly documents their availability.
 
 [[extensions]]
 === Extensions

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -224,11 +224,12 @@ value of the feature macro must compare greater than the prior value of the
 feature macro.
 
 As specified in <<C99-spec,section 7.1.3 of the C99 Specification>> double
-underscore identifiers are reserved for any use and therefore compilers
+underscore identifiers are reserved and therefore implementations
 for earlier OpenCL C versions are allowed to define feature test macros
 but they are not required doing so. This means that applications which
-target earlier OpenCL C versions shouldn't rely on the presence of
-feature test macros unless compiler explicitly documents their availability.
+target earlier OpenCL C versions should not rely on the presence of
+feature test macros because there is no guarantee that feature test macros
+will be defined and indicate support of functionallity.
 
 [[extensions]]
 === Extensions

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -226,10 +226,11 @@ feature macro.
 As specified in <<C99-spec,section 7.1.3 of the C99 Specification>> double
 underscore identifiers are reserved and therefore implementations
 for earlier OpenCL C versions are allowed to define feature test macros
-but they are not required doing so. This means that applications which
+but they are not required to do so. This means that applications which
 target earlier OpenCL C versions should not rely on the presence of
 feature test macros because there is no guarantee that feature test macros
-will be defined and indicate support of functionallity.
+will be defined and that if defined they will indicate the presence of the 
+corresponding optional functionality.
 
 [[extensions]]
 === Extensions


### PR DESCRIPTION
We discussed it with @bashbaug.

So basically this is just a clarification of this IMPORTANT note in order to allow compilers for earlier OpenCL C versions to define feature macros. For example when compiling for OpenCL C 2.0 compiler could define all the features and use macros internally in header. Furthermore, I don't see any stronger concerns if compiler for OpenCL C 2.0 will define (for example) `__opencl_c_pipes` macro because pipes are core OpenCL C 2.0 feature.  The way I see it: the spec strictly prohibits to do so now without allowing this implementation defined behavior.

We can adjust the wording and the place where to put it in the spec.