### PR TITLE
Extended Subgroups

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -82,6 +82,8 @@ include::ext/cl_khr_async_work_group_copy_fence.asciidoc[]
 include::ext/cl_khr_device_uuid.asciidoc[]
 include::ext/cl_khr_extended_versioning.asciidoc[]
 
+include::ext/cl_khr_subgroup_extensions.asciidoc[]
+
 // NOTE: To keep meaningful section numbers, new
 // extension documents should be added above here!
 

--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -247,6 +247,8 @@ For the instruction *OpGroupNonUniformBallot*, the valid _Result Type_ is an *Op
 
 For the instructions *OpGroupNonUniformInverseBallot*, *OpGroupNonUniformBallotBitExtract*, *OpGroupNonUniformBallotBitCount*, *OpGroupNonUniformBallotFindLSB*, and *OpGroupNonUniformBallotFindMSB*, the valid type for _Value_ is an *OpTypeVector* with four _Component Count_ components of *OpTypeInt*, with _Width_ equal to 32 and _Signedness_ equal to 0 (equivalent to `uint4`).
 
+For built-in variables decorated with *SubgroupEqMask*, *SubgroupGeMask*, *SubgroupGtMask*, *SubgroupLeMask*, or *SubgroupLtMask*, the supported variable type is an *OpTypeVector* with four _Component Count_ components of *OpTypeInt*, with _Width_ equal to 32 and _Signedness_ equal to 0 (equivalent to `uint4`).
+
 ==== `cl_khr_subgroup_non_uniform_arithmetic`
 
 If the OpenCL environment supports the extension `cl_khr_subgroup_non_uniform_arithmetic`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:

--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -180,6 +180,137 @@ If the OpenCL environment supports the extension `cl_khr_spirv_no_integer_wrap_d
 
 If the OpenCL environment supports the extension `cl_khr_spirv_no_integer_wrap_decoration` and use of the SPIR-V extension `SPV_KHR_no_integer_wrap_decoration` is declared in the module via *OpExtension*, then the environment must accept modules that include the *NoSignedWrap* or *NoUnsignedWrap* decorations.
 
+==== `cl_khr_subgroup_extended_types`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_extended_types`, then additional types are valid for the following for *Groups* instructions with _Scope_ for _Execution_ equal to *Subgroup*:
+
+* *OpGroupBroadcast*
+* *OpGroupIAdd*, *OpGroupFAdd*
+* *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+* *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+
+For these instructions, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+Additionally, for *OpGroupBroadcast*, valid types for _Value_ are:
+
+* *OpTypeVectors* with 2, 3, 4, 8, or 16 _Component Count_ components of supported types:
+** *OpTypeInt* (equivalent to `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, and `ulong__n__`)
+** *OpTypeFloat* (equivalent to `half__n__`, `float__n__`, and `double__n__`)
+
+==== `cl_khr_subgroup_non_uniform_vote`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_non_uniform_vote`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniform*
+* *GroupNonUniformVote*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+For the instruction *OpGroupNonUniformAllEqual*, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+==== `cl_khr_subgroup_ballot`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_ballot`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniformBallot*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+For the non-uniform broadcast instruction *OpGroupNonUniformBroadcast*, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+* *OpTypeVectors* with 2, 3, 4, 8, or 16 _Component Count_ components of supported types:
+** *OpTypeInt* (equivalent to `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, and `ulong__n__`)
+** *OpTypeFloat* (equivalent to `half__n__`, `float__n__`, and `double__n__`)
+
+For the instruction *OpGroupNonUniformBroadcastFirst*, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+For the instruction *OpGroupNonUniformBallot*, the valid _Result Type_ is an *OpTypeVector* with four _Component Count_ components of *OpTypeInt*, with _Width_ equal to 32 and _Signedness_ equal to 0 (equivalent to `uint4`).
+
+For the instructions *OpGroupNonUniformInverseBallot*, *OpGroupNonUniformBallotBitExtract*, *OpGroupNonUniformBallotBitCount*, *OpGroupNonUniformBallotFindLSB*, and *OpGroupNonUniformBallotFindMSB*, the valid type for _Value_ is an *OpTypeVector* with four _Component Count_ components of *OpTypeInt*, with _Width_ equal to 32 and _Signedness_ equal to 0 (equivalent to `uint4`).
+
+==== `cl_khr_subgroup_non_uniform_arithmetic`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_non_uniform_arithmetic`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniformArithmetic*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+For the instructions *OpGroupNonUniformLogicalAnd*, *OpGroupNonUniformLogicalOr*, and *OpGroupNonUniformLogicalXor*, the valid type for _Value_ is *OpTypeBool*.
+
+Otherwise, for the *GroupNonUniformArithmetic* scan and reduction instructions, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+For the *GroupNonUniformArithmetic* scan and reduction instructions, the optional _ClusterSize_ operand must not be present.
+
+==== `cl_khr_subgroup_shuffle`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_shuffle`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniformShuffle*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+For the instructions *OpGroupNonUniformShuffle* and *OpGroupNonUniformShuffleXor* requiring these capabilities, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+==== `cl_khr_subgroup_shuffle_relative`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_shuffle_relative`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniformShuffleRelative*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+For the *GroupNonUniformShuffleRelative* instructions, valid types for _Value_ are:
+
+* Scalars of supported types:
+** *OpTypeInt* (equivalent to `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`)
+** *OpTypeFloat* (equivalent to `half`, `float`, and `double`)
+
+==== `cl_khr_subgroup_clustered_reduce`
+
+If the OpenCL environment supports the extension `cl_khr_subgroup_clustered_reduce`, then the environment must accept SPIR-V modules that declare the following SPIR-V capabilities:
+
+* *GroupNonUniformClustered*
+
+For instructions requiring these capabilities, _Scope_ for _Execution_ may be:
+
+* *Subgroup*
+
+When the *GroupNonUniformClustered* capability is declared, the *GroupNonUniformArithmetic* scan and reduction instructions may include the optional _ClusterSize_ operand.
+
 === Embedded Profile Extensions
 
 ==== `cles_khr_int64`

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -254,7 +254,8 @@ gentype sub_group_non_uniform_broadcast(
     uint index )
 ----
 | Returns _value_ for the work item with subgroup local ID equal to _index_.
-The value of _index_ must be equivalent for all active work items in the subgroup.
+
+Behavior is undefined when the value of _index_ is not equivalent for all active work items in the subgroup.
 
 The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
 
@@ -280,8 +281,9 @@ int sub_group_inverse_ballot(
     uint4 value )
 ----
 | Returns the predicate value for this work item in the subgroup from the bitfield _value_ representing predicate values from all work items in the subgroup.
-The bitfield _value_ must be equivalent for all active work items in the subgroup.
 The predicate return value will be non-zero if the bit in the bitfield _value_ for this work item is set, and zero otherwise.
+
+Behavior is undefined when _value_ is not equivalent for all active work items in the subgroup.
 
 This is a specialized function that may perform better than the equivalent `sub_group_ballot_bit_extract` on some implementations.
 

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -180,7 +180,7 @@ For the `sub_group_broadcast` function, the generic type name `gentype` may addi
 This section describes functionality added by `cl_khr_subgroup_non_uniform_vote`.
 This extension adds the ability to elect a single work item from a subgroup to perform a task and to hold votes among work items in a subgroup.
 
-==== Add a new Section 6.13.X - Subgroup Vote and Elect Built-in Functions
+==== Add a new Section 6.15.X - Subgroup Vote and Elect Built-in Functions
 
 The table below describes the OpenCL C programming language built-in functions to elect a single work item in a subgroup to perform a task and to collectively vote to determine a boolean condition for the subgroup.
 These functions need not be encountered by all work items in a subgroup executing the kernel.
@@ -233,7 +233,7 @@ Integer types use a bitwise test for equality.  Floating-point types use an orde
 This section describes functionality added by `cl_khr_subgroup_ballot`.
 This extension adds the ability to collect and operate on ballots from work items in the subgroup.
 
-==== Add a new Section 6.13.X - Subgroup Ballot Built-in Functions
+==== Add a new Section 6.15.X - Subgroup Ballot Built-in Functions
 
 The table below describes the OpenCL C programming language built-in functions to allow work items in a subgroup to collect and operate on ballots from work items in the subgroup.
 These functions need not be encountered by all work items in a subgroup executing the kernel.
@@ -378,7 +378,7 @@ Bit zero of the first vector component represents the subgroup local ID zero, wi
 This section describes functionality added by `cl_khr_subgroup_non_uniform_arithmetic`.
 This extension adds the ability to use some subgroup functions within non-uniform flow control, including additional scan and reduction operators.
 
-==== Add a new Section 6.13.X - Non Uniform Subgroup Scan and Reduction Built-in Functions
+==== Add a new Section 6.15.X - Non Uniform Subgroup Scan and Reduction Built-in Functions
 
 ===== Arithmetic Operations
 
@@ -437,7 +437,7 @@ gentype sub_group_non_uniform_scan_exclusive_mul(
 If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
 For *add*, the identity value is `0`.
 For *min*, the identity value is the largest representable value for integer types, or `+INF` for floating point types.
-For *max*, the identity value is the smallest representable value for integer types, or `-INF` for floating point types.
+For *max*, the identity value is the minimum representable value for integer types, or `-INF` for floating point types.
 For *mul*, the identity value is `1`.
 
 Note: This behavior is the same as the *add*, *min*, and *max* exclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
@@ -552,7 +552,7 @@ For *or* and *xor*, the identity value is `false` (zero).
 This section describes functionality added by `cl_khr_subgroup_shuffle`.
 This extension adds additional ways to exchange data among work items in a subgroup.
 
-==== Add a new Section 6.13.X - Subgroup Shuffle Built-in Functions
+==== Add a new Section 6.15.X - Subgroup Shuffle Built-in Functions
 
 The table below describes the OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
 These functions need not be encountered by all work items in a subgroup executing the kernel.
@@ -593,7 +593,7 @@ This is a specialized function that may perform better than the equivalent `sub_
 This section describes functionality added by `cl_khr_subgroup_shuffle_relative`.
 This extension adds specialized ways to exchange data among work items in a subgroup that may perform better on some implementations.
 
