### PR TITLE
clarify that a NULL origin or region is a CL_INVALID_VALUE

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -988,10 +988,10 @@ Otherwise, they return one of the following errors:
     _buffer_ are not the same or if the context associated with
     _command_queue_ and events in _event_wait_list_ are not the same.
   * {CL_INVALID_MEM_OBJECT} if _buffer_ is not a valid buffer object.
+  * {CL_INVALID_VALUE} if _buffer_origin_, _host_origin_, or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the region being read or written specified by
     (_buffer_origin_, _region_, _buffer_row_pitch_, _buffer_slice_pitch_) is
     out of bounds.
-  * {CL_INVALID_VALUE} if _ptr_ is a `NULL` value.
   * {CL_INVALID_VALUE} if any _region_ array element is 0.
   * {CL_INVALID_VALUE} if _buffer_row_pitch_ is not 0 and is less than
     _region_[0].
@@ -1003,6 +1003,7 @@ Otherwise, they return one of the following errors:
   * {CL_INVALID_VALUE} if _host_slice_pitch_ is not 0 and is less than
     _region_[1] {times} _host_row_pitch_ and not a multiple of
     _host_row_pitch_.
+  * {CL_INVALID_VALUE} if _ptr_ is `NULL`.
   * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
     _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
     _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
@@ -1263,9 +1264,10 @@ Otherwise, it returns one of the following errors:
     the same.
   * {CL_INVALID_MEM_OBJECT} if _src_buffer_ and _dst_buffer_ are not valid
     buffer objects.
-  * {CL_INVALID_VALUE} if (_src_origin, region, src_row_pitch,
-    src_slice_pitch_) or (_dst_origin, region, dst_row_pitch,
-    dst_slice_pitch_) require accessing elements outside the _src_buffer_
+  * {CL_INVALID_VALUE} if _src_origin_, _dst_origin_, or _region_ is `NULL`.
+  * {CL_INVALID_VALUE} if (_src_origin_, _region_, _src_row_pitch_,
+    _src_slice_pitch_) or (_dst_origin_, _region_, _dst_row_pitch_,
+    _dst_slice_pitch_) require accessing elements outside the _src_buffer_
     and _dst_buffer_ buffer objects respectively.
   * {CL_INVALID_VALUE} if any _region_ array element is 0.
   * {CL_INVALID_VALUE} if _src_row_pitch_ is not 0 and is less than
@@ -2667,11 +2669,13 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
     _image_ are not the same or if the context associated with
     _command_queue_ and events in _event_wait_list_ are not the same.
-  * {CL_INVALID_MEM_OBJECT} if i_mage_ is not a valid image object.
+  * {CL_INVALID_MEM_OBJECT} if _image_ is not a valid image object.
+  * {CL_INVALID_VALUE} if _origin_ or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the region being read or written specified by
-    _origin_ and _region_ is out of bounds or if _ptr_ is a `NULL` value.
+    _origin_ and _region_ is out of bounds.
   * {CL_INVALID_VALUE} if values in _origin_ and _region_ do not follow rules
     described in the argument description for _origin_ and _region_.
+  * {CL_INVALID_VALUE} if _ptr_ is `NULL`.
   * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
     _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
     _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
@@ -2827,6 +2831,7 @@ Otherwise, it returns one of the following errors:
     objects.
   * {CL_IMAGE_FORMAT_MISMATCH} if _src_image_ and _dst_image_ do not use the
     same image format.
+  * {CL_INVALID_VALUE} if _src_origin_, _dst_origin_, or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the 2D or 3D rectangular region specified by
     _src_origin_ and _src_origin_ {plus} _region_ refers to a region outside
     _src_image_, or if the 2D or 3D rectangular region specified by
@@ -2946,8 +2951,9 @@ Otherwise, it returns one of the following errors:
     _command_queue_ and events in _event_wait_list_ are not the same.
   * {CL_INVALID_MEM_OBJECT} if _image_ is not a valid image object.
   * {CL_INVALID_VALUE} if _fill_color_ is `NULL`.
+  * {CL_INVALID_VALUE} if _origin_ or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the region being filled as specified by _origin_ and
-    _region_ is out of bounds or if _ptr_ is a `NULL` value.
+    _region_ is out of bounds.
   * {CL_INVALID_VALUE} if values in _origin_ and _region_ do not follow rules
     described in the argument description for _origin_ and _region_.
   * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
