### PR TITLE
[C++ for OpenCL] Added references to execution and memory models

### DIFF
--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -7,7 +7,7 @@
 
 This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
-from OpenCL C and {cpp} is inherited. Since both OpenCL C and {cpp} are
+from {cpp} and OpenCL C is inherited. Since both OpenCL C and {cpp} are
 derived from C and moreover {cpp} is backward compatible with C, the main
 design principle of {cpp} for OpenCL is to reapply existing OpenCL concepts
 to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section 3.2

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -8,10 +8,10 @@
 This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
 from {cpp} and OpenCL C is inherited. Since both OpenCL C and {cpp} are
-derived from C and moreover {cpp} is backward compatible with C, the main
-design principle of {cpp} for OpenCL is to reapply existing OpenCL concepts
-to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section 3.2
-and section 3.3 detailing fundamental differences of OpenCL execution and
+derived from C and moreover {cpp} is almost fully backward compatible with C,
+the main design principle of {cpp} for OpenCL is to reapply existing OpenCL
+concepts to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section
+3.2 and section 3.3 detailing fundamental differences of OpenCL execution and
 memory models from the conventional C and {cpp} view.
 
 This document describes the programming language in details. It is not

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -12,7 +12,7 @@ derived from C and moreover {cpp} is backward compatible with C, the main
 design principle of {cpp} for OpenCL is to reapply existing OpenCL concepts
 to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section 3.2
 and section 3.3 detailing fundamental differences of OpenCL execution and
-memory models from the convention C and {cpp} view.
+memory models from the conventional C and {cpp} view.
 
 This document describes the programming language in details. It is not
 structured as a standalone document, but rather as an addition to `OpenCL C

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -7,7 +7,12 @@
 
 This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
-from OpenCL C and {cpp} is inherited.
+from OpenCL C and {cpp} is inherited. Since both OpenCL C and {cpp} are
+derived from C and moreover {cpp} is backward compatible to C, the main
+design principle of {cpp} for OpenCL is to reapply existing OpenCL concepts
+to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section 3.2
+and section 3.3 detailing fundamental differences of OpenCL execution and
+memory models from the convention C and {cpp} view.
 
 This document describes the programming language in details. It is not
 structured as a standalone document, but rather as an addition to `OpenCL C

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -8,7 +8,7 @@
 This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
 from OpenCL C and {cpp} is inherited. Since both OpenCL C and {cpp} are
-derived from C and moreover {cpp} is backward compatible to C, the main
+derived from C and moreover {cpp} is backward compatible with C, the main
 design principle of {cpp} for OpenCL is to reapply existing OpenCL concepts
 to {cpp}. Therefore, it is important to refer to OpenCL v2.0 section 3.2
 and section 3.3 detailing fundamental differences of OpenCL execution and


### PR DESCRIPTION
Improved introduction by highlighting the fundamental difference in the execution and memory model between OpenCL and C/C++.