### PR TITLE
clarify the size of a pipe is implementation-defined

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1880,7 +1880,9 @@ The behavior of applying the `sizeof` operator to the `bool`, `image2d_t`,
 `image3d_t`, `image2d_array_t`, `image1d_t`, `image1d_buffer_t`,
 `image1d_array_t`, `image2d_depth_t`, `image2d_array_depth_t`,
 `sampler_t`, `queue_t`, `ndrange_t`, `clk_event_t`, `reserve_id_t`, and
-`event_t` types is implementation-defined.
+`event_t` types is implementation-defined.  Additionally, the behavior of
+applying the `sizeof` operator to a pipe object (a type with the `pipe` type
+specifier keyword) is implementation-defined.
 --
 
 


### PR DESCRIPTION
Clarifies that the size of a pipe object is implementation-defined.  Fixes #563 .