### PR TITLE
Increase the number of TOC levels for the extension specification

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -8,7 +8,7 @@ Khronos{R} OpenCL Working Group
 :data-uri:
 :icons: font
 :toc2:
-:toclevels: 1
+:toclevels: 2
 :max-width: 100
 :numbered:
 :imagewidth: 800

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -8,7 +8,9 @@ Khronos{R} OpenCL Working Group
 :data-uri:
 :icons: font
 :toc2:
-:toclevels: 2
+// Only one TOC level for the HTML output, two TOC levels for everything else.
+ifdef::backend-html5[:toclevels: 1]
+ifndef::backend-html5[:toclevels: 2]
 :max-width: 100
 :numbered:
 :imagewidth: 800


### PR DESCRIPTION
Makes the specificaiton much more navigable. We may want to revisit section
titles for some of the older extensions but overall it feels like a good
change as is to me.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>
Change-Id: I7ac819888e702075aec02001d47ff3084cab2819