### PR TITLE
Require the cl_mipmap_filter_mode_img type for cl_img_generate_mipmap.

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5962,6 +5962,9 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_img_generate_mipmap" supported="opencl">
+            <require>
+                <type name="cl_mipmap_filter_mode_img"/>
+            </require>
             <require comment="cl_mipmap_filter_mode_img">
                 <enum name="CL_MIPMAP_FILTER_ANY_IMG"/>
                 <enum name="CL_MIPMAP_FILTER_BOX_IMG"/>


### PR DESCRIPTION
To help tools which parse the cl.xml file and conditionally output types.