### PR TITLE
move asciidoctor attributes to a separate file for ref pages

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -16,10 +16,11 @@ Khronos{R} OpenCL Working Group
 :source-highlighter: coderay
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
-:cpp: pass:[C++]
-
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 // Formatting and links for API functions and enums.
 include::api/dictionary.asciidoc[]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -17,27 +17,11 @@ Khronos{R} OpenCL Working Group
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 :sectnumoffset: 5
 
-// Needed for expressing C math in unary ops section
-:pp: ++
-
-:cpp: pass:[C++]
-:cpp11: pass:[C++11]
-:kernel: pass:[__kernel]
-:read_only: pass:[__read_only]
-:write_only: pass:[__write_only]
-:read_write: pass:[__read_write]
-:private: pass:[__private]
-:global: pass:[__global]
-:local: pass:[__local]
-:constant: pass:[__constant]
-:generic: pass:[__generic]
-:rte: pass:[_rte]
-:rtz: pass:[_rtz]
-:rtn: pass:[_rtn]
-:rtp: pass:[_rtp]
-
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 // Feature Dictionary
 include::c/feature-dictionary.asciidoc[]

--- a/OpenCL_Cxx.txt
+++ b/OpenCL_Cxx.txt
@@ -16,9 +16,6 @@ Khronos{R} OpenCL Working Group
 :source-highlighter: coderay
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
-:cpp: pass:[C++]
-:cpp14: pass:[C++14]
-
 // type of the source code in the document
 :language: c++
 
@@ -26,6 +23,9 @@ Khronos{R} OpenCL Working Group
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 include::copyrights.txt[]
 

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -16,12 +16,11 @@ Khronos{R} OpenCL Working Group
 :source-highlighter: coderay
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
-:blank: pass:[ +]
-:cpp: pass:[C++]
-:cpp14: pass:[C++14]
-
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 // Formatting and links for API functions and enums.
 include::env/dictionary.asciidoc[]

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -18,20 +18,11 @@ ifndef::backend-html5[:toclevels: 2]
 :source-highlighter: coderay
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
-:blank: pass:[ +]
-:cpp: pass:[C++]
-:cpp14: pass:[C++14]
-:private: pass:[__private]
-:global: pass:[__global]
-:local: pass:[__local]
-:constant: pass:[__constant]
-:rte: pass:[_rte]
-:rtz: pass:[_rtz]
-:rtn: pass:[_rtn]
-:rtp: pass:[_rtp]
-
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 // Formatting and links for API functions and enums.
 include::ext/dictionary.asciidoc[]

--- a/OpenCL_ICD_Installation.txt
+++ b/OpenCL_ICD_Installation.txt
@@ -17,12 +17,11 @@ Khronos{R} OpenCL Working Group
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 //:title-page-background-image: image:images/Khronos_Dec14.svg["Khronos Logo",pdfwidth=50%,scaledwidth=50%]
 
-:blank: pass:[ +]
-:cpp: pass:[C++]
-:cpp14: pass:[C++14]
-
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]
+
+// Attributes that are shared by OpenCL specifications.
+include::config/opencl.asciidoc[]
 
 // type of the source code in the document
 :language: {basebackend@docbook:c++:cpp}

--- a/config/opencl.asciidoc
+++ b/config/opencl.asciidoc
@@ -1,0 +1,24 @@
+// Copyright 2017-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Attributes that are shared by OpenCL specifications.
+
+:blank: pass:[ +]
+:pp: ++
+:cpp: pass:[C++]
+:cpp11: pass:[C++11]
+:cpp14: pass:[C++14]
+:kernel: pass:[__kernel]
+:read_only: pass:[__read_only]
+:write_only: pass:[__write_only]
+:read_write: pass:[__read_write]
+:private: pass:[__private]
+:global: pass:[__global]
+:local: pass:[__local]
+:constant: pass:[__constant]
+:generic: pass:[__generic]
+:rte: pass:[_rte]
+:rtz: pass:[_rtz]
+:rtn: pass:[_rtn]
+:rtp: pass:[_rtp]

--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -211,6 +211,7 @@ class OpenCLConventions(ConventionsBase):
     def extra_refpage_headers(self):
         """Return any extra text to add to refpage headers."""
         return 'include::../config/attribs.txt[]\n' + \
+            'include::../config/opencl.asciidoc[]\n' + \
             'include::../api/footnotes.asciidoc[]\n' + \
             'include::../c/footnotes.asciidoc[]\n' + \
             'include::../c/feature-dictionary.asciidoc[]\n' + \


### PR DESCRIPTION
A few of the OpenCL specifications were defining their own asciidoctor attributes.  This PR:

* Moves all asciidoctor attributes to a separate file for easier re-use and includes it instead.
* Updates the reference page tooling to also include the new file.

This PR has no affect on the generated specifications but it does fix a few places where the attributes were not being correclty substituted in the reference pages.

We could put these attributes into the existing "attribs.txt", but this looked like a shared file, so I didn't want to modify it.