### PR TITLE
C++ for OpenCL 2021 (i.e OpenCL 3.0-compatible)

### DIFF
--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The C++ for OpenCL 1.0 Programming Language Documentation
+= The C++ for OpenCL 1.0 and 1.1 Programming Language Documentation
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:

--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-= The C++ for OpenCL 1.0 and 1.1 Programming Language Documentation
+= The C++ for OpenCL 1.0 and 2021 Programming Language Documentation
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group
 :data-uri:

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -13,7 +13,7 @@ conversion rules are extended from the qualification conversion {cpp}17
 overlapping of address spaces from `section 5.1.3` of <<embedded-c-spec,
 The Embedded C Specification>>. For OpenCL it means that implicit
 conversions are allowed from a named address space (except for `+__constant+`)
-to generic (`OpenCL C v2.0 6.7.5`). The reverse conversion is only allowed
+to generic (`OpenCL C v3.0 6.7.5`). The reverse conversion is only allowed
 explicitly. The `+__constant+` address space does not overlap with any other
 and therefore no valid conversion between `+__constant+` and any other address
 space exists. Most of the rules follow this logic.

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -333,16 +333,16 @@ class C {
 };
 ------------
 
-TODO: As an optimisation we can do an upgrade in this version and always infer
+`TODO: As an optimisation we can do an upgrade in this version and always infer
 the concrete address space! See "Builtin operators" for details. Needs
-confirmation that code size doesn't increase significantly.
+confirmation that code size doesn't increase significantly.`
 
 ==== Builtin operators
 
 All builtin operators are available in the specific named address spaces, thus
 no address space conversions (i.e. to generic address space) are performed.
 
-TODO:Why are assignment operators different? See "Implicit special members".
+`TODO: Why are assignment operators different? See "Implicit special members".`
 
 ==== Templates
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -36,7 +36,7 @@ operator (as an implicit conversion); converting from generic to named address
 space can only be done using the dedicated `addrspace_cast` operator. The
 `addrspace_cast` operator can only convert between address spaces for pointers and
 references and no other conversions are allowed to occur. Note that conversions
-between `__constant` and any other other address space are disallowed.
+between `+__constant+` and any other other address space are disallowed.
 
 [source,cpp]
 ------------
@@ -151,8 +151,8 @@ Address spaces are not deduced for:
     specializations or non-type type based template parameters.
   * non-pointer/non-reference class members except for static data members
     that are deduced to the `+__global+` address space for {cpp} for OpenCL 1.0
-    or {cpp} for OpenCL 2021 with the `__opencl_c_program_scope_global_variables`
-    feature.
+    or {cpp} for OpenCL 2021 with the
+    `+__opencl_c_program_scope_global_variables+` feature.
   * non-pointer/non-reference type alias declarations.
   * decltype expressions.
 
@@ -402,7 +402,7 @@ void bar(){
 
 ==== Temporary materialization
 
-All temporaries are materialized in `__private` address space. If a reference
+All temporaries are materialized in `+__private+` address space. If a reference
 with another address space is bound to them, a conversion will be generated
 in case it is valid, otherwise compilation will fail with a diagnostic.
 
@@ -434,7 +434,7 @@ constructors and destructors, the implementation defines an ABI format for
 runtime initialization and destruction of global objects before/after all
 kernels are enqueued.
 
-Objects in `__local` address space can not have initializers in
+Objects in `+__local+` address space can not have initializers in
 declarations and therefore a constructor can not be called. All objects
 created in the local address space have undefined state at the point of
 their declaration. Developers are free to define a special member function
@@ -465,7 +465,7 @@ __kernel void foo() {
 }
 ------------
 
-User defined constructors in `__constant` address space must be `constexpr`.
+User defined constructors in `+__constant+` address space must be `constexpr`.
 Such objects can be initialized using literals and initialization lists if they
 do not require any user defined conversions.
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -337,16 +337,10 @@ class C {
 };
 ------------
 
-`TODO: As an optimisation we can do an upgrade in this version and always infer
-the concrete address space! See "Builtin operators" for details. Needs
-confirmation that code size doesn't increase significantly.`
-
 ==== Builtin operators
 
 All builtin operators are available in the specific named address spaces, thus
 no address space conversions (i.e. to generic address space) are performed.
-
-`TODO: Why are assignment operators different? See "Implicit special members".`
 
 ==== Templates
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -124,7 +124,7 @@ address space objects.
 Class static data members are deduced to `+__global+` address space. Note,
 that if the {cpp} for OpenCL 2021 implementation does not support program
 scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
-from `OpenCL C 3.0 s6.1`) the address space qualifier must be  specified
+from `OpenCL C 3.0 s6.1` is unsupported) the address space qualifier must be specified
 explicitly and it must be the `+__constant+` address space.
 
 All non-static member functions take an implicit object parameter `this`
@@ -138,7 +138,7 @@ object parameter `this` is explicitly specified using address space qualifiers
 on member functions (see <<addrspace-member-function-qualifiers,
 _Member function qualifier_>>). For example, use of member functions with
 objects in `+__constant+` address space will always require a `+__constant+`
-member function qualifier as `__constant` address space is disjoint with any
+member function qualifier as `+__constant+` address space is disjoint with any
 other.
 
 Member function qualifiers can also be used in case address space conversions

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -5,32 +5,33 @@
 [[address_space]]
 === Address spaces
 
-{cpp} for OpenCL inherits address space behavior from `OpenCL C v3.0 s6.7`.
+{cpp} for OpenCL inherits address space behavior from `OpenCL C 3.0 s6.7`.
 
 This section only documents behavior related to {cpp} features. For example
 conversion rules are extended from the qualification conversion {cpp}17
 `[conv.qual]` but the compatibility is determined using notation of sets and
 overlapping of address spaces from `section 5.1.3` of <<embedded-c-spec,
 The Embedded C Specification>>. For OpenCL kernel languages there are two
-main semantics depending on whether generic address space (`OpenCL C v3.0 6.7.`)
+main semantics depending on whether generic address space (`OpenCL C 3.0 6.7.`)
 is supported on not. The generic address space is always supported for
- * {cpp} for OpenCL v1.0;
- * {cpp} for OpenCL v1.1 with the presence of `+__opencl_c_generic_address_space+`
-   feature as explained in `OpenCL C v3.0 s6.2.1`.
+
+ * {cpp} for OpenCL 1.0;
+ * {cpp} for OpenCL 1.1 with the presence of `+__opencl_c_generic_address_space+`
+   feature as explained in `OpenCL C 3.0 s6.2.1`.
 
 If generic address space is not supported qualification conversions with pointer
 type where address spaces differ are not allowed. If generic address space is
 supported implicit conversions are allowed from a named address space (except for
-`+__constant+`) to generic. The reverse conversion is only allowed explicitly.
-The `+__constant+` address space does not overlap with any other and therefore no
-valid conversion between `+__constant+` and any other address space exists. This is
-aligned with rules from `OpenCL C v3.0 s6.7.9` and this logic regulates semantics
-described in this section.
+`+__constant+`) to generic address space. The reverse conversion is only allowed
+explicitly. The `+__constant+` address space does not overlap with any other and
+therefore no valid conversion between `+__constant+` and any other address space
+exists. This is aligned with rules from `OpenCL C 3.0 s6.7.9` and this logic
+regulates semantics described in this section.
 
 ==== Casts
 
-C-style casts follow rules of `OpenCL C v3.0 s6.7.9`. Conversions of
-pointers and references to the generic address space can be done by any {cpp} cast
+C-style casts follow rules of `OpenCL C 3.0 s6.7.9`. Conversions of
+references and pointers to the generic address space can be done by any {cpp} cast
 operator (as an implicit conversion); converting from generic to named address
 space can only be done using the dedicated `addrspace_cast` operator. The
 `addrspace_cast` operator can only convert between address spaces for pointers and
@@ -41,28 +42,33 @@ between `__constant` and any other other address space are disallowed.
 ------------
 // Example assumes generic address space support.
 int * genptr; // points to generic address space.
+
 // named -> generic address space conversions.
 __private float * ptrfloat = reinterpret_cast<__private float*>(genptr); // illegal.
 __private float * ptrfloat = addrspace_cast<__private float*>(genptr); // illegal.
 __private int * ptr = addrspace_cast<__private int*>(genptr); // legal.
+
 // generic -> named address space conversion.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
+
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(genptr); // illegal.
 ------------
 
-Note that if generic address space is not supported any conversion of pointers
+If generic address space is not supported any conversion of references/pointers
 pointing to different address spaces is illegal.
 
 [source,cpp]
 ------------
 // Example without generic address space support.
 int * privptr; // points to private address space.
+
 // The same address space conversions.
 __private float * ptrfloat = reinterpret_cast<__private float*>(privptr); // legal.
 __private float * ptrfloat = addrspace_cast<__private float*>(privptr); // illegal.
 __private int * ptr = addrspace_cast<__private int*>(genptr); // legal, no op.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
+
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(privptr); // illegal.
 ------------
@@ -80,16 +86,36 @@ __private int & ref = ...; // references int in __private address space.
 By default references refer to generic address space objects if generic
 address space is supported or private address space otherwise, except
 for dependent types that are not template specializations (see
-<<addrspace-deduction, _Deduction_>>). Address space compatibility checks
-are performed when references are bound to values. The logic follows the
-rules from address space pointer conversion (`OpenCL v3.0 s6.7.9`).
+<<addrspace-deduction, _Deduction_>>).
+
+[source,cpp]
+------------
+int & ref = ...; // references int in generic address space if it is
+                 // supported otherwise in __private address space.
+------------
+
+Address space compatibility checks are performed when references are
+bound to values. The logic follows the rules from address space pointer
+conversion (`OpenCL 3.0 s6.7.9`).
+
+[source,cpp]
+------------
+__global const int& f(__global float &ref) {
+  return ref; // error reference to global address space object cannot bind
+              // to a temporary object created in __private  address space.
+}
+const int& f(float &ref) {
+  return ref; // legal - reference to generic/__private address space object can
+              // bind to a temporary object created in __private  address space.
+}
+------------
 
 [[addrspace-deduction]]
