### PR TITLE
Clarify optionality support for the double precision literals.

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -336,8 +336,8 @@ The following table describes the list of built-in scalar data types.
 If double precision floating-point extension {cl_khr_fp64} or feature
 {opencl_c_fp64} is not supported, implementations are allowed to
 implicitly cast double precision floating-point literals to
-single-precision literals. The use of double precision literals without
-double-precision support should result in a diagnostic.
+single precision literals. The use of double precision literals without
+double precision support should result in a diagnostic.
 
 Most built-in scalar data types are also declared as appropriate types in
 the OpenCL API (and header files) that can be used by an application.
@@ -481,7 +481,8 @@ The following table describes the list of built-in vector data types.
 | `double__n__` footnote:[{fn-double-vec}]
     | A vector of _n_ 64-bit floating-point values.
 
-      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer. In
+      OpenCL C 3.0 it requires support of {opencl_c_fp64} feature.
       Also see extension *cl_khr_fp64*.
 |====
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4822,7 +4822,7 @@ all arguments and the return type, unless otherwise specified.
     | Returns a quiet NaN.
       The _nancode_ may be placed in the significand of the resulting NaN.
 | gentype *nextafter*(gentype _x_, gentype _y_)
-    | Computes the next representable single-precision floating-point value
+    | Computes the next representable single precision floating-point value
       following _x_ in the direction of _y_.
       Thus, if _y_ is less than _x_, *nextafter*() returns the largest
       representable floating-point number less than _x_.
@@ -5064,7 +5064,7 @@ single precision floating-point number.
 |====
 | *Constant Name* | *Description*
 | `MAXFLOAT`
-    | Value of maximum non-infinite single-precision floating-point number.
+    | Value of maximum non-infinite single precision floating-point number.
 | `HUGE_VALF`
     | A positive `float` constant expression.
       `HUGE_VALF` evaluates to +infinity.
@@ -8189,7 +8189,7 @@ a following *a*, *A*, *e*, *E*, *f*, *F*, *g*, or *G* conversion specifier
 applies to a `double__n__` argument.
 The *l* modifier is supported by the full profile.
 For the embedded profile, the *l* modifier is supported only if 64-bit
-integers or double-precision floating-point are supported by the device.
+integers or double precision floating-point are supported by the device.
 
 If a vector specifier appears without a length modifier, the behavior is
 undefined.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -334,10 +334,10 @@ The following table describes the list of built-in scalar data types.
 |====
 
 If double precision floating-point extension {cl_khr_fp64} or feature
-{opencl_c_fp64} is not supported, the implementations are allowed to
+{opencl_c_fp64} is not supported, implementations are allowed to
 implicitly cast double precision floating-point literals to
 single-precision literals. The use of double precision literals without
-the double-precision support should results in a diagnostic.
+double-precision support should result in a diagnostic.
 
 Most built-in scalar data types are also declared as appropriate types in
 the OpenCL API (and header files) that can be used by an application.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -307,7 +307,8 @@ The following table describes the list of built-in scalar data types.
       The `double` data type must conform to the IEEE 754 double precision
       storage format.
 
-      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
+      <<unified-spec, Requires>> support for OpenCL C 1.2 or newer. In
+      OpenCL C 3.0 it requires support of {opencl_c_fp64} feature.
       Also see extension *cl_khr_fp64*.
 | `half`
     | A 16-bit floating-point.
@@ -331,6 +332,12 @@ The following table describes the list of built-in scalar data types.
     | The `void` type comprises an empty set of values; it is an incomplete
       type that cannot be completed.
 |====
+
+If double precision floating-point extension {cl_khr_fp64} or feature
+{opencl_c_fp64} is not supported, the implementations are allowed to
+implicitly cast double precision floating-point literals to
+single-precision literals. The use of double precision literals without
+the double-precision support should results in a diagnostic.
 
 Most built-in scalar data types are also declared as appropriate types in
 the OpenCL API (and header files) that can be used by an application.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -308,7 +308,7 @@ The following table describes the list of built-in scalar data types.
       storage format.
 
       <<unified-spec, Requires>> support for OpenCL C 1.2 or newer. In
