### PR TITLE
cl_ext_float_atomics

### DIFF
--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -320,11 +320,11 @@ C atomic_fetch_max_explicit(volatile __local A *object, M operand,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_min_max feature
-// or the __opencl_c_ext_fp16_local_atomic_min_mas feature (for atomic_half),
+// or the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
 // requires the __opencl_c_ext_fp32_global_atomic_min_max feature
-// or the __opencl_c_ext_fp32_local_atomic_min_mas feature (for atomic_float), or
+// or the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
 // requires the __opencl_c_ext_fp64_global_atomic_min_max feature
-// or the __opencl_c_ext_fp64_local_atomic_min_mas feature (for atomic_double).
+// or the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
 C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
@@ -589,12 +589,12 @@ C atomic_fetch_max_explicit(volatile __local A *object, M operand,
     memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
-// requires the __opencl_c_ext_fp16_global_atomic_min_mas feature
-// or the __opencl_c_ext_fp16_local_atomic_min_mas feature (for atomic_half),
-// requires the __opencl_c_ext_fp32_global_atomic_min_mas feature
-// or the __opencl_c_ext_fp32_local_atomic_min_mas feature (for atomic_float), or
-// requires the __opencl_c_ext_fp64_global_atomic_min_mas feature
-// or the __opencl_c_ext_fp64_local_atomic_min_mas feature (for atomic_double).
+// requires the __opencl_c_ext_fp16_global_atomic_min_max feature
+// or the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_min_max feature
+// or the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_min_max feature
+// or the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
 C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -3,6 +3,7 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 :data-uri:
+:sectanchors:
 :icons: font
 :source-highlighter: coderay
 

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -642,7 +642,7 @@ If the OpenCL environment supports the extension `cl_ext_float_atomics` and the 
   * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_add`.
-If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float16_add`.
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
 Additionally:
 
   * When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -1,0 +1,607 @@
+// Copyright 2018-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+:data-uri:
+:icons: font
+:source-highlighter: coderay
+
+= cl_ext_float_atomics
+:R: pass:q,r[^(R)^]
+Khronos{R} OpenCL Working Group
+
+== Name Strings
+
+`cl_ext_float_atomics`
+
+== Contact
+
+Please see the *Issues* list in the Khronos *OpenCL-Docs* repository: +
+https://github.com/KhronosGroup/OpenCL-Docs
+
+== Contributors
+
+// spell-checker: disable
+Ben Ashbaugh, Intel +
+Alex Paige, Intel +
+Lukasz Towarek, Intel
+// spell-checker: enable
+
+== Notice
+
+Copyright TBD
+
+== Status
+
+Working Draft - [red]*DO NOT SHIP*
+
+== Version
+
+Built On: {docdate} +
+Revision: 0.9.0
+
+== Dependencies
+
+This extension is written against the OpenCL API Specification, OpenCL C Specification, and OpenCL SPIR-V Environment Specification Versions 3.0.5.
+
+The functionality added by this extension uses the OpenCL C 2.0 atomic syntax and hence requires OpenCL 2.0 or newer.
+
+This extension interacts with `cl_khr_fp16` by optionally adding the ability to atomically operate on 16-bit floating point values in memory.
+
+This extension depends on `SPV_EXT_shader_float_atomic_add` and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
+
+== Overview
+
+This extension enables programmers to perform atomic operations on floating-point numbers in memory.
+An OpenCL device supporting this extension may support atomic operations on 16-bit half-precision floating-point values (`fp16`), 32-bit single-precision floating-point values (`fp32`), or 64-bit double-precision floating-point values (`fp64`).
+For these types, an OpenCL device may support basic atomic operations (load, store, and exchange), atomic addition and subtraction, and atomic min and max.
+The floating-point numbers may be in global or local memory.
+
+== New API Functions
+
+None.
+
+== New API Enums
+
+Accepted value for the _param_name_ parameter to *clGetDeviceInfo* to query the floating-point atomic capabilities of an OpenCL device:
+
+[source]
+----
+#define CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT 0xXXXX
+#define CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT 0xXXXX
+#define CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT   0xXXXX
+----
+
+Bitfield type describing the floating-point atomic capabilities of an OpenCL device.
+Subsequent versions of this extension may add additional floating-point atomic capabilities:
+
+[source]
+----
+typedef cl_bitfield         cl_device_fp_atomic_capabilities;
+
+#define CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT       (1 << 0)
+#define CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT              (1 << 1)
+#define CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT          (1 << 2)
+
+/* bits 3 - 15 are currently unused */
+
+#define CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT        (1 << 16)
+#define CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT               (1 << 17)
+#define CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT           (1 << 18)
+
+/* bits 19 and beyond are currently unused */
+----
+
+== New OpenCL C Feature Names
+
+[source]
+----
+__opencl_c_ext_fp16_global_atomic_load_store
+__opencl_c_ext_fp16_local_atomic_load_store
+__opencl_c_ext_fp16_global_atomic_add
+__opencl_c_ext_fp32_global_atomic_add
+__opencl_c_ext_fp64_global_atomic_add
+__opencl_c_ext_fp16_local_atomic_add
+__opencl_c_ext_fp32_local_atomic_add
+__opencl_c_ext_fp64_local_atomic_add
+__opencl_c_ext_fp16_global_atomic_min_max
+__opencl_c_ext_fp32_global_atomic_min_max
+__opencl_c_ext_fp64_global_atomic_min_max
+__opencl_c_ext_fp16_local_atomic_min_max
+__opencl_c_ext_fp32_local_atomic_min_max
+__opencl_c_ext_fp64_local_atomic_min_max
+----
+
+== New OpenCL C Types
+
+[source]
+----
+atomic_half
+----
+
+== New OpenCL C Functions
+
+Add support for `atomic_half` for the following functions:
+
+[source]
+----
+// atomic_store:
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+void atomic_store(volatile __global A *object, C desired)
+void atomic_store_explicit(volatile __global A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+void atomic_store(volatile __local A *object, C desired)
+void atomic_store_explicit(volatile __local A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+void atomic_store(volatile A *object, C desired)
+void atomic_store_explicit(volatile A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+
+// atomic_load:
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+C atomic_load(volatile __global A *object)
+C atomic_load_explicit(volatile __global A *object, memory_order order)
+C atomic_load_explicit(volatile __global A *object, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_load(volatile __local A *object)
+C atomic_load_explicit(volatile __local A *object, memory_order order)
+C atomic_load_explicit(volatile __local A *object, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_load(volatile A *object)
+C atomic_load_explicit(volatile A *object, memory_order order)
+C atomic_load_explicit(volatile A *object, memory_order order, memory_scope scope)
+
+// atomic_exchange:
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+C atomic_exchange(volatile __global A *object, C desired)
+C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_exchange(volatile __local A *object, C desired)
+C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_exchange(volatile A *object, C desired)
+C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+----
+
+Add support for `atomic_half`, `atomic_float`, and `atomic_double` for the following functions:
+
+[source]
+----
+// atomic_fetch_add / atomic_fetch_sub:
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile __global A *object, M operand)
+C atomic_fetch_sub(volatile __global A *object, M operand)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile __local A *object, M operand)
+C atomic_fetch_sub(volatile __local A *object, M operand)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_add feature
+// or the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_add feature
+// or the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_add feature
+// or the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile A *object, M operand)
+C atomic_fetch_sub(volatile A *object, M operand)
+C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+
+// atomic_fetch_min / atomic_fetch_max:
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_min_max feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_min_max feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_min_max feature (for atomic_double).
+C atomic_fetch_min(volatile __global A *object, M operand)
+C atomic_fetch_max(volatile __global A *object, M operand)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
+C atomic_fetch_min(volatile __local A *object, M operand)
+C atomic_fetch_max(volatile __local A *object, M operand)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp16_local_atomic_min_mas feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp32_local_atomic_min_mas feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp64_local_atomic_min_mas feature (for atomic_double).
+C atomic_fetch_min(volatile A *object, M operand)
+C atomic_fetch_max(volatile A *object, M operand)
+C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+----
+
+== Modifications to the OpenCL API Specification
+
+Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
++
+--
+[caption="Table 5. "]
+.List of supported param_names by clGetDeviceInfo
+[width="100%",cols="3,2,5",options="header"]
+|====
+| Device Info | Return Type | Description
+| `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`
+  `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`
+  `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT`
+  | `cl_device_fp_atomic_capabilities`
+      | Describes the floating-point atomic operations supported by the device.
+        This is a bit-field that describes a combination of the following values:
+
+        `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` - Can perform floating-point load, store, and exchange atomic operations in global memory. +
+        `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in global memory.
+        `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` - Can perform floating-point min and max atomic operations in global memory.
+
+        `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT` - Can perform floating-point load, store, and exchange atomic operations in local memory. +
+        `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in local memory.
+        `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT` - Can perform floating-point min and max atomic operations in local memory.
+|====
+--
+
+== Modifications to the OpenCL C Specification
+
+Add to Table 1 - Optional features in OpenCL C 3.0 or newer and their predefined macros: ::
++
+--
+[caption="Table 1. "]
+.Optional features in OpenCL C 3.0 or newer and their predefined macros
+[cols="1,1",options="header",]
+|====
+| *Feature Macro/Name*
+| *Brief Description*
+
+| `+__opencl_c_ext_fp16_global_atomic_load_store+`, +
+  `+__opencl_c_ext_fp16_local_atomic_load_store+`
+
+| The OpenCL C compiler supports built-in functions to atomically load, store, or exchange 16-bit floating-point values in `+__global+` or `+__local+` memory.
+
+OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_load_store+` or `+__opencl_c_ext_fp16_local_atomic_load_store+` must also support the OpenCL extension `cl_khr_fp16`.
+
+Note: built-in functions to atomically load, store, or exchange 32-bit and 64-bit floating-point values are already in OpenCL C 2.0 and newer.
+
+| `+__opencl_c_ext_fp16_global_atomic_add+`, +
+  `+__opencl_c_ext_fp32_global_atomic_add+`, +
+  `+__opencl_c_ext_fp64_global_atomic_add+`, +
+  `+__opencl_c_ext_fp16_local_atomic_add+`, +
+  `+__opencl_c_ext_fp32_local_atomic_add+`, +
+  `+__opencl_c_ext_fp64_local_atomic_add+`
+| The OpenCL C compiler supports built-in functions to atomically add to or subtract from 16-bit, 32-bit, or 64-bit floating-point values in `+__global+` or `+__local+` memory.
+
+OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_add+` or `+__opencl_c_ext_fp16_local_atomic_add+` must also support the OpenCL extension `cl_khr_fp16`.
+
+OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp64_global_atomic_add+` or `+__opencl_c_ext_fp64_local_atomic_add+` must also define the feature macro `+__opencl_c_fp64+`.
+
+| `+__opencl_c_ext_fp16_global_atomic_min_max+`, +
+  `+__opencl_c_ext_fp32_global_atomic_min_max+`, +
+  `+__opencl_c_ext_fp64_global_atomic_min_max+`, +
+  `+__opencl_c_ext_fp16_local_atomic_min_max+`, +
+  `+__opencl_c_ext_fp32_local_atomic_min_max+`, +
+  `+__opencl_c_ext_fp64_local_atomic_min_max+`
+| The OpenCL C compiler supports built-in functions to atomically compute the minimum or maximum of a 16-bit, 32-bit, or 64-bit floating-point operand and a value in `+__global+` or `+__local+` memory.
+
+OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_min_max+` or `+__opencl_c_ext_fp16_local_atomic_min_max+` must also support the OpenCL extension `cl_khr_fp16`.
+
+OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp64_global_atomic_min_max+` or `+__opencl_c_ext_fp64_local_atomic_min_max+` must also define the feature macro `+__opencl_c_fp64+`.
+
+|====
+--
+
+Add to the list of atomic type names in Section 6.15.12.6 Atomic integer and floating-point types: ::
++
+--
+[none]
+* `atomic_half` ^`*`^
+
+^`*`^ Only if the `cl_khr_fp16` extension is supported and has been enabled.
+
+[red]*TODO* Does this type need an `ext` prefix or suffix?
+--
+
+Add `atomic_half` to the list of atomic types supported by the `atomic_store` functions in section 6.15.12.7.1: ::
++
+--
+[source]
+----
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+void atomic_store(volatile __global A *object, C desired)
+void atomic_store_explicit(volatile __global A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+void atomic_store(volatile __local A *object, C desired)
+void atomic_store_explicit(volatile __local A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+void atomic_store(volatile A *object, C desired)
+void atomic_store_explicit(volatile A *object, C desired, memory_order order)
+void atomic_store_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+----
+--
+
+Add `atomic_half` to the list of atomic types supported by the `atomic_load` functions in section 6.15.12.7.2: ::
++
+--
+[source]
+----
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+C atomic_load(volatile __global A *object)
+C atomic_load_explicit(volatile __global A *object, memory_order order)
+C atomic_load_explicit(volatile __global A *object, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_load(volatile __local A *object)
+C atomic_load_explicit(volatile __local A *object, memory_order order)
+C atomic_load_explicit(volatile __local A *object, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_load(volatile A *object)
+C atomic_load_explicit(volatile A *object, memory_order order)
+C atomic_load_explicit(volatile A *object, memory_order order, memory_scope scope)
+----
+--
+
+Add `atomic_half` to the list of atomic types supported by the `atomic_exchange` functions in section 6.15.12.7.3: ::
++
+--
+[source]
+----
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
+C atomic_exchange(volatile __global A *object, C desired)
+C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_exchange(volatile __local A *object, C desired)
+C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_load_store feature
+// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+C atomic_exchange(volatile A *object, C desired)
+C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
+C atomic_exchange_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+----
+--
+
+Add new floating-point atomic fetch and modify functions for the atomic operations add and sub for the atomic types `atomic_half`, `atomic_float`, and `atomic_double`: ::
++
+--
+[source]
+----
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile __global A *object, M operand)
+C atomic_fetch_sub(volatile __global A *object, M operand)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile __local A *object, M operand)
+C atomic_fetch_sub(volatile __local A *object, M operand)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_add feature
+// or the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_add feature
+// or the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_add feature
+// or the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+C atomic_fetch_add(volatile A *object, M operand)
+C atomic_fetch_sub(volatile A *object, M operand)
+C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+----
+--
+
+Also add new floating-point atomic fetch and modify functions for the atomic operations min and max for the atomic types `atomic_half`, `atomic_float`, and `atomic_double`: ::
++
+--
+[source]
+----
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_min_max feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_min_max feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_min_max feature (for atomic_double).
+C atomic_fetch_min(volatile __global A *object, M operand)
+C atomic_fetch_max(volatile __global A *object, M operand)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
+C atomic_fetch_min(volatile __local A *object, M operand)
+C atomic_fetch_max(volatile __local A *object, M operand)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+
+// In addition to the requirements described in the OpenCL C 3.0 specification,
+// requires the __opencl_c_ext_fp16_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp16_local_atomic_min_mas feature (for atomic_half),
+// requires the __opencl_c_ext_fp32_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp32_local_atomic_min_mas feature (for atomic_float), or
+// requires the __opencl_c_ext_fp64_global_atomic_min_mas feature
+// or the __opencl_c_ext_fp64_local_atomic_min_mas feature (for atomic_double).
+C atomic_fetch_min(volatile A *object, M operand)
+C atomic_fetch_max(volatile A *object, M operand)
+C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order)
+C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+----
+--
+
+== Modifications to the OpenCL SPIR-V Environment Specification
+
+(Add a new section 5.2.X - `cl_ext_float_atomics`) ::
++
+--
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, then for the *Atomic Instructions* *OpAtomicLoad*, *OpAtomicStore*, and *OpAtomicExchange*:
+
+  * 16-bit floating-point types are supported for the _Result Type_ and type of _Value_.
+  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+// TODO: Do we need to say this explicitly?  It is debatably already covered by
+// the exiting validation rule describing the GenericPointer capability and
+// Atomic instructions.
+//  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
+Additionally:
+
+  * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.
+  * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat64AddEXT* capability must be supported.
+  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat16AddEXT* capability must be supported.
+  * For the *Atomic Instruction* *OpAtomicFAddEXT* added by these extensions:
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+//   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_min_max`.
+Additionally:
+
+  * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat32MinMaxEXT* capability must be supported.
+  * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat64MinMaxEXT* capability must be supported.
+  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat16MinMaxEXT* capability must be supported.
+  * For the *Atomic Instructions* *OpAtomicFMinEXT* and *OpAtomicFMaxEXT* added by this extension:
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+//   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+
+--
+
+== Issues
+
+. Do the enums added by this extension need an `EXT` suffix?
++
+--
+`RESOLVED`: Yes, as per the extension template, enums and APIs added by EXT extensions need an `EXT` suffix.
+--
+
+. Do the OpenCL C built-in functions or types added by this extension need an `ext` prefix or suffix?
++
+--
+`UNRESOLVED`: I do not think we have had an EXT extension that extends OpenCL C yet.
+--
+
+. Do we need to establish a naming convention for OpenCL C feature and feature test macro names added by extensions?
++
+--
+`UNRESOLVED`: The core feature names are all `+__opencl_c_feature_name+`.
+For extensions we could either keep the same convention, or adopt something similar to `+__opencl_c_<khr|ext|vendor>_feature_name+`?
+This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C feature test macro names it adds.
+--
+
+. Do we need to support the legacy OpenCL C 1.x atomic syntax, or is it sufficient to only support the newer OpenCL C 2.0 atomic syntax?
++
+--
+`UNRESOLVED`: It is straightforward to add the legacy syntax if desired.
+--
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Version|Date|Author|Changes
+|0.9.0|2020-01-26|Ben Ashbaugh|*Initial public revision.*
+|========================================
+
+//************************************************************************
+//Other formatting suggestions:
+//
+//* Use *bold* text for host APIs, or [source] syntax highlighting.
+//* Use `mono` text for device APIs, or [source] syntax highlighting.
+//* Use `mono` text for extension names, types, or enum values.
+//* Use _italics_ for parameters.
+//************************************************************************

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -23,27 +23,29 @@ https://github.com/KhronosGroup/OpenCL-Docs
 == Contributors
 
 // spell-checker: disable
+Stuart Brady, ARM +
 Ben Ashbaugh, Intel +
 Alex Paige, Intel +
-Lukasz Towarek, Intel
+Lukasz Towarek, Intel +
+Ruihao Zhang, Qualcomm
 // spell-checker: enable
 
 == Notice
 
-Copyright TBD
+Copyright (c) 2021 The Khronos Group Inc.
 
 == Status
 
-Working Draft - [red]*DO NOT SHIP*
+Final Draft
 
 == Version
 
 Built On: {docdate} +
-Revision: 0.9.1
+Revision: 0.9.3
 
 == Dependencies
 
-This extension is written against the OpenCL API Specification, OpenCL C Specification, and OpenCL SPIR-V Environment Specification Versions 3.0.5.
+This extension is written against the OpenCL API Specification, OpenCL C Specification, and OpenCL SPIR-V Environment Specification Versions 3.0.8.
 
 The functionality added by this extension uses the OpenCL C 2.0 atomic syntax and hence requires OpenCL 2.0 or newer.
 
@@ -257,11 +259,11 @@ C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order 
 C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
-// requires the __opencl_c_ext_fp16_global_atomic_min_mas feature
+// requires the __opencl_c_ext_fp16_global_atomic_min_max feature
 // or the __opencl_c_ext_fp16_local_atomic_min_mas feature (for atomic_half),
-// requires the __opencl_c_ext_fp32_global_atomic_min_mas feature
+// requires the __opencl_c_ext_fp32_global_atomic_min_max feature
 // or the __opencl_c_ext_fp32_local_atomic_min_mas feature (for atomic_float), or
-// requires the __opencl_c_ext_fp64_global_atomic_min_mas feature
+// requires the __opencl_c_ext_fp64_global_atomic_min_max feature
 // or the __opencl_c_ext_fp64_local_atomic_min_mas feature (for atomic_double).
 C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
@@ -596,37 +598,35 @@ Additionally:
 . Do the OpenCL C built-in functions or types added by this extension need an `ext` prefix or suffix?
 +
 --
-`UNRESOLVED`: I do not think we have had an EXT extension that extends OpenCL C yet.
+`RESOLVED`: No prefix is required for built-in functions added by EXT extensions if the functionality is unlikely to change if it becomes a KHR or core feature.
 --
 
 . Do we need to establish a naming convention for OpenCL C feature and feature test macro names added by extensions?
 +
 --
-`UNRESOLVED`: The core feature names are all `+__opencl_c_feature_name+`.
-For extensions we could either keep the same convention, or adopt something similar to `+__opencl_c_<khr|ext|vendor>_feature_name+`?
-This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C feature test macro names it adds.
+`RESOLVED`: Yes, we will include a prefix in the name of the feature and feature test macro names for EXT and vendor extensions.
+This gives us the ability to change functionality if it becomes a KHR or core feature.
+Because this is an EXT extension it will use `+__opencl_c_ext_feature_name+` for the OpenCL C feature names it adds.
 --
 
 . Do we need to support the legacy OpenCL C 1.x atomic syntax, or is it sufficient to only support the newer OpenCL C 2.0 atomic syntax?
 +
 --
-`UNRESOLVED`: It is straightforward to add the legacy syntax if desired.
+`RESOLVED`: We will only support the newer OpenCL 2.0 atomic syntax in the initial version of this extension.
 --
 
 . Do we need to document any special floating-point behavior for floating-point atomic add?
 +
 --
-`UNRESOLVED`: Consider NaNs, infinities, rounding modes, denorm behavior, +/-0.
-
-Note, we do say explicitly that floating-point atomic add may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
+`RESOLVED`: Floating-point atomic add may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`, otherwise there is no special behavior.
 --
 
 . Do we need to document any special floating-point behavior for floating-point atomic min and max?
 +
 --
-`UNRESOLVED`: This spec currently inherits all of the special-case NaN behavior from the SPIR-V atomic min and max spec.
-
-Note, we do say explicitly that floating-point atomic min and max may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
+`RESOLVED`: This spec inherits all of the special-case NaN behavior from the SPIR-V atomic min and max spec.
+Additionally, floating-point atomic min and max may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
+Otherwise, there is no special behavior.
 --
 
 
@@ -640,6 +640,7 @@ Note, we do say explicitly that floating-point atomic min and max may be affecte
 |0.9.0|2020-01-26|Ben Ashbaugh|*Initial public revision.*
 |0.9.1|2020-01-28|Ben Ashbaugh|Fixed typo, added issues for special floating-point behavior.
 |0.9.2|2020-05-31|Ben Ashbaugh|Fixed formatting, documented interactions with compiler options affecting floating-point behavior.
+|0.9.3|2020-08-09|Ben Ashbaugh|Finalized names of built-in functions and feature test macros.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -476,6 +476,8 @@ C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
 C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
 ----
+
+The floating-point atomic add and sub operations may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
 --
 
 Also add new floating-point atomic fetch and modify functions for the atomic operations min and max for the atomic types `atomic_half`, `atomic_float`, and `atomic_double`: ::
@@ -520,7 +522,10 @@ C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, m
 C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
 ----
 
-The floating-point atomic min and max operations may behave differently than the `fmin` and `fmax` built-in functions in some cases.
+The floating-point atomic min and max operations may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
+
+Additionally, the floating-point atomic min and max operations may behave differently than the `fmin` and `fmax` built-in functions in some cases.
+
 For the floating-point atomic min operation:
 
 * *min*(x, y) = x if x < y and y otherwise,
@@ -562,6 +567,7 @@ Additionally:
   * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat64AddEXT* capability must be supported.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat16AddEXT* capability must be supported.
   * For the *Atomic Instruction* *OpAtomicFAddEXT* added by these extensions:
+   ** The instruction may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
 //   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
@@ -573,10 +579,10 @@ Additionally:
   * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat64MinMaxEXT* capability must be supported.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat16MinMaxEXT* capability must be supported.
   * For the *Atomic Instructions* *OpAtomicFMinEXT* and *OpAtomicFMaxEXT* added by this extension:
+   ** These instructions may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
 //   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
-
 --
 
 == Issues
@@ -611,12 +617,16 @@ This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C f
 +
 --
 `UNRESOLVED`: Consider NaNs, infinities, rounding modes, denorm behavior, +/-0.
+
+Note, we do say explicitly that floating-point atomic add may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
 --
 
 . Do we need to document any special floating-point behavior for floating-point atomic min and max?
 +
 --
 `UNRESOLVED`: This spec currently inherits all of the special-case NaN behavior from the SPIR-V atomic min and max spec.
+
+Note, we do say explicitly that floating-point atomic min and max may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
 --
 
 
@@ -629,6 +639,7 @@ This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C f
 |Version|Date|Author|Changes
 |0.9.0|2020-01-26|Ben Ashbaugh|*Initial public revision.*
 |0.9.1|2020-01-28|Ben Ashbaugh|Fixed typo, added issues for special floating-point behavior.
+|0.9.2|2020-05-31|Ben Ashbaugh|Fixed formatting, documented interactions with compiler options affecting floating-point behavior.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -641,7 +641,8 @@ If the OpenCL environment supports the extension `cl_ext_float_atomics` and the 
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
-If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_add`.
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float16_add`.
 Additionally:
 
   * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -7,6 +7,47 @@
 :icons: font
 :source-highlighter: coderay
 
+ifdef::backend-html5[]
+:CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_<wbr>SINGLE_<wbr>FP_<wbr>ATOMIC_<wbr>CAPABILITIES_<wbr>EXT`]
+:CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_<wbr>DOUBLE_<wbr>FP_<wbr>ATOMIC_<wbr>CAPABILITIES_<wbr>EXT`]
+:CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_<wbr>HALF_<wbr>FP_<wbr>ATOMIC_<wbr>CAPABILITIES_<wbr>EXT`]
+:cl_device_fp_atomic_capabilities_ext_TYPE: pass:q[`cl_device_<wbr>fp_<wbr>atomic_<wbr>capabilities_<wbr>ext`]
+:opencl_c_ext_fp16_global_atomic_load_store: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>global_<wbr>atomic_<wbr>load_<wbr>store`]
+:opencl_c_ext_fp16_local_atomic_load_store: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>local_<wbr>atomic_<wbr>load_<wbr>store`]
+:opencl_c_ext_fp16_global_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>global_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp32_global_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp32_<wbr>global_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp64_global_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp64_<wbr>global_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp16_local_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>local_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp32_local_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp32_<wbr>local_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp64_local_atomic_add: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp64_<wbr>local_<wbr>atomic_<wbr>add`]
+:opencl_c_ext_fp16_global_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>global_<wbr>atomic_<wbr>min_<wbr>max`]
+:opencl_c_ext_fp32_global_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp32_<wbr>global_<wbr>atomic_<wbr>min_<wbr>max`]
+:opencl_c_ext_fp64_global_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp64_<wbr>global_<wbr>atomic_<wbr>min_<wbr>max`]
+:opencl_c_ext_fp16_local_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp16_<wbr>local_<wbr>atomic_<wbr>min_<wbr>max`]
+:opencl_c_ext_fp32_local_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp32_<wbr>local_<wbr>atomic_<wbr>min_<wbr>max`]
+:opencl_c_ext_fp64_local_atomic_min_max: pass:q[`\__opencl_c_<wbr>ext_<wbr>fp64_<wbr>local_<wbr>atomic_<wbr>min_<wbr>max`]
+endif::[]
+ifndef::backend-html5[]
+:CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_&#8203;SINGLE_&#8203;FP_&#8203;ATOMIC_&#8203;CAPABILITIES_&#8203;EXT`]
+:CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_&#8203;DOUBLE_&#8203;FP_&#8203;ATOMIC_&#8203;CAPABILITIES_&#8203;EXT`]
+:CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT: pass:q[`CL_DEVICE_&#8203;HALF_&#8203;FP_&#8203;ATOMIC_&#8203;CAPABILITIES_&#8203;EXT`]
+:cl_device_fp_atomic_capabilities_ext_TYPE: pass:q[`cl_device_&#8203;fp_&#8203;atomic_&#8203;capabilities_&#8203;ext`]
+:opencl_c_ext_fp16_global_atomic_load_store: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;global_&#8203;atomic_&#8203;load_&#8203;store`]
+:opencl_c_ext_fp16_local_atomic_load_store: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;local_&#8203;atomic_&#8203;load_&#8203;store`]
+:opencl_c_ext_fp16_global_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;global_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp32_global_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp32_&#8203;global_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp64_global_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp64_&#8203;global_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp16_local_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;local_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp32_local_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp32_&#8203;local_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp64_local_atomic_add: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp64_&#8203;local_&#8203;atomic_&#8203;add`]
+:opencl_c_ext_fp16_global_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;global_&#8203;atomic_&#8203;min_&#8203;max`]
+:opencl_c_ext_fp32_global_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp32_&#8203;global_&#8203;atomic_&#8203;min_&#8203;max`]
+:opencl_c_ext_fp64_global_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp64_&#8203;global_&#8203;atomic_&#8203;min_&#8203;max`]
+:opencl_c_ext_fp16_local_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp16_&#8203;local_&#8203;atomic_&#8203;min_&#8203;max`]
+:opencl_c_ext_fp32_local_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp32_&#8203;local_&#8203;atomic_&#8203;min_&#8203;max`]
+:opencl_c_ext_fp64_local_atomic_min_max: pass:q[`\__opencl_c_&#8203;ext_&#8203;fp64_&#8203;local_&#8203;atomic_&#8203;min_&#8203;max`]
+endif::[]
+
 = cl_ext_float_atomics
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
@@ -283,10 +324,10 @@ Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
 [width="100%",cols="3,2,5",options="header"]
 |====
 | Device Info | Return Type | Description
