### PR TITLE
Tighten vec_step builtin specification

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7648,14 +7648,15 @@ integer data types.
   int *vec_step*(_type_)
     | The *vec_step* built-in function takes a built-in scalar or vector
       data type argument and returns an integer value representing the
-      number of elements in the scalar or vector.
+      number of elements in the scalar or vector.  The argument is not
+      evaluated.
 
       For all scalar types, *vec_step* returns 1.
 
       The *vec_step* built-in functions that take a 3-component vector
       return 4.
 
-      *vec_step* may also take a pure type as an argument, e.g.
+      *vec_step* may also take a type name as an argument, e.g.
       *vec_step*(float2)
 
       <<unified-spec, Requires>> support for OpenCL C 1.1 or newer.


### PR DESCRIPTION
 * Specify that the vec_step argument is not evaluated, so any side
   effects of the argument expression will not have an effect.  This
   makes vec_step follow the evaluation behavior of the sizeof
   operator.  Clang currently already assumes that the vec_step
   argument is not evaluated.

 * Replace "pure type" by "type name", as the spec does not define
   what a "pure type" is and it intends to refer to the type name.