### PR TITLE
[C++ for OpenCL] define __opencl_cpp_global_destructors

### DIFF
--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -337,7 +337,7 @@ constructors and destructors, the implementation defines an ABI format for
 runtime initialization and destruction of global objects before/after all
 kernels are enqueued.
 
-Non-trivial destructors with global objects is not required to be supported
+Non-trivial destructors for global objects is not required to be supported
 by all implementations. The predefined macro `__opencl_cpp_global_destructor`
 can be used to check whether destruction of such objects is supported
 automatically. If destructors are supported this macro will be defined and if

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -332,9 +332,17 @@ __global const int& f(__global float &ref) {
 
 Construction, initialization and destruction of objects in `+__private+`
 and `+__global+` address space follow the general principles of {cpp}. For
-program scope objects, the implementation (i.e. compiler) defines an ABI
-format for initialization and destruction of global objects before/after
-all kernels are enqueued.
+program scope objects or static objects in the function scope with non-trivial
+constructors and destructors, the implementation defines an ABI format for
+runtime initialization and destruction of global objects before/after all
+kernels are enqueued.
+
+Non-trivial destructors with global objects is not required to be supported
+by all implementations. The predefined macro `__opencl_cpp_global_destructor`
+can be used to check whether destruction of such objects is supported
+automatically. If destructors are supported this macro will be defined and if
+they are not supported the macro is not defined during the compilation of
+kernel code.
 
 Objects in `__local` address space can not have initializers in
 declarations and therefore a constructor can not be called. All objects

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -337,8 +337,8 @@ constructors and destructors, the implementation defines an ABI format for
 runtime initialization and destruction of global objects before/after all
 kernels are enqueued.
 
-Non-trivial destructors for global objects is not required to be supported
-by all implementations. The predefined macro `__opencl_cpp_global_destructor`,
+Non-trivial destructors for global objects are not required to be supported
+by all implementations. The macro `__opencl_cpp_global_destructor`,
 which is defined if and only if such destructors are supported by the implementation,
 can be used to check whether this functionality is available when compiling kernel code.
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -338,11 +338,9 @@ runtime initialization and destruction of global objects before/after all
 kernels are enqueued.
 
 Non-trivial destructors for global objects is not required to be supported
-by all implementations. The predefined macro `__opencl_cpp_global_destructor`
-can be used to check whether destruction of such objects is supported
-automatically. If destructors are supported this macro will be defined and if
-they are not supported the macro is not defined during the compilation of
-kernel code.
+by all implementations. The predefined macro `__opencl_cpp_global_destructor`,
+which is defined if and only if such destructors are supported by the implementation,
+can be used to check whether this functionality is available when compiling kernel code.
 
 Objects in `__local` address space can not have initializers in
 declarations and therefore a constructor can not be called. All objects


### PR DESCRIPTION
After a comprehensive analysis in upstream tooling llvm.org/PR48047, it became evident that supporting non-trivial global destructors will require a non-conformant behavior i.e. extension for function pointers or at least some sort of it.

It means that on some targets this might not be implementable. Therefore, it is now made an optional functionality with a feature test macro indicating its presence.