-| `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`
-  `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`
-  `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT`
-  | `cl_device_fp_atomic_capabilities_ext`
+| {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}
+  {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}
+  {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT}
+  | {cl_device_fp_atomic_capabilities_ext_TYPE}
       | Describes the floating-point atomic operations supported by the device.
         This is a bit-field that describes a combination of the following values:
 
@@ -312,38 +353,38 @@ Add to Table 1 - Optional features in OpenCL C 3.0 or newer and their predefined
 | *Feature Macro/Name*
 | *Brief Description*
 
-| `+__opencl_c_ext_fp16_global_atomic_load_store+`, +
-  `+__opencl_c_ext_fp16_local_atomic_load_store+`
+| {opencl_c_ext_fp16_global_atomic_load_store}, +
+  {opencl_c_ext_fp16_local_atomic_load_store}
 
 | The OpenCL C compiler supports built-in functions to atomically load, store, or exchange 16-bit floating-point values in `+__global+` or `+__local+` memory.
 
-OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_load_store+` or `+__opencl_c_ext_fp16_local_atomic_load_store+` must also support the OpenCL extension `cl_khr_fp16`.
+OpenCL C compilers that define the feature macros {opencl_c_ext_fp16_global_atomic_load_store} or {opencl_c_ext_fp16_local_atomic_load_store} must also support the OpenCL extension `cl_khr_fp16`.
 
 Note: built-in functions to atomically load, store, or exchange 32-bit and 64-bit floating-point values are already in OpenCL C 2.0 and newer.
 
-| `+__opencl_c_ext_fp16_global_atomic_add+`, +
-  `+__opencl_c_ext_fp32_global_atomic_add+`, +
-  `+__opencl_c_ext_fp64_global_atomic_add+`, +
-  `+__opencl_c_ext_fp16_local_atomic_add+`, +
-  `+__opencl_c_ext_fp32_local_atomic_add+`, +
-  `+__opencl_c_ext_fp64_local_atomic_add+`
+| {opencl_c_ext_fp16_global_atomic_add}, +
+  {opencl_c_ext_fp32_global_atomic_add}, +
+  {opencl_c_ext_fp64_global_atomic_add}, +
+  {opencl_c_ext_fp16_local_atomic_add}, +
+  {opencl_c_ext_fp32_local_atomic_add}, +
+  {opencl_c_ext_fp64_local_atomic_add}
 | The OpenCL C compiler supports built-in functions to atomically add to or subtract from 16-bit, 32-bit, or 64-bit floating-point values in `+__global+` or `+__local+` memory.
 
-OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_add+` or `+__opencl_c_ext_fp16_local_atomic_add+` must also support the OpenCL extension `cl_khr_fp16`.
+OpenCL C compilers that define the feature macros {opencl_c_ext_fp16_global_atomic_add} or {opencl_c_ext_fp16_local_atomic_add} must also support the OpenCL extension `cl_khr_fp16`.
 
-OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp64_global_atomic_add+` or `+__opencl_c_ext_fp64_local_atomic_add+` must also define the feature macro `+__opencl_c_fp64+`.
+OpenCL C compilers that define the feature macros {opencl_c_ext_fp64_global_atomic_add} or {opencl_c_ext_fp64_local_atomic_add} must also define the feature macro `+__opencl_c_fp64+`.
 
-| `+__opencl_c_ext_fp16_global_atomic_min_max+`, +
-  `+__opencl_c_ext_fp32_global_atomic_min_max+`, +
-  `+__opencl_c_ext_fp64_global_atomic_min_max+`, +
-  `+__opencl_c_ext_fp16_local_atomic_min_max+`, +
-  `+__opencl_c_ext_fp32_local_atomic_min_max+`, +
-  `+__opencl_c_ext_fp64_local_atomic_min_max+`
+| {opencl_c_ext_fp16_global_atomic_min_max}, +
+  {opencl_c_ext_fp32_global_atomic_min_max}, +
+  {opencl_c_ext_fp64_global_atomic_min_max}, +
+  {opencl_c_ext_fp16_local_atomic_min_max}, +
+  {opencl_c_ext_fp32_local_atomic_min_max}, +
+  {opencl_c_ext_fp64_local_atomic_min_max}
 | The OpenCL C compiler supports built-in functions to atomically compute the minimum or maximum of a 16-bit, 32-bit, or 64-bit floating-point operand and a value in `+__global+` or `+__local+` memory.
 
-OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp16_global_atomic_min_max+` or `+__opencl_c_ext_fp16_local_atomic_min_max+` must also support the OpenCL extension `cl_khr_fp16`.
+OpenCL C compilers that define the feature macros {opencl_c_ext_fp16_global_atomic_min_max} or {opencl_c_ext_fp16_local_atomic_min_max} must also support the OpenCL extension `cl_khr_fp16`.
 
