### PR TITLE
add required alignment of types to the OpenCL SPIR-V Environment spec

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -426,7 +426,7 @@ write the `half` scalar or vector value to memory.
 --
 
 The `char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned int`,
-`long`, `unsigned long`, `float` and `double vector data types are supported.
+`long`, `unsigned long`, `float` and `double` vector data types are supported.
 footnote:[{fn-vector-types}]
 The vector data type is defined with the type name, i.e. `char`, `uchar`,
 `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, or `double`

--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -393,3 +393,20 @@ additional types in an entry point's parameter list.
 An *OpVariable* in a SPIR-V module with the *BuiltIn* decoration represents
 a built-in variable.
 All built-in variables must be in the *Input* storage class.
+
+=== Alignment of Types
+
+Objects of type *OpTypeInt*, *OpTypeFloat*, and *OpTypePointer* must be aligned
+in memory to the size of the type in bytes. Objects of type *OpTypeVector* with
+these component types must be aligned in memory to the size of the vector type
+in bytes. For 3-component vector types, the size of the vector type is four
+times the size the component type.
+
+The compiler is responsible for aligning objects allocated by *OpVariable* to
+the appropriate alignment as required by the _Result Type_.
+
+For *OpTypePointer* arguments to a function, the compiler may assume that the
+pointer is appropriately aligned as required by the _Type_ that the pointer
+points to.
+
+Behavior of an unaligned load or store is undefined.


### PR DESCRIPTION
This is a possible fix for #147.

It adds a section to the OpenCL SPIR-V Environment specification describing the required alignment of types, similar to the [related section in the OpenCL C spec](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#alignment-of-types).

This PR also fixes a minor formatting issue in the OpenCL C spec I found while researching these changes.