### PR TITLE
Drop claim about not requiring SPIR-V extensions

### DIFF
--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -18,8 +18,7 @@ corresponding SPIR-V extension.
 This section describes how the OpenCL environment is modified by Khronos
 (`khr`) OpenCL extensions.  Other OpenCL extensions, such as multi-vendor
 (`ext`) extensions or vendor-specific extensions, describe how they modify
-the OpenCL environment in their individual extension specifications.  The
-Khronos OpenCL extensions require no corresponding SPIR-V extensions.
+the OpenCL environment in their individual extension specifications.
 
 === Declaring SPIR-V Extensions
 


### PR DESCRIPTION
The Environment Specification later contradicts this claim:

    If the OpenCL environment supports the extension
    cl_khr_extended_bit_ops, then the environment must accept modules
    that declare use of the extension SPV_KHR_bit_instructions