### PR TITLE
Reserve additional enums for internal MR180

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1530,8 +1530,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x1284"        name="CL_PROFILING_COMMAND_COMPLETE"/>
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
             <unused start="0x1290" end="0x1292" comment="Reserved for MR179"/>
-            <unused start="0x1293" end="0x12AB" comment="Reserved for MR180"/>
-            <unused start="0x12AC" end="0x1FFF" comment="Reserved for core API tokens"/>
+            <unused start="0x1293" end="0x12AE" comment="Reserved for MR180"/>
+            <unused start="0x12AF" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
     <enums start="0x2000" end="0x201F" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">


### PR DESCRIPTION
Reserve 3 more enums `0x12AC`, `0x12AD`, & `0x12AE`.