### PR TITLE
move SPIR-V changes for cl_khr_extended_bit_ops to environment spec

### DIFF
--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -324,6 +324,12 @@ If the OpenCL environment supports the extension `cl_khr_spirv_linkonce_odr`, th
 
 If the OpenCL environment supports the extension `cl_khr_spirv_linkonce_odr` and use of the SPIR-V extension `SPV_KHR_linkonce_odr` is declared in the module via *OpExtension*, then the environment must accept modules that include the *LinkOnceODR* linkage type.
 
+==== `cl_khr_extended_bit_ops`
+
+If the OpenCL environment supports the extension `cl_khr_extended_bit_ops`, then the environment must accept modules that declare use of the extension `SPV_KHR_bit_instructions` via *OpExtension*.
+
+If the OpenCL environment supports the extension `cl_khr_extended_bit_ops` and use of the SPIR-V extension `SPV_KHR_bit_instructions` is declared in the module via *OpExtension*, then the environment must accept modules that declare the *BitInstructions* capability.
+
 ==== `cl_khr_integer_dot_product`
 
 If the OpenCL environment supports the extension `cl_khr_integer_dot_product`,

--- a/ext/cl_khr_extended_bit_ops.asciidoc
+++ b/ext/cl_khr_extended_bit_ops.asciidoc
@@ -129,15 +129,3 @@ That is, the bit numbered _n_ of the result value will be taken from the bit num
 
 |===
 --
-
-=== Modifications to the OpenCL SPIR-V Environment Specification
-
-==== Add to Section 5 - OpenCL Extensions
-
-Add a new Section 5.2.X - `cl_khr_extended_bit_ops`: ::
-+
---
-If the OpenCL environment supports the extension `cl_khr_extended_bit_ops`, then the environment must accept modules that declare use of the extension `SPV_KHR_bit_instructions` via *OpExtension*.
-
-If the OpenCL environment supports the extension `cl_khr_extended_bit_ops` and use of the SPIR-V extension `SPV_KHR_bit_instructions` is declared in the module via *OpExtension*, then the environment must accept modules that declare the *BitInstructions* capability.
---


### PR DESCRIPTION
This PR moves the SPIR-V changes for cl_khr_extended_bit_ops from the OpenCL Extensions spec to the OpenCL SPIR-V Environment spec.

Fixes #607