### PR TITLE
Removed CL_API_ENTRY from typedefs

### DIFF
--- a/ext/introduction.asciidoc
+++ b/ext/introduction.asciidoc
@@ -204,7 +204,7 @@ host API:
 // function pointer typedefs must use the
 // following naming convention
 
-typedef CL_API_ENTRY return_type
+typedef return_type
             (CL_API_CALL *clExtensionFunctionNameTAG_fn)(...);
 
 #endif // _extension_name_
@@ -233,7 +233,7 @@ This extension would add the following to cl_gl_ext.h:
 
 // function pointer typedefs must use the
 // following naming convention
-typedef CL_API_ENTRY cl_int
+typedef cl_int
         (CL_API_CALL *clGetGLContextInfoKHR_fn)(
             const cl_context_properties * /* properties */,
             cl_gl_context_info /* param_name */,

--- a/man/static/clGetExtensionFunctionAddressForPlatform.txt
+++ b/man/static/clGetExtensionFunctionAddressForPlatform.txt
@@ -67,7 +67,7 @@ The following convention must be followed for all extensions affecting the host 
 
 // function pointer typedefs must use the
 // following naming convention
-typedef CL_API_ENTRY return type
+typedef return type
       (CL_API_CALL *clextension_func_nameTAG_fn)(...);
 
 #endif // extension_name
@@ -94,7 +94,7 @@ This extension would add the following to `cl_gl_ext.h`:
 
 // function pointer typedefs must use the
 // following naming convention
-typedef CL_API_ENTRY cl_int
+typedef cl_int
      (CL_API_CALL *clGetGLContextInfoKHR_fn)(
               const cl_context_properties * /* properties */,
               cl_gl_context_info /* param_name */,


### PR DESCRIPTION
The macro `CL_API_ENTRY` is obviously intended for storage-class attributes, e.g. `__declspec(dllexport)`. Those attributes are not allowed in `typedef` declarations and will result in compilation errors. I have also submitter a [PR](https://github.com/KhronosGroup/OpenCL-Headers/pull/162) to fix the CL headers.