### PR TITLE
Reserve More Enums for mr180

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -617,11 +617,11 @@ server's OpenCL/api-docs repository.
             <unused start="-1126" end="-1137"/>
     </enums>
 
-    <enums start="-1138" end="-1140" name="ErrorCodes.1138" vendor="Khronos" comment="Reserved for MR180">
+    <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="Reserved for MR180">
     </enums>
 
-    <enums start="-1141" end="-9999" name="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
-            <unused start="-1138" end="-9999"/>
+    <enums start="-1142" end="-9999" name="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
+            <unused start="-1142" end="-9999"/>
     </enums>
 
     <enums name="cl_bool" vendor="Khronos" comment="Boolean values">


### PR DESCRIPTION
* Reserve 1 additional error code enum.
* Correct start tag of future error codes.