-OpenCL C compilers that define the feature macros `+__opencl_c_ext_fp64_global_atomic_min_max+` or `+__opencl_c_ext_fp64_local_atomic_min_max+` must also define the feature macro `+__opencl_c_fp64+`.
+OpenCL C compilers that define the feature macros {opencl_c_ext_fp64_global_atomic_min_max} or {opencl_c_ext_fp64_local_atomic_min_max} must also define the feature macro `+__opencl_c_fp64+`.
 
 |====
 --
@@ -355,8 +396,6 @@ Add to the list of atomic type names in Section 6.15.12.6 Atomic integer and flo
 * `atomic_half` ^`*`^
 
 ^`*`^ Only if the `cl_khr_fp16` extension is supported and has been enabled.
-
-[red]*TODO* Does this type need an `ext` prefix or suffix?
 --
 
 Add `atomic_half` to the list of atomic types supported by the `atomic_store` functions in section 6.15.12.7.1: ::
@@ -552,17 +591,15 @@ For the floating-point atomic max operation:
 (Add a new section 5.2.X - `cl_ext_float_atomics`) ::
 +
 --
-If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, then for the *Atomic Instructions* *OpAtomicLoad*, *OpAtomicStore*, and *OpAtomicExchange*:
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, then for the *Atomic Instructions* *OpAtomicLoad*, *OpAtomicStore*, and *OpAtomicExchange*:
 
   * 16-bit floating-point types are supported for the _Result Type_ and type of _Value_.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-// TODO: Do we need to say this explicitly?  It is debatably already covered by
