### PR TITLE
add recommendation for bits in bitfields

### DIFF
--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -465,6 +465,7 @@ best not to renumber issues, either.
 | 0.4.0   | 2019-10-25 | Kévin Petit  | Added conformance tests section.
 | 0.5.0   | 2020-02-13 | Kévin Petit  | Syntax fixes + added SPIR-V environment section.
 | 0.6.0   | 2020-04-20 | Alastair Murray | Use naming conventions in the new type example.
+| 0.7.0   | 2021-10-05 | Ben Ashbaugh | Added recommendation for bits in bitfields.
 |====
 
 ****

--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -237,6 +237,10 @@ lowercase.
 
 If the extension does not add any new API enumerants then this section
 may be omitted.
+
+Please note that bits in bitfields (such as `cl_mem_flags`) are limited
+in number.  When possible, it is recommended to use properties instead,
+to conserve bitfield bits.
 ****
 
 == New OpenCL C Functions

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -778,6 +778,8 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums name="cl_mem_flags" vendor="Khronos" type="bitmask">
+        <!-- Note: cl_mem_flags bits are limited!  When possible, using
+             cl_mem_properties or cl_pipe_properties is recommended instead. -->
         <enum bitpos="0"            name="CL_MEM_READ_WRITE"/>
         <enum bitpos="1"            name="CL_MEM_WRITE_ONLY"/>
         <enum bitpos="2"            name="CL_MEM_READ_ONLY"/>


### PR DESCRIPTION
As discussed in the October 4th teleconference, adds a comment recommending usage of properties instead of bits int a bitfield to the XML file and the extension template, which may help to conserve bitfield bits.