### PR TITLE
Added new return code for clGetKernelSuggestedLocalWorkSizeKHR.

### DIFF
--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -89,8 +89,8 @@ Otherwise, it returns one of the following errors:
 * `CL_INVALID_GLOBAL_WORK_SIZE` if _global_work_size_ is NULL or if any of the values specified in _global_work_size_ are 0.
 * `CL_INVALID_GLOBAL_WORK_SIZE` if any of the values specified in _global_work_size_ exceed the maximum value representable by `size_t` on the device associated with _command_queue_.
 * `CL_INVALID_GLOBAL_OFFSET` if the value specified in _global_work_size_ plus the corresponding value in _global_work_offset_ for dimension exceeds the maximum value representable by `size_t` on the device associated with _command_queue_.
+* `CL_INVALID_VALUE` if _suggested_local_work_size_ is NULL.
 * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * `CL_OUT_OF_HOST_RESOURCES` if there is a failure to allocate resources required by the OpenCL implementation on the host.
-* `CL_INVALID_VALUE` if _suggested_local_work_size_ is NULL.
 
 NOTE: These error conditions are consistent with error conditions for *clEnqueueNDRangeKernel*.

--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -91,5 +91,6 @@ Otherwise, it returns one of the following errors:
 * `CL_INVALID_GLOBAL_OFFSET` if the value specified in _global_work_size_ plus the corresponding value in _global_work_offset_ for dimension exceeds the maximum value representable by `size_t` on the device associated with _command_queue_.
 * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * `CL_OUT_OF_HOST_RESOURCES` if there is a failure to allocate resources required by the OpenCL implementation on the host.
+* `CL_INVALID_VALUE` if _suggested_local_work_size_ is NULL.
 
 NOTE: These error conditions are consistent with error conditions for *clEnqueueNDRangeKernel*.


### PR DESCRIPTION
Return CL_INVALID_VALUE if suggested_local_work_size is NULL.

Fixes #641 