### PR TITLE
add required type for SPIR-V built-in variables

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -400,49 +400,13 @@ In this table, `size_t` is used as a generic type to represent:
   * *OpTypeInt* with _Width_ equal to 32 if the _Addressing Model_ declared in *OpMemoryModel* is *Physical32*.
   * *OpTypeInt* with _Width_ equal to 64 if the _Addressing Model_ declared in *OpMemoryModel* is *Physical64*.
 
-The mapping from an OpenCL C built-in function is informational and non-normative.
+The mapping from an OpenCL C built-in function to the SPIR-V *BuiltIn* is informational and non-normative.
 
 [cols="2,2,3",options="header"]
 |====
 |*OpenCL C Function*
 |*SPIR-V BuiltIn*
 |*Required SPIR-V Type*
-
-| `get_num_groups`
- | *NumWorkgroups*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_local_size`
- | *WorkgroupSize*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_group_id`
- | *WorkgroupId*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_num_groups`
- | *NumWorkgroups*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_local_size`
- | *WorkgroupSize*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_group_id`
- | *WorkgroupId*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_local_id`
- | *LocalInvocationId*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_global_id`
- | *GlobalInvocationId*
-  | *OpTypeVector* of 3 components of `size_t`
-
-| `get_local_linear_id`
- | *LocalInvocationIndex*
-  | `size_t`
 
 | `get_work_dim`
  | *WorkDim*
@@ -452,8 +416,28 @@ The mapping from an OpenCL C built-in function is informational and non-normativ
  | *GlobalSize*
   | *OpTypeVector* of 3 components of `size_t`
 
+| `get_global_id`
+ | *GlobalInvocationId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_size`
+ | *WorkgroupSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
 | `get_enqueued_local_size`
  | *EnqueuedWorkgroupSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_id`
+ | *LocalInvocationId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_num_groups`
+ | *NumWorkgroups*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_group_id`
+ | *WorkgroupId*
   | *OpTypeVector* of 3 components of `size_t`
 
 | `get_global_offset`
@@ -462,6 +446,10 @@ The mapping from an OpenCL C built-in function is informational and non-normativ
 
 | `get_global_linear_id`
  | *GlobalLinearId*
+  | `size_t`
+
+| `get_local_linear_id`
+ | *LocalInvocationIndex*
   | `size_t`
 
 | `get_sub_group_size`

--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -394,6 +394,123 @@ An *OpVariable* in a SPIR-V module with the *BuiltIn* decoration represents
 a built-in variable.
 All built-in variables must be in the *Input* storage class.
 
+The following table describes the required SPIR-V type for built-in variables.
+In this table, `size_t` is used as a generic type to represent:
+
+  * *OpTypeInt* with _Width_ equal to 32 if the _Addressing Model_ declared in *OpMemoryModel* is *Physical32*.
+  * *OpTypeInt* with _Width_ equal to 64 if the _Addressing Model_ declared in *OpMemoryModel* is *Physical64*.
+
+The mapping from an OpenCL C built-in function is informational and non-normative.
+
+[cols="2,2,3",options="header"]
+|====
+|*OpenCL C Function*
+|*SPIR-V BuiltIn*
+|*Required SPIR-V Type*
+
+| `get_num_groups`
+ | *NumWorkgroups*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_size`
+ | *WorkgroupSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_group_id`
+ | *WorkgroupId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_num_groups`
+ | *NumWorkgroups*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_size`
+ | *WorkgroupSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_group_id`
+ | *WorkgroupId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_id`
+ | *LocalInvocationId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_global_id`
+ | *GlobalInvocationId*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_local_linear_id`
+ | *LocalInvocationIndex*
+  | `size_t`
+
+| `get_work_dim`
+ | *WorkDim*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_global_size`
+ | *GlobalSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_enqueued_local_size`
+ | *EnqueuedWorkgroupSize*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_global_offset`
+ | *GlobalOffset*
+  | *OpTypeVector* of 3 components of `size_t`
+
+| `get_global_linear_id`
+ | *GlobalLinearId*
+  | `size_t`
+
+| `get_sub_group_size`
+ | *SubgroupSize*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_max_sub_group_size`
+ | *SubgroupMaxSize*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_num_sub_groups`
+ | *NumSubgroups*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_enqueued_num_sub_groups`
+ | *NumEnqueuedSubgroups*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_sub_group_id`
+ | *SubgroupId*
+  | *OpTypeInt* with _Width_ equal to 32
+
+| `get_sub_group_local_id`
+ | *SubgroupLocalInvocationId*
+  | *OpTypeInt* with _Width_ equal to 32
+
+// TODO: Ensure this is documented as part of the extension!
+//| `get_sub_group_eq_mask`
+// | *SubgroupEqMask*
+//  | *OpTypeVector* of 4 components of *OpTypeInt* with _Width_ equal to 32
+//
+//| `get_sub_group_ge_mask`
+// | *SubgroupGeMask*
+//  | *OpTypeVector* of 4 components of *OpTypeInt* with _Width_ equal to 32
+//
+//| `get_sub_group_gt_mask`
+// | *SubgroupGtMask*
+//  | *OpTypeVector* of 4 components of *OpTypeInt* with _Width_ equal to 32
+//
+//| `get_sub_group_le_mask`
+// | *SubgroupLeMask*
+//  | *OpTypeVector* of 4 components of *OpTypeInt* with _Width_ equal to 32
+//
+//| `get_sub_group_lt_mask`
+// | *SubgroupLtMask*
+//  | *OpTypeVector* of 4 components of *OpTypeInt* with _Width_ equal to 32
+
+|====
+
 === Alignment of Types
 
 Objects of type *OpTypeInt*, *OpTypeFloat*, and *OpTypePointer* must be aligned


### PR DESCRIPTION
This is a possible fix for #279.

This PR essentially adds an Asciidoctor version of the table described in https://github.com/KhronosGroup/OpenCL-Docs/issues/279#issuecomment-633175823, with a few minor changes:

* For all of the OpenCL built-in functions that accept a `dim` argument, I've required that the SPIR-V variables must be a vector with three components.  This matches the behavior of the SPIR-V LLVM Translator, but is not strictly required, as described in the issue.

* For all of the OpenCL built-in functions that return a `size_t`, I've required that the SPIR-V variables also be a `size_t`, which means that they must be 64-bit integers for 64-bit pointers.  This also matches the behavior of the SPIR-V LLVM Translator, but is also not strictly required, as described in the issue.

I've left the column showing the associated OpenCL C built-in function for now since I think it's useful, but it is informational and non-normative and could be removed.