### PR TITLE
Reserve some XML values for unpublished extensions.

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -556,7 +556,11 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums start="-1122" end="-1137" name="ErrorCodes.1122" vendor="IMG" comment="Reserved for Imagination extensions">
-            <unused start="-1122" end="-1137"/>
+        <enum value="-1122"         name="CL_ERROR_RESERVED0_IMG"/>
+        <enum value="-1123"         name="CL_ERROR_RESERVED1_IMG"/>
+        <enum value="-1124"         name="CL_ERROR_RESERVED2_IMG"/>
+        <enum value="-1125"         name="CL_ERROR_RESERVED3_IMG"/>
+            <unused start="-1126" end="-1137"/>
     </enums>
 
     <enums start="-1138" end="-9999" name="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
@@ -1728,7 +1732,10 @@ server's OpenCL/api-docs repository.
         <enum value="0x40D5"        name="CL_INVALID_GRALLOC_OBJECT_IMG"/>
         <enum value="0x40D6"        name="CL_COMMAND_GENERATE_MIPMAP_IMG"/>
         <enum value="0x40D7"        name="CL_MEM_ALLOC_FLAGS_IMG"/>
-            <unused start="0x40D8" end="0x40DF"/>
+        <enum value="0x40D8"        name="CL_RESERVED0_IMG"/>
+        <enum value="0x40D9"        name="CL_RESERVED1_IMG"/>
+        <enum value="0x40DA"        name="CL_RESERVED2_IMG"/>
+            <unused start="0x40DB" end="0x40DF"/>
     </enums>
 
     <enums start="0x40E0" end="0x40EF" name="enums.40E0" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">


### PR DESCRIPTION
These will be re-named later after publication.