-// the exiting validation rule describing the GenericPointer capability and
-// Atomic instructions.
+// Note: Already covered by the exiting validation rule describing the GenericPointer capability and Atomic instructions:
 //  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
-If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
 Additionally:
 
   * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.
@@ -574,7 +611,7 @@ Additionally:
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
 //   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
-If the OpenCL environment supports the extension `cl_ext_float_atomics` and the `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT` bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_min_max`.
+If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_min_max`.
 Additionally:
 
   * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat32MinMaxEXT* capability must be supported.
@@ -632,7 +669,7 @@ Otherwise, there is no special behavior.
 
 == Revision History
 
-[cols="5,15,15,70"]
+[cols="5,15,15,65"]
 [grid="rows"]
 [options="header"]
 |========================================

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -360,6 +360,8 @@ Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
         `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT` - Can perform floating-point load, store, and exchange atomic operations in local memory. +
         `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in local memory. +
         `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT` - Can perform floating-point min and max atomic operations in local memory.
+        
+        There is no mandated minimum capability.
 |====
 --
 

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -289,11 +289,11 @@ Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
         This is a bit-field that describes a combination of the following values:
 
         `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` - Can perform floating-point load, store, and exchange atomic operations in global memory. +
-        `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in global memory.
+        `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in global memory. +
         `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` - Can perform floating-point min and max atomic operations in global memory.
 
         `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT` - Can perform floating-point load, store, and exchange atomic operations in local memory. +
-        `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in local memory.
+        `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT` - Can perform floating-point addition and subtraction atomic operations in local memory. +
         `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT` - Can perform floating-point min and max atomic operations in local memory.
 |====
 --

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -65,6 +65,7 @@ https://github.com/KhronosGroup/OpenCL-Docs
 
 // spell-checker: disable
 Stuart Brady, ARM +
+Sven van Haastregt, ARM +
 Ben Ashbaugh, Intel +
 Alex Paige, Intel +
 Lukasz Towarek, Intel +

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -39,7 +39,7 @@ Working Draft - [red]*DO NOT SHIP*
 == Version
 
 Built On: {docdate} +
-Revision: 0.9.0
+Revision: 0.9.1
 
 == Dependencies
 
@@ -49,7 +49,7 @@ The functionality added by this extension uses the OpenCL C 2.0 atomic syntax an
 
 This extension interacts with `cl_khr_fp16` by optionally adding the ability to atomically operate on 16-bit floating point values in memory.
 