@@ -3051,6 +3057,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_MEM_OBJECT} if _src_image_ is not a valid image object or
     _dst_buffer_ is not a valid buffer object or if _src_image_ is a 1D
     image buffer object created from _dst_buffer_.
+  * {CL_INVALID_VALUE} if _src_origin_ or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the 1D, 2D or 3D rectangular region specified by
     _src_origin_ and _src_origin_ + _region_ refers to a region outside
     _src_image_, or if the region specified by _dst_offset_ and _dst_offset_
@@ -3167,6 +3174,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_MEM_OBJECT} if _src_buffer_ is not a valid buffer object or
     _dst_image_ is not a valid image object or if _dst_image_ is a 1D image
     buffer object created from _src_buffer_.
+  * {CL_INVALID_VALUE} if _dst_origin_ or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if the 1D, 2D or 3D rectangular region specified by
     _dst_origin_ and _dst_origin_ + _region_ refer to a region outside
     _dst_image_, or if the region specified by _src_offset_ and _src_offset_
@@ -3299,8 +3307,9 @@ values returned in _errcode_ret_:
     _image_ are not the same or if context associated with _command_queue_
     and events in _event_wait_list_ are not the same.
   * {CL_INVALID_MEM_OBJECT} if _image_ is not a valid image object.
+  * {CL_INVALID_VALUE} if _origin_ or _region_ is `NULL`.
   * {CL_INVALID_VALUE} if region being mapped given by (_origin_,
-    _origin+region_) is out of bounds or if values specified in _map_flags_
+    _origin_ + _region_) is out of bounds or if values specified in _map_flags_
     are not valid.
   * {CL_INVALID_VALUE} if values in _origin_ and _region_ do not follow rules
     described in the argument description for _origin_ and _region_.
@@ -4635,7 +4644,7 @@ Otherwise, it returns one of the following errors:
   * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the copy operation is
     blocking and the execution status of any of the events in
     _event_wait_list_ is a negative integer value.
-  * {CL_INVALID_VALUE} if _dst_ptr_ or _src_ptr_ are `NULL`.
+  * {CL_INVALID_VALUE} if _dst_ptr_ or _src_ptr_ is `NULL`.
   * {CL_MEM_COPY_OVERLAP} if the values specified for _dst_ptr_, _src_ptr_ and
     _size_ result in an overlapping copy.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
@@ -5496,7 +5505,7 @@ returned in _errcode_ret_:
   * {CL_INVALID_VALUE} if _device_list_ is `NULL` or _num_devices_ is zero.
   * {CL_INVALID_DEVICE} if any device in _device_list_ is not in
     the list of devices associated with _context_.
-  * {CL_INVALID_VALUE} if _lengths_ or _binaries_ are `NULL` or if any entry
+  * {CL_INVALID_VALUE} if _lengths_ or _binaries_ is `NULL` or if any entry
     in _lengths_[i] is zero or _binaries_[i] is `NULL`.
   * {CL_INVALID_BINARY} if an invalid program binary was encountered for any
     device.

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -3015,8 +3015,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
-            <param>const <type>size_t</type>*                           <name>buffer_offset</name></param>
-            <param>const <type>size_t</type>*                           <name>host_offset</name></param>
+            <param>const <type>size_t</type>*                           <name>buffer_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>host_origin</name></param>
             <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>buffer_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>buffer_slice_pitch</name></param>
@@ -3044,8 +3044,8 @@ server's OpenCL/api-docs repository.
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
-            <param>const <type>size_t</type>*                           <name>buffer_offset</name></param>
-            <param>const <type>size_t</type>*                           <name>host_offset</name></param>
+            <param>const <type>size_t</type>*                           <name>buffer_origin</name></param>
+            <param>const <type>size_t</type>*                           <name>host_origin</name></param>
             <param>const <type>size_t</type>*                           <name>region</name></param>
             <param><type>size_t</type>                                  <name>buffer_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>buffer_slice_pitch</name></param>


### PR DESCRIPTION
Fixes #478.

This is also a partial fix for #496, but we will need a similar fix in the OpenCL headers.