### PR TITLE
Add deploy build artifacts on releases to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,12 @@ before_install:
 script:
   - git describe --tags --dirty
   - make api c env ext cxx4opencl
+
+deploy:
+  provider: releases
+  api_key: "FIXME - ADD GITHUB OAUTH TOKEN"
+  file_glob: true
+  file: out/pdf/*
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ script:
 
 deploy:
   provider: releases
-  api_key: "FIXME - ADD GITHUB OAUTH TOKEN"
+  api_key: $GH_TOKEN
   file_glob: true
   file: out/pdf/*
   skip_cleanup: true
   on:
     tags: true
+  edge: true


### PR DESCRIPTION
Setup upload of build artifacts to Trevis. In the current change only pdfs will be uploaded to tags along with archives of sources. See example in: https://github.com/AnastasiaStulova/OpenCL-Docs/releases/tag/testci6.

@bashbaug do you think we should upload htmls too or anything else?

@Khronoswebmaster I would need help with setting up api_key and also activating Travis for OpenCL-Docs repo.

Btw once the Travis is activated the build will run for all the commits to the master. I assume this is desirable behavior though, otherwise, we can look into disabling this. 

