### PR TITLE
Unify Fast Math ULP Tables

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11653,6 +11653,7 @@ requires>> support for OpenCL C 2.0 or newer.
 
 | *acosh*(_x_)
     | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ - 1)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *acospi*(_x_)
     | Derived implementations may implement as *acos*(_x_) * `M_PI_F`.
@@ -11663,6 +11664,7 @@ requires>> support for OpenCL C 2.0 or newer.
 
 | *asinh*(_x_)
     | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ + 1)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *asinpi*(_x_)
     | Derived implementations may implement as *asin*(_x_) * `M_PI_F`.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11671,12 +11671,12 @@ requires>> support for OpenCL C 2.0 or newer.
 | *atan*(_x_)
     | {leq} 4096 ulp
 
-//| *atanh*(_x_)
-//  | Defined for _x_ in the domain (-1, 1).
-//    For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
-//    For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
-//    0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
-//    For non-derived implementations, the error is {leq} 8192 ulp.
+| *atanh*(_x_)
+  | Defined for _x_ in the domain (-1, 1).
+    For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
+    For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
+    0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
+    For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *atanpi*(_x_)
     | Derived implementations may implement as *atan*(_x_) * `M_1_PI_F`.
@@ -11803,13 +11803,13 @@ requires>> support for OpenCL C 2.0 or newer.
       *sin*(_x_) * (1.0f / *cos*(_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
 
-//| *tanh*(_x_)
-//  | Defined for _x_ in the domain [-{inf}, {inf}].
-//    For _x_ in [-2^-10^, 2^-10^], derived implementations
-//    may implement as _x_.
-//    For _x_ outside of [-2^-10^, 2^-10^], derived implementations
-//    may implement as (*exp*(_x_) - *exp*(-_x_)) / (*exp*(_x_) + *exp*(-_x_)).
-//    For non-derived implementations, the error is {leq} 8192 ULP.
+| *tanh*(_x_)
+  | Defined for _x_ in the domain [-{inf}, {inf}].
+    For _x_ in [-2^-10^, 2^-10^], derived implementations
+    may implement as _x_.
+    For _x_ outside of [-2^-10^, 2^-10^], derived implementations
+    may implement as (*exp*(_x_) - *exp*(-_x_)) / (*exp*(_x_) + *exp*(-_x_)).
+    For non-derived implementations, the error is {leq} 8192 ULP.
 
 | *tanpi*(_x_)
     | Derived implementations may implement as *tan*(_x_ * `M_PI_F`).

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1378,6 +1378,7 @@ profile.
 
 | *OpExtInst* *acosh*
     | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ - 1)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *acospi*
     | Derived implementations may implement as *acos*(_x_) * `M_PI_F`.
@@ -1388,6 +1389,7 @@ profile.
 
 | *OpExtInst* *asinh*
     | Derived implementations may implement as *log*(_x_ + *sqrt*(_x_ * _x_ + 1)).
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *asinpi*
     | Derived implementations may implement as *asin*(_x_) * `M_PI_F`.

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1425,7 +1425,7 @@ profile.
       is {leq} 2^-11^ and larger otherwise.
 
 | *OpExtInst* *cosh*
-    | Defined for _x_ in the domain [-{inf}, {inf}].
+    | Defined for _x_ in the domain [-88, 88].
       Derived implementations may implement as 0.5f * (*exp*(_x_) + *exp*(-_x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
 
@@ -1517,7 +1517,7 @@ profile.
     | ulp values as defined for *sin*(_x_) and *cos*(_x_).
 
 | *OpExtInst* *sinh*
-    | Defined for _x_ in the domain [-{inf}, {inf}].
+    | Defined for _x_ in the domain [-88, 88].
       For _x_ in [-2^-10^, 2^-10^], derived implementations
       may implement as _x_.
       For _x_ outside of [-2^-10^, 2^-10^], derived implementations


### PR DESCRIPTION
This PR is a follow-on to #544 that fixes the remaining discrepancies in the fast math tables between the OpenCL C and SPIR-V environment specs.

Fixes #545.