### PR TITLE
remove unnecessary phrase from subgroup mask function descriptions

### DIFF
--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -339,35 +339,35 @@ If no bits representing predicate values from all work items in the subgroup are
 ----
 uint4 get_sub_group_eq_mask()
 ----
-| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index equals the subgroup local ID and unset otherwise.
+| Generates a bitmask where the bit is set in the bitmask if the bit index equals the subgroup local ID and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
 |[source,c]
 ----
 uint4 get_sub_group_ge_mask()
 ----
-| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is greater than or equal to the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than or equal to the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
 |[source,c]
 ----
 uint4 get_sub_group_gt_mask()
 ----
-| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is greater than the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
 |[source,c]
 ----
 uint4 get_sub_group_le_mask()
 ----
-| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is less than or equal to the subgroup local ID and unset otherwise.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is less than or equal to the subgroup local ID and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
 |[source,c]
 ----
 uint4 get_sub_group_lt_mask()
 ----
-| Generates a bitmask of all work items in the subgroup, where the bit is set in the bitmask if the bit index is less than the subgroup local ID and unset otherwise.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is less than the subgroup local ID and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
 |=======================================================================


### PR DESCRIPTION
Fixes #625.

Removes an extraneous phrase from the descriptions of the subgroup mask built-in functions.