-==== Deduction & Default address space
+====  Address space inference
 
 This section details what happens if address spaces for types are not
 provided in the source code explicitly. Most of the logic for address space
-deduction (i.e. default address space) follows rules from `OpenCL v3.0 s6.7.8`.
+inference (i.e. default address space) follows rules from `OpenCL 3.0 s6.7.8`.
 
 References inherit rules from pointers and therefore refer to generic
 address space objects by default (see <<references, _References_>>) if
@@ -97,9 +123,9 @@ generic address space is supported, otherwise they refer to private
 address space objects.
 
 Class static data members are deduced to `+__global+` address space. Note,
-that if implementations of {cpp} for OpenCL v1.1 does not support program
+that if implementations of {cpp} for OpenCL 1.1 does not support program
 scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
-from `OpenCL v3.0 s6.1`) the address space qualifier must be  specified
+from `OpenCL 3.0 s6.1`) the address space qualifier must be  specified
 explicitly and it must be `+__constant+` address space.
 
 All non-static member functions take an implicit object parameter `this`
@@ -112,7 +138,7 @@ in disjoint address spaces will not be compiled unless the address for the
 object parameter `this` is explicitly specified using address space qualifiers
 on member functions (see <<addrspace-member-function-qualifiers,
 _Member function qualifier_>>). For example, use of member functions with
-objects in `+__constant+` address space will always require a `__constant`
+objects in `+__constant+` address space will always require a `+__constant+`
 member function qualifier as `__constant` address space is disjoint with any
 other.
 
@@ -137,9 +163,9 @@ template <typename T>
 void foo() {
   T m; // address space of 'm' will be known at template instantiation time.
   T * ptr; // 'ptr' points to generic address space object when it is
-           // supported other to private address space.
+           // supported other to __private address space.
   T & ref = ...; // 'ref' references an object in generic address space when
-                 // it is supported otherwise to private address space.
+                 // it is supported otherwise in __private address space.
 };
 
 template <int N>
@@ -148,9 +174,9 @@ struct S {
   static int ii; // 'ii' is in global address space if program scope variables
                  // are supported otherwise this statement is not legal.
   int * ptr; // 'ptr' points to int in generic address space if it is supported
-             // otherwise to private address space.
+             // otherwise to __private address space.
   int & ref = ...; // 'ref' references int in generic address space if it is
-                   // supported otherwise to private address space.
+                   // supported otherwise in __private address space.
 };
 
 template <int N>
@@ -166,7 +192,7 @@ struct c1 {};
 using alias_c1 = c1; // 'alias_c1' is 'c1'.
 using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to 'c1'
                            // when generic address space is supported otherwise it
-                           // points to 'c1' located in private address space.
+                           // points to 'c1' located in __private address space.
 ------------
 
 [source,cpp]
@@ -328,23 +354,23 @@ instantiation.
 
 [source,cpp]
 ------------
-template<typename T>
-void foo(T* i){
-  T var;
- }
-
-__global int g;
-void bar(){
-  foo(&g); // error: template instantiation failed as function scope variable 'var'
-           // appears to be declared in __global address space (see line 3).
-}
+1  template<typename T>
+2  void foo(T* i){
+3   T var;
+4  }
+5 
+6  __global int g;
+7  void bar(){
+8    foo(&g); // error: template instantiation failed as function scope variable 'var'
+9             // appears to be declared in __global address space (see line 3).
+10 }
 ------------
 
 It is not legal to specify multiple different address spaces between
 template definition and instantiation. If multiple different address
 spaces are specified in a template definition and instantiation,
 compilation of such a program will fail with a diagnostic. This
-restriction immediately follows from `OpenCL C v3.0 s6.7` that
+restriction immediately follows from `OpenCL C 3.0 s6.7` that
 disallows multiple address space qualifiers on a type.
 
 [source,cpp]
@@ -444,7 +470,7 @@ User defined constructors in `__constant` address space must be `constexpr`.
 Such objects can be initialized using literals and initialization lists if they
 do not require any user defined conversions.
 
-Objects in `__constant` address space can be initialized using:
+Objects in `+__constant+` address space can be initialized using:
 
  * Literal expressions;
  * Uniform initialization syntax `{}`;

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -11,31 +11,60 @@ This section only documents behavior related to {cpp} features. For example
 conversion rules are extended from the qualification conversion {cpp}17
 `[conv.qual]` but the compatibility is determined using notation of sets and
 overlapping of address spaces from `section 5.1.3` of <<embedded-c-spec,
-The Embedded C Specification>>. For OpenCL it means that implicit
-conversions are allowed from a named address space (except for `+__constant+`)
-to generic (`OpenCL C v3.0 6.7.5`). The reverse conversion is only allowed
-explicitly. The `+__constant+` address space does not overlap with any other
-and therefore no valid conversion between `+__constant+` and any other address
-space exists. Most of the rules follow this logic.
+The Embedded C Specification>>. For OpenCL kernel languages there are two
+main semantics depending on whether generic address space (`OpenCL C v3.0 6.7.`)
+is supported on not. The generic address space is always supported for
+ * {cpp} for OpenCL v1.0;
+ * {cpp} for OpenCL v1.1 with the presence of `+__opencl_c_generic_address_space+`
+   feature as explained in `OpenCL C v3.0 s6.2.1`.
+
+If generic address space is not supported qualification conversions with pointer
+type where address spaces differ are not allowed. If generic address space is
+supported implicit conversions are allowed from a named address space (except for
+`+__constant+`) to generic. The reverse conversion is only allowed explicitly.
+The `+__constant+` address space does not overlap with any other and therefore no
+valid conversion between `+__constant+` and any other address space exists. This is
+aligned with rules from `OpenCL C v3.0 s6.7.9` and this logic regulates semantics
+described in this section.
 
 ==== Casts
 
-C-style casts follow rules of `OpenCL C v3.0 s6.7.5`. Conversions of
+C-style casts follow rules of `OpenCL C v3.0 s6.7.9`. Conversions of
 pointers and references to the generic address space can be done by any {cpp} cast
 operator (as an implicit conversion); converting from generic to named address
 space can only be done using the dedicated `addrspace_cast` operator. The
-`addrspace_cast` operator can only convert between address spaces for pointers and references
-and no other conversions are allowed to occur. Note that conversions between
-`__constant` and any other other address space are disallowed.
+`addrspace_cast` operator can only convert between address spaces for pointers and
+references and no other conversions are allowed to occur. Note that conversions
+between `__constant` and any other other address space are disallowed.
 
 [source,cpp]
-----------
-int * genptr;
+------------
+// Example assumes generic address space support.
+int * genptr; // points to generic address space.
+// named -> generic address space conversions.
 __private float * ptrfloat = reinterpret_cast<__private float*>(genptr); // illegal.
 __private float * ptrfloat = addrspace_cast<__private float*>(genptr); // illegal.
 __private int * ptr = addrspace_cast<__private int*>(genptr); // legal.
+// generic -> named address space conversion.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
+// disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(genptr); // illegal.
+----------
+
+Note that if generic address space is not supported any conversion of pointers
+pointing to different address spaces is illegal.
+
+[source,cpp]
+------------
+// Example without generic address space support.
+int * privptr; // points to private address space.
+// The same address space conversions.
+__private float * ptrfloat = reinterpret_cast<__private float*>(privptr); // legal.
+__private float * ptrfloat = addrspace_cast<__private float*>(privptr); // illegal.
+__private int * ptr = addrspace_cast<__private int*>(genptr); // legal, no op.
+float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
+// disjoint address space conversion.
+__constant int * constptr = addrspace_cast<__constant int*>(privptr); // illegal.
 ----------
 
 [[references]]
@@ -48,12 +77,12 @@ Reference types can be qualified with an address space.
 __private int & ref = ...; // references int in __private address space.
 ----------
 
-By default references refer to generic address space objects, except
+By default references refer to generic address space objects if generic
+address space is supported or private address space otherwise, except
 for dependent types that are not template specializations (see
 <<addrspace-deduction, _Deduction_>>). Address space compatibility checks
 are performed when references are bound to values. The logic follows the
-rules from address space pointer conversion (`OpenCL v3.0 s6.7.5`).
-
+rules from address space pointer conversion (`OpenCL v3.0 s6.7.9`).
 
 [[addrspace-deduction]]
 ==== Deduction & Default address space
@@ -63,49 +92,65 @@ provided in the source code explicitly. Most of the logic for address space
 deduction (i.e. default address space) follows rules from `OpenCL v3.0 s6.7.8`.
 
 References inherit rules from pointers and therefore refer to generic
-address space objects by default (see <<references, _References_>>).
+address space objects by default (see <<references, _References_>>) if
+generic address space is supported, otherwise they refer to private
+address space objects.
 
-Class static data members are deduced to `+__global+` address space.
+Class static data members are deduced to `+__global+` address space. Note,
+that if implementations of {cpp} for OpenCL v1.1 does not support program
+scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
+from `OpenCL v3.0 s6.1`) the address space qualifier must be  specified
+explicitly and it must be `+__constant+` address space.
 
 All non-static member functions take an implicit object parameter `this`
 that is a pointer type. By default the `this` pointer parameter is in the
