### PR TITLE
clarify table structure for backwards compatible appendix

### DIFF
--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -9,6 +9,8 @@
 OpenCL 3.0 breaks backwards compatibility with earlier versions of OpenCL by making some features that were previously required for FULL_PROFILE or EMBEDDED_PROFILE devices optional.
 This appendix describes the features that were previously required that are now optional, how to detect whether an optional feature is supported, and expected behavior when an optional feature is not supported.
 
+NOTE: Informally, in the tables below the first row usually describes a feature detection mechanism ("May return this value indicating that the feature is not supported") and subsequent rows usually describe behavior when a feature is not supported ("Returns this value if the feature is not supported").
+
 == Shared Virtual Memory
 
 Shared Virtual Memory (SVM) is optional for devices supporting OpenCL 3.0.


### PR DESCRIPTION
Adds an informative note describing that the first row in the backwards compatibility tables usually describes a detection mechanism and subsequent rows usually describe implications if a feature is not supported.

Fixes #568.