### PR TITLE
Clarify semantics for CL_KERNEL_ARG_TYPE_NAME

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7892,9 +7892,16 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_NAME.asciidoc[]
         _arg_index_.
         The type name returned will be the argument type name as it was
         declared with any whitespace removed.
-        If argument type name is an unsigned scalar type (i.e. unsigned
-        char, unsigned short, unsigned int, unsigned long), uchar, ushort,
-        uint and ulong will be returned.
+        If the argument type name includes an unsigned scalar type (e.g.
+        `unsigned char`, `unsigned short`, `unsigned int`, `unsigned long`),
+        `uchar`, `ushort`, `uint` and `ulong` will be substituted.
+        If the argument type name includes a signed scalar type with a
+        `signed` type specifier (e.g. `signed char`, `signed short`,
+        `signed int`, `signed long`), `char`, `short`, `int` and `long`
+        will be substituted, with all other type specifiers removed.
+        Any subscript denoting a pointer type (e.g. `[]`) will be replaced
+        with `*`, including subscripts containing an unused integer value.
+        Any superfluous parentheses will be removed.
         The argument type name returned does not include any type
         qualifiers.
 | {CL_KERNEL_ARG_TYPE_QUALIFIER_anchor}


### PR DESCRIPTION
This changes the specification of CL_KERNEL_ARG_TYPE_NAME in two respects:
* It specifies substitutions for signed integer scalar types matching the already specified substitutions for unsigned scalar types. (For `short`, `int`, and `long` the newly specified substitutions match the existing behavior of Clang. For `char`, the behavior of Clang was inconsistent to this, which will be addressed by https://reviews.llvm.org/D96161.)
* It specifies further canonicalization that had been omitted from the specification, for subscript-based pointer syntax and superfluous type specifiers and parentheses. (This canonicalization is consistent with the existing behavior of Clang.)