-This extension depends on `SPV_EXT_shader_float_atomic_add` and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
+This extension depends on `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
 
 == Overview
 
@@ -519,6 +519,25 @@ C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
 C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
 ----
+
+The floating-point atomic min and max operations may behave differently than the `fmin` and `fmax` built-in functions in some cases.
+For the floating-point atomic min operation:
+
+* *min*(x, y) = x if x < y and y otherwise,
+* *min*(-0, +0) = *min*(+0, -0) = +0 or -0,
+* *min*(x, qNaN) = *min*(qNaN, x) = x,
+* *min*(qNaN, qNaN) = qNaN,
+* *min*(x, sNaN) = *min*(sNaN, x) = NaN or x, and
+* *min*(NaN, sNaN) = *min*(sNaN, NaN) = NaN
+
+For the floating-point atomic max operation:
+
+* *max*(x, y) = y if x < y and x otherwise,
+* *max*(-0, +0) = *max*(+0, -0) = +0 or -0,
+* *max*(x, qNaN) = *max*(qNaN, x) = x,
+* *max*(qNaN, qNaN) = qNaN,
+* *max*(x, sNaN) = *max*(sNaN, x) = NaN or x, and
+* *max*(NaN, sNaN) = *max*(sNaN, NaN) = NaN
 --
 
 == Modifications to the OpenCL SPIR-V Environment Specification
@@ -588,6 +607,19 @@ This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C f
 `UNRESOLVED`: It is straightforward to add the legacy syntax if desired.
 --
 
+. Do we need to document any special floating-point behavior for floating-point atomic add?
++
+--
+`UNRESOLVED`: Consider NaNs, infinities, rounding modes, denorm behavior, +/-0.
+--
+
+. Do we need to document any special floating-point behavior for floating-point atomic min and max?
++
+--
+`UNRESOLVED`: This spec currently inherits all of the special-case NaN behavior from the SPIR-V atomic min and max spec.
+--
+
+
 == Revision History
 
 [cols="5,15,15,70"]
@@ -596,6 +628,7 @@ This extension currently uses `+__opencl_c_ext_feature_name+` for the OpenCL C f
 |========================================
 |Version|Date|Author|Changes
 |0.9.0|2020-01-26|Ben Ashbaugh|*Initial public revision.*
+|0.9.1|2020-01-28|Ben Ashbaugh|Fixed typo, added issues for special floating-point behavior.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -41,7 +41,7 @@ Final Draft
 == Version
 
 Built On: {docdate} +
-Revision: 0.9.3
+Revision: 1.0.0
 
 == Dependencies
 
@@ -70,9 +70,9 @@ Accepted value for the _param_name_ parameter to *clGetDeviceInfo* to query the 
 
 [source]
 ----
-#define CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT 0xXXXX
-#define CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT 0xXXXX
-#define CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT   0xXXXX
+#define CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT 0x4231
+#define CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT 0x4232
+#define CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT   0x4233
 ----
 
 Bitfield type describing the floating-point atomic capabilities of an OpenCL device.
@@ -80,7 +80,7 @@ Subsequent versions of this extension may add additional floating-point atomic c
 
 [source]
 ----
-typedef cl_bitfield         cl_device_fp_atomic_capabilities;
+typedef cl_bitfield         cl_device_fp_atomic_capabilities_ext;
 
 #define CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT       (1 << 0)
 #define CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT              (1 << 1)
@@ -286,7 +286,7 @@ Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
 | `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT`
   `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT`
   `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT`
-  | `cl_device_fp_atomic_capabilities`
+  | `cl_device_fp_atomic_capabilities_ext`
       | Describes the floating-point atomic operations supported by the device.
         This is a bit-field that describes a combination of the following values:
 
@@ -641,6 +641,8 @@ Otherwise, there is no special behavior.
 |0.9.1|2020-01-28|Ben Ashbaugh|Fixed typo, added issues for special floating-point behavior.
 |0.9.2|2020-05-31|Ben Ashbaugh|Fixed formatting, documented interactions with compiler options affecting floating-point behavior.
 |0.9.3|2020-08-09|Ben Ashbaugh|Finalized names of built-in functions and feature test macros.
+|0.9.4|2020-08-11|Ben Ashbaugh|Assigned enum values.
+|1.0.0|2020-08-12|Ben Ashbaugh|*Final draft.*
 |========================================
 
 //************************************************************************

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -637,34 +637,34 @@ For the floating-point atomic max operation:
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, then for the *Atomic Instructions* *OpAtomicLoad*, *OpAtomicStore*, and *OpAtomicExchange*:
 
   * 16-bit floating-point types are supported for the _Result Type_ and type of _Value_.
-  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
-  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+  * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+  * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+  * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_add`.
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfield includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float16_add`.
 Additionally:
 
-  * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.
-  * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat64AddEXT* capability must be supported.
-  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat16AddEXT* capability must be supported.
+  * When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat32AddEXT* capability must be supported.
+  * When {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat64AddEXT* capability must be supported.
+  * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the *AtomicFloat16AddEXT* capability must be supported.
   * For the *Atomic Instruction* *OpAtomicFAddEXT* added by these extensions:
    ** The instruction may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_min_max`.
 Additionally:
 
