### PR TITLE
[C++ for OpenCL] Lift restriction on reference members w local objects

### DIFF
--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -343,10 +343,8 @@ their declaration. Developers are free to define a special member function
 that can initialize local address space objects after their declaration. Any
 default values provided for the initialization of members in a class
 declaration are ignored when creating the local address space objects.
-Classes that are instantiated with local address space objects can not
-have references as their members. The same restriction applies recursively
-to the members and base classes. Destructors of local address space objects
-are not invoked automatically. They can be called manually if required.
+Destructors of local address space objects are not invoked automatically.
+They can be called manually if required.
 
 User defined constructors are not allowed to construct objects in `__constant`
 address space. Such objects can be initialized using literals and

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -344,7 +344,7 @@ that can initialize local address space objects after their declaration. Any
 default values provided for the initialization of members in a class
 declaration are ignored when creating the local address space objects.
 Destructors of local address space objects are not invoked automatically.
-They can be called manually if required.
+They can be called manually.
 
 User defined constructors are not allowed to construct objects in `__constant`
 address space. Such objects can be initialized using literals and

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -342,9 +342,11 @@ created in the local address space have undefined state at the point of
 their declaration. Developers are free to define a special member function
 that can initialize local address space objects after their declaration. Any
 default values provided for the initialization of members in a class
-declaration are ignored when creating the local address space objects.
-Destructors of local address space objects are not invoked automatically.
-They can be called manually.
+declaration are ignored when creating the local address space objects. Since
+the initialization is performed after the variable declaration special handling
+is required for classes with data members that are references as their values
+can not be overwritten trivially. Destructors of local address space objects
+are not invoked automatically. They can be called manually.
 
 User defined constructors are not allowed to construct objects in `__constant`
 address space. Such objects can be initialized using literals and

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -343,8 +343,8 @@ their declaration. Developers are free to define a special member function
 that can initialize local address space objects after their declaration. Any
 default values provided for the initialization of members in a class
 declaration are ignored when creating the local address space objects. Since
-the initialization is performed after the variable declaration special handling
-is required for classes with data members that are references as their values
+the initialization is performed after the variable declaration, special handling
+is required for classes with data members that are references because their values
 can not be overwritten trivially. Destructors of local address space objects
 are not invoked automatically. They can be called manually.
 


### PR DESCRIPTION
`__local` addr space variables can't be initialized and therefore it was thought that such objects shouldn't have members that are references. This seems unnecessary because user defined constructor/assignments can be provided to work around reference initialization.

See example: https://godbolt.org/z/5Ee6Ps

**Note** that if user default special members are not provided the diagnostic will be given about their absence when objects in local address space are initialized in assignment operations. Therefore, invalid behavior will be rejected anyway.