### PR TITLE
explicitly say that OpTypeSampledImage may be used in an OpenCL environment

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -163,6 +163,10 @@ OpenCL environments:
 // sampler_t
 *OpTypeSampler* may be used to declare sampler types in OpenCL environments.
 
+// This cannot be passed to a kernel or expressed directly in OpenCL C but
+// should be mentioned explicitly, see internal issue 273:
+*OpTypeSampledImage* may be used to declare combined image and sampler types in OpenCL environments.
+
 ==== Other Data Types
 
 The following table describes other data types that may be used in an

--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -44,7 +44,7 @@ For all *Atomic Instructions*:
   * Only 32-bit integer types are supported for the _Result Type_ and/or
     type of _Value_.
   * The _Pointer_ operand must be a pointer to the *Function*, *Workgroup*,
-    or *CrossWorkGroup* _Storage Classes_.  Note that an *Atomic Instruction*
+    or *CrossWorkgroup* _Storage Classes_.  Note that an *Atomic Instruction*
     on a pointer to the *Function* _Storage Class_ is valid, but does not
     have defined behavior.
 


### PR DESCRIPTION
Fixes internal issue 273.

Tagging @dneto0.