### PR TITLE
reserve cl_mem_flags bits for an upcoming Intel extension

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -793,7 +793,9 @@ server's OpenCL/api-docs repository.
         <enum bitpos="12"           name="CL_MEM_KERNEL_READ_AND_WRITE"/>
             <unused start="13" end="19"/>
         <enum bitpos="20"           name="CL_MEM_FORCE_HOST_MEMORY_INTEL"/>
-            <unused start="21" end="23"/>
+        <enum bitpos="21"           name="CL_MEM_RESERVED21_INTEL"/>
+        <enum bitpos="22"           name="CL_MEM_RESERVED22_INTEL"/>
+            <unused start="23" end="23"/>
         <enum bitpos="24"           name="CL_MEM_NO_ACCESS_INTEL"/>
         <enum bitpos="25"           name="CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL"/>
         <enum bitpos="26"           name="CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG"/>


### PR DESCRIPTION
Please reserve two cl_mem_flags bits for an upcoming Intel extension.

Note, we have started to move functionality that we would have traditionally expressed via cl_mem_flags to properties instead in order to conserve cl_mem_flags bits, but for this case a significant amount of internal code has already been written to use cl_mem_flags, so we would prefer to continue using cl_mem_flags.

If both this PR and #685 is merged we will have allocated 32 of the possible 64 cl_mem_flags bits.

