### PR TITLE
fix several bugs and formatting in the fast math ulp tables

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11619,136 +11619,188 @@ requires>> support for OpenCL C 2.0 or newer.
 
 [[table-float-ulp-relaxed]]
 .ULP values for single precision built-in math functions with unsafe math optimizations in the full and embedded profiles
-[cols=",",]
+[cols="3,7",]
 |====
-| *Function* | *Min Accuracy - ULP values*
+| *Function*
+| *Minimum Accuracy*
+
 | *1.0 / _x_*
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
       profile, and {leq} 3 ulp for the embedded profile.
+
 | _x_ / _y_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-62^ to 2^62^ and _y_ in the
       domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for
       the embedded profile.
+
 | *acos*(_x_)
     | {leq} 4096 ulp
+
+| *acosh*(_x_)
+    | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ - 1)).
+
 | *acospi*(_x_)
-    | Implemented as *acos*(_x_) * `M_PI_F`.
+    | Derived implementations may implement as *acos*(_x_) * `M_PI_F`.
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *asin*(_x_)
     | {leq} 4096 ulp
+
+| *asinh*(_x_)
+    | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ + 1)).
+
 | *asinpi*(_x_)
-    | Implemented as *asin*(_x_) * `M_PI_F`.
+    | Derived implementations may implement as *asin*(_x_) * `M_PI_F`.
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *atan*(_x_)
     | {leq} 4096 ulp
-| *atan2*(_y_, _x_)
-    | Implemented as *atan*(_y_ / _x_) for _x_ > 0, *atan*(_y_ / _x_) +
-      `M_1_PI_F` for _x_ < 0 and _y_ > 0 and *atan*(_y_ / _x_) -
-      `M_1_PI_F` for _x_ < 0 and _y_ < 0.
+
+//| *atanh*(_x_)
+//  | Defined for _x_ in the domain (-1, 1).
+//    For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
+//    For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
+//    0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
+//    For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *atanpi*(_x_)
-    | Implemented as *atan*(_x_) * `M_1_PI_F`.
+    | Derived implementations may implement as *atan*(_x_) * `M_1_PI_F`.
       For non-derived implementations, the error is {leq} 8192 ulp.
+
+| *atan2*(_y_, _x_)
+    | Derived implementations may implement as *atan*(_y_ / _x_) for _x_ > 0,
+      *atan*(_y_ / _x_) + `M_PI_F` for _x_ < 0 and _y_ > 0, and
+      *atan*(_y_ / _x_) - `M_PI_F` for _x_ < 0 and _y_ < 0.
+
 | *atan2pi*(_y_, _x_)
-    | Implemented as *atan2*(_y_, _x_) * `M_PI_F`.
+    | Derived implementations may implement as *atan2*(_y_, _x_) * `M_1_PI_F`.
       For non-derived implementations, the error is {leq} 8192 ulp.
-| *acosh*(_x_)
-    | Implemented as *log*(_x_ + *sqrt*(_x_ * _x_ - 1)).
-| *asinh*(_x_)
-    | Implemented as *log*(_x_ + *sqrt*(_x_ * _x_ + 1)).
+
 | *cbrt*(_x_)
-    | Implemented as *rootn*(_x_, 3).
+    | Derived implementations may implement as *rootn*(_x_, 3).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *cos*(_x_)
     | For _x_ in the domain [-{pi}, {pi}], the maximum absolute error
       is {leq} 2^-11^ and larger otherwise.
+
 | *cosh*(_x_)
