### PR TITLE
Improved description for pipe specifier.

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -191,7 +191,7 @@ OpenCL C compilers for FULL profile devices or devices with 64-bit pointers
 must always define the {opencl_c_int64} feature macro.
 
 | {opencl_c_pipes}
-| The OpenCL C compiler supports the pipe modifier and built-in functions
+| The OpenCL C compiler supports the pipe specifier and built-in functions
 to read and write from a pipe.
 
 OpenCL C compilers that define the feature macro {opencl_c_pipes} must
@@ -10070,14 +10070,14 @@ pipe user_type_t pipeB; // a pipe with user_type_t packets
 ----------
 
 The `read_only` (or `+__read_only+`) and `write_only` (or `+__write_only+`)
-qualifiers must be used with the `pipe` qualifier when a pipe is a parameter
+qualifiers must be used with the `pipe` specifier when a pipe is a parameter
 of a kernel or of a user-defined function to identify if a pipe can be read
 from or written to by a kernel and its callees and enqueued child kernels.
 If no qualifier is specified, `read_only` is assumed.
 
 A kernel cannot read from and write to the same pipe object.
 Using the `read_write` (or `+__read_write+`) qualifier with the `pipe`
-qualifier is a compilation error.
+specifier is a compilation error.
 
 In the following example
 
@@ -10102,7 +10102,7 @@ The macro `CLK_NULL_RESERVE_ID` refers to an invalid reservation ID.
   * Pipes can only be passed as arguments to a function (including kernel
     functions).
     The <<operators,C operators>> cannot be used with variables declared
-    with the pipe qualifier.
+    with the pipe specifier.
   * The `pipe` specifier cannot be used with variables declared inside a
     kernel, a structure or union field, a pointer type, an array, global
     variables declared in program scope or the return type of a function.


### PR DESCRIPTION
Pipe specifies a very distinct type from its
element and therefore a better wording describing
it should be `'type specifier'`.

Note that pipe can not be a type qualifier because
in C-based languages, a type qualifier is an optional
property that doesn't modify the representation of the
type (i.e. casting away qualifiers is valid in certain
circumstances). OpenCL spec never allowed to cast away
pipe and doing so won't result in anything useful
unless there is some knowledge of its implementation.