### PR TITLE
clarify subgroup barrier behavior in non-uniform control flow

### DIFF
--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -117,6 +117,11 @@ And, the memory-order constraint in _Memory Semantics_ must be one of:
        supporting {CL_DEVICE_ATOMIC_ORDER_SEQ_CST} in
        {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES}.
 
+In all OpenCL environments, for the *Barrier Instruction* *OpControlBarrier*,
+when the _Scope_ for _Execution_ is *Subgroup*, behavior is undefined unless
+all invocations in the subgroup execute the same dynamic instance of the
+instruction.
+
 In an OpenCL 1.2 environment,
 for the *Atomic Instructions*, the _Scope_ for _Memory_ must be *Device*,
 and the memory-order constraint in _Memory Semantics_ must be *Relaxed*.


### PR DESCRIPTION
Fixes #492.

Clarifies in that behavior is undefined in an OpenCL environment for a subgroup barrier unless all work-items in the subgroup execute the same dynamic instance of the barrier.  This brings the OpenCL SPIR-V Environment spec in line with the OpenCL C spec.