-      OpenCL C 3.0 it requires support of {opencl_c_fp64} feature.
+      OpenCL C 3.0 it requires support of the {opencl_c_fp64} feature.
       Also see extension *cl_khr_fp64*.
 | `half`
     | A 16-bit floating-point.
@@ -333,11 +333,11 @@ The following table describes the list of built-in scalar data types.
       type that cannot be completed.
 |====
 
-If double precision floating-point extension {cl_khr_fp64} or feature
-{opencl_c_fp64} is not supported, implementations are allowed to
-implicitly cast double precision floating-point literals to
-single precision literals. The use of double precision literals without
-double precision support should result in a diagnostic.
+If the double-precision floating-point extension {cl_khr_fp64} or the
+{opencl_c_fp64} feature is not supported, implementations may
+implicitly cast double-precision floating-point literals to
+single-precision literals. The use of double-precision literals without
+double-precision support should result in a diagnostic.
 
 Most built-in scalar data types are also declared as appropriate types in
 the OpenCL API (and header files) that can be used by an application.
@@ -482,7 +482,7 @@ The following table describes the list of built-in vector data types.
     | A vector of _n_ 64-bit floating-point values.
 
       <<unified-spec, Requires>> support for OpenCL C 1.2 or newer. In
-      OpenCL C 3.0 it requires support of {opencl_c_fp64} feature.
+      OpenCL C 3.0 it requires support of the {opencl_c_fp64} feature.
       Also see extension *cl_khr_fp64*.
 |====
 
@@ -4822,7 +4822,7 @@ all arguments and the return type, unless otherwise specified.
     | Returns a quiet NaN.
       The _nancode_ may be placed in the significand of the resulting NaN.
 | gentype *nextafter*(gentype _x_, gentype _y_)
-    | Computes the next representable single precision floating-point value
+    | Computes the next representable single-precision floating-point value
       following _x_ in the direction of _y_.
       Thus, if _y_ is less than _x_, *nextafter*() returns the largest
       representable floating-point number less than _x_.
@@ -5064,7 +5064,7 @@ single precision floating-point number.
 |====
 | *Constant Name* | *Description*
 | `MAXFLOAT`
-    | Value of maximum non-infinite single precision floating-point number.
+    | Value of maximum non-infinite single-precision floating-point number.
 | `HUGE_VALF`
     | A positive `float` constant expression.
       `HUGE_VALF` evaluates to +infinity.
@@ -8189,7 +8189,7 @@ a following *a*, *A*, *e*, *E*, *f*, *F*, *g*, or *G* conversion specifier
 applies to a `double__n__` argument.
 The *l* modifier is supported by the full profile.
 For the embedded profile, the *l* modifier is supported only if 64-bit
-integers or double precision floating-point are supported by the device.
+integers or double-precision floating-point are supported by the device.
 
 If a vector specifier appears without a length modifier, the behavior is
 undefined.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6211,7 +6211,7 @@ These options control compiler behavior regarding floating-point arithmetic.
 These options trade off between speed and correctness.
 
 `-cl-single-precision-constant` ::
-    This option forces implicit conversions of double precision floating-point
+    This option forces implicit conversions of double-precision floating-point
     literals to single precision.
     This option is ignored for programs created with IL.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6211,8 +6211,8 @@ These options control compiler behavior regarding floating-point arithmetic.
 These options trade off between speed and correctness.
 
 `-cl-single-precision-constant` ::
-    Treat double precision floating-point constant as single precision
-    constant.
+    This option forces implicit conversions of double precision floating-point
+    literals to a single precision.
     This option is ignored for programs created with IL.
 
 `-cl-denorms-are-zero` ::

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6212,7 +6212,7 @@ These options trade off between speed and correctness.
 
 `-cl-single-precision-constant` ::
     This option forces implicit conversions of double precision floating-point
-    literals to a single precision.
+    literals to single precision.
     This option is ignored for programs created with IL.
 
 `-cl-denorms-are-zero` ::


### PR DESCRIPTION
This change adds clarifications regarding double precision
literals when double precision is not supported.

It also improves wording for -cl-single-precision-constant
flag to make it more precise.