### PR TITLE
[C++ for OpenCL] Misc small fixes.

### DIFF
--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -13,7 +13,7 @@ however, there are some differences that are documented in this section.
 The following {cpp} language features are not supported:
 
   * Virtual functions ({cpp}17 `[class.virtual]`);
-  * References to functions including member functions ({cpp}17 `[class.mfct]`);
+  * References to functions ({cpp}17 `[class.mfct]`);
   * Pointers to class member functions (in addition to the regular non-member
     functions that are already restricted in OpenCL C);
   * Exceptions ({cpp}17 `[except]`);

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -167,9 +167,9 @@ atomic_int acnt;
 acnt++; // equivalent to atomic_fetch_add(&acnt, 1);
 ----------
 
-===== Use of Clang Blocks
+===== Use of Blocks
 
-Clang Blocks that are defined by the Objective-C language are not supported
+Blocks that are defined in `OpenCL C v2.0 s6.12` are not supported
 and their use can be replaced by lambdas ({cpp}17 `[expr.prim.lambda]`).
 
 The above implies that builtin functions using blocks, such as `enqueue_kernel`,


### PR DESCRIPTION
- references to member functions are not supported in C++
  either and therefore mentioning it is misleading.
- OpenCL C doesn't call Clang Blocks.