### PR TITLE
[C++ for OpenCL] Improve description of restricted C++ features.

### DIFF
--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -23,7 +23,7 @@ The following {cpp} language features are not supported:
   * Standard C++ libraries ({cpp}17 `[library]`).
 
 Thread-safe initialization of static local objects is not guaranteed ({cpp}17
-`[stmt.dcl]`) and whether an implementation provides a thread-safety is
+`[stmt.dcl]`) and whether an implementation provides thread-safety is
 indicated by the presence of `__cpp_threadsafe_static_init` predefined feature
 test macro.
 

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -22,10 +22,14 @@ The following {cpp} language features are not supported:
     `[expr.new]`/`[expr.delete]`);
   * Standard C++ libraries ({cpp}17 `[library]`).
 
-Thread-safe initialization of static local objects is not guaranteed ({cpp}17
-`[stmt.dcl]`) and whether an implementation provides thread-safety is
-indicated by the presence of the `__cpp_threadsafe_static_init` feature
-test macro.
+:fn-feature-macro: footnote:[The macro belongs to the list of {cpp}20's \
+feature test macros.]
+
+Simultaneous initialization of static local objects performed by
+different work-items is not guaranteed to be free from race-condition.
+Whether an implementation provides such a guarantee is indicated by the
+presence of the `__cpp_threadsafe_static_init` feature test
+macro{fn-feature-macro}.
 
 The list above only contains extra restrictions that are not detailed in OpenCL
 C. As OpenCL restricts a number of C features, the same restrictions are

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -28,6 +28,6 @@ indicated by the presence of the `__cpp_threadsafe_static_init` feature
 test macro.
 
 The list above only contains extra restrictions that are not detailed in OpenCL
-C. As OpenCL restricts a number of C features the same restrictions are
+C. As OpenCL restricts a number of C features, the same restrictions are
 inherited by C++ for OpenCL. The detailed list of C feature restrictions
 is provided in `OpenCL C v2.0 section 6.9`.

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -26,7 +26,7 @@ The following {cpp} language features are not supported:
 feature test macros.]
 
 Simultaneous initialization of static local objects performed by
-different work-items is not guaranteed to be free from race-condition.
+different work-items is not guaranteed to be free from race-conditions.
 Whether an implementation provides such a guarantee is indicated by the
 presence of the `__cpp_threadsafe_static_init` feature test
 macro{fn-feature-macro}.

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -12,8 +12,22 @@ however, there are some differences that are documented in this section.
 
 The following {cpp} language features are not supported:
 
-  * Virtual functions
-  * Exceptions
-  * `dynamic_cast` operator
-  * Non-placement `new`/`delete` operators
-  * Standard C++ libraries
+  * Virtual functions ({cpp}17 `[class.virtual]`);
+  * References to functions including member functions ({cpp}17 `[class.mfct]`);
+  * Pointers to class member functions (in addition to the regular non-member
+    functions that are already restricted in OpenCL C);
+  * Exceptions ({cpp}17 `[except]`);
+  * `dynamic_cast` operator ({cpp}17 `[expr.dynamic.cast]`);
+  * Non-placement `new`/`delete` operators ({cpp}17
+    `[expr.new]`/`[expr.delete]`);
+  * Standard C++ libraries ({cpp}17 `[library]`).
+
+Thread-safe initialization of static local objects is not guaranteed ({cpp}17
+`[stmt.dcl]`) and whether an implementation provides a thread-safety is
+indicated by the presence of `__cpp_threadsafe_static_init` predefined feature
+test macro.
+
+The list above only contains extra restrictions that are not detailed in OpenCL
+C. As OpenCL restricts a number of C features the same restrictions are
+inherited by C++ for OpenCL. The detailed list of C feature restrictions
+is provided in `OpenCL C v2.0 section 6.9`.

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -24,7 +24,7 @@ The following {cpp} language features are not supported:
 
 Thread-safe initialization of static local objects is not guaranteed ({cpp}17
 `[stmt.dcl]`) and whether an implementation provides thread-safety is
-indicated by the presence of `__cpp_threadsafe_static_init` predefined feature
+indicated by the presence of the `__cpp_threadsafe_static_init` feature
 test macro.
 
 The list above only contains extra restrictions that are not detailed in OpenCL


### PR DESCRIPTION
Added the following restrictions that were omitted:
- references to functions;
- pointers to member functions;

Added clarification for:
- thread-safety of static locals initialization.

Added references to C++ spec sections where applicable.