-  * When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat32MinMaxEXT* capability must be supported.
-  * When `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat64MinMaxEXT* capability must be supported.
-  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat16MinMaxEXT* capability must be supported.
+  * When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat32MinMaxEXT* capability must be supported.
+  * When {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat64MinMaxEXT* capability must be supported.
+  * When {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the *AtomicFloat16MinMaxEXT* capability must be supported.
   * For the *Atomic Instructions* *OpAtomicFMinEXT* and *OpAtomicFMaxEXT* added by this extension:
    ** These instructions may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
+   ** When {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 --
 
 == Issues

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -175,20 +175,23 @@ Add support for `atomic_half` for the following functions:
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 void atomic_store(volatile __global A *object, C desired)
 void atomic_store_explicit(volatile __global A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile __global A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile __local A *object, C desired)
 void atomic_store_explicit(volatile __local A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile __local A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile A *object, C desired)
 void atomic_store_explicit(volatile A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // atomic_load:
 
@@ -196,20 +199,23 @@ void atomic_store_explicit(volatile A *object, C desired, memory_order order, me
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 C atomic_load(volatile __global A *object)
 C atomic_load_explicit(volatile __global A *object, memory_order order)
-C atomic_load_explicit(volatile __global A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile __global A *object,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile __local A *object)
 C atomic_load_explicit(volatile __local A *object, memory_order order)
-C atomic_load_explicit(volatile __local A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile __local A *object,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile A *object)
 C atomic_load_explicit(volatile A *object, memory_order order)
-C atomic_load_explicit(volatile A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile A *object,
+    memory_order order, memory_scope scope)
 
 // atomic_exchange:
 
@@ -217,20 +223,23 @@ C atomic_load_explicit(volatile A *object, memory_order order, memory_scope scop
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 C atomic_exchange(volatile __global A *object, C desired)
 C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile __global A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile __local A *object, C desired)
 C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile __local A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile A *object, C desired)
 C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile A *object, C desired,
+    memory_order order, memory_scope scope)
 ----
 
 Add support for `atomic_half`, `atomic_float`, and `atomic_double` for the following functions:
@@ -247,8 +256,10 @@ C atomic_fetch_add(volatile __global A *object, M operand)
 C atomic_fetch_sub(volatile __global A *object, M operand)
 C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
@@ -258,8 +269,10 @@ C atomic_fetch_add(volatile __local A *object, M operand)
 C atomic_fetch_sub(volatile __local A *object, M operand)
 C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_add feature
@@ -272,8 +285,10 @@ C atomic_fetch_add(volatile A *object, M operand)
 C atomic_fetch_sub(volatile A *object, M operand)
 C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // atomic_fetch_min / atomic_fetch_max:
 
@@ -285,8 +300,10 @@ C atomic_fetch_min(volatile __global A *object, M operand)
 C atomic_fetch_max(volatile __global A *object, M operand)
 C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
@@ -296,8 +313,10 @@ C atomic_fetch_min(volatile __local A *object, M operand)
 C atomic_fetch_max(volatile __local A *object, M operand)
 C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_min_max feature
@@ -310,8 +329,10 @@ C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
 ----
 
 == Modifications to the OpenCL API Specification
@@ -321,12 +342,12 @@ Add to Table 5 - OpenCL Device Queries in Section 4.2 - Querying Devices: ::
 --
 [caption="Table 5. "]
 .List of supported param_names by clGetDeviceInfo
-[width="100%",cols="3,2,5",options="header"]
+[width="100%",cols="4,3,5",options="header"]
 |====
 | Device Info | Return Type | Description
-| {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}
-  {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}
-  {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT}
+| {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT} +
+  {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT} +
+  {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} +
   | {cl_device_fp_atomic_capabilities_ext_TYPE}
       | Describes the floating-point atomic operations supported by the device.
         This is a bit-field that describes a combination of the following values:
@@ -407,20 +428,23 @@ Add `atomic_half` to the list of atomic types supported by the `atomic_store` fu
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 void atomic_store(volatile __global A *object, C desired)
 void atomic_store_explicit(volatile __global A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile __global A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile __local A *object, C desired)
 void atomic_store_explicit(volatile __local A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile __local A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile A *object, C desired)
 void atomic_store_explicit(volatile A *object, C desired, memory_order order)
-void atomic_store_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+void atomic_store_explicit(volatile A *object, C desired,
+    memory_order order, memory_scope scope)
 ----
 --
 
@@ -433,20 +457,23 @@ Add `atomic_half` to the list of atomic types supported by the `atomic_load` fun
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 C atomic_load(volatile __global A *object)
 C atomic_load_explicit(volatile __global A *object, memory_order order)
-C atomic_load_explicit(volatile __global A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile __global A *object,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile __local A *object)
 C atomic_load_explicit(volatile __local A *object, memory_order order)
-C atomic_load_explicit(volatile __local A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile __local A *object,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile A *object)
 C atomic_load_explicit(volatile A *object, memory_order order)
-C atomic_load_explicit(volatile A *object, memory_order order, memory_scope scope)
+C atomic_load_explicit(volatile A *object,
+    memory_order order, memory_scope scope)
 ----
 --
 
@@ -459,20 +486,23 @@ Add `atomic_half` to the list of atomic types supported by the `atomic_exchange`
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature.
 C atomic_exchange(volatile __global A *object, C desired)
 C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile __global A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile __global A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile __local A *object, C desired)
 C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile __local A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile __local A *object, C desired,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
 // or the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile A *object, C desired)
 C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
-C atomic_exchange_explicit(volatile A *object, C desired, memory_order order, memory_scope scope)
+C atomic_exchange_explicit(volatile A *object, C desired,
+    memory_order order, memory_scope scope)
 ----
 --
 
@@ -489,8 +519,10 @@ C atomic_fetch_add(volatile __global A *object, M operand)
 C atomic_fetch_sub(volatile __global A *object, M operand)
 C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
@@ -500,8 +532,10 @@ C atomic_fetch_add(volatile __local A *object, M operand)
 C atomic_fetch_sub(volatile __local A *object, M operand)
 C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_add feature
@@ -514,8 +548,10 @@ C atomic_fetch_add(volatile A *object, M operand)
 C atomic_fetch_sub(volatile A *object, M operand)
 C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order)
-C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_sub_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_add_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_sub_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
 ----
 
 The floating-point atomic add and sub operations may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
@@ -534,8 +570,10 @@ C atomic_fetch_min(volatile __global A *object, M operand)
 C atomic_fetch_max(volatile __global A *object, M operand)
 C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile __global A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __global A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
@@ -545,8 +583,10 @@ C atomic_fetch_min(volatile __local A *object, M operand)
 C atomic_fetch_max(volatile __local A *object, M operand)
 C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile __local A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile __local A *object, M operand,
+    memory_order order, memory_scope scope)
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_min_mas feature
@@ -559,8 +599,10 @@ C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
 C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order)
-C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
-C atomic_fetch_max_explicit(volatile A *object, M operand, memory_order order, memory_scope scope)
+C atomic_fetch_min_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
+C atomic_fetch_max_explicit(volatile A *object, M operand,
+    memory_order order, memory_scope scope)
 ----
 
 The floating-point atomic min and max operations may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -187,7 +187,7 @@ void atomic_store_explicit(volatile __local A *object, C desired,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile A *object, C desired)
 void atomic_store_explicit(volatile A *object, C desired, memory_order order)
 void atomic_store_explicit(volatile A *object, C desired,
@@ -211,7 +211,7 @@ C atomic_load_explicit(volatile __local A *object,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile A *object)
 C atomic_load_explicit(volatile A *object, memory_order order)
 C atomic_load_explicit(volatile A *object,
@@ -235,7 +235,7 @@ C atomic_exchange_explicit(volatile __local A *object, C desired,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile A *object, C desired)
 C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
 C atomic_exchange_explicit(volatile A *object, C desired,
@@ -276,11 +276,11 @@ C atomic_fetch_sub_explicit(volatile __local A *object, M operand,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_add feature
-// or the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// and the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
 // requires the __opencl_c_ext_fp32_global_atomic_add feature
-// or the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// and the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
 // requires the __opencl_c_ext_fp64_global_atomic_add feature
-// or the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+// and the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
 C atomic_fetch_add(volatile A *object, M operand)
 C atomic_fetch_sub(volatile A *object, M operand)
 C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
@@ -320,11 +320,11 @@ C atomic_fetch_max_explicit(volatile __local A *object, M operand,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_min_max feature
-// or the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
+// and the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
 // requires the __opencl_c_ext_fp32_global_atomic_min_max feature
-// or the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
+//and the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
 // requires the __opencl_c_ext_fp64_global_atomic_min_max feature
-// or the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
+// and the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
 C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
@@ -440,7 +440,7 @@ void atomic_store_explicit(volatile __local A *object, C desired,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 void atomic_store(volatile A *object, C desired)
 void atomic_store_explicit(volatile A *object, C desired, memory_order order)
 void atomic_store_explicit(volatile A *object, C desired,
@@ -469,7 +469,7 @@ C atomic_load_explicit(volatile __local A *object,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_load(volatile A *object)
 C atomic_load_explicit(volatile A *object, memory_order order)
 C atomic_load_explicit(volatile A *object,
@@ -498,7 +498,7 @@ C atomic_exchange_explicit(volatile __local A *object, C desired,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_load_store feature
-// or the __opencl_c_ext_fp16_local_atomic_load_store feature.
+// and the __opencl_c_ext_fp16_local_atomic_load_store feature.
 C atomic_exchange(volatile A *object, C desired)
 C atomic_exchange_explicit(volatile A *object, C desired, memory_order order)
 C atomic_exchange_explicit(volatile A *object, C desired,
@@ -539,11 +539,11 @@ C atomic_fetch_sub_explicit(volatile __local A *object, M operand,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_add feature
-// or the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
+// and the __opencl_c_ext_fp16_local_atomic_add feature (for atomic_half),
 // requires the __opencl_c_ext_fp32_global_atomic_add feature
-// or the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
+// and the __opencl_c_ext_fp32_local_atomic_add feature (for atomic_float), or
 // requires the __opencl_c_ext_fp64_global_atomic_add feature
-// or the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
+// and the __opencl_c_ext_fp64_local_atomic_add feature (for atomic_double).
 C atomic_fetch_add(volatile A *object, M operand)
 C atomic_fetch_sub(volatile A *object, M operand)
 C atomic_fetch_add_explicit(volatile A *object, M operand, memory_order order)
@@ -590,11 +590,11 @@ C atomic_fetch_max_explicit(volatile __local A *object, M operand,
 
 // In addition to the requirements described in the OpenCL C 3.0 specification,
 // requires the __opencl_c_ext_fp16_global_atomic_min_max feature
-// or the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
+// and the __opencl_c_ext_fp16_local_atomic_min_max feature (for atomic_half),
 // requires the __opencl_c_ext_fp32_global_atomic_min_max feature
-// or the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
+// and the __opencl_c_ext_fp32_local_atomic_min_max feature (for atomic_float), or
 // requires the __opencl_c_ext_fp64_global_atomic_min_max feature
-// or the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
+// and the __opencl_c_ext_fp64_local_atomic_min_max feature (for atomic_double).
 C atomic_fetch_min(volatile A *object, M operand)
 C atomic_fetch_max(volatile A *object, M operand)
 C atomic_fetch_min_explicit(volatile A *object, M operand, memory_order order)
@@ -638,8 +638,7 @@ If the OpenCL environment supports the extension `cl_ext_float_atomics` and the 
   * 16-bit floating-point types are supported for the _Result Type_ and type of _Value_.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
   * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-// Note: Already covered by the exiting validation rule describing the GenericPointer capability and Atomic instructions:
-//  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+  * When `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, then the environment must accept modules that declare use of the extensions `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float16_add`.
 Additionally:
