### PR TITLE
[OpenCL C] lift restriction on l-value vec literal

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -717,7 +717,7 @@ Vector literals can be used to create vectors from a list of scalars,
 vectors or a mixture thereof.
 A vector literal can be used either as a vector initializer or as a primary
 expression.
-A vector literal cannot be used as an l-value.
+Whether a vector literal can be used as an l-value is implementation-defined.
 
 A vector literal is written as a parenthesized vector type followed by a
 parenthesized comma delimited list of parameters.


### PR DESCRIPTION
OpenCL C has disallowed vector literals to be l-values. However,
similar functionality in C99 is allowed for the compound literals.

This therefore prevented implementing the restriction in upstream
tooling, therefore it is decided to change to an implementation
defined behavior instead of restricting the functionality.