### PR TITLE
Removed void parameter from clUnloadCompiler in cl.xml

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -3521,7 +3521,6 @@ server's OpenCL/api-docs repository.
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>cl_int</type> <name>clUnloadCompiler</name></proto>
-            <param><type>void</type>                                    </param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>void</type>*  <name>clGetExtensionFunctionAddress</name></proto>


### PR DESCRIPTION
The function clUnloadCompiler has no parameters and should not have a void parameter in the xml. This would be consistent with other Khronos xml specs.