@@ -651,7 +650,7 @@ Additionally:
    ** The instruction may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-//   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 
 If the OpenCL environment supports the extension `cl_ext_float_atomics` and the {CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT}, {CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT}, or {CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT} bitfields include `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, then the environment must accept modules that declare use of the extension `SPV_EXT_shader_atomic_float_min_max`.
 Additionally:
@@ -663,7 +662,7 @@ Additionally:
    ** These instructions may be affected by compiler options affecting floating-point behavior, such as `-cl-no-signed-zeros`, `-cl-denorms-are-zero`, and `-cl-finite-math-only`.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *CrossWorkGroup* _Storage Class_.
    ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, the _Pointer_ operand may be a pointer to the *Workgroup* _Storage Class_.
-//   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` or `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
+   ** When `CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES`, `CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES`, or `CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES` includes `CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT` and `CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT`, and the *GenericPointer* capability is supported and declared, the _Pointer_ operand may be a pointer to the *Generic* _Storage Class_.
 --
 
 == Issues
@@ -716,11 +715,6 @@ Otherwise, there is no special behavior.
 [options="header"]
 |========================================
 |Version|Date|Author|Changes
-|0.9.0|2020-01-26|Ben Ashbaugh|*Initial public revision.*
-|0.9.1|2020-01-28|Ben Ashbaugh|Fixed typo, added issues for special floating-point behavior.
-|0.9.2|2020-05-31|Ben Ashbaugh|Fixed formatting, documented interactions with compiler options affecting floating-point behavior.
-|0.9.3|2020-08-09|Ben Ashbaugh|Finalized names of built-in functions and feature test macros.
-|0.9.4|2020-08-11|Ben Ashbaugh|Assigned enum values.
 |1.0.0|2020-08-12|Ben Ashbaugh|*Final draft.*
 |========================================
 

--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -243,6 +243,32 @@ in number.  When possible, it is recommended to use properties instead,
 to conserve bitfield bits.
 ****
 
+== New OpenCL C Feature Names
+
+[source,c]
+----
+__opencl_c_interesting_feature
+----
+
+****
+The 'New OpenCL C Feature Names' section should list any optional OpenCL C
+feature names.  This can be a simple list because the feature names and
+associated feature test macros will be described in detail in following
+sections.
+
+The feature name for a KHR extension will not include an origin string, but
+features added by EXT or vendor-specific extensions will include the origin
+string in the feature name, e.g.
+
+[source,c]
+----
+__opencl_c_ext_interesting_feature
+----
+
+If the extension does not add any new OpenCL C feature names then this
+section may be omitted.
+****
+
 == New OpenCL C Functions
 
 Does interesting things:
@@ -267,6 +293,11 @@ string, e.g.
 ----
 int company_func( int param )
 ----
+
+Multi-vendor EXT extensions may omit a device-side function prefix for
+functionality that is unlikely to change if or when the functionality is
+standardized as a KHR extension or a core feature, but are encouraged to
+include a function prefix otherwise.
 
 If the extension does not add any new device-side functions then this
 section may be omitted.
@@ -466,6 +497,7 @@ best not to renumber issues, either.
 | 0.5.0   | 2020-02-13 | Kévin Petit  | Syntax fixes + added SPIR-V environment section.
 | 0.6.0   | 2020-04-20 | Alastair Murray | Use naming conventions in the new type example.
 | 0.7.0   | 2021-10-05 | Ben Ashbaugh | Added recommendation for bits in bitfields.
+| 0.8.0   | 2021-12-13 | Ben Ashbaugh | Added OpenCL C feature names section
 |====
 
 ****

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -243,6 +243,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_flags_khr</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
         <type category="define">typedef struct _cl_mutable_command_khr* <name>cl_mutable_command_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_fp_atomic_capabilities_ext</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
@@ -1267,6 +1268,17 @@ server's OpenCL/api-docs repository.
         <enum value="3"            name="CL_COMMAND_BUFFER_STATE_INVALID_KHR"/>
     </enums>
 
+    <enums name="cl_device_fp_atomic_capabilities_ext" vendor="EXT" type="bitmask">
+        <enum bitpos="0"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT"/>
+        <enum bitpos="1"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT"/>
+        <enum bitpos="2"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT"/>
+            <unused start="3" end="15"/>
+        <enum bitpos="16"           name="CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT"/>
+        <enum bitpos="17"           name="CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT"/>
+        <enum bitpos="18"           name="CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT"/>
+            <unused start="19" end="63"/>
+    </enums>
+
     <enums start="0x10000" end="0x1FFFF" name="cl_khronos_vendor_id" vendor="Khronos">
         <comment>
             In order to synchronize vendor IDs across Khronos APIs, Vulkan's vk.xml
@@ -2096,7 +2108,10 @@ server's OpenCL/api-docs repository.
 
     <enums start="0x4230" end="0x423F" name="enums.4230" comment="Reserved for EXT extensions">
         <enum value="0x4230"        name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
-            <unused start="0x4231" end="0x423F"/>
+        <enum value="0x4231"        name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
+        <enum value="0x4232"        name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
+        <enum value="0x4233"        name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
+            <unused start="0x4234" end="0x423F"/>
     </enums>
 
     <enums start="0x4240" end="0x424F" name="enums.4240" comment="Reserved for ICD Loader Layers">
@@ -6889,6 +6904,27 @@ server's OpenCL/api-docs repository.
         <extension name="cl_arm_protected_memory_allocation" supported="opencl">
             <require>
                 <enum name="CL_MEM_PROTECTED_ALLOC_ARM"/>
+            </require>
+        </extension>
+        <extension name="cl_ext_float_atomics" supported="opencl">
+            <require>
+                <type name="CL/cl.h"/>
+            </require>
+            <require>
+                <type name="cl_device_fp_atomic_capabilities_ext"/>
+            </require>
+            <require comment="cl_device_fp_atomic_capabilities_ext">
+                <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT"/>
+                <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT"/>
+                <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT"/>
+                <enum name="CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT"/>
+                <enum name="CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT"/>
+                <enum name="CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
+                <enum name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
+                <enum name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
This PR is for a multi-vendor (EXT) extension for floating-point atomics.

It is currently a draft PR because there are a few issues to resolve before it should be considered "done", but it is ready for review.  I am hoping we can close the remaining issues promptly, at which time I will remove the draft status and bump the version to `1.0.0`.

The most important areas where I would like feedback are:

- [x] Do the OpenCL C function names and types added by this extension need a prefix?  Past extensions have prefixed function names and types for vendor-specific extensions, but not for standard (KHR) extensions.  I don't think we have had an EXT extension that extensions OpenCL C before.
- [x] What should the convention be for OpenCL C feature names added by extensions?  This extension uses `__opencl_c_ext_feature_name`, which seems reasonable for an EXT extension, but I can switch to a different convention if desired.
- [x] Are there any general comments or requested changes regarding the use of OpenCL C features and feature macros to guard the optional parts of this extension, since this is the first extension that has added OpenCL C features?
- [x] Is there any need or desire to support floating-point atomics using the pre-OpenCL C 2.0 legacy atomic syntax?  Note, I think this could be added later as a follow-on extension or a newer version of this extension, if desired.

Other minor TODOs:

- [x] Confirm the correct copyright for an EXT extension - should this be the Khronos copyright or somethign different?
- [x] Assign enums in the XML file for the new API queries.  This can come out of an Intel block or a shared block.
- [x] Final editorial pass to fix any awkward wrapping, especially for long feature names or function prototypes.
- [x] Summarize any of the decisions above in the extension template.