### PR TITLE
C++ for OpenCL Documentation for Ternary Operator (?:)

### DIFF
--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -129,6 +129,18 @@ label:  // invalid: jumping forward over declaration of n
    // ...
 ----------
 
+===== Ternary Selection Operator
+
+The ternary selection operator (`?:`) inherits its behaviour from both
+{cpp} and OpenCL C. It operates on three expressions
+`(exp1 ? exp2 : exp3)`. If all three expressions are scalar values,
+the {cpp}17 rules for ternary operator are followed. If the result is
+a vector value, then this is equivalent to calling
+`select(exp3, exp2, exp1)` as described in `OpenCL C v2.0 s6.13.6`.
+The rules from OpenCL C impose limitation that `exp1` cannot be a
+vector of float values. However, `exp1` can be evaluated to a scalar
+float as it is contextually convertible to bool in {cpp}.
+
 ==== OpenCL specific difference
 
 This section describes where {cpp} for OpenCL differs from OpenCL C


### PR DESCRIPTION
Since C++ and OpenCL C use different rules for ternary operator,
C++ for OpenCL had to adapt to those differences. The documentation
section is written that explains usage of ternary operator in C++
for OpenCL.