### PR TITLE
Remove phrase about kernel argument pointer types

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3075,10 +3075,6 @@ address space qualifiers.
     built-in scalar types `bool`, `size_t`, `ptrdiff_t`, `intptr_t`, and
     `uintptr_t` or a struct and/or union that contain fields declared to be
     one of these built-in scalar types.
-    The size in bytes of these types are implementation-defined and in
-    addition can also be different for the OpenCL device and the host
-    processor making it difficult to allocate buffer objects to be passed as
-    arguments to a kernel declared as pointer to these types.
   . `half` is not supported as `half` can be used as a storage format
     footnote:[{fn-cl_khr_fp16}] only and is not a data type on which
     floating-point arithmetic can be performed.


### PR DESCRIPTION
This phrase seems to be purely advisory and is not an explicit
restriction.  The Clang implementation has always been accepting
pointer types for the affected types.

Fixes https://github.com/KhronosGroup/OpenCL-Docs/issues/504

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>