### PR TITLE
Move descriptions of identity value for exclusive scan

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9996,16 +9996,9 @@ The *<op>* in *work_group_reduce_<op>*, *work_group_scan_exclusive_<op>* and
 *work_group_scan_inclusive_<op>* defines the operator and can be *add*,
 *min* or *max*.
 
-The inclusive scan operation takes a binary operator *op* with an identity I
-and _n_ (where _n_ is the size of the work-group) elements [a~0~, a~1~, ...
-a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ...
-*op* a~n-1~)].
-If *op* = add, the identity I is 0.
-If *op* = min, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`,
-`ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
-floating-point types.
-Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and
-`-INF`.
+The inclusive scan operation takes a binary operator *op* with _n_ (where _n_
+is the size of the work-group) elements [a~0~, a~1~, ... a~n-1~] and returns
+[a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ...  *op* a~n-1~)].
 
 Consider the following example:
 
@@ -10030,6 +10023,12 @@ The exclusive scan operation takes a binary associative operator *op* with
 an identity I and n (where n is the size of the work-group) elements [a~0~,
 a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op*
 a~1~ *op* ... *op* a~n-2~)].
+If *op* = add, the identity I is 0.
+If *op* = min, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`,
+`ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
+floating-point types.
+Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and
+`-INF`.
 For the example above, the exclusive scan add operation on the ordered set
 [3 1 7 0 4 1 6 3] would return [0 3 4 11 11 15 16 22].
 

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -340,7 +340,7 @@ The *<op>* in *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_
 
 The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
 
-The inclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
+The inclusive scan operation takes a binary operator *op* with _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
 
 If *op* = *add*, the identity I is 0.
 If *op* = *min*, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`, `ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for


### PR DESCRIPTION
The identify value is introduced in the description of the inclusive scan operations, despite only being referenced in the description of the exclusive scan operations.  Move its description into that of the exclusive scan operations, where it belongs.