-generic address space. All concrete objects passed as an argument to the
-implicit `this` parameter will be converted to the generic address
-space first if such conversion is valid. Therefore programs using objects
-in the `+__constant+` address space will not be compiled unless the address
-space is explicitly specified using address space qualifiers on member
-functions (see <<addrspace-member-function-qualifiers,
-_Member function qualifier_>>) as the conversion between `+__constant+` 
-and generic is disallowed. Member function qualifiers can also be used
-in case conversion to the generic address space is undesirable (even if
-it is legal). For example, a method can be implemented to exploit memory
-access coalescing for segments with memory bank. This not only applies
-to regular member functions but to constructors and destructors too.
+generic address space if it is supported and in the private address space
+otherwise. All concrete objects passed as an argument to the
+implicit `this` parameter will be converted to this default (generic or private)
+address space first if such conversion is valid. Therefore programs using objects
+in disjoint address spaces will not be compiled unless the address for the
+object parameter `this` is explicitly specified using address space qualifiers
+on member functions (see <<addrspace-member-function-qualifiers,
+_Member function qualifier_>>). For example, use of member functions with
+objects in `+__constant+` address space will always require a `__constant`
+member function qualifier as `__constant` address space is disjoint with any
+other.
+
+Member function qualifiers can also be used in case address space conversions
+are undesirable for example for performance reasons. For example, a method can
+be implemented to exploit memory access coalescing for segments with memory bank.
 
 Address spaces are not deduced for:
 
   * non-pointer/non-reference template parameters except for template
     specializations or non-type type based template parameters.
   * non-pointer/non-reference class members except for static data members
-    that are deduced to `+__global+` address space.
+    that are deduced to `+__global+` address space for {cpp} for OpenCL v1.0
+    or {cpp} for OpenCL v1.1 with `__opencl_c_program_scope_global_variables`
+    feature.
   * non-pointer/non-reference type alias declarations.
   * decltype expressions.
 
 [source,cpp]
-----------
+------------
 template <typename T>
 void foo() {
   T m; // address space of 'm' will be known at template instantiation time.
-  T * ptr; // 'ptr' points to generic address space object.
-  T & ref = ...; // 'ref' references an object in generic address space.
+  T * ptr; // 'ptr' points to generic address space object when it is
+           // supported other to private address space.
+  T & ref = ...; // 'ref' references an object in generic address space when
+                 // it is supported otherwise to private address space.
 };
 
 template <int N>
 struct S {
   int i; // 'i' has no address space.
-  static int ii; // 'ii' is in global address space.
-  int * ptr; // 'ptr' points to int in generic address space.
-  int & ref = ...; // 'ref' references int in generic address space.
+  static int ii; // 'ii' is in global address space if program scope variables
+                 // are supported otherwise this statement is not legal.
+  int * ptr; // 'ptr' points to int in generic address space if it is supported
+             // otherwise to private address space.
+  int & ref = ...; // 'ref' references int in generic address space if it is
+                   // supported otherwise to private address space.
 };
 
 template <int N>
@@ -119,7 +164,9 @@ void bar()
 ----------
 struct c1 {};
 using alias_c1 = c1; // 'alias_c1' is 'c1'.
-using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to 'c1'.
+using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to 'c1'
+                           // when generic address space is supported otherwise it
+                           // points to 'c1' located in private address space.
 ----------
 
 [source,cpp]
@@ -138,7 +185,8 @@ of the initialization expression. The logic follows rules for `const` and
 `volatile` qualifiers.
 
 [source,cpp]
