### PR TITLE
Generate asciidoc api snippets for all supported extensions

### DIFF
--- a/scripts/gencl.py
+++ b/scripts/gencl.py
@@ -140,7 +140,7 @@ def makeGenOpts(args):
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
-            defaultExtensions = None,
+            defaultExtensions = defaultExtensions,
             addExtensions     = addExtensionsPat,
             removeExtensions  = removeExtensionsPat,
             emitExtensions    = emitExtensionsPat,

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -81,6 +81,7 @@ server's OpenCL/api-docs repository.
         <type category="basetype" requires="CL/cl_platform.h" name="char"/>
         <type category="basetype" requires="CL/cl_platform.h" name="int"/>
         <type category="basetype" requires="CL/cl_platform.h" name="unsigned char"/>
+        <type category="basetype" requires="CL/cl_platform.h" name="unsigned int"/>
         <type category="basetype" requires="CL/cl_platform.h" name="intptr_t"/>
         <type category="basetype" requires="CL/cl_platform.h" name="size_t"/>
         <type category="basetype" requires="CL/cl_platform.h" name="float"/>


### PR DESCRIPTION
Prototypes, structures and definitions are now generated by default
for all extensions that are declared with 'supported="opencl"' in cl.xml.

Also define the missing "unsigned int" type in cl.xml, the generation
tool flagged its absence.

Contributes to #652

Signed-off-by: Kevin Petit <kevin.petit@arm.com>
Change-Id: I6a56f2c33e59db5bc549780bbcbb6095c2dc8d98