### PR TITLE
clarify relationship between optional core features and extensions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -121,8 +121,8 @@ by the presence of special predefined macros.
 IMPORTANT: Feature test macros <<unified-spec, require>> support for OpenCL C
 3.0 or newer.
 
-Optional language features are described in this document. They are optional
-from OpenCL C 3.0 onwards and therefore are not supported by all
+Optional core language features are described in this document. They are
+optional from OpenCL C 3.0 onwards and therefore are not supported by all
 implementations. When an OpenCL C 3.0 optional feature is supported, an
 associated __feature test macro__ will be predefined.
 
@@ -226,20 +226,21 @@ feature macro.
 [[extensions]]
 === Extensions
 
-Optional functionality that is not defined in this document is referred to
-as extensions. Extensions are described in
-<<opencl-extension-spec,the OpenCL Extension Specification>>.
+Other optional functionality may be described by language extensions to OpenCL
+C. Extensions are described in the <<opencl-extension-spec,OpenCL Extension
+Specification>>.  When an OpenCL C extension is supported an associated
+__extension macro__ will be predefined.  Please refer to the OpenCL Extension
+Specification for more information about predefined extension macros.
 
-[NOTE]
---
-Prior to OpenCL C 3.0 some optional features described in this document were
-referred to as optional core features. Their presence could be
-indicated by the predefined extension macros. If any of the features has been
-an optional extension in earlier OpenCL versions it can still be used as an
-extension i.e. the same predefined extension macros are still valid in OpenCL C
-3.0 or newer. However, the use of feature macros is preferred whenever
-possible.
---
+Prior to OpenCL C 3.0, support for some optional core language features was
+indicated using predefined extension macros.
+
+When an optional core language feature began as an extension it may have both an
+associated feature macro and an associated extension macro.  If an optional core
+language feature was an optional extension to an earlier version of OpenCL C it
+can still be used as an extension, i.e. the same predefined extension macros are
+still valid in OpenCL C 3.0 or newer, however the use of feature macros is
+preferred whenever possible.
 
 [[supported-data-types]]
 == Supported Data Types


### PR DESCRIPTION
See #500.

This PR attempts to clarify the relationship between optional core language features and language extensions.