-----------
+------------
+// Assumes that generic address space is supported.
 __kernel void foo()
 {
   __local int i;
@@ -175,7 +223,8 @@ diagnostic.
 ----------
 struct C {
   void foo() __local;
-  void foo();
+  void foo(); // This is implicitly qualified by generic address space
+              // if it is supported otherwise by '__private'.
 };
 
 __kernel void bar() {
@@ -185,16 +234,21 @@ __kernel void bar() {
   c1.foo(); // will resolve to the first 'foo'.
   c2.foo(); // will resolve to the second 'foo'.
   c3.foo(); // error due to mismatching address spaces - can't convert to
-            // '__local' or generic addr spaces.
+            // '__local' or generic/'__private' addr spaces.
 }
 ----------
+
+All  member functions can be qualified by an address space qualifier including
+constructors and destructors.
+
 
 ==== Lambda function
 
 The address space qualifier can be optionally added for lambda
 expressions after the attributes. Similar to method qualifiers,
 they will alter the default address space of lambda call operator
-that has generic address space by default. 
+that has generic address space by default if it is supported otherwise 
+private address space. 
 
 [source,cpp]
 ----------
@@ -217,38 +271,53 @@ __kernel void foo() {
 ==== Implicit special members
 
 The prototype for implicit special members (default, copy or move constructor,
-copy or move assignment, destructor) has the generic address space for an implicit
+copy or move assignment, destructor) has the default address space for an implicit
 object pointer and reference parameters (see also
-<<addrspace-member-function-qualifiers, _Member function qualifier_>>).
+<<addrspace-member-function-qualifiers, _Member function qualifier_>>). This default
+address space is generic if it is supported or private otherwise.
 
 [source,cpp]
 ----------
 class C {
   // Has the following implicitly defined member functions.
 
-  // void C(); /* implicit 'this' parameter is a pointer to */
-               /* object in generic address space. */
+  // C(); /* implicit 'this' parameter is a pointer to */
+          /* object in generic address space if supported */
+          /* in private address space otherwise. */
 
-  // void C(const C & par); /* 'this'/'par' is a pointer/reference to */
-                            /*  object in generic address space. */
+  // C(const C & par); /* 'this'/'par' is a pointer/reference to */
+                       /*  object in generic address space */
+                       /*  if supported */
+                       /* in private address space otherwise. */
 
-  // void C(C && par); /* 'this'/'par' is a pointer/r-val reference to */
-                       /* object in generic address space. */
+  // C(C && par); /* 'this'/'par' is a pointer/r-val reference to */
+                  /* object in generic address space if supported */
+                  /* in private address space otherwise. */
 
-  // operator= C &(const C & par); /* 'this'/'par'/return value is */
+  // C & operator=(const C & par); /* 'this'/'par'/return value is */
                                    /* a pointer/reference/reference to */
-                                   /* object in generic address space. */
+                                   /* object in generic address space */
+                                   /* if supported */ 
+                                   /* in private address space otherwise. */
 
-  // operator= C &(C && par)'; /* 'this'/'par'/return value is */
+  // C & operator=(C && par)'; /* 'this'/'par'/return value is */
                                /* a pointer/r-val reference/reference to */
                                /* object in generic address space. */
+                               /* if supported */ 
+                               /* in private address space otherwise. */
 };
 ----------
+
+TODO: As an optimisation we can do an upgrade in this version and always infer
+the concrete address space! See "Builtin operators" for details. Needs
+confirmation that code size doesn't increase significantly.
 
 ==== Builtin operators
 
 All builtin operators are available in the specific named address spaces, thus
-no conversion to generic address space is performed.
+no address space conversions (i.e. to generic address space) are performed.
+
+TODO:Why are assignment operators different? See "Implicit special members".
 
 ==== Templates
 
@@ -275,7 +344,9 @@ void bar(){
 It is not legal to specify multiple different address spaces between
 template definition and instantiation. If multiple different address
 spaces are specified in a template definition and instantiation,
-compilation of such a program will fail with a diagnostic.
+compilation of such a program will fail with a diagnostic. This
+restriction immediately follows from `OpenCL C v3.0 s6.7` that
+disallows multiple address space qualifiers on a type.
 
 [source,cpp]
 ----------
@@ -314,11 +385,14 @@ in case it is valid, otherwise compilation will fail with a diagnostic.
 
 [source,cpp]
 ----------
-int bar(const unsigned int &i);
+int bar(const unsigned int &i); // references generic address space object
+                                // if generic address space is supported
+                                // otherwise private address space object.
 
 void foo() {
-  bar(1); // temporary is created in __private address space but converted
-          // to generic address space of parameter reference.
+  bar(1); // temporary is created in __private address space but (if generic
+          // address space is supported) converted to generic address space
+          // of parameter reference.
 }
 
 __global const int& f(__global float &ref) {
@@ -353,8 +427,13 @@ are not invoked automatically. They can be called manually.
 ------------
 class C {
   int m;
+// If generic address space is not supported or for performance optimization
+// purposes the following members might be required.
+public:
+  __local C & operator=(const C & par) __local;
+  ~C() __local;
 };
-
+__
 kernel void foo() {
   __local C locobj{}; // error: local address space objects can't be initialized
   __local C locobj; // uninitialised object
@@ -440,12 +519,12 @@ when converting between address spaces in nested pointers:
 
 [source,cpp]
 ----------
-local int * * locgenptr;
-constant int * * cnstgenptr;
-int * * gengenptr;
-gengenptr = const_cast<int**>(locgenptr); // illegal.
-gengenptr = static_cast<int**>(cnstgenptr); // illegal.
-gengenptr = addrspace_cast<int**>(cnstgenptr); // illegal.
-gengenptr = reinterpret_cast<int**>(locgenptr); // legal.
-gengenptr = reinterpret_cast<int**>(cnstgenptr); // legal.
+local int * * locdefptr;
+constant int * * cnstdefptr;
+int * * defdefptr;
+defdefptr = const_cast<int * *>(locdefptr); // illegal.
+defdefptr = static_cast<int * *>(cnstdefptr); // illegal.
+defdefptr = addrspace_cast<int * *>(cnstdefptr); // illegal.
+defdefptr = reinterpret_cast<int * *>(locdefptr); // legal.
+defdefptr = reinterpret_cast<int * *>(cnstdefptr); // legal.
 ----------

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -7,24 +7,24 @@
 
 {cpp} for OpenCL inherits address space behavior from `OpenCL C 3.0 s6.7`.
 
-This section only documents behavior related to {cpp} features. For example
-conversion rules are extended from the qualification conversion {cpp}17
+This section only documents behavior related to {cpp} features. For example,
+conversion rules are extended from the qualification conversion in {cpp}17
 `[conv.qual]` but the compatibility is determined using notation of sets and
 overlapping of address spaces from `section 5.1.3` of <<embedded-c-spec,
 The Embedded C Specification>>. For OpenCL kernel languages there are two
-main semantics depending on whether generic address space (`OpenCL C 3.0 6.7.`)
+main semantics depending on whether generic address space (`OpenCL C 3.0 s6.7.5`)
 is supported on not. The generic address space is always supported for
 
  * {cpp} for OpenCL 1.0;
  * {cpp} for OpenCL 2021 with the presence of `+__opencl_c_generic_address_space+`
    feature as explained in `OpenCL C 3.0 s6.2.1`.
 
-If generic address space is not supported qualification conversions with pointer
+If generic address space is not supported, qualification conversions with pointer
 type where address spaces differ are not allowed. If generic address space is
-supported implicit conversions are allowed from a named address space (except for
+supported, implicit conversions are allowed from a named address space (except for
 `+__constant+`) to generic address space. The reverse conversion is only allowed
-explicitly. The `+__constant+` address space does not overlap with any other and
-therefore no valid conversion between `+__constant+` and any other address space
+explicitly. The `+__constant+` address space does not overlap with any other,
+therefore, no valid conversion between `+__constant+` and any other address space
 exists. This is aligned with rules from `OpenCL C 3.0 s6.7.9` and this logic
 regulates semantics described in this section.
 
@@ -43,19 +43,19 @@ between `__constant` and any other other address space are disallowed.
 // Example assumes generic address space support.
 int * genptr; // points to generic address space.
 
-// named -> generic address space conversions.
+// generic -> named address space conversions.
 __private float * ptrfloat = reinterpret_cast<__private float*>(genptr); // illegal.
 __private float * ptrfloat = addrspace_cast<__private float*>(genptr); // illegal.
 __private int * ptr = addrspace_cast<__private int*>(genptr); // legal.
 
-// generic -> named address space conversion.
+// named -> generic address space conversion.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
 
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(genptr); // illegal.
 ------------
 
-If generic address space is not supported any conversion of references/pointers
+If generic address space is not supported, any conversion of references/pointers
 pointing to different address spaces is illegal.
 
 [source,cpp]
@@ -66,8 +66,8 @@ int * privptr; // points to private address space.
 // The same address space conversions.
 __private float * ptrfloat = reinterpret_cast<__private float*>(privptr); // legal.
 __private float * ptrfloat = addrspace_cast<__private float*>(privptr); // illegal.
-__private int * ptr = addrspace_cast<__private int*>(genptr); // legal, no op.
-float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
+__private int * ptr = addrspace_cast<__private int*>(privptr); // legal, no op.
+float * privptrfloat = reinterpret_cast<float*>(ptr); // legal.
 
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(privptr); // illegal.
@@ -96,7 +96,7 @@ int & ref = ...; // references int in generic address space if it is
 
 Address space compatibility checks are performed when references are
 bound to values. The logic follows the rules from address space pointer
-conversion (`OpenCL 3.0 s6.7.9`).
+conversion (`OpenCL C 3.0 s6.7.9`).
 
 [source,cpp]
 ------------
@@ -114,7 +114,7 @@ void f(float &ref, __global float &globref) {
 
 This section details what happens if address spaces for types are not
 provided in the source code explicitly. Most of the logic for address space
-inference (i.e. default address space) follows rules from `OpenCL 3.0 s6.7.8`.
+inference (i.e. default address space) follows rules from `OpenCL C 3.0 s6.7.8`.
 
 References inherit rules from pointers and therefore refer to generic
 address space objects by default (see <<references, _References_>>) if
@@ -122,9 +122,9 @@ generic address space is supported, otherwise they refer to private
 address space objects.
 
 Class static data members are deduced to `+__global+` address space. Note,
-that if implementations of {cpp} for OpenCL 2021 does not support program
+that if implementation of {cpp} for OpenCL 2021 does not support program
 scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
-from `OpenCL 3.0 s6.1`) the address space qualifier must be  specified
+from `OpenCL C 3.0 s6.1`) the address space qualifier must be  specified
 explicitly and it must be `+__constant+` address space.
 
 All non-static member functions take an implicit object parameter `this`
@@ -132,8 +132,8 @@ that is a pointer type. By default the `this` pointer parameter is in the
 generic address space if it is supported and in the private address space
 otherwise. All concrete objects passed as an argument to the
 implicit `this` parameter will be converted to this default (generic or private)
-address space first if such conversion is valid. Therefore programs using objects
-in disjoint address spaces will not be compiled unless the address for the
+address space first if such conversion is valid. Therefore, programs using objects
+in disjoint address spaces will not be compiled unless the address spaces for the
 object parameter `this` is explicitly specified using address space qualifiers
 on member functions (see <<addrspace-member-function-qualifiers,
 _Member function qualifier_>>). For example, use of member functions with
@@ -150,7 +150,7 @@ Address spaces are not deduced for:
   * non-pointer/non-reference template parameters except for template
     specializations or non-type type based template parameters.
   * non-pointer/non-reference class members except for static data members
-    that are deduced to `+__global+` address space for {cpp} for OpenCL v1.0
+    that are deduced to `+__global+` address space for {cpp} for OpenCL 1.0
     or {cpp} for OpenCL 2021 with `__opencl_c_program_scope_global_variables`
     feature.
   * non-pointer/non-reference type alias declarations.
@@ -189,9 +189,9 @@ void bar()
 ------------
 struct c1 {};
 using alias_c1 = c1; // 'alias_c1' is 'c1'.
-using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to 'c1'
-                           // when generic address space is supported otherwise it
-                           // points to 'c1' located in __private address space.
+using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to
+                           // 'c1' when generic address space is supported otherwise
+                           // it points to 'c1' located in __private address space.
 ------------
 
 [source,cpp]
@@ -292,7 +292,8 @@ __kernel void foo() {
   [&] () __global {} (); // error: lambda temporary is in __private address space.
 
   [&] () mutable __private {} ();
-  [&] () __private mutable {} (); // error: mutable specifier should precede address space.
+  [&] () __private mutable {} (); // error: mutable specifier should precede address
+                                  // space.
 }
 ------------
 
@@ -465,7 +466,8 @@ __kernel void foo() {
   __local C locobj{}; // error: local address space objects can't be initialized
   __local C locobj; // uninitialised object
   locobj = {}; // calling copy assignment operator is allowed
-  locobj.~C(); // local address space object destructors are not invoked automatically.
+  locobj.~C(); // local address space object destructors are not invoked
+               // automatically.
 }
 ------------
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -49,7 +49,7 @@ __private int * ptr = addrspace_cast<__private int*>(genptr); // legal.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(genptr); // illegal.
-----------
+------------
 
 Note that if generic address space is not supported any conversion of pointers
 pointing to different address spaces is illegal.
@@ -65,7 +65,7 @@ __private int * ptr = addrspace_cast<__private int*>(genptr); // legal, no op.
 float * genptrfloat = reinterpret_cast<float*>(ptr); // legal.
 // disjoint address space conversion.
 __constant int * constptr = addrspace_cast<__constant int*>(privptr); // illegal.
-----------
+------------
 
 [[references]]
 ==== References
@@ -73,9 +73,9 @@ __constant int * constptr = addrspace_cast<__constant int*>(privptr); // illegal
 Reference types can be qualified with an address space.
 
 [source,cpp]
-----------
+------------
 __private int & ref = ...; // references int in __private address space.
-----------
+------------
 
 By default references refer to generic address space objects if generic
 address space is supported or private address space otherwise, except
@@ -158,25 +158,25 @@ void bar()
 {
   S<N> s; // 's' is in __private address space.
 }
-----------
+------------
 
 [source,cpp]
-----------
+------------
 struct c1 {};
 using alias_c1 = c1; // 'alias_c1' is 'c1'.
 using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to 'c1'
                            // when generic address space is supported otherwise it
                            // points to 'c1' located in private address space.
-----------
+------------
 
 [source,cpp]
-----------
+------------
 __kernel void foo()
 {
   __local int i;
   decltype(i)* ii; // type of 'ii' is '__local int *__private'.
 }
-----------
+------------
 
 For the placeholder type specifier `auto` an address space of the outer type is
 deduced as if it would be any other regular type. However if `auto` is used in a
@@ -205,7 +205,7 @@ __kernel void foo()
                        // is deduced regularly,
                        // addr space of a pointee is taken from the pointee of 'ptr').
 }
-----------
+------------
 
 [[addrspace-member-function-qualifiers]]
 ==== Member function qualifier
@@ -220,7 +220,7 @@ to an address space among candidates, compilation will fail with a
 diagnostic.
 
 [source,cpp]
-----------
+------------
 struct C {
   void foo() __local;
   void foo(); // This is implicitly qualified by generic address space
@@ -236,7 +236,7 @@ __kernel void bar() {
   c3.foo(); // error due to mismatching address spaces - can't convert to
             // '__local' or generic/'__private' addr spaces.
 }
-----------
+------------
 
 All  member functions can be qualified by an address space qualifier including
 constructors and destructors.
@@ -251,7 +251,7 @@ that has generic address space by default if it is supported otherwise
 private address space. 
 
 [source,cpp]
-----------
+------------
 __kernel void foo() {
   auto priv1 = []() __private {};
   priv1();
@@ -265,8 +265,7 @@ __kernel void foo() {
   [&] () mutable __private {} ();
   [&] () __private mutable {} (); // error: mutable specifier should precede address space.
 }
-----------
-
+------------
 
 ==== Implicit special members
 
@@ -277,7 +276,7 @@ object pointer and reference parameters (see also
 address space is generic if it is supported or private otherwise.
 
 [source,cpp]
-----------
+------------
 class C {
   // Has the following implicitly defined member functions.
 
@@ -306,7 +305,7 @@ class C {
                                /* if supported */ 
                                /* in private address space otherwise. */
 };
-----------
+------------
 
 TODO: As an optimisation we can do an upgrade in this version and always infer
 the concrete address space! See "Builtin operators" for details. Needs
@@ -328,18 +327,18 @@ during type deduction if it is not explicitly provided in the
 instantiation.
 
 [source,cpp]
-----------
+------------
 template<typename T>
 void foo(T* i){
   T var;
  }
 
- __global int g;
+__global int g;
 void bar(){
   foo(&g); // error: template instantiation failed as function scope variable 'var'
            // appears to be declared in __global address space (see line 3).
 }
-----------
+------------
 
 It is not legal to specify multiple different address spaces between
 template definition and instantiation. If multiple different address
@@ -349,7 +348,7 @@ restriction immediately follows from `OpenCL C v3.0 s6.7` that
 disallows multiple address space qualifiers on a type.
 
 [source,cpp]
-----------
+------------
 template <typename T>
 void foo() {
   __private T var;
@@ -359,13 +358,13 @@ void bar() {
   foo<__global int>(); // error: conflicting address space qualifiers are provided
                        // for 'var', '__global' and '__private'.
 }
-----------
+------------
 
 Once a template has been instantiated, regular restrictions for
 address spaces will apply.
 
 [source,cpp]
-----------
+------------
 template<typename T>
 void foo(){
   T var;
@@ -375,7 +374,7 @@ void bar(){
   foo<__global int>(); // error: function scope variable 'var' cannot be declared
                        // in '__global' address space.
 }
-----------
+------------
 
 ==== Temporary materialization
 
@@ -384,7 +383,7 @@ with another address space is bound to them, a conversion will be generated
 in case it is valid, otherwise compilation will fail with a diagnostic.
 
 [source,cpp]
-----------
+------------
 int bar(const unsigned int &i); // references generic address space object
                                 // if generic address space is supported
                                 // otherwise private address space object.
@@ -400,7 +399,7 @@ __global const int& f(__global float &ref) {
               // created to hold value converted float->int and return
               // value type (can't convert from __private to __global).
 }
-----------
+------------
 
 ==== Construction, initialization and destruction
 
@@ -433,8 +432,7 @@ public:
   __local C & operator=(const C & par) __local;
   ~C() __local;
 };
-__
-kernel void foo() {
+__kernel void foo() {
   __local C locobj{}; // error: local address space objects can't be initialized
   __local C locobj; // uninitialised object
   locobj = {}; // calling copy assignment operator is allowed
@@ -518,7 +516,7 @@ when converting between address spaces in nested pointers:
    address spaces in nested pointers.
 
 [source,cpp]
-----------
+------------
 local int * * locdefptr;
 constant int * * cnstdefptr;
 int * * defdefptr;
@@ -527,4 +525,4 @@ defdefptr = static_cast<int * *>(cnstdefptr); // illegal.
 defdefptr = addrspace_cast<int * *>(cnstdefptr); // illegal.
 defdefptr = reinterpret_cast<int * *>(locdefptr); // legal.
 defdefptr = reinterpret_cast<int * *>(cnstdefptr); // legal.
-----------
+------------

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -100,13 +100,12 @@ conversion (`OpenCL 3.0 s6.7.9`).
 
 [source,cpp]
 ------------
-__global const int& f(__global float &ref) {
-  return ref; // error reference to global address space object cannot bind
-              // to a temporary object created in __private  address space.
-}
-const int& f(float &ref) {
-  return ref; // legal - reference to generic/__private address space object can
-              // bind to a temporary object created in __private  address space.
+void f(float &ref, __global float &globref) {
+  const int& tmp = ref; // legal - reference to generic/__private address space object can
+                        // bind to a temporary object created in __private  address space.
+
+  __global const int& globtmp = globref; // error reference to global address space object cannot bind
+                                         // to a temporary object created in __private  address space.
 }
 ------------
 
@@ -248,15 +247,19 @@ diagnostic.
 [source,cpp]
 ------------
 struct C {
+  C() __local {};
+  C() __private {};
+  constexpr C() __constant {};
+
   void foo() __local;
   void foo(); // This is implicitly qualified by generic address space
               // if it is supported otherwise by '__private'.
 };
 
 __kernel void bar() {
-  __local C c1;
-  __private C c2;
-  __constant C c3;
+  __local C c1;      // will resolve to the first constructor overload.
+  __private C c2;    // will resolve to the second constructor overload.
+  __constant C c3{}; // will resolve to the third constructor overload.
   c1.foo(); // will resolve to the first 'foo'.
   c2.foo(); // will resolve to the second 'foo'.
   c3.foo(); // error due to mismatching address spaces - can't convert to

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -163,7 +163,7 @@ template <typename T>
 void foo() {
   T m; // address space of 'm' will be known at template instantiation time.
   T * ptr; // 'ptr' points to generic address space object when it is
-           // supported other to __private address space.
+           // supported otherwise to __private address space.
   T & ref = ...; // 'ref' references an object in generic address space when
                  // it is supported otherwise in __private address space.
 };
@@ -212,7 +212,7 @@ of the initialization expression. The logic follows rules for `const` and
 
 [source,cpp]
 ------------
-// Assumes that generic address space is supported.
+// This example assumes that generic address space is supported.
 __kernel void foo()
 {
   __local int i;
@@ -260,7 +260,7 @@ __kernel void bar() {
   c1.foo(); // will resolve to the first 'foo'.
   c2.foo(); // will resolve to the second 'foo'.
   c3.foo(); // error due to mismatching address spaces - can't convert to
-            // '__local' or generic/'__private' addr spaces.
+            // '__local' or generic/'__private' address spaces.
 }
 ------------
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -122,10 +122,10 @@ generic address space is supported, otherwise they refer to private
 address space objects.
 
 Class static data members are deduced to `+__global+` address space. Note,
-that if implementation of {cpp} for OpenCL 2021 does not support program
+that if the {cpp} for OpenCL 2021 implementation does not support program
 scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
 from `OpenCL C 3.0 s6.1`) the address space qualifier must be  specified
-explicitly and it must be `+__constant+` address space.
+explicitly and it must be the `+__constant+` address space.
 
 All non-static member functions take an implicit object parameter `this`
 that is a pointer type. By default the `this` pointer parameter is in the
@@ -150,8 +150,8 @@ Address spaces are not deduced for:
   * non-pointer/non-reference template parameters except for template
     specializations or non-type type based template parameters.
   * non-pointer/non-reference class members except for static data members
-    that are deduced to `+__global+` address space for {cpp} for OpenCL 1.0
-    or {cpp} for OpenCL 2021 with `__opencl_c_program_scope_global_variables`
+    that are deduced to the `+__global+` address space for {cpp} for OpenCL 1.0
+    or {cpp} for OpenCL 2021 with the `__opencl_c_program_scope_global_variables`
     feature.
   * non-pointer/non-reference type alias declarations.
   * decltype expressions.
@@ -171,11 +171,11 @@ template <int N>
 struct S {
   int i; // 'i' has no address space.
   static int ii; // 'ii' is in global address space if program scope variables
-                 // are supported otherwise this statement is not legal.
-  int * ptr; // 'ptr' points to int in generic address space if it is supported
+                 // are supported; otherwise this statement is not legal.
+  int * ptr; // 'ptr' points to int in generic address space if it is supported;
              // otherwise to __private address space.
   int & ref = ...; // 'ref' references int in generic address space if it is
-                   // supported otherwise in __private address space.
+                   // supported; otherwise in __private address space.
 };
 
 template <int N>
@@ -190,7 +190,7 @@ void bar()
 struct c1 {};
 using alias_c1 = c1; // 'alias_c1' is 'c1'.
 using alias_c1_ptr = c1 *; // 'alias_c1_ptr' is a generic address space pointer to
-                           // 'c1' when generic address space is supported otherwise
+                           // 'c1' when generic address space is supported; otherwise
                            // it points to 'c1' located in __private address space.
 ------------
 
@@ -267,7 +267,7 @@ __kernel void bar() {
 }
 ------------
 
-All  member functions can be qualified by an address space qualifier including
+All member functions can be qualified by an address space qualifier including
 constructors and destructors.
 
 
@@ -311,7 +311,7 @@ class C {
   // Has the following implicitly defined member functions.
 
   // C(); /* implicit 'this' parameter is a pointer to */
-          /* object in generic address space if supported */
+          /* object in generic address space if supported, or */
           /* in private address space otherwise. */
 
   // C(const C & par); /* 'this'/'par' is a pointer/reference to */
@@ -360,7 +360,7 @@ instantiation.
 ------------
 1  template<typename T>
 2  void foo(T* i){
-3   T var;
+3    T var;
 4  }
 5 
 6  __global int g;

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -331,8 +331,8 @@ class C {
 
   // C & operator=(C && par)'; /* 'this'/'par'/return value is */
                                /* a pointer/r-val reference/reference to */
-                               /* object in generic address space. */
-                               /* if supported */ 
+                               /* object in generic address space, */
+                               /* if it is supported or */ 
                                /* in private address space otherwise. */
 };
 ------------

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -16,7 +16,7 @@ main semantics depending on whether generic address space (`OpenCL C 3.0 6.7.`)
 is supported on not. The generic address space is always supported for
 
  * {cpp} for OpenCL 1.0;
- * {cpp} for OpenCL 1.1 with the presence of `+__opencl_c_generic_address_space+`
+ * {cpp} for OpenCL 2021 with the presence of `+__opencl_c_generic_address_space+`
    feature as explained in `OpenCL C 3.0 s6.2.1`.
 
 If generic address space is not supported qualification conversions with pointer
@@ -123,7 +123,7 @@ generic address space is supported, otherwise they refer to private
 address space objects.
 
 Class static data members are deduced to `+__global+` address space. Note,
-that if implementations of {cpp} for OpenCL 1.1 does not support program
+that if implementations of {cpp} for OpenCL 2021 does not support program
 scope variables (i.e. `+__opencl_c_program_scope_global_variables+` feature
 from `OpenCL 3.0 s6.1`) the address space qualifier must be  specified
 explicitly and it must be `+__constant+` address space.
@@ -152,7 +152,7 @@ Address spaces are not deduced for:
     specializations or non-type type based template parameters.
   * non-pointer/non-reference class members except for static data members
     that are deduced to `+__global+` address space for {cpp} for OpenCL v1.0
-    or {cpp} for OpenCL v1.1 with `__opencl_c_program_scope_global_variables`
+    or {cpp} for OpenCL 2021 with `__opencl_c_program_scope_global_variables`
     feature.
   * non-pointer/non-reference type alias declarations.
   * decltype expressions.

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -5,7 +5,7 @@
 [[address_space]]
 === Address spaces
 
-{cpp} for OpenCL inherits address space behavior from `OpenCL C v2.0 s6.5`.
+{cpp} for OpenCL inherits address space behavior from `OpenCL C v3.0 s6.7`.
 
 This section only documents behavior related to {cpp} features. For example
 conversion rules are extended from the qualification conversion {cpp}17
@@ -13,14 +13,14 @@ conversion rules are extended from the qualification conversion {cpp}17
 overlapping of address spaces from `section 5.1.3` of <<embedded-c-spec,
 The Embedded C Specification>>. For OpenCL it means that implicit
 conversions are allowed from a named address space (except for `+__constant+`)
-to generic (`OpenCL C v2.0 6.5.5`). The reverse conversion is only allowed
+to generic (`OpenCL C v2.0 6.7.5`). The reverse conversion is only allowed
 explicitly. The `+__constant+` address space does not overlap with any other
 and therefore no valid conversion between `+__constant+` and any other address
 space exists. Most of the rules follow this logic.
 
 ==== Casts
 
-C-style casts follow rules of `OpenCL C v2.0 s6.5.5`. Conversions of
+C-style casts follow rules of `OpenCL C v3.0 s6.7.5`. Conversions of
 pointers and references to the generic address space can be done by any {cpp} cast
 operator (as an implicit conversion); converting from generic to named address
 space can only be done using the dedicated `addrspace_cast` operator. The
@@ -52,7 +52,7 @@ By default references refer to generic address space objects, except
 for dependent types that are not template specializations (see
 <<addrspace-deduction, _Deduction_>>). Address space compatibility checks
 are performed when references are bound to values. The logic follows the
-rules from address space pointer conversion (`OpenCL v2.0 s6.5.5`).
+rules from address space pointer conversion (`OpenCL v3.0 s6.7.5`).
 
 
 [[addrspace-deduction]]
@@ -60,7 +60,7 @@ rules from address space pointer conversion (`OpenCL v2.0 s6.5.5`).
 
 This section details what happens if address spaces for types are not
 provided in the source code explicitly. Most of the logic for address space
-deduction (i.e. default address space) follows rules from `OpenCL v2.0 s6.5`.
+deduction (i.e. default address space) follows rules from `OpenCL v3.0 s6.7.8`.
 
 References inherit rules from pointers and therefore refer to generic
 address space objects by default (see <<references, _References_>>).

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -29,7 +29,7 @@ feature test macros.]
 Simultaneous initialization of static local objects performed by
 different work-items is not guaranteed to be free from race-conditions.
 Whether an implementation provides such a guarantee is indicated by the
-presence of the `__cpp_threadsafe_static_init` feature test
+presence of the `+__cpp_threadsafe_static_init+` feature test
 macro{fn-feature-macro}.
 
 The list above only contains extra restrictions that are not detailed in OpenCL

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -35,4 +35,4 @@ macro{fn-feature-macro}.
 The list above only contains extra restrictions that are not detailed in OpenCL
 C. As OpenCL restricts a number of C features, the same restrictions are
 inherited by C++ for OpenCL. The detailed list of C feature restrictions
-is provided in `OpenCL C v2.0 section 6.9`.
+is provided in `OpenCL C v3.0 section 6.11`.

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -35,4 +35,4 @@ macro{fn-feature-macro}.
 The list above only contains extra restrictions that are not detailed in OpenCL
 C. As OpenCL restricts a number of C features, the same restrictions are
 inherited by C++ for OpenCL. The detailed list of C feature restrictions
-is provided in `OpenCL C v3.0 section 6.11`.
+is provided in `OpenCL C 3.0 section 6.11`.

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -33,6 +33,6 @@ presence of the `__cpp_threadsafe_static_init` feature test
 macro{fn-feature-macro}.
 
 The list above only contains extra restrictions that are not detailed in OpenCL
-C. As OpenCL restricts a number of C features, the same restrictions are
-inherited by C++ for OpenCL. The detailed list of C feature restrictions
+C specification. As OpenCL restricts a number of C features, the same restrictions
+are inherited by C++ for OpenCL. The detailed list of C feature restrictions
 is provided in `OpenCL C 3.0 section 6.11`.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -149,12 +149,12 @@ in OpenCL specific behavior.
 ===== Variadic macros
 
 {cpp} for OpenCL eliminates the restriction on variadic macros from
-`OpenCL C v3.0 s6.11.f`.
+`OpenCL C 3.0 s6.11.f`.
 Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
 
-The macro `+__OPENCL_C_VERSION__+` described in `OpenCL C v2.0 s6.10`,
+The macro `+__OPENCL_C_VERSION__+` described in `OpenCL C v3.0 s6.12`,
 is not defined.
 
 The following new predefined macros are added in {cpp} for OpenCL:
@@ -163,23 +163,22 @@ The following new predefined macros are added in {cpp} for OpenCL:
    for OpenCL version the translation unit is compiled for. The value
    `100` corresponds to the language version 1.0 and `110` corresponds
    to the version 1.1.
- * `+__CL_CPP_VERSION_1_0__+` also set to `100` and can be used for
+ * `+__CL_CPP_VERSION_1_0__+` set to `100` and can be used for
    convenience instead of a literal.
- * `+__CL_CPP_VERSION_1_1__+` also set to `110` and can be used for
+ * `+__CL_CPP_VERSION_1_1__+` set to `110` and can be used for
    convenience instead of a literal.
 
 ===== Atomic operations
 
-{cpp} for OpenCL relaxes restriction from `OpenCL C v3.0 s6.15.12` to
+{cpp} for OpenCL relaxes restriction from `OpenCL C 3.0 s6.15.12` to
 atomic types allowing them to be used by builtin operators, and not
-only by builtin functions unless an implementation of {cpp} for OpenCL
-version 1.1 has no support of sequential consistency memory model
-(i.e. `__opencl_c_atomic_order_seq_cst` feature).
+only by builtin functions. This relaxation does not apply to
+{cpp} for OpenCL version 1.1 if sequential consistency memory model
+(i.e. `__opencl_c_atomic_order_seq_cst` feature) is not supported.
 
 Operators on atomic types behave as described in {cpp}17
 sections `[atomics.types.int]` `[atomics.types.pointer]`
 `[atomics.types.float]`.
-
 [source,c]
 ----------
 // Assumes support of sequential consistency memory model.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -136,7 +136,7 @@ The ternary selection operator (`?:`) inherits its behaviour from both
 `(exp1 ? exp2 : exp3)`. If all three expressions are scalar values,
 the {cpp}17 rules for ternary operator are followed. If the result is
 a vector value, then this is equivalent to calling
-`select(exp3, exp2, exp1)` as described in `OpenCL C v2.0 s6.13.6`.
+`select(exp3, exp2, exp1)` as described in `OpenCL C 3.0 s6.15.6`.
 The rules from OpenCL C impose limitation that `exp1` cannot be a
 vector of float values. However, `exp1` can be evaluated to a scalar
 float as it is contextually convertible to bool in {cpp}.

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -173,7 +173,7 @@ The following new predefined macros are added in {cpp} for OpenCL:
 {cpp} for OpenCL relaxes restriction from `OpenCL C 3.0 s6.15.12` to
 atomic types allowing them to be used by builtin operators, and not
 only by builtin functions. This relaxation does not apply to
-{cpp} for OpenCL version 2021 if sequential consistency memory model
+{cpp} for OpenCL version 2021 if the sequential consistency memory model
 (i.e. `__opencl_c_atomic_order_seq_cst` feature) is not supported.
 
 Operators on atomic types behave as described in {cpp}17

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -172,7 +172,9 @@ The following new predefined macros are added in {cpp} for OpenCL:
 
 {cpp} for OpenCL relaxes restriction from `OpenCL C v3.0 s6.15.12` to
 atomic types allowing them to be used by builtin operators, and not
-only by builtin functions.
+only by builtin functions unless an implementation of {cpp} for OpenCL
+version 1.1 has no support of sequential consistency memory model
+(i.e. `__opencl_c_atomic_order_seq_cst` feature).
 
 Operators on atomic types behave as described in {cpp}17
 sections `[atomics.types.int]` `[atomics.types.pointer]`
@@ -180,6 +182,7 @@ sections `[atomics.types.int]` `[atomics.types.pointer]`
 
 [source,c]
 ----------
+// Assumes support of sequential consistency memory model.
 atomic_int acnt;
 acnt++; // equivalent to atomic_fetch_add(&acnt, 1);
 ----------

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -102,7 +102,7 @@ encouraged to define `NULL` as an alias to pointer literal `nullptr`.
 
 {cpp}17 does not support `restrict` and therefore {cpp} for OpenCL
 can not support it either. Some compilers might provide extensions
-with some functionality of `restrict` in {cpp}, e.g. `__restrict`
+with some functionality of `restrict` in {cpp}, e.g. `+__restrict+`
 in Clang.
 
 This feature only affects optimizations and the source
@@ -110,7 +110,7 @@ code can be modified by removing it. As a workaround to avoid manual
 modifications, macro substitutions can be used to either remove the
 keyword during the preprocessing by defining `restrict` as an empty
 macro or mapping it to another similar compiler features, e.g.
-`__restrict` in Clang. This can be done in headers or using `-D`
+`+__restrict+` in Clang. This can be done in headers or using `-D`
 compilation flag.
 
 ===== Limitations of goto statements
@@ -174,7 +174,7 @@ The following new predefined macros are added in {cpp} for OpenCL:
 atomic types allowing them to be used by builtin operators, and not
 only by builtin functions. This relaxation does not apply to
 {cpp} for OpenCL version 2021 if the sequential consistency memory model
-(i.e. `__opencl_c_atomic_order_seq_cst` feature) is not supported.
+(i.e. `+__opencl_c_atomic_order_seq_cst+` feature) is not supported.
 
 Operators on atomic types behave as described in {cpp}17
 sections `[atomics.types.int]` `[atomics.types.pointer]`

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -154,7 +154,7 @@ Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
 
-The macro `+__OPENCL_C_VERSION__+` described in `OpenCL C v3.0 s6.12`,
+The macro `+__OPENCL_C_VERSION__+` described in `OpenCL C 3.0 s6.12`,
 is not defined.
 
 The following new predefined macros are added in {cpp} for OpenCL:

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -161,11 +161,11 @@ The following new predefined macros are added in {cpp} for OpenCL:
 
  * `+__OPENCL_CPP_VERSION__+` set to integer value reflecting the C++
    for OpenCL version the translation unit is compiled for. The value
-   `100` corresponds to the language version 1.0 and `110` corresponds
-   to the version 1.1.
+   `100` corresponds to the language version 1.0 and `202100` corresponds
+   to the version 2021.
  * `+__CL_CPP_VERSION_1_0__+` set to `100` and can be used for
    convenience instead of a literal.
- * `+__CL_CPP_VERSION_1_1__+` set to `110` and can be used for
+ * `+__CL_CPP_VERSION_2021__+` set to `202100` and can be used for
    convenience instead of a literal.
 
 ===== Atomic operations
@@ -173,7 +173,7 @@ The following new predefined macros are added in {cpp} for OpenCL:
 {cpp} for OpenCL relaxes restriction from `OpenCL C 3.0 s6.15.12` to
 atomic types allowing them to be used by builtin operators, and not
 only by builtin functions. This relaxation does not apply to
-{cpp} for OpenCL version 1.1 if sequential consistency memory model
+{cpp} for OpenCL version 2021 if sequential consistency memory model
 (i.e. `__opencl_c_atomic_order_seq_cst` feature) is not supported.
 
 Operators on atomic types behave as described in {cpp}17

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -149,7 +149,7 @@ in OpenCL specific behavior.
 ===== Variadic macros
 
 {cpp} for OpenCL eliminates the restriction on variadic macros from
-`OpenCL C v2.0 s6.9.e`.
+`OpenCL C v3.0 s6.11.f`.
 Variadic macros can be used normally as per {cpp}17 `[cpp.replace]`.
 
 ===== Predefined macros
@@ -159,13 +159,18 @@ is not defined.
 
 The following new predefined macros are added in {cpp} for OpenCL:
 
- * `+__OPENCL_CPP_VERSION__+` set to value `100`.
+ * `+__OPENCL_CPP_VERSION__+` set to integer value reflecting the C++
+   for OpenCL version the translation unit is compiled for. The value
+   `100` corresponds to the language version 1.0 and `110` corresponds
+   to the version 1.1.
  * `+__CL_CPP_VERSION_1_0__+` also set to `100` and can be used for
+   convenience instead of a literal.
+ * `+__CL_CPP_VERSION_1_1__+` also set to `110` and can be used for
    convenience instead of a literal.
 
 ===== Atomic operations
 
-{cpp} for OpenCL relaxes restriction from `OpenCL C v2.0 s6.13.11` to
+{cpp} for OpenCL relaxes restriction from `OpenCL C v3.0 s6.15.12` to
 atomic types allowing them to be used by builtin operators, and not
 only by builtin functions.
 

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -35,6 +35,18 @@ This document describes C++ for OpenCL language:
  * version 1.0 that is backward compatible with OpenCL 2.0;
  * version 1.1 that is backward compatible with OpenCL 3.0.
 
+== Version differences 
+
+The main difference  between {cpp} for OpenCL version 1.0 and version 1.1
+comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
+are respectively compatible. {cpp} for OpenCL 1.1 makes some functionality
+optional as described in `OpenCL 3.0 s6.2.1`.
+
+This impacts some C++ specific sematics mainly due to optionality of
+generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or
+program scope variables (i.e. `__opencl_c_program_scope_global_variables` feature)
+support.
+
 == The {cpp} for OpenCL Programming Language 
 
 This programming language inherits features from `OpenCL C v3.0,

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -31,22 +31,22 @@ The majority of content covers the behavior that is not documented in
 the `OpenCL C 3.0 s6` and {cpp}17 specifications. This is mainly
 related to interactions between OpenCL and {cpp} language features.
 
-This document describes C++ for OpenCL language:
+This document describes the C++ for OpenCL language:
 
  * version 1.0 that is backward compatible with OpenCL 2.0;
  * version 2021 that is backward compatible with OpenCL 3.0.
 
 == Version differences 
 
-The main difference  between {cpp} for OpenCL version 1.0 and version 2021
+The main difference between {cpp} for OpenCL version 1.0 and version 2021
 comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
 are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
 has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature
 macros can be used to detect which optional features are present. 
 
-This impacts some C++ specific sematics mainly due to optionality of
+This impacts some C++ specific sematics mainly due to optionality of the
 generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or
-program scope variables (i.e. `__opencl_c_program_scope_global_variables`
+program scope variables (i.e. `+__opencl_c_program_scope_global_variables+`
 feature).
 
 == The {cpp} for OpenCL Programming Language 

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -33,7 +33,9 @@ related to interactions between OpenCL and {cpp} language features.
 
 This document describes the C++ for OpenCL language:
 
- * version 1.0 that is backward compatible with OpenCL 2.0;
+This document describes C++ for OpenCL language
+
+ * version 1.0 that is backward compatible with OpenCL 2.0; and
  * version 2021 that is backward compatible with OpenCL 3.0.
 
 == Version differences 
@@ -42,7 +44,7 @@ The main difference between {cpp} for OpenCL version 1.0 and version 2021
 comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
 are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
 has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature
-macros can be used to detect which optional features are present. 
+macros from OpenCL C 3.0 can be used to detect which optional features are present.
 
 This impacts some C++ specific sematics mainly due to optionality of the
 generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -15,7 +15,7 @@ concepts to {cpp}. Therefore, it is important to refer to
 3.2` and `section 3.3` detailing fundamental differences of OpenCL execution
 and memory models from the conventional C and {cpp} view.
 
-This document describes the programming language in details. It is not
+This document describes the programming language in detail. It is not
 structured as a standalone document, but rather as an addition to OpenCL C
 3.0 unified specification defined in <<openclc-spec, The OpenCL C Specification,
 Version 3.0>> and {cpp}17 defined in <<cpp17-spec, The C++17 Specification>>.
@@ -28,7 +28,7 @@ The description of {cpp} for OpenCL starts from highlighting <<diff2openclc,
 _the differences to OpenCL C_>> and <<diff2cxx, _the differences to {cpp}_>>.
 
 The majority of content covers the behavior that is not documented in
-the OpenCL C 3.0 `section 6` and {cpp}17 specifications. This is mainly
+the `OpenCL C 3.0 s6` and {cpp}17 specifications. This is mainly
 related to interactions between OpenCL and {cpp} language features.
 
 This document describes C++ for OpenCL language:
@@ -42,7 +42,7 @@ The main difference  between {cpp} for OpenCL version 1.0 and version 2021
 comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
 are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
 has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature
-macros can be used to detect if optional feature is present. 
+macros can be used to detect which optional features are present. 
 
 This impacts some C++ specific sematics mainly due to optionality of
 generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or
@@ -51,7 +51,7 @@ feature).
 
 == The {cpp} for OpenCL Programming Language 
 
-This programming language inherits features from `OpenCL C 3.0, s6` as well
+This programming language inherits features from `OpenCL C 3.0 s6` as well
 as {cpp}17. Detailed aspects of OpenCL and {cpp} are not described in this
 document as they can be found in their official specifications.
  

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -56,7 +56,7 @@ as {cpp}17. Detailed aspects of OpenCL and {cpp} are not described in this
 document as they can be found in their official specifications.
  
 This section documents various language features of {cpp} for OpenCL that are
-not covered in either OpenCL or {cpp} specifications, in particular:
+not covered in neither OpenCL nor {cpp} specifications, in particular:
 
  * any behavior that deviates from {cpp}17;
  * any behavior that deviates from OpenCL C 3.0;

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -34,11 +34,11 @@ related to interactions between OpenCL and {cpp} language features.
 This document describes C++ for OpenCL language:
 
  * version 1.0 that is backward compatible with OpenCL 2.0;
- * version 1.1 that is backward compatible with OpenCL 3.0.
+ * version 2021 that is backward compatible with OpenCL 3.0.
 
 == Version differences 
 
-The main difference  between {cpp} for OpenCL version 1.0 and version 1.1
+The main difference  between {cpp} for OpenCL version 1.0 and version 2021
 comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
 are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
 has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -59,7 +59,7 @@ This section documents various language features of {cpp} for OpenCL that are
 not covered in neither OpenCL nor {cpp} specifications, in particular:
 
  * any behavior that deviates from {cpp}17;
- * any behavior that deviates from OpenCL C 3.0;
+ * any behavior that deviates from OpenCL C 2.0 or 3.0;
  * any behavior that is not governed by OpenCL C and {cpp}.
 
 All language extensions to OpenCL C v2.0 or earlier are applicable to

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -5,7 +5,7 @@
 [[intro]]
 == Introduction
 
-This language is built on top of OpenCL C v3.0 unified and {cpp}17 enabling
+This language is built on top of OpenCL C 3.0 unified and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
 from {cpp} and OpenCL C is inherited. Since both OpenCL C and {cpp} are
 derived from C and moreover {cpp} is almost fully backward compatible with C,
@@ -17,21 +17,22 @@ and memory models from the conventional C and {cpp} view.
 
 This document describes the programming language in details. It is not
 structured as a standalone document, but rather as an addition to OpenCL C
-v3.0 unified defined in <<openclc-spec, The OpenCL C Specification, Version 3.0>>
-and {cpp}17 defined in <<cpp17-spec, The C++17 Specification>>. Where necessary
-this document refers to the specifications of those languages accordingly.
-A full understanding of {cpp} for OpenCL requires familiarity with the
-specifications or other documentation of both languages that {cpp} for OpenCL
+3.0 unified specification defined in <<openclc-spec, The OpenCL C Specification,
+Version 3.0>> and {cpp}17 defined in <<cpp17-spec, The C++17 Specification>>.
+Where necessary this document refers to the specifications of those languages
+accordingly. A full understanding of {cpp} for OpenCL requires familiarity with
+the specifications or other documentation of both languages that {cpp} for OpenCL
 is built upon.
 
 The description of {cpp} for OpenCL starts from highlighting <<diff2openclc,
 _the differences to OpenCL C_>> and <<diff2cxx, _the differences to {cpp}_>>.
 
 The majority of content covers the behavior that is not documented in
-the OpenCL C v3.0 `section 6` and {cpp}17 specifications. This is mainly
+the OpenCL C 3.0 `section 6` and {cpp}17 specifications. This is mainly
 related to interactions between OpenCL and {cpp} language features.
 
 This document describes C++ for OpenCL language:
+
  * version 1.0 that is backward compatible with OpenCL 2.0;
  * version 1.1 that is backward compatible with OpenCL 3.0.
 
@@ -39,26 +40,26 @@ This document describes C++ for OpenCL language:
 
 The main difference  between {cpp} for OpenCL version 1.0 and version 1.1
 comes from the difference between OpenCL 2.0 and OpenCL 3.0 with which they
-are respectively compatible. {cpp} for OpenCL 1.1 makes some functionality
-optional as described in `OpenCL 3.0 s6.2.1`.
+are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
+has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature
+macros can be used to detect if optional feature is present. 
 
 This impacts some C++ specific sematics mainly due to optionality of
 generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or
-program scope variables (i.e. `__opencl_c_program_scope_global_variables` feature)
-support.
+program scope variables (i.e. `__opencl_c_program_scope_global_variables`
+feature).
 
 == The {cpp} for OpenCL Programming Language 
 
-This programming language inherits features from `OpenCL C v3.0,
-s6` as well as {cpp}17. Detailed aspects of OpenCL and {cpp} are not
-described in this document as they can be found in their official
-specifications.
+This programming language inherits features from `OpenCL C 3.0, s6` as well
+as {cpp}17. Detailed aspects of OpenCL and {cpp} are not described in this
+document as they can be found in their official specifications.
  
 This section documents various language features of {cpp} for OpenCL that are
 not covered in either OpenCL or {cpp} specifications, in particular:
 
  * any behavior that deviates from {cpp}17;
- * any behavior that deviates from OpenCL C v3.0;
+ * any behavior that deviates from OpenCL C 3.0;
  * any behavior that is not governed by OpenCL C and {cpp}.
 
 All language extensions to OpenCL C v2.0 or earlier are applicable to

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -46,7 +46,7 @@ are respectively compatible. Support for some features of {cpp} for OpenCL 1.0
 has become optional as described in `OpenCL 3.0 s6.2.1`. Predefined feature
 macros from OpenCL C 3.0 can be used to detect which optional features are present.
 
-This impacts some C++ specific sematics mainly due to optionality of the
+This impacts some C++ specific semantics mainly due to optionality of the
 generic address space (i.e. `+__opencl_c_generic_address_space+` feature) or
 program scope variables (i.e. `+__opencl_c_program_scope_global_variables+`
 feature).

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -5,19 +5,19 @@
 [[intro]]
 == Introduction
 
-This language is built on top of OpenCL C v2.0 and {cpp}17 enabling
+This language is built on top of OpenCL C v3.0 unified and {cpp}17 enabling
 most of regular {cpp} features in OpenCL kernel code. Most functionality
 from {cpp} and OpenCL C is inherited. Since both OpenCL C and {cpp} are
 derived from C and moreover {cpp} is almost fully backward compatible with C,
 the main design principle of {cpp} for OpenCL is to reapply existing OpenCL
 concepts to {cpp}. Therefore, it is important to refer to
-<<opencl-spec, The OpenCL Specification, Version 2.0>> `section
+<<opencl-spec, The OpenCL Specification, Version 3.0>> `section
 3.2` and `section 3.3` detailing fundamental differences of OpenCL execution
 and memory models from the conventional C and {cpp} view.
 
 This document describes the programming language in details. It is not
 structured as a standalone document, but rather as an addition to OpenCL C
-v2.0 defined in <<openclc-spec, The OpenCL C Specification, Version 2.0>>
+v3.0 unified defined in <<openclc-spec, The OpenCL C Specification, Version 3.0>>
 and {cpp}17 defined in <<cpp17-spec, The C++17 Specification>>. Where necessary
 this document refers to the specifications of those languages accordingly.
 A full understanding of {cpp} for OpenCL requires familiarity with the
@@ -28,12 +28,16 @@ The description of {cpp} for OpenCL starts from highlighting <<diff2openclc,
 _the differences to OpenCL C_>> and <<diff2cxx, _the differences to {cpp}_>>.
 
 The majority of content covers the behavior that is not documented in
-the OpenCL C v2.0 `section 6` and {cpp}17 specifications. This is mainly
+the OpenCL C v3.0 `section 6` and {cpp}17 specifications. This is mainly
 related to interactions between OpenCL and {cpp} language features.
+
+This document describes C++ for OpenCL language:
+ * version 1.0 that is backward compatible with OpenCL 2.0;
+ * version 1.1 that is backward compatible with OpenCL 3.0.
 
 == The {cpp} for OpenCL Programming Language 
 
-This programming language inherits features from `OpenCL C v2.0,
+This programming language inherits features from `OpenCL C v3.0,
 s6` as well as {cpp}17. Detailed aspects of OpenCL and {cpp} are not
 described in this document as they can be found in their official
 specifications.
@@ -42,7 +46,7 @@ This section documents various language features of {cpp} for OpenCL that are
 not covered in either OpenCL or {cpp} specifications, in particular:
 
  * any behavior that deviates from {cpp}17;
- * any behavior that deviates from OpenCL C v2.0;
+ * any behavior that deviates from OpenCL C v3.0;
  * any behavior that is not governed by OpenCL C and {cpp}.
 
 All language extensions to OpenCL C v2.0 or earlier are applicable to

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -64,5 +64,8 @@ not covered in neither OpenCL nor {cpp} specifications, in particular:
  * any behavior that deviates from OpenCL C 2.0 or 3.0;
  * any behavior that is not governed by OpenCL C and {cpp}.
 
-All language extensions to OpenCL C v2.0 or earlier are applicable to
-C++ for OpenCL.
+All language extensions to OpenCL C are applicable to C++ for OpenCL.
+ * Extensions to OpenCL C 2.0 or earlier versions apply to C++ for OpenCL
+   version 1.0.
+ * Extensions to OpenCL 3.0 or earlier versions except for OpenCL 2.0, apply to
+   C++ for OpenCL 2021.

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -31,8 +31,6 @@ The majority of content covers the behavior that is not documented in
 the `OpenCL C 3.0 s6` and {cpp}17 specifications. This is mainly
 related to interactions between OpenCL and {cpp} language features.
 
-This document describes the C++ for OpenCL language:
-
 This document describes C++ for OpenCL language
 
  * version 1.0 that is backward compatible with OpenCL 2.0; and

--- a/cxx4opencl/kernel.txt
+++ b/cxx4opencl/kernel.txt
@@ -24,5 +24,4 @@ Moreover the types used in parameters of the kernel functions must be:
     references{fn-ker-par-ref} if an implementation supports them in kernel
     parameters.
 
-These are additional restrictions to the list detailed in `OpenCL C v3.0
-section 6.11`.
+These are additional restrictions to the list detailed in `OpenCL C 3.0 s6.11`.

--- a/cxx4opencl/kernel.txt
+++ b/cxx4opencl/kernel.txt
@@ -24,5 +24,5 @@ Moreover the types used in parameters of the kernel functions must be:
     references{fn-ker-par-ref} if an implementation supports them in kernel
     parameters.
 
-These are additional restrictions to the list detailed in `OpenCL C v2.0
-section 6.9`.
+These are additional restrictions to the list detailed in `OpenCL C v3.0
+section 6.11`.

--- a/cxx4opencl/references.txt
+++ b/cxx4opencl/references.txt
@@ -4,9 +4,9 @@
 
 == Normative References
 
-   . [[opencl-spec]] "`The OpenCL Specification, Version 2.0`",
+   . [[opencl-spec]] "`The OpenCL Specification, Version 3.0`",
      https://www.khronos.org/registry/OpenCL/.
-   . [[openclc-spec]] "`The OpenCL C Specification, Version 2.0`",
+   . [[openclc-spec]] "`The OpenCL C Specification, Version 3.0`",
      https://www.khronos.org/registry/OpenCL/.
    . [[cpp17-spec]] "`ISO/IEC 14882:2017 - Programming languages — {CPP}`",
      https://www.iso.org/standard/68564.html.


### PR DESCRIPTION
A draft for C++ for OpenCL that is aligned with OpenCL 3.0 making features optional.

Compiled PDF is attached to https://github.com/AnastasiaStulova/OpenCL-Docs/releases/tag/cxxforopencl-v2021-draft

