### PR TITLE
Update vendor copyrights to 2021

### DIFF
--- a/extensions/cl_arm_scheduling_controls.asciidoc
+++ b/extensions/cl_arm_scheduling_controls.asciidoc
@@ -20,7 +20,7 @@ Kevin Petit, Arm Ltd.
 
 == Notice
 
-Copyright (c) 2020 Arm Ltd.
+Copyright (c) 2020-2021 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_img_cached_allocations.asciidoc
+++ b/extensions/cl_img_cached_allocations.asciidoc
@@ -24,7 +24,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2021 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_generate_mipmap.asciidoc
+++ b/extensions/cl_img_generate_mipmap.asciidoc
@@ -26,7 +26,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2021 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_mem_properties.asciidoc
+++ b/extensions/cl_img_mem_properties.asciidoc
@@ -23,7 +23,7 @@ Anitha Raj,  Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2021 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_use_gralloc_ptr.asciidoc
+++ b/extensions/cl_img_use_gralloc_ptr.asciidoc
@@ -25,7 +25,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2021 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_yuv_image.asciidoc
+++ b/extensions/cl_img_yuv_image.asciidoc
@@ -25,7 +25,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2021 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_intel_create_buffer_with_properties.asciidoc
+++ b/extensions/cl_intel_create_buffer_with_properties.asciidoc
@@ -32,7 +32,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2020 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2021 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_mem_channel_property.asciidoc
+++ b/extensions/cl_intel_mem_channel_property.asciidoc
@@ -37,7 +37,7 @@ Contributors
 Notice
 ------
 
-Copyright (c) 2020 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2021 Intel Corporation. All rights reserved.
 
 Status
 ------

--- a/extensions/cl_intel_mem_force_host_memory.asciidoc
+++ b/extensions/cl_intel_mem_force_host_memory.asciidoc
@@ -30,7 +30,7 @@ Filip Hazubski, Intel
 
 == Notice
 
-Copyright (c) 2020 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2021 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_required_subgroup_size.asciidoc
+++ b/extensions/cl_intel_required_subgroup_size.asciidoc
@@ -39,7 +39,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
@@ -29,7 +29,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_media_block_io.asciidoc
+++ b/extensions/cl_intel_spirv_media_block_io.asciidoc
@@ -30,7 +30,7 @@ Pawel Jurek, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_subgroups.asciidoc
+++ b/extensions/cl_intel_spirv_subgroups.asciidoc
@@ -31,7 +31,7 @@ Mariusz Merecki, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -42,7 +42,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_char.asciidoc
+++ b/extensions/cl_intel_subgroups_char.asciidoc
@@ -33,7 +33,7 @@ Konrad Trifunovic, Intel
 
 == Notice
 
-Copyright (c) 2020 Intel Corporation.  All rights reserved.
+Copyright (c) 2020-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_long.asciidoc
+++ b/extensions/cl_intel_subgroups_long.asciidoc
@@ -30,7 +30,7 @@ Konrad Trifunovic, Intel
 
 == Notice
 
-Copyright (c) 2020 Intel Corporation.  All rights reserved.
+Copyright (c) 2020-2021 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -40,7 +40,7 @@ Insoo Woo, Intel
 
 == Notice
 
-Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2021 Intel Corporation.  All rights reserved.
 
 == Status
 


### PR DESCRIPTION
Done separately from the Khronos copyrights to make reviewing clearer.

Each vendor is a separate commit, so very easy to change or drop anything per-vendor.