### PR TITLE
reserve a block of enums for ICD loader layers

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1847,8 +1847,12 @@ server's OpenCL/api-docs repository.
             <unused start="0x4231" end="0x423F"/>
     </enums>
 
-    <enums start="0x4240" end="0x4FFF" name="enums.4240" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x4240" end="0x4FFF"/>
+    <enums start="0x4240" end="0x424F" name="enums.4240" comment="Reserved for ICD Loader Layers">
+        <unused start="0x4240" end="0x424F"/>
+    </enums>
+
+    <enums start="0x4250" end="0x4FFF" name="enums.4250" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x4250" end="0x4FFF"/>
     </enums>
 
     <enums start="0x10000" end="0x10FFF" name="enums.10000" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">


### PR DESCRIPTION
As discussed in the November 24th teleconference, please reserve a block of enums for ICD loader layers.

See: https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/125