-    | Defined for _x_ in the domain [-88,88] and implemented as 0.5f *
-      (*exp*(_x_) + *exp*(-_x_)).
+    | Defined for _x_ in the domain [-88, 88].
+      Derived implementations may implement as 0.5f * (*exp*(_x_) + *exp*(-_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *cospi*(_x_)
     | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
       2^-11^ and larger otherwise.
+
 | *exp*(_x_)
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
       4 ulp for the embedded profile.
+
 | *exp2*(_x_)
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
       4 ulp for the embedded profile.
+
 | *exp10*(_x_)
-    | Derived implementations implement this as *exp2*(_x_ * *log2*(10)).
+    | Derived implementations may implement as *exp2*(_x_ * *log2*(10)).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *expm1*(_x_)
-    | Derived implementations implement this as *exp*(_x_) - 1.
+    | Derived implementations may implement as *exp*(_x_) - 1.
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *log*(_x_)
     | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
-      2^-21^; otherwise the maximum error is {leq}3 ulp for the full profile
-      and {leq} 4 ulp for the embedded profile
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
+
 | *log2*(_x_)
     | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
-      2^-21^; otherwise the maximum error is {leq}3 ulp for the full profile
-      and {leq} 4 ulp for the embedded profile
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
+
 | *log10*(_x_)
     | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
-      2^-21^; otherwise the maximum error is {leq}3 ulp for the full profile
-      and {leq} 4 ulp for the embedded profile
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
+
 | *log1p*(_x_)
-    | Derived implementations implement this as *log*(_x_ + 1).
+    | Derived implementations may implement as *log*(_x_ + 1).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *pow*(_x_, _y_)
     | Undefined for _x_ = 0 and _y_ = 0.
-      Undefined for _x_ < 0 and non-integer y.
-      Undefined for _x_ < 0 and _y_ outside the domain [-2^24, 2^24].
-      For _x_ > 0 or _x_ < 0 and even _y_, derived implementations implement
-      this as *exp2*(_y_ * *log2*(*fabs*(_x_))).
-      For _x_ < 0 and odd _y_, derived implementations implement this as
+      Undefined for _x_ < 0 and non-integer _y_.
+      Undefined for _x_ < 0 and _y_ outside the domain [-2^24^, 2^24^].
+      For _x_ > 0 or _x_ < 0 and even _y_, derived implementations may implement as
+      *exp2*(_y_ * *log2*(*fabs*(_x_))).
+      For _x_ < 0 and odd _y_, derived implementations may implement as
       -*exp2*(_y_ * *log2*(*fabs*(_x_)).
-      For _x_ == 0 and nonzero _y_, derived implementations return zero.
+      For _x_ == 0 and non-zero _y_, for derived implementations may return zero.
       For non-derived implementations, the error is {leq} 8192 ulp.
       footnote:[{fn-pow-performance}]
+
 | *pown*(_x_, _y_)
-    | Defined only for integer values of y.
+    | Defined only for integer values of _y_.
       Undefined for _x_ = 0 and _y_ = 0.
-      For _x_ >= 0 or _x_ < 0 and even _y_, derived implementations
-      implement this as *exp2*(_y_ * *log2*(*fabs*(_x_))).
-      For _x_ < 0 and odd _y_, derived implementations implement this as
-      -*exp2*(_y_ * *log2*(*fabs*(_x_)).
+      For _x_ >= 0 or _x_ < 0 and even _y_, derived implementations may implement as
+      *exp2*(_y_ * *log2*(*fabs*(_x_))).
+      For _x_ < 0 and odd _y_, derived implementations may implement as
+      -*exp2*(_y_ * *log2*(*fabs*(_x_))).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *powr*(_x_, _y_)
     | Defined only for _x_ >= 0.
       Undefined for _x_ = 0 and _y_ = 0.
-      Derived implementations implement this as *exp2*(_y_ * *log2*(_x_)).
+      Derived implementations may implement as *exp2*(_y_ * *log2*(_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *rootn*(_x_, _y_)
-    | Defined for _x_ > 0 when _y_ is nonzero, derived implementations
-      implement this case as *exp2*(log2(_x_) / _y_).
-      Defined for _x_ < 0 when _y_ is odd, derived implementations implement
-      this case as -*exp2*(*log2*(-_x_) / _y_).
-      Defined for _x_ = +/-0 when _y_ > 0, derived implementations will
+    | Defined for _x_ > 0 when _y_ is non-zero, derived implementations
+      may implement this case as *exp2*(*log2*(_x_) / _y_).
+      Defined for _x_ < 0 when _y_ is odd, derived implementations
+      may implement this case as -*exp2*(*log2*(-_x_) / _y_).
+      Defined for _x_ = +/-0 when _y_ > 0, derived implementations may
       return +0 in this case.
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *sin*(_x_)
     | For _x_ in the domain [-{pi}, {pi}], the maximum absolute error is
       {leq} 2^-11^ and larger otherwise.
+
 | *sincos*(_x_)
-    | ulp values as defined for *sin*(_x_) and *cos*(_x_)
+    | ulp values as defined for *sin*(_x_) and *cos*(_x_).
+
 | *sinh*(_x_)
     | Defined for _x_ in the domain [-88,88].
-      For _x_ in [-2^-10,2^-10], derived implementations implement as _x_.
-      For _x_ outside of [-2^10,2^10], derived implement as *0.5f *
-      (*exp*(_x_) - *exp*(-_x_)).
+      For _x_ in [-2^-10^, 2^-10^], derived implementations
+      may implement as _x_.
+      For _x_ outside of [-2^-10^, 2^-10^], derived implementations
+      may implement as 0.5f * (*exp*(_x_) - *exp*(-_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
 | *sinpi*(_x_)
     | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
       2^-11^ and larger otherwise.
+
 | *tan*(_x_)
-    | Derived implementations implement this as *sin*(_x_) * (`1.0f` /
-      *cos*(_x_)).
+    | Derived implementations may implement as
+      *sin*(_x_) * (1.0f / *cos*(_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
+
+//| *tanh*(_x_)
+//  | Defined for _x_ in the domain [-{inf}, {inf}].
+//    For _x_ in [-2^-10^, 2^-10^], derived implementations
+//    may implement as _x_.
+//    For _x_ outside of [-2^-10^, 2^-10^], derived implementations
+//    may implement as (*exp*(_x_) - *exp*(-_x_)) / (*exp*(_x_) + *exp*(-_x_)).
+//    For non-derived implementations, the error is {leq} 8192 ULP.
+
 | *tanpi*(_x_)
-    | Derived implementations implement this as *tan*(_x_ * `M_PI_F`).
+    | Derived implementations may implement as *tan*(_x_ * `M_PI_F`).
       For non-derived implementations, the error is {leq} 8192 ulp for _x_
       in the domain [-1, 1].
+
 | _x_ * _y_ + _z_
     | Implemented either as a correctly rounded *fma* or as a multiply and
       an add both of which are correctly rounded.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11295,7 +11295,7 @@ there was sufficient range, meets ULP error tolerance.
 | _x_ + _y_             | Correctly rounded
 | _x_ - _y_             | Correctly rounded
 | _x_ * _y_             | Correctly rounded
-| *1.0 / _x_*           | {leq} 2.5 ulp
+| 1.0 / _x_             | {leq} 2.5 ulp
 | _x_ / _y_             | {leq} 2.5 ulp
 | |
 | *acos*                | {leq} 4 ulp
@@ -11481,7 +11481,7 @@ is the infinitely precise result.
 | _x_ + _y_         | Correctly rounded
 | _x_ - _y_         | Correctly rounded
 | _x_ * _y_         | Correctly rounded
-| *1.0 / _x_*       | {leq} 3 ulp
+| 1.0 / _x_         | {leq} 3 ulp
 | _x_ / _y_         | {leq} 3 ulp
 | |
 | *acos*            | {leq} 4 ulp
@@ -11624,7 +11624,7 @@ requires>> support for OpenCL C 2.0 or newer.
 | *Function*
 | *Minimum Accuracy*
 
-| *1.0 / _x_*
+| 1.0 / _x_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
       profile, and {leq} 3 ulp for the embedded profile.
 

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1357,197 +1357,199 @@ Profile>> table when operating in the full profile, and as defined in the
 instructions for Embedded Profile>> table when operating in the embedded
 profile.
 
-// TODO: Eventually add appropriate bolding to the instructions in the table below.
-
 [[ulp_values_for_math_instructions_with_fast_relaxed_math]]
 .ULP Values for Single Precision Math Instructions with _-cl-unsafe-math-optimizations_
 [width="100%",cols="30%,70%",options="header"]
 |====
-| *SPIR-V Instruction*
+| *Function*
 | *Minimum Accuracy*
 
-| *OpFDiv* for 1.0 / _x_
-| \<= 2.5 ulp for x in the domain of 2^-126^ to 2^126^ for the full profile,
-  and \<= 3 ulp for the embedded profile.
+| *1.0 / _x_*
+    | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
+      profile, and {leq} 3 ulp for the embedded profile.
 
 | *OpFDiv* for _x_ / _y_
-| \<= 2.5 ulp for x in the domain of 2^-62^ to 2^62^ and _y_ in the domain
-  of 2^-62^ to 2^62^ for the full profile, and \<= 3 ulp for the embedded
-  profile.
+    | {leq} 2.5 ulp for _x_ in the domain of 2^-62^ to 2^62^ and _y_ in the
+      domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for
+      the embedded profile.
 
 | *OpExtInst* *acos*
-| \<= 4096 ulp
+    | {leq} 4096 ulp
 
 | *OpExtInst* *acosh*
-| Implemented as log( x + sqrt(x*x - 1) ).
+    | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ - 1)).
 
 | *OpExtInst* *acospi*
-| Implemented as acos(x) * M_PI_F.
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *acos*(_x_) * `M_PI_F`.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *asin*
-| \<= 4096 ulp
+    | {leq} 4096 ulp
 
 | *OpExtInst* *asinh*
-| Implemented as log( x + sqrt(x*x + 1) ).
+    | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ + 1)).
 
 | *OpExtInst* *asinpi*
-| Implemented as asin(x) * M_PI_F.
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *asin*(_x_) * `M_PI_F`.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *atan*
-| \<= 4096 ulp
+    | {leq} 4096 ulp
 
 | *OpExtInst* *atanh*
-| Defined for x in the domain (-1, 1).
-  For x in [-2^-10^, 2^-10^], implemented as x.
-  For x outside of [-2^-10^, 2^-10^], implemented as 0.5f * log( (1.0f + x)
-  / (1.0f - x) ).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Defined for _x_ in the domain (-1, 1).
+      For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
+      For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
+      0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *atanpi*
-| Implemented as atan(x) * M_1_PI_F.
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *atan*(_x_) * `M_1_PI_F`.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *atan2*
-| Implemented as atan(y/x) for x > 0, atan(y/x) + M_PI_F for x < 0 and y >
-  0, and atan(y/x) - M_PI_F for x < 0 and y < 0.
+    | Derived implementations may implement as *atan*(_y_ / _x_) for _x_ > 0,
+      *atan*(_y_ / _x_) + `M_PI_F` for _x_ < 0 and _y_ > 0, and
+      *atan*(_y_ / _x_) - `M_PI_F` for _x_ < 0 and _y_ < 0.
 
 | *OpExtInst* *atan2pi*
-| Implemented as atan2(y, x) * M_1_PI_F.
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *atan2*(_y_, _x_) * `M_1_PI_F`.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *cbrt*
-| Implemented as rootn(x, 3).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *rootn*(_x_, 3).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *cos*
-| For x in the domain [-{pi}, {pi}], the maximum absolute error is \<=
-  2^-11^ and larger otherwise.
+    | For _x_ in the domain [-{pi}, {pi}], the maximum absolute error
+      is {leq} 2^-11^ and larger otherwise.
 
 | *OpExtInst* *cosh*
-| Defined for x in the domain [-{inf}, {inf}] and implemented as 0.5f * (
-  exp(x) + exp(-x) ).
-  For non-derived implementations, the error is \<= 8192 ULP.
+    | Defined for _x_ in the domain [-{inf}, {inf}].
+      Derived implementations may implement as 0.5f * (*exp*(_x_) + *exp*(-_x_)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *cospi*
-| For x in the domain [-1, 1], the maximum absolute error is \<= 2^-11^ and
-  larger otherwise.
+    | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
+      2^-11^ and larger otherwise.
 
 | *OpExtInst* *exp*
-| \<= 3 + floor( fabs(2 * x) ) ulp for the full profile, and \<= 4 ulp for
-  the embedded profile.
+    | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
+      4 ulp for the embedded profile.
 
 | *OpExtInst* *exp2*
-| \<= 3 + floor( fabs(2 * x) ) ulp for the full profile, and \<= 4 ulp for
-  the embedded profile.
+    | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
+      4 ulp for the embedded profile.
 
 | *OpExtInst* *exp10*
-| Derived implementations implement this as exp2( x * log2(10) ).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *exp2*(_x_ * *log2*(10)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *expm1*
-| Derived implementations implement this as exp(x) - 1.
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *exp*(_x_) - 1.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *log*
-| For x in the domain [0.5, 2] the maximum absolute error is \<= 2^-21^;
-  otherwise the maximum error is \<=3 ulp for the full profile and \<= 4 ulp
-  for the embedded profile
+    | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
 
 | *OpExtInst* *log2*
-| For x in the domain [0.5, 2] the maximum absolute error is \<= 2^-21^;
-  otherwise the maximum error is \<=3 ulp for the full profile and \<= 4 ulp
-  for the embedded profile
+    | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
 
 | *OpExtInst* *log10*
-| For x in the domain [0.5, 2] the maximum absolute error is \<= 2^-21^;
-  otherwise the maximum error is \<=3 ulp for the full profile and \<= 4 ulp
-  for the embedded profile
+    | For _x_ in the domain [0.5, 2] the maximum absolute error is {leq}
+      2^-21^; otherwise the maximum error is {leq} 3 ulp for the full profile
+      and {leq} 4 ulp for the embedded profile.
 
 | *OpExtInst* *log1p*
-| Derived implementations implement this as log(x + 1).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as *log*(_x_ + 1).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *pow*
-| Undefined for x = 0 and y = 0.
-  Undefined for x < 0 and non-integer y.
-  Undefined for x < 0 and y outside the domain [-2^24^, 2^24^].
-  For x > 0 or x < 0 and even y, derived implementations implement this as
-  exp2( y * log2( fabs(x) ) ).
-  For x < 0 and odd y, derived implementations implement this as -exp2( y *
-  log2( fabs(x) ).
-  For x == 0 and nonzero y, derived implementations return zero.
-  For non-derived implementations, the error is \<= 8192 ULP.
+    | Undefined for _x_ = 0 and _y_ = 0.
+      Undefined for _x_ < 0 and non-integer _y_.
+      Undefined for _x_ < 0 and _y_ outside the domain [-2^24^, 2^24^].
+      For _x_ > 0 or _x_ < 0 and even _y_, derived implementations may implement as
+      *exp2*(_y_ * *log2*(*fabs*(_x_))).
+      For _x_ < 0 and odd _y_, derived implementations may implement as
+      -*exp2*(_y_ * *log2*(*fabs*(_x_)).
+      For _x_ == 0 and non-zero _y_, for derived implementations may return zero.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
-  On some implementations, powr() or pown() may perform faster
-  than pow().
-  If x is known to be >= 0, consider using powr() in place of pow(),
-  or if y is known to be an integer, consider using pown() in place of
-  pow().
+      On some implementations, powr() or pown() may perform faster
+      than pow().
+      If x is known to be >= 0, consider using powr() in place of pow(),
+      or if y is known to be an integer, consider using pown() in place of
+      pow().
 
 | *OpExtInst* *pown*
-| Defined only for integer values of y.
-  Undefined for x = 0 and y = 0.
-  For x >= 0 or x < 0 and even y, derived implementations implement this as
-  exp2( y * log2( fabs(x) ) ).
-  For x < 0 and odd y, derived implementations implement this as -exp2( y *
-  log2( fabs(x) ) ).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Defined only for integer values of _y_.
+      Undefined for _x_ = 0 and _y_ = 0.
+      For _x_ >= 0 or _x_ < 0 and even _y_, derived implementations may implement as
+      *exp2*(_y_ * *log2*(*fabs*(_x_))).
+      For _x_ < 0 and odd _y_, derived implementations may implement as
+      -*exp2*(_y_ * *log2*(*fabs*(_x_))).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *powr*
-| Defined only for x >= 0.
-  Undefined for x = 0 and y = 0.
-  Derived implementations implement this as exp2( y * log2(x) ).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Defined only for _x_ >= 0.
+      Undefined for _x_ = 0 and _y_ = 0.
+      Derived implementations may implement as *exp2*(_y_ * *log2*(_x_)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *rootn*
-| Defined for x > 0 when y is non-zero, derived implementations implement
-  this case as exp2( log2(x) / y ).
-  Defined for x < 0 when y is odd, derived implementations implement this
-  case as -exp2( log2(-x) / y ).
-  Defined for x = +/-0 when y > 0, derived implementations will return +0 in
-  this case.
-  For non-derived implementations, the error is \<= 8192 ULP.
+    | Defined for _x_ > 0 when _y_ is non-zero, derived implementations
+      may implement this case as *exp2*(*log2*(_x_) / _y_).
+      Defined for _x_ < 0 when _y_ is odd, derived implementations
+      may implement this case as -*exp2*(*log2*(-_x_) / _y_).
+      Defined for _x_ = +/-0 when _y_ > 0, derived implementations may
+      return +0 in this case.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *sin*
-| For x in the domain [-{pi}, {pi}], the maximum absolute error is \<=
-  2^-11^ and larger otherwise.
+    | For _x_ in the domain [-{pi}, {pi}], the maximum absolute error is
+      {leq} 2^-11^ and larger otherwise.
 
 | *OpExtInst* *sincos*
-| ulp values as defined for sin(x) and cos(x).
+    | ulp values as defined for *sin*(_x_) and *cos*(_x_).
 
 | *OpExtInst* *sinh*
-| Defined for x in the domain [-{inf}, {inf}].
-  For x in [-2^-10^, 2^-10^], derived implementations implement as x.
-  For x outside of [-2^-10^, 2^-10^], derived implement as 0.5f * ( exp(x) -
-  exp(-x) ).
-  For non-derived implementations, the error is \<= 8192 ULP.
+    | Defined for _x_ in the domain [-{inf}, {inf}].
+      For _x_ in [-2^-10^, 2^-10^], derived implementations
+      may implement as _x_.
+      For _x_ outside of [-2^-10^, 2^-10^], derived implementations
+      may implement as 0.5f * (*exp*(_x_) - *exp*(-_x_)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *sinpi*
-| For x in the domain [-1, 1], the maximum absolute error is \<= 2^-11^ and
-  larger otherwise.
+    | For _x_ in the domain [-1, 1], the maximum absolute error is {leq}
+      2^-11^ and larger otherwise.
 
 | *OpExtInst* *tan*
-| Derived implementations implement this as sin(x) * ( 1.0f / cos(x) ).
-  For non-derived implementations, the error is \<= 8192 ulp.
+    | Derived implementations may implement as
+      *sin*(_x_) * (1.0f / *cos*(_x_)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *tanh*
-| Defined for x in the domain [-{inf}, {inf}].
-  For x in [-2^-10^, 2^-10^], derived implementations implement as x.
-  For x outside of [-2^-10^, 2^-10^], derived implementations implement as
-  (exp(x) - exp(-x)) / (exp(x) + exp(-x)).
-  For non-derived implementations, the error is \<= 8192 ULP.
+    | Defined for _x_ in the domain [-{inf}, {inf}].
+      For _x_ in [-2^-10^, 2^-10^], derived implementations
+      may implement as _x_.
+      For _x_ outside of [-2^-10^, 2^-10^], derived implementations
+      may implement as (*exp*(_x_) - *exp*(-_x_)) / (*exp*(_x_) + *exp*(-_x_)).
+      For non-derived implementations, the error is {leq} 8192 ULP.
 
 | *OpExtInst* *tanpi*
-| Derived implementations implement this as tan(x * M_PI_F).
-  For non-derived implementations, the error is \<= 8192 ulp for x in the
-  domain [-1, 1].
+    | Derived implementations may implement as *tan*(_x_ * `M_PI_F`).
+      For non-derived implementations, the error is {leq} 8192 ulp for _x_
+      in the domain [-1, 1].
 
 | *OpFMul* and *OpFAdd*, +
   for _x_ * _y_ + _z_
-| Implemented either as a correctly rounded fma or as a multiply and an add
-  both of which are correctly rounded.
+    | Implemented either as a correctly rounded *fma* or as a multiply and
+      an add both of which are correctly rounded.
 
 |====
 

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1364,7 +1364,7 @@ profile.
 | *Function*
 | *Minimum Accuracy*
 
-| *1.0 / _x_*
+| *OpFDiv* for 1.0 / _x_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
       profile, and {leq} 3 ulp for the embedded profile.
 


### PR DESCRIPTION
This PR fixes several bugs in the fast math tables in both the OpenCL C and SPIR-V environment specifications and also adds consistent bold and italics to the SPIR-V environment specification (see internal issue 98).

The easiest way to review these changes is to review the OpenCL C specification first, since there were fewer changes there.  There are more changes to the SPIR-V environment specification, but they are exclusively for wording and formatting.

A summary of the non-cosmetic changes is:

* In the OpenCL C spec, the derived formula for `atan2` was wrong - need to add or subtract `M_PI_F` and not `M_1_PI_F`.
* In the OpenCL C spec, the derived formula for `atan2pi` was wrong - need to multiply by `M_1_PI_F` (equivalent to dividing by pi), not by `M_PI_F`.
* In the OpenCL C spec, the expansion with `exp` applies outside of the range `[-2^-10, +2^-10]`, not outside of the range `[-2^10, 2^10]`.

There are still a few differences between the OpenCL C specs and the SPIR-V environment specs but I will file a separate issue for them.