### PR TITLE
Update OpenGL trademark

### DIFF
--- a/copyrights.txt
+++ b/copyrights.txt
@@ -30,7 +30,7 @@ WebCL, OpenVX, OpenVG, EGL, COLLADA, glTF, NNEF, OpenKODE, OpenKCAM, StreamInput
 OpenWF, OpenSL ES, OpenMAX, OpenMAX AL, OpenMAX IL, OpenMAX DL, OpenML and DevU are
 trademarks of the Khronos Group Inc. ASTC is a trademark of ARM Holdings PLC,
 OpenCL is a trademark of Apple Inc. and OpenGL and OpenML are registered trademarks
-and the OpenGL ES and OpenGL SC logos are trademarks of Silicon Graphics
-International used under license by Khronos. All other product names, trademarks,
+and the OpenGL ES and OpenGL SC logos are trademarks of Hewlett Packard Enterprise
+used under license by Khronos. All other product names, trademarks,
 and/or company names are used solely for identification and belong to their
 respective owners.


### PR DESCRIPTION
Bring the description of the OpenGL trademarks in line with this text:
https://www.khronos.org/legal/Khronos_Specification_Copyright_License_Header

An alternative source for this being the up to date information is the Vulkan
specification:
https://github.com/KhronosGroup/Vulkan-Docs/blob/88da24862cf91d692801c6ae64665d26d39f06c4/copyright-spec.txt#L80-L81