-==== Add a new Section 6.13.X - Subgroup Relative Shuffle Built-in Functions
+==== Add a new Section 6.15.X - Subgroup Relative Shuffle Built-in Functions
 
 The table below describes specialized OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
 These functions need not be encountered by all work items in a subgroup executing the kernel.
@@ -636,7 +636,7 @@ This is a specialized function that may perform better than the equivalent `sub_
 This section describes functionality added by `cl_khr_subgroup_clustered_reduce`.
 This extension adds support for clustered reductions that operate on a subset of work items in the subgroup.
 
-==== Add a new Section 6.13.X - Subgroup Clustered Reduction Built-in Functions
+==== Add a new Section 6.15.X - Subgroup Clustered Reduction Built-in Functions
 
 This section describes arithmetic operations that are performed subset of work items in a subgroup, referred to as a cluster.
 A cluster is described by a specified cluster size.

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -28,6 +28,18 @@ The functionality added by these extensions includes:
 This section describes changes to the OpenCL C Language for these extensions.
 There are no new API functions or enums added by these extensions.
 
+=== General information
+
+==== Version history
+
+For all of the extensions described in this section:
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2020-09-28 | 1.0.0     | First assigned version.
+|====
+
 [[extended-subgroups-summary]]
 === Summary of New OpenCL C Functions
 

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -1,0 +1,1058 @@
+== Extended Subgroup Functions
+
+[[extended-subgroups]]
+=== Overview
+
+This section describes a family of extensions that provide extended subgroup functionality.
+The extensions in this family are:
+
+* `cl_khr_subgroup_extended_types`
+* `cl_khr_subgroup_non_uniform_vote`
+* `cl_khr_subgroup_ballot`
+* `cl_khr_subgroup_non_uniform_arithmetic`
+* `cl_khr_subgroup_shuffle`
+* `cl_khr_subgroup_shuffle_relative`
+* `cl_khr_subgroup_clustered_reduce`
+
+The functionality added by these extensions includes:
+
+* Additional data type support for subgroup broadcast, scan, and reduction functions;
+* The ability to elect a single work item from a subgroup to perform a task;
+* The ability to hold votes among work items in a subgroup;
+* The ability to collect and operate on ballots from work items in the subgroup;
+* The ability to use some subgroup functions, such as any, all, broadcasts, scans, and reductions within non-uniform flow control;
+* Additional scan and reduction operators;
+* Additional ways to exchange data among work items in a subgroup;
+* Clustered reductions, that operate on a subset of work items in the subgroup.
+
+This section describes changes to the OpenCL C Language for these extensions.
+There are no new API functions or enums added by these extensions.
+
+[[extended-subgroups-summary]]
+=== Summary of New OpenCL C Functions
+
+[source,c]
+----
+// These functions are available to devices supporting
+// cl_khr_subgroup_extended_types:
+
+// Note: Existing functions supporting additional data types.
+
+gentype sub_group_broadcast( gentype value, uint index )
+
+gentype sub_group_reduce_add( gentype value )
+gentype sub_group_reduce_min( gentype value )
+gentype sub_group_reduce_max( gentype value )
+
+gentype sub_group_scan_inclusive_add( gentype value )
+gentype sub_group_scan_inclusive_min( gentype value )
+gentype sub_group_scan_inclusive_max( gentype value )
+
+gentype sub_group_scan_exclusive_add( gentype value )
+gentype sub_group_scan_exclusive_min( gentype value )
+gentype sub_group_scan_exclusive_max( gentype value )
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_non_uniform_vote:
+
+int sub_group_elect()
+
+int sub_group_non_uniform_all( int predicate )
+int sub_group_non_uniform_any( int predicate )
+int sub_group_non_uniform_all_equal( gentype value )
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_ballot:
+
+gentype sub_group_non_uniform_broadcast( gentype value, uint index )
+gentype sub_group_broadcast_first( gentype value )
+
+uint4 sub_group_ballot( int predicate )
+int   sub_group_inverse_ballot( uint4 value )
+int   sub_group_ballot_bit_extract( uint4 value, uint index )
+uint  sub_group_ballot_bit_count( uint4 value )
+uint  sub_group_ballot_inclusive_scan( uint4 value )
+uint  sub_group_ballot_exclusive_scan( uint4 value )
+uint  sub_group_ballot_find_lsb( uint4 value )
+uint  sub_group_ballot_find_msb( uint4 value )
+
+uint4 get_sub_group_eq_mask()
+uint4 get_sub_group_ge_mask()
+uint4 get_sub_group_gt_mask()
+uint4 get_sub_group_le_mask()
+uint4 get_sub_group_lt_mask()
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_non_uniform_arithmetic:
+
+gentype sub_group_non_uniform_reduce_add( gentype value )
+gentype sub_group_non_uniform_reduce_mul( gentype value )
+gentype sub_group_non_uniform_reduce_min( gentype value )
+gentype sub_group_non_uniform_reduce_max( gentype value )
+gentype sub_group_non_uniform_reduce_and( gentype value )
+gentype sub_group_non_uniform_reduce_or( gentype value )
+gentype sub_group_non_uniform_reduce_xor( gentype value )
+int     sub_group_non_uniform_reduce_logical_and( int predicate )
+int     sub_group_non_uniform_reduce_logical_or( int predicate )
+int     sub_group_non_uniform_reduce_logical_xor( int predicate )
+
+gentype sub_group_non_uniform_scan_inclusive_add( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_mul( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_min( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_max( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_and( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_or( gentype value )
+gentype sub_group_non_uniform_scan_inclusive_xor( gentype value )
+int     sub_group_non_uniform_scan_inclusive_logical_and( int predicate )
+int     sub_group_non_uniform_scan_inclusive_logical_or( int predicate )
+int     sub_group_non_uniform_scan_inclusive_logical_xor( int predicate )
+
+gentype sub_group_non_uniform_scan_exclusive_add( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_mul( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_min( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_max( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_and( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_or( gentype value )
+gentype sub_group_non_uniform_scan_exclusive_xor( gentype value )
+int     sub_group_non_uniform_scan_exclusive_logical_and( int predicate )
+int     sub_group_non_uniform_scan_exclusive_logical_or( int predicate )
+int     sub_group_non_uniform_scan_exclusive_logical_xor( int predicate )
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_shuffle:
+
+gentype sub_group_shuffle( gentype value, uint index )
+gentype sub_group_shuffle_xor( gentype value, uint mask )
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_shuffle_relative:
+
+gentype sub_group_shuffle_up( gentype value, uint delta )
+gentype sub_group_shuffle_down( gentype value, uint delta )
+
+// These functions are available to devices supporting
+// cl_khr_subgroup_clustered_reduce:
+
+gentype sub_group_clustered_reduce_add( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_mul( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_min( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_max( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_and( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_or( gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_xor( gentype value, uint clustersize )
+int     sub_group_clustered_reduce_logical_and( int predicate, uint clustersize )
+int     sub_group_clustered_reduce_logical_or( int predicate, uint clustersize )
+int     sub_group_clustered_reduce_logical_xor( int predicate, uint clustersize )
+----
+
+[[cl_khr_subgroup_extended_types]]
+=== Extended Types
+
+This section describes functionality added by `cl_khr_subgroup_extended_types`.
+This extension adds additional supported data types to the existing subgroup broadcast, scan, and reduction functions.
+
+==== Modify the Existing Section Describing Subgroup Functions
+
+Modify the first paragraph in this section that describes `gentype` type support for the subgroup `broadcast`, `scan`, and `reduction` functions to add scalar `char`, `uchar`, `short`, and `ushort` support, and to additionally add built-in vector type support for `broadcast` specifically.
+The functions in the table and their descriptions remain unchanged by this extension:
+
+The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
+These built-in functions must be encountered by all work items in the subgroup executing the kernel.
+We use the generic type name `gentype` to indicate the built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+For the `sub_group_broadcast` function, the generic type name `gentype` may additionally be one of the supported built-in vector data types `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `float__n__`, `double__n__` (if double precision is supported), or `half__n__` (if half precision is supported).
+
+[[cl_khr_subgroup_non_uniform_vote]]
+=== Votes and Elections
+
+This section describes functionality added by `cl_khr_subgroup_non_uniform_vote`.
+This extension adds the ability to elect a single work item from a subgroup to perform a task and to hold votes among work items in a subgroup.
+
+==== Add a new Section 6.13.X - Subgroup Vote and Elect Built-in Functions
+
+The table below describes the OpenCL C programming language built-in functions to elect a single work item in a subgroup to perform a task and to collectively vote to determine a boolean condition for the subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+int sub_group_elect()
+----
+| Elects a single work item in the subgroup to perform a task.
+This function will return true (nonzero) for the active work item in the subgroup with the smallest subgroup local ID, and false (zero) for all other active work items in the subgroup.
+
+|[source,c]
+----
+int sub_group_non_uniform_all(
+    int predicate )
+----
+| Examines _predicate_ for all active work items in the subgroup and returns a non-zero value if _predicate_ is non-zero for all active work items in the subgroup and zero otherwise.
+
+Note: This behavior is the same as `sub_group_all` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
+
+|[source,c]
+----
+int sub_group_non_uniform_any(
+    int predicate )
+----
+| Examines _predicate_ for all active work items in the subgroup and returns a non-zero value if _predicate_ is non-zero for any active work item in the subgroup and zero otherwise.
+
+Note: This behavior is the same as `sub_group_any` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
+
+|[source,c]
+----
+int sub_group_non_uniform_all_equal(
+    gentype value )
+----
+| Examines _value_ for all active work items in the subgroup and returns a non-zero value if _value_ is equivalent for all active invocations in the subgroup and zero otherwise.
+
+Integer types use a bitwise test for equality.  Floating-point types use an ordered floating-point test for equality.
+
+|=======================================================================
+
+[[cl_khr_subgroup_ballot]]
+=== Ballots
+
+This section describes functionality added by `cl_khr_subgroup_ballot`.
+This extension adds the ability to collect and operate on ballots from work items in the subgroup.
+
+==== Add a new Section 6.13.X - Subgroup Ballot Built-in Functions
+
+The table below describes the OpenCL C programming language built-in functions to allow work items in a subgroup to collect and operate on ballots from work items in the subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+
+For the `sub_group_non_uniform_broadcast` and `sub_group_broadcast_first` functions, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+For the `sub_group_non_uniform_broadcast` function, the generic type name `gentype` may additionally be one of the supported built-in vector data types `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `float__n__`, `double__n__` (if double precision is supported), or `half__n__` (if half precision is supported).
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_non_uniform_broadcast(
+    gentype value,
+    uint index )
+----
+| Returns _value_ for the work item with subgroup local ID equal to _index_.
+The value of _index_ must be equivalent for all active work items in the subgroup.
+
+The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
+
+|[source,c]
+----
+gentype sub_group_broadcast_first(
+    gentype value )
+----
+| Returns _value_ for the work item with the smallest subgroup local ID among active work items in the subgroup.
+
+|[source,c]
+----
+uint4 sub_group_ballot(
+    int predicate )
+----
+| Returns a bitfield combining the _predicate_ values from all work items in the subgroup.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+The representative bit in the bitfield is set if the work item is active and the _predicate_ is non-zero, and is unset otherwise.
+
+|[source,c]
+----
+int sub_group_inverse_ballot(
+    uint4 value )
+----
+| Returns the predicate value for this work item in the subgroup from the bitfield _value_ representing predicate values from all work items in the subgroup.
+The bitfield _value_ must be equivalent for all active work items in the subgroup.
+The predicate return value will be non-zero if the bit in the bitfield _value_ for this work item is set, and zero otherwise.
+
+This is a specialized function that may perform better than the equivalent `sub_group_ballot_bit_extract` on some implementations.
+
+|[source,c]
+----
+int sub_group_ballot_bit_extract(
+    uint4 value,
+    uint index )
+----
+| Returns the predicate value for the work item with subgroup local ID equal to _index_ from the bitfield _value_ representing predicate values from all work items in the subgroup.
+The predicate return value will be non-zero if the bit in the bitfield _value_ for the work item with subgroup local ID equal to _index_ is set, and zero otherwise.
+
+The predicate return value is undefined if the work item with subgroup local ID equal to _index_ is greater than or equal to the size of the subgroup.
+
+|[source,c]
+----
+uint sub_group_ballot_bit_count(
+    uint4 value )
+----
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
+
+|[source,c]
+----
+uint sub_group_ballot_inclusive_scan(
+    uint4 value )
+----
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than or equal to this work item's subgroup local ID.
+
+|[source,c]
+----
+uint sub_group_ballot_exclusive_scan(
+    uint4 value )
+----
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than this work item's subgroup local ID.
+
+|[source,c]
+----
+uint sub_group_ballot_find_lsb(
+    uint4 value )
+----
+| Returns the smallest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
+If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
+
+|[source,c]
+----
+uint sub_group_ballot_find_msb(
+    uint4 value )
+----
+| Returns the largest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
+If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
+
+|[source,c]
+----
+uint4 get_sub_group_eq_mask()
+----
+| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index equals the subgroup local ID and unset otherwise.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+
+|[source,c]
+----
+uint4 get_sub_group_ge_mask()
+----
+| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is greater than or equal to the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+
+|[source,c]
+----
+uint4 get_sub_group_gt_mask()
+----
+| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is greater than the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+
+|[source,c]
+----
+uint4 get_sub_group_le_mask()
+----
+| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is less than or equal to the subgroup local ID and unset otherwise.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+
+|[source,c]
+----
+uint4 get_sub_group_lt_mask()
+----
+| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is less than the subgroup local ID and unset otherwise.
+Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+
+|=======================================================================
+
+[[cl_khr_subgroup_non_uniform_arithmetic]]
+=== Non-Uniform Arithmetic
+ 
+This section describes functionality added by `cl_khr_subgroup_non_uniform_arithmetic`.
+This extension adds the ability to use some subgroup functions within non-uniform flow control, including additional scan and reduction operators.
+
+==== Add a new Section 6.13.X - Non Uniform Subgroup Scan and Reduction Built-in Functions
+
+===== Arithmetic Operations
+
+The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations across work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+[cols="3a,2",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_non_uniform_reduce_add(
+    gentype value )
+gentype sub_group_non_uniform_reduce_min(
+    gentype value )
+gentype sub_group_non_uniform_reduce_max(
+    gentype value )
+gentype sub_group_non_uniform_reduce_mul(
+    gentype value )
+----
+| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup.
+
+Note: This behavior is the same as the *add*, *min*, and *max* reduction built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+
+|[source,c]
+----
+gentype sub_group_non_uniform_scan_inclusive_add(
+    gentype value )
+gentype sub_group_non_uniform_scan_inclusive_min(
+    gentype value )
+gentype sub_group_non_uniform_scan_inclusive_max(
+    gentype value )
+gentype sub_group_non_uniform_scan_inclusive_mul(
+    gentype value )
+----
+| Returns the result of an inclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+
+Note: This behavior is the same as the *add*, *min*, and *max* inclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+
+|[source,c]
+----
+gentype sub_group_non_uniform_scan_exclusive_add(
+    gentype value )
+gentype sub_group_non_uniform_scan_exclusive_min(
+    gentype value )
+gentype sub_group_non_uniform_scan_exclusive_max(
+    gentype value )
+gentype sub_group_non_uniform_scan_exclusive_mul(
+    gentype value )
+----
+| Returns the result of an exclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+
+If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+For *add*, the identity value is `0`.
+For *min*, the identity value is the largest representable value for integer types, or `+INF` for floating point types.
+For *max*, the identity value is the smallest representable value for integer types, or `-INF` for floating point types.
+For *mul*, the identity value is `1`.
+
+Note: This behavior is the same as the *add*, *min*, and *max* exclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+
+|=======================================================================
+
+Note: The order of floating-point operations is not guaranteed for the subgroup scan and reduction built-in functions that operate on floating point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+
+===== Bitwise Operations
+
+The table below describes the OpenCL C programming language built-in functions that perform simple bitwise integer operations across work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`.
+
+[cols="3a,2",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_non_uniform_reduce_and(
+    gentype value )
+gentype sub_group_non_uniform_reduce_or(
+    gentype value )
+gentype sub_group_non_uniform_reduce_xor(
+    gentype value )
+----
+| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup.
+
+|[source,c]
+----
+gentype sub_group_non_uniform_scan_inclusive_and(
+    gentype value )
+gentype sub_group_non_uniform_scan_inclusive_or(
+    gentype value )
+gentype sub_group_non_uniform_scan_inclusive_xor(
+    gentype value )
+----
+| Returns the result of an inclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+
+|[source,c]
+----
+gentype sub_group_non_uniform_scan_exclusive_and(
+    gentype value )
+gentype sub_group_non_uniform_scan_exclusive_or(
+    gentype value )
+gentype sub_group_non_uniform_scan_exclusive_xor(
+    gentype value )
+----
+| Returns the result of an exclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+
+If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+For *and*, the identity value is `~0` (all bits set).
+For *or* and *xor*, the identity value is `0`.
+
+|=======================================================================
+
+===== Logical Operations
+
+The table below describes the OpenCL C programming language built-in functions that perform simple logical operations across work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For these functions, a non-zero _predicate_ argument or return value is logically `true` and a zero _predicate_ argument or return value is logically `false`.
+
+[cols="2a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+int sub_group_non_uniform_reduce_logical_and(
+    int predicate )
+int sub_group_non_uniform_reduce_logical_or(
+    int predicate )
+int sub_group_non_uniform_reduce_logical_xor(
+    int predicate )
+----
+| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup.
+
+|[source,c]
+----
+int sub_group_non_uniform_scan_inclusive_logical_and(
+    int predicate )
+int sub_group_non_uniform_scan_inclusive_logical_or(
+    int predicate )
+int sub_group_non_uniform_scan_inclusive_logical_xor(
+    int predicate )
+----
+| Returns the result of an inclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+
+|[source,c]
+----
+int sub_group_non_uniform_scan_exclusive_logical_and(
+    int predicate )
+int sub_group_non_uniform_scan_exclusive_logical_or(
+    int predicate )
+int sub_group_non_uniform_scan_exclusive_logical_xor(
+    int predicate )
+----
+| Returns the result of an exclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+
+If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+For *and*, the identity value is `true` (non-zero).
+For *or* and *xor*, the identity value is `false` (zero).
+
+|=======================================================================
+
+[[cl_khr_subgroup_shuffle]]
+=== General Purpose Shuffles
+
+This section describes functionality added by `cl_khr_subgroup_shuffle`.
+This extension adds additional ways to exchange data among work items in a subgroup.
+
+==== Add a new Section 6.13.X - Subgroup Shuffle Built-in Functions
+
+The table below describes the OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_shuffle(
+    gentype value, uint index )
+----
+| Returns _value_ for the work item with subgroup local ID equal to _index_.
+The shuffle _index_ need not be the same for all work items in the subgroup.
+
+The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
+
+|[source,c]
+----
+gentype sub_group_shuffle_xor(
+    gentype value, uint mask )
+----
+| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID xor'd with _mask_.
+The shuffle _mask_ need not be the same for all work items in the subgroup.
+
+The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive or if the calculated index is greater than or equal to the size of the subgroup.
+
+This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
+
+|=======================================================================
+
+[[cl_khr_subgroup_shuffle_relative]]
+=== Relative Shuffles
+
+This section describes functionality added by `cl_khr_subgroup_shuffle_relative`.
+This extension adds specialized ways to exchange data among work items in a subgroup that may perform better on some implementations.
+
+==== Add a new Section 6.13.X - Subgroup Relative Shuffle Built-in Functions
+
+The table below describes specialized OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_shuffle_up(
+    gentype value, uint delta )
+----
+| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID minus _delta_.
+The shuffle _delta_ need not be the same for all work items in the subgroup.
+
+The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive, or _delta_ is greater than this work item's subgroup local ID.
+
+This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
+
+|[source,c]
+----
+gentype sub_group_shuffle_down(
+    gentype value, uint delta )
+----
+| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID plus _delta_.
+The shuffle _delta_ need not be the same for all work items in the subgroup.
+
+The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive, or this work item's subgroup local ID plus _delta_ is greater than or equal to the size of the subgroup.
+
+This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
+
+|=======================================================================
+
+[[cl_khr_subgroup_clustered_reduce]]
+=== Clustered Reductions
+
+This section describes functionality added by `cl_khr_subgroup_clustered_reduce`.
+This extension adds support for clustered reductions that operate on a subset of work items in the subgroup.
+
+==== Add a new Section 6.13.X - Subgroup Clustered Reduction Built-in Functions
+
+This section describes arithmetic operations that are performed subset of work items in a subgroup, referred to as a cluster.
+A cluster is described by a specified cluster size.
+Work items in a subgroup are assigned to clusters such that for cluster size _n_, the _n_ work items in the subgroup with the smallest subgroup local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest subgroup local IDs are assigned to the next cluster, and so on.
+The specified cluster size must be an integer constant expression that is a power-of-two.
+Behavior is undefined if the specified cluster size is greater than the maximum size of a subgroup within the dispatch.
+
+===== Arithmetic Operations
+
+The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations on a cluster of work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_clustered_reduce_add(
+    gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_mul(
+    gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_min(
+    gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_max(
+    gentype value, uint clustersize )
+----
+| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+
+|=======================================================================
+
+Note: The order of floating-point operations is not guaranteed for the subgroup clustered reduction built-in functions that operate on floating point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+
+===== Bitwise Operations
+
+The table below describes the OpenCL C programming language built-in functions to perform simple bitwise integer operations across a cluster of work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, or `ulong`.
+
+[cols="1a,1",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+gentype sub_group_clustered_reduce_and(
+    gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_or(
+    gentype value, uint clustersize )
+gentype sub_group_clustered_reduce_xor(
+    gentype value, uint clustersize )
+----
+| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+
+|=======================================================================
+
+===== Logical Operations
+
+The table below describes the OpenCL C programming language built-in functions to perform simple logical operations across a cluster of work items in a subgroup.
+These functions need not be encountered by all work items in a subgroup executing the kernel.
+For these functions, a non-zero _predicate_ argument or return value is logically `true` and a zero _predicate_ argument or return value is logically `false`.
+
+[cols="3a,2",options="header",]
+|=======================================================================
+|*Function*
+|*Description*
+
+|[source,c]
+----
+int sub_group_clustered_reduce_logical_and(
+    int predicate, uint clustersize )
+int sub_group_clustered_reduce_logical_or(
+    int predicate, uint clustersize )
+int sub_group_clustered_reduce_logical_xor(
+    int predicate, uint clustersize )
+----
+| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+
+|=======================================================================
+
+[[extended-subgroups-mapping]]
+=== Function Mapping and Capabilities
+
+This section describes a possible mapping between OpenCL built-in functions and SPIR-V instructions and required SPIR-V capabilities.
+
+This section is informational and non-normative.
+
+// Note: the Unicode "zero with space" (&#8203;) causes long function names to break much more sensibly.
+
+[cols="1,1,1",options="header"]
+|=======================================================================
+|*OpenCL C Function*
+|*SPIR-V BuiltIn or Instruction*
+|*Enabling SPIR-V Capability*
+
+3+| For OpenCL 2.1 or `cl_khr_subgroups`:
+
+| `get_&#8203;sub_&#8203;group_&#8203;size`
+       | *SubgroupSize*
+            | *Kernel*
+| `get_&#8203;max_&#8203;sub_&#8203;group_&#8203;size`
+       | *SubgroupMaxSize*
+            | *Kernel*
+| `get_&#8203;num_&#8203;sub_&#8203;groups`
+        | *NumSubgroups*
+            | *Kernel*
+| `get_&#8203;enqueued_&#8203;num_&#8203;sub_&#8203;groups`
+        | *NumEnqueuedSubgroups*
+            | *Kernel*
+| `get_&#8203;sub_&#8203;group_&#8203;id`
+        | *SubgroupId*
+            | *Kernel*
+| `get_&#8203;sub_&#8203;group_&#8203;local_&#8203;id`
+        | *SubgroupLocalInvocationId*
+            | *Kernel*
+
+| `sub_&#8203;group_&#8203;barrier`
+        | *OpControlBarrier*
+            | None Needed
+
+| `sub_&#8203;group_&#8203;all`
+        | *OpGroupAll*
+            | *Groups*
+| `sub_&#8203;group_&#8203;any`
+        | *OpGroupAny*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;broadcast`
+        | *OpGroupBroadcast*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;reduce_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;reduce_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;reduce_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;reserve_&#8203;read_&#8203;pipe`
+        | *OpGroupReserveReadPipePackets*
+            | *Pipes*
+| `sub_&#8203;group_&#8203;reserve_&#8203;write_&#8203;pipe`
+        | *OpGroupReserveReadWritePackets*
+            | *Pipes*
+| `sub_&#8203;group_&#8203;commit_&#8203;read_&#8203;pipe`
+        | *OpGroupCommitReadPipe*
+            | *Pipes*
+| `sub_&#8203;group_&#8203;commit_&#8203;write_&#8203;pipe`
+        | *OpGroupCommitWritePipe*
+            | *Pipes*
+
+| `get_&#8203;kernel_&#8203;sub_&#8203;group_&#8203;count_&#8203;for_&#8203;ndrange`
+        | *OpGetKernelNDrangeSubGroupCount*
+            | *DeviceEnqueue*
+| `get_&#8203;kernel_&#8203;max_&#8203;sub_&#8203;group_&#8203;size_&#8203;for_&#8203;ndrange`
+        | *OpGetKernelNDrangeMaxSubGroupSize*
+            | *DeviceEnqueue*
+
+3+| For `cl_khr_subgroup_extended_types`: +
+Note: This extension adds new types to uniform subgroup operations.
+
+| `sub_&#8203;group_&#8203;broadcast`
+        | *OpGroupBroadcast*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;reduce_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;reduce_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;reduce_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;exclusive_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;add`
+        | *OpGroupIAdd*, *OpGroupFAdd*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;min`
+        | *OpGroupSMin*, *OpGroupUMin*, *OpGroupFMin*
+            | *Groups*
+| `sub_&#8203;group_&#8203;scan_&#8203;inclusive_&#8203;max`
+        | *OpGroupSMax*, *OpGroupUMax*, *OpGroupFMax*
+            | *Groups*
+
+3+| For `cl_khr_subgroup_non_uniform_vote`:
+
+| `sub_&#8203;group_&#8203;elect`
+        | *OpGroupNonUniformElect*
+            | *GroupNonUniform*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;all`
+        | *OpGroupNonUniformAll*
+            | *GroupNonUniformVote*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;any`
+        | *OpGroupNonUniformAny*
+            | *GroupNonUniformVote*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;all_&#8203;equal`
+        | *OpGroupNonUniformAllEqual*
+            | *GroupNonUniformVote*
+
+3+| For `cl_khr_subgroup_ballot`:
+
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;broadcast`
+        | *OpGroupNonUniformBroadcast*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;broadcast_&#8203;first`
+        | *OpGroupNonUniformBroadcastFirst*
+            | *GroupNonUniformBallot*
+
+| `sub_&#8203;group_&#8203;ballot`
+        | *OpGroupNonUniformBallot*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;inverse_&#8203;ballot`
+        | *OpGroupNonUniformInverseBallot*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;bit_&#8203;extract`
+        | *OpGroupNonUniformBallotBitExtract*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;bit_&#8203;count`
+        | *OpGroupNonUniformBallotBitCount*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;inclusive_&#8203;scan`
+        | *OpGroupNonUniformBallotBitCount*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;exclusive_&#8203;scan`
+        | *OpGroupNonUniformBallotBitCount*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;find_&#8203;lsb`
+        | *OpGroupNonUniformBallotFindLSB*
+            | *GroupNonUniformBallot*
+| `sub_&#8203;group_&#8203;ballot_&#8203;find_&#8203;msb`
+        | *OpGroupNonUniformBallotFindMSB*
+            | *GroupNonUniformBallot*
+
+| `get_&#8203;sub_&#8203;group_&#8203;eq_&#8203;mask`
+        | *SubgroupEqMask*
+            | *GroupNonUniformBallot*
+| `get_&#8203;sub_&#8203;group_&#8203;ge_&#8203;mask`
+        | *SubgroupGeMask*
+            | *GroupNonUniformBallot*
+| `get_&#8203;sub_&#8203;group_&#8203;gt_&#8203;mask`
+        | *SubgroupGtMask*
+            | *GroupNonUniformBallot*
+| `get_&#8203;sub_&#8203;group_&#8203;le_&#8203;mask`
+        | *SubgroupLeMask*
+            | *GroupNonUniformBallot*
+| `get_&#8203;sub_&#8203;group_&#8203;lt_&#8203;mask`
+        | *SubgroupLtMask*
+            | *GroupNonUniformBallot*
+
+3+| For `cl_khr_subgroup_non_uniform_arithmetic`:
+
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;add`
+        | *OpGroupNonUniformIAdd*, *OpGroupNonUniformFAdd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;mul`
+        | *OpGroupNonUniformIMul*, *OpGroupNonUniformFMul*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;min`
+        | *OpGroupNonUniformSMin*, *OpGroupNonUniformUMin*, *OpGroupNonUniformFMin*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;max`
+        | *OpGroupNonUniformSMax*, *OpGroupNonUniformUMax*, *OpGroupNonUniformFMax*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;and`
+        | *OpGroupNonUniformBitwiseAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;or`
+        | *OpGroupNonUniformBitwiseOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;xor`
+        | *OpGroupNonUniformBitwiseXor*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;logical_&#8203;and`
+        | *OpGroupNonUniformLogicalAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;logical_&#8203;or`
+        | *OpGroupNonUniformLogicalOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;reduce_&#8203;logical_&#8203;xor`
+        | *OpGroupNonUniformLogicalXor*
+            | *GroupNonUniformArithmetic*
+
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;add`
+        | *OpGroupNonUniformIAdd*, *OpGroupNonUniformFAdd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;mul`
+        | *OpGroupNonUniformIMul*, *OpGroupNonUniformFMul*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;min`
+        | *OpGroupNonUniformSMin*, *OpGroupNonUniformUMin*, *OpGroupNonUniformFMin*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;max`
+        | *OpGroupNonUniformSMax*, *OpGroupNonUniformUMax*, *OpGroupNonUniformFMax*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;and`
+        | *OpGroupNonUniformBitwiseAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;or`
+        | *OpGroupNonUniformBitwiseOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;xor`
+        | *OpGroupNonUniformBitwiseXor*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;logical_&#8203;and`
+        | *OpGroupNonUniformLogicalAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;logical_&#8203;or`
+        | *OpGroupNonUniformLogicalOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;inclusive_&#8203;logical_&#8203;xor`
+        | *OpGroupNonUniformLogicalXor*
+            | *GroupNonUniformArithmetic*
+
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;exclusive_&#8203;add`
+        | *OpGroupNonUniformIAdd*, *OpGroupNonUniformFAdd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;exclusive_&#8203;mul`
+        | *OpGroupNonUniformIMul*, *OpGroupNonUniformFMul*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;scan_&#8203;exclusive_&#8203;min`
+        | *OpGroupNonUniformSMin*, *OpGroupNonUniformUMin*, *OpGroupNonUniformFMin*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;max`
+        | *OpGroupNonUniformSMax*, *OpGroupNonUniformUMax*, *OpGroupNonUniformFMax*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;and`
+        | *OpGroupNonUniformBitwiseAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;or`
+        | *OpGroupNonUniformBitwiseOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;xor`
+        | *OpGroupNonUniformBitwiseXor*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;logical_&#8203;and`
+        | *OpGroupNonUniformLogicalAnd*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;logical_&#8203;or`
+        | *OpGroupNonUniformLogicalOr*
+            | *GroupNonUniformArithmetic*
+| `sub_&#8203;group_&#8203;non_&#8203;uniform_&#8203;&#8203;scan_&#8203;exclusive_&#8203;logical_&#8203;xor`
+        | *OpGroupNonUniformLogicalXor*
+            | *GroupNonUniformArithmetic*
+
+3+| For `cl_khr_subgroup_shuffle`:
+
+| `sub_&#8203;group_&#8203;shuffle`
+        | *OpGroupNonUniformShuffle*
+            | *GroupNonUniformShuffle*
+| `sub_&#8203;group_&#8203;shuffle_&#8203;xor`
+        | *OpGroupNonUniformShuffleXor*
+            | *GroupNonUniformShuffle*
+
+3+| For `cl_khr_subgroup_shuffle_relative`:
+
+| `sub_&#8203;group_&#8203;shuffle_&#8203;up`
+        | *OpGroupNonUniformShuffleUp*
+            | *GroupNonUniformShuffleRelative*
+| `sub_&#8203;group_&#8203;shuffle_&#8203;down`
+        | *OpGroupNonUniformShuffleDown*
+            | *GroupNonUniformShuffleRelative*
+
+3+| For `cl_khr_subgroup_clustered_reduce`:
+
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;add`
+        | *OpGroupNonUniformIAdd*, *OpGroupNonUniformFAdd*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;mul`
+        | *OpGroupNonUniformIMul*, *OpGroupNonUniformFMul*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;min`
+        | *OpGroupNonUniformSMin*, *OpGroupNonUniformUMin*, *OpGroupNonUniformFMin*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;max`
+        | *OpGroupNonUniformSMax*, *OpGroupNonUniformUMax*, *OpGroupNonUniformFMax*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;and`
+        | *OpGroupNonUniformBitwiseAnd*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;or`
+        | *OpGroupNonUniformBitwiseOr*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;xor`
+        | *OpGroupNonUniformBitwiseXor*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;logical_&#8203;and`
+        | *OpGroupNonUniformLogicalAnd*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;logical_&#8203;or`
+        | *OpGroupNonUniformLogicalOr*
+            | *GroupNonUniformClustered*
+| `sub_&#8203;group_&#8203;reduce_&#8203;clustered_&#8203;logical_&#8203;xor`
+        | *OpGroupNonUniformLogicalXor*
+            | *GroupNonUniformClustered*
+
+|=======================================================================

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -37,7 +37,7 @@ For all of the extensions described in this section:
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
-| 2020-09-28 | 1.0.0     | First assigned version.
+| 2020-12-15 | 1.0.0     | First assigned version.
 |====
 
 [[extended-subgroups-summary]]

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -157,13 +157,41 @@
 | Write to sRGB Images
 | Extension
 
+| <<cl_khr_subgroups,cl_khr_subgroups>>
+| Sub-Groupings of Work Items
+| Core Feature in OpenCL 2.1 (with minor changes)
+
+| <<cl_khr_subgroup_ballot,cl_khr_subgroup_ballot>>
+| Exchange Ballots Among Sub-Groupings of Work Items
+| Extension
+
+| <<cl_khr_subgroup_clustered_reduce,cl_khr_subgroup_clustered_reduce>>
+| Clustered Reductions for Sub-Groupings of Work Items
+| Extension
+
+| <<cl_khr_subgroup_extended_types,cl_khr_subgroup_extended_types>>
+| Additional Type Support for Sub-Group Functions
+| Extension
+
 | <<cl_khr_subgroup_named_barrier,cl_khr_subgroup_named_barrier>>
 | Barriers for Subsets of a Work Group
 | Extension
 
-| <<cl_khr_subgroups,cl_khr_subgroups>>
-| Sub-Groupings of Work Items
-| Core Feature in OpenCL 2.1 (with minor changes)
+| <<cl_khr_subgroup_non_uniform_arithmetic,cl_khr_subgroup_non_uniform_arithmetic>>
+| Sub-Group Arithmetic Functions in Non-Uniform Control Flow
+| Extension
+
+| <<cl_khr_subgroup_non_uniform_vote,cl_khr_subgroup_non_uniform_vote>>
+| Hold Votes Among Sub-Groupings of Work Items
+| Extension
+
+| <<cl_khr_subgroup_shuffle,cl_khr_subgroup_shuffle>>
+| General-Purpose Shuffles Among Sub-Groupings of Work Items
+| Extension
+
+| <<cl_khr_subgroup_shuffle_relative,cl_khr_subgroup_shuffle_relative>>
+| Relative Shuffles Among Sub-Groupings of Work Items
+| Extension
 
 | <<cl_khr_terminate_context,cl_khr_terminate_context>>
 | Terminate an OpenCL Context


### PR DESCRIPTION
This PR adds a family of extensions that provide extended subgroup functionality. The extensions in this family are:

* `cl_khr_subgroup_extended_types`
* `cl_khr_subgroup_non_uniform_vote`
* `cl_khr_subgroup_ballot`
* `cl_khr_subgroup_non_uniform_arithmetic`
* `cl_khr_subgroup_shuffle`
* `cl_khr_subgroup_shuffle_relative`
* `cl_khr_subgroup_clustered_reduce`

The functionality added by these extensions includes:

* Additional data type support for subgroup broadcast, scan, and reduction functions;
* The ability to elect a single work item from a subgroup to perform a task;
* The ability to hold votes among work items in a subgroup;
* The ability to collect and operate on ballots from work items in the subgroup;
* The ability to use some subgroup functions, such as any, all, broadcasts, scans, and reductions within non-uniform flow control;
* Additional scan and reduction operators;
* Additional ways to exchange data among work items in a subgroup;
* Clustered reductions, that operate on a subset of work items in the subgroup.