### PR TITLE
Fix naming of layer header file.

### DIFF
--- a/ext/cl_loader_layers.asciidoc
+++ b/ext/cl_loader_layers.asciidoc
@@ -177,5 +177,5 @@ The official API headers are available on github, at:
 
 https://github.com/KhronosGroup/OpenCL-Headers
 The header file *CL/cl_icd.h* defines the OpenCL dispatch table.
-The header file *CL/cl_icd_layer.h* defines the necessary types
+The header file *CL/cl_layer.h* defines the necessary types
 and API entry points.

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -412,7 +412,7 @@ server's OpenCL/api-docs repository.
         <enum value="0"             name="CL_QUEUE_DEFAULT_CAPABILITIES_INTEL"/>
     </enums>
 
-    <enums name="Constants.cl_loader_layers" vendor="Khronos" comment="Defined Layer API version, in cl_icd_layer.h">
+    <enums name="Constants.cl_loader_layers" vendor="Khronos" comment="Defined Layer API version, in cl_layer.h">
         <enum value="100"           name="CL_LAYER_API_VERSION_100"/>
     </enums>
 


### PR DESCRIPTION
Fix naming of layer header to reflect final file name from https://github.com/KhronosGroup/OpenCL-Headers/pull/148.