### PR TITLE
Minor formatting fixes for cl_khr_fp64

### DIFF
--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -594,7 +594,7 @@ a number (NaN).
 the argument type is a scalar and returns -1 if one or both arguments are
 not a number (NaN) and the argument type is a vector.
 
-The functions described in _table 6.14_ are extended to include the `doublen``
+The functions described in _table 6.14_ are extended to include the `doublen`
 vector types.
 
 ._Double Precision Relational Functions_
@@ -611,7 +611,7 @@ vector types.
   long__n__ *isnotequal* (double__n x__, double__n y__)
 | Returns the component-wise compare of _x_ != _y_.
 
-| int *isgreater* (double _x_, double _y_)
+| int *isgreater* (double _x_, double _y_) +
   long__n__ *isgreater* (double__n x__, double__n y__)
 | Returns the component-wise compare of _x_ > _y_.
 


### PR DESCRIPTION
Add a missing line break and fix a stray ` in the markup.