### PR TITLE
reserve enum block 0x4250 for Intel extensions

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1945,8 +1945,12 @@ server's OpenCL/api-docs repository.
             <unused start="0x4241" end="0x424F"/>
     </enums>
 
-    <enums start="0x4250" end="0x4FFF" name="enums.4250" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x4250" end="0x4FFF"/>
+    <enums start="0x4250" end="0x425F" name="enums.4250" vendor="Intel">
+            <unused start="0x4250" end="0x425F"/>
+    </enums>
+
+    <enums start="0x4260" end="0x4FFF" name="enums.4260" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x4260" end="0x4FFF"/>
     </enums>
 
     <enums start="0x10000" end="0x10FFF" name="enums.10000" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">


### PR DESCRIPTION
Please reserve enum block 0x4250 for upcoming Intel extensions.  Thank you!