### PR TITLE
add missing types for cl_intel_sharing_format_query to the XML file

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -54,6 +54,7 @@ server's OpenCL/api-docs repository.
         <type category="include" name="d3d11.h">#include &lt;d3d11.h&gt;</type>
         <type category="include" name="d3d9.h">#include &lt;d3d9.h&gt;</type>
         <type category="include" name="d3d9types.h">#include &lt;d3d9types.h&gt;</type>
+        <type category="include" name="dxgiformat.h">#include &lt;dxgiformat.h&gt;</type>
         <type category="include" name="dxvahd.h">#include &lt;dxvahd.h&gt;</type>
         <type category="include" name="wtypes.h">#include &lt;wtypes.h&gt;</type>
         <type category="include" name="ID3D10Buffer" requires="d3d10.h"/>
@@ -63,12 +64,15 @@ server's OpenCL/api-docs repository.
         <type category="include" name="ID3D11Texture2D" requires="d3d11.h"/>
         <type category="include" name="ID3D11Texture3D" requires="d3d11.h"/>
         <type category="include" name="IDirect3DSurface9" requires="d3d9.h"/>
+        <type category="include" name="D3DFORMAT" requires="d3d9types.h"/>
         <type category="include" name="HANDLE" requires="d3d9types.h"/>
+        <type category="include" name="DXGI_FORMAT" requires="dxgiformat.h"/>
         <type category="include" name="UINT" comment="Requires one of the D3D headers, which in turn probably pulls in windows.h"/>
 
             <comment>Non-CL headers and types</comment>
         <type category="include" name="va/va.h">#include &lt;va/va.h&gt;</type>
         <type category="include" name="VASurfaceID" requires="va/va.h"/>
+        <type category="include" name="VAImageFormat" requires="va/va.h"/>
 
             <comment>CL headers and types</comment>
         <type category="include" name="CL/cl.h">#include &lt;CL/cl.h&gt;</type>


### PR DESCRIPTION
Adds missing types for [cl_intel_sharing_format_query](https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_sharing_format_query.html) to the XML file.

Fixes #655.