### PR TITLE
cosmetic updates for the OpenCL specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - gem install rouge -v 3.19.0
   - gem install ttfunk -v 1.5.1
   - gem install asciidoctor-pdf -v 1.5.0
-  - MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
+  - gem install asciidoctor-mathematical -v 0.3.5
 
 script:
   - git describe --tags --dirty

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ rvm:
 
 before_install:
   - sudo apt-get install -y libpango1.0-dev ghostscript fonts-lyx
-  - gem install asciidoctor -v 1.5.8
+  - gem install asciidoctor -v 2.0.16
   - gem install coderay -v 1.1.1
+  - gem install rouge -v 3.19.0
   - gem install ttfunk -v 1.5.1
   - gem install asciidoctor-pdf -v 1.5.0
   - MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ ATTRIBOPTS_NO_VERSION	= -a revdate="$(SPECDATE)" \
 ATTRIBOPTS   = -a revnumber="$(SPECREVISION)" \
 	       $(ATTRIBOPTS_NO_VERSION)
 
-ADOCEXTS	      = -r $(CURDIR)/config/sectnumoffset-treeprocessor.rb -r $(CURDIR)/config/spec-macros.rb
+ADOCEXTS	      = -r $(CURDIR)/config/sectnumoffset-treeprocessor.rb \
+	-r $(CURDIR)/config/spec-macros.rb \
+	-r $(CURDIR)/config/rouge_opencl.rb
 ADOCOPTS_NO_VERSION   = -d book $(ATTRIBOPTS_NO_VERSION) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
 ADOCCOMMONOPTS	      = -a apispec="$(CURDIR)/api" \
 			-a config="$(CURDIR)/config" \

--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -13,7 +13,8 @@ Khronos{R} OpenCL Working Group
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-style: github
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
 // Various special / math symbols. This is easier to edit with than Unicode.

--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -9,12 +9,13 @@ Khronos{R} OpenCL Working Group
 :icons: font
 :toc2:
 :toclevels: 3
-:max-width: 100
+:max-width: 100%
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
 :source-highlighter: rouge
-:rouge-style: github
+:source-language: opencl
+:rouge-style: opencl.spec
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
 // Various special / math symbols. This is easier to edit with than Unicode.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9,12 +9,13 @@ Khronos{R} OpenCL Working Group
 :icons: font
 :toc2:
 :toclevels: 3
-:max-width: 100
+:max-width: 100%
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
 :source-highlighter: rouge
-:rouge-style: github
+:source-language: opencl_c
+:rouge-style: opencl.spec
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 :sectnumoffset: 5
 
@@ -379,7 +380,7 @@ The `half` data type can only be used to declare a pointer to a buffer that
 contains `half` values.
 A few valid examples are given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 void
 bar (__global half *p)
@@ -400,7 +401,7 @@ foo (__global half *pg, __local half *pl)
 
 Below are some examples that are not valid usage of the `half` type:
 
-[source,c]
+[source,opencl_c]
 ----------
 half a;
 half b[100];
@@ -741,7 +742,7 @@ In addition, a form with a single scalar of the same type as the element
 type of the vector is available.
 For example, the following forms are available for `float4`:
 
-[source,c]
+[source,opencl_c]
 ----------
 (float4)( float, float, float, float )
 (float4)( float2, float, float )
@@ -766,7 +767,7 @@ replicated across all lanes of the vector.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 f = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
 uint4 u = (uint4)(1); //  u will be (1, 1, 1, 1).
@@ -794,7 +795,7 @@ Vector data types with four or more components can access `.rgba` elements.
 Accessing components beyond those declared for the vector type is an error
 so, for example:
 
-[source,c]
+[source,opencl_c]
 ----------
 float2 coord;
 coord.x = 1.0f; // is legal
@@ -810,7 +811,7 @@ pos.w = 1.0f; // is illegal, since pos only has three components
 The component selection syntax allows multiple components to be selected by
 appending their names after the period (*.*).
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 c;
 
@@ -823,7 +824,7 @@ c.xyz = (float3)(3.0f, 4.0f, 5.0f);
 The component selection syntax also allows components to be permuted or
 replicated.
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 pos = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
 
@@ -839,7 +840,7 @@ contain no duplicate components, and it results in an l-value of scalar or
 vector type, depending on number of components specified.
 Each component must be a supported scalar or vector type.
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 pos = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
 
@@ -881,7 +882,7 @@ The numeric indices must be preceded by the letter `s` or `S`.
 
 In the following example
 
-[source,c]
+[source,opencl_c]
 ----------
 float8 f;
 ----------
@@ -891,7 +892,7 @@ refers to the 8^th^ element of the `float8` variable `f`.
 
 In the following example
 
-[source,c]
+[source,opencl_c]
 ----------
 float16 x;
 ----------
@@ -906,7 +907,7 @@ cannot be intermixed with `.xyzw` notation used to access elements of a 1 ..
 
 For example
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 f, a;
 
@@ -929,7 +930,7 @@ The `.odd` suffix refers to the odd elements of a vector.
 
 Some examples to help illustrate this are given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 vf;
 
@@ -946,7 +947,7 @@ vector type with the value in the `w` component undefined.
 
 Some examples are given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 float8 vf;
 float4 odd = vf.odd;
@@ -994,7 +995,7 @@ It is illegal to take the address of a vector element and will result in a
 compilation error.
 For example:
 
-[source,c]
+[source,opencl_c]
 ----------
 float8 vf;
 
@@ -1070,7 +1071,7 @@ Standard typecasts for built-in scalar data types defined in
 `void` and `half` footnote:[{fn-cl_khr_fp16}]).
 In the example below:
 
-[source,c]
+[source,opencl_c]
 ----------
 float f = 1.0f;
 int i = (int)f;
@@ -1082,7 +1083,7 @@ value `1.0f` in `f` converted to an integer value.
 Explicit casts between vector types are not legal.
 The examples below will generate a compilation error.
 
-[source,c]
+[source,opencl_c]
 ----------
 int4 i;
 uint4 u = (uint4) i; //  not allowed
@@ -1107,7 +1108,7 @@ otherwise.
 
 Below are some correct examples of explicit casts.
 
-[source,c]
+[source,opencl_c]
 ----------
 float f = 1.0f;
 float4 va = (float4)f;
@@ -1137,7 +1138,7 @@ uchar4 vtrue = (uchar4)true;
 
 Explicit conversions may be performed using the
 
-[source,c]
+[source,opencl_c]
 ----------
 convert_destType(sourceType)
 ----------
@@ -1154,7 +1155,7 @@ The number of elements in the source and destination vectors must match.
 
 In the example below:
 
-[source,c]
+[source,opencl_c]
 ----------
 uchar4 u;
 int4 c = convert_int4(u);
@@ -1162,7 +1163,7 @@ int4 c = convert_int4(u);
 
 `convert_int4` converts a `uchar4` vector `u` to an `int4` vector `c`.
 
-[source,c]
+[source,opencl_c]
 ----------
 float f;
 int i = convert_int(f);
@@ -1176,7 +1177,7 @@ behavior.
 
 The full form of the scalar convert function is:
 
-[source,c]
+[source,opencl_c]
 ----------
 destType convert_destType<_sat><_roundingMode>(sourceType)
 ----------
@@ -1185,7 +1186,7 @@ where `dstType` is the destination scalar type and `sourceType` is the source sc
 
 The full form of the vector convert function is:
 
-[source,c]
+[source,opencl_c]
 ----------
 destTypen convert_destTypen<_sat><_roundingMode>(sourceTypen)
 ----------
@@ -1265,7 +1266,7 @@ formats.
 
 Example 1:
 
-[source,c]
+[source,opencl_c]
 ----------
 short4 s;
 
@@ -1279,7 +1280,7 @@ char4 c = convert_char4_sat( s );
 
 Example 2:
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 f;
 
@@ -1303,7 +1304,7 @@ int4 i4 = convert_int4_sat_rte( f );
 
 Example 3:
 
-[source,c]
+[source,opencl_c]
 ----------
 int4 i;
 
@@ -1343,7 +1344,7 @@ then the value of the additional bytes is undefined.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // d only if double precision is supported
 union { float f; uint u; double d; } u;
@@ -1397,7 +1398,7 @@ reinterpret data to a type of a different number of bytes.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 float f = 1.0f;
 uint u = as_uint(f); // Legal. Contains:  0x3f800000
@@ -2003,7 +2004,7 @@ independently on each component of the vector, in a component-wise fashion.
 
 For example,
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 v, u;
 float f;
@@ -2013,7 +2014,7 @@ v = u + f;
 
 will be equivalent to
 
-[source,c]
+[source,opencl_c]
 ----------
 v.x = u.x + f;
 v.y = u.y + f;
@@ -2023,7 +2024,7 @@ v.w = u.w + f;
 
 And
 
-[source,c]
+[source,opencl_c]
 ----------
 float4 v, u, w;
 
@@ -2032,7 +2033,7 @@ w = v + u;
 
 will be equivalent to
 
-[source,c]
+[source,opencl_c]
 ----------
 w.x = v.x + u.x;
 w.y = v.y + u.y;
@@ -2068,7 +2069,7 @@ corresponding address space names with the `+__+` prefix.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // declares a pointer p in the global address space that
 // points to an object in the global address space
@@ -2093,7 +2094,7 @@ C it is allowed to qualify local variables with an address space qualifier.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // OK.
 int f() { ... }
@@ -2143,7 +2144,7 @@ object is allocated via appropriate API calls in the host code.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 global float4 *color; // An array of float4 elements
 
@@ -2180,7 +2181,7 @@ are allocated in local memory and shared by all work-items in a work-group.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void my_func(...)
 {
@@ -2225,7 +2226,7 @@ result in a compilation error.
 
 Example:
 
-[source,c]
+[source,opencl_c]
 ----------
 constant int a = 3; // int allocated in the constant address space
 kernel void k1(global int *buf)
@@ -2259,7 +2260,7 @@ variables, in particular variables with automatic storage duration.
 
 Example:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void foo(...)
 {
@@ -2281,7 +2282,7 @@ types and it represents a placeholder for any of the named address spaces
 in one of these concrete named address spaces. The exact address space
 resolution can occur dynamically during the kernel execution.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void foo(int a)
 {
@@ -2306,7 +2307,7 @@ kernel function can be qualified by the local or constant address spaces.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void my_func(...)
 {
@@ -2332,7 +2333,7 @@ specifier:
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_program_scope_global_variables feature macro.
@@ -2362,7 +2363,7 @@ must point to one of the named address spaces `{global}`, `{local}` or
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
  // OK.
 kernel void my_kernel(global int *ptr)
@@ -2393,7 +2394,7 @@ allowed to be given.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 global int a = 12;      // Initialization is allowed.
 global int b;           // Zero initialized.
@@ -2448,7 +2449,7 @@ For all other cases that are not listed above the address space is inferred to
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_program_scope_global_variables feature macro.
@@ -2620,7 +2621,7 @@ This is the canonical example.
 In this example, function `foo` is declared with an argument that is a
 pointer with the unnamed generic address space address space qualifier.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2649,7 +2650,7 @@ In the example below, `var` is a pointer to the unnamed generic address space.
 A pointer to the `global` or `local` address space may be assigned to `var`
 depending on the result of a conditional expression.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2674,7 +2675,7 @@ objects in the `global`, `local`, and `private` address spaces,
 but it is not legal for a pointer to the unnamed generic address to
 point to an object in the `constant` address space.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2703,7 +2704,7 @@ a pointer to the unnamed generic address space.
 It is also not legal to assign a pointer to the unnamed generic address
 space to a pointer to a named address space without a cast.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2730,7 +2731,7 @@ cp = p; // Error.
 The example below illustrates the implicit conversion between named address
 spaces.
 
-[source,c]
+[source,opencl_c]
 ----------
 global int *gp;
 local int *lp;
@@ -2760,7 +2761,7 @@ cp = gp; // Error.
 The example below demonstrates explicit conversions for pointers pointing to
 different address spaces.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2781,7 +2782,7 @@ Explicitly casting between different address spaces in nested pointers is
 allowed but the use of such pointers can lead to incorrect behavior such as
 accessing invalid memory locations.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2831,7 +2832,7 @@ Conversions between disjoint address spaces are disallowed in OpenCL
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2861,7 +2862,7 @@ kernel void test1()
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2892,7 +2893,7 @@ if (lptr == gptr) // illegal, compiler error
 
 Consider the following example:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2921,7 +2922,7 @@ operator is replaced with a relational operator.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2963,7 +2964,7 @@ if (l == NULL) // legal
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -2990,7 +2991,7 @@ kernel void test1()
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // Note: these examples assume OpenCL C 2.0 or the
 // __opencl_c_generic_address_space feature support.
@@ -3043,7 +3044,7 @@ The default access qualifier is `read_only`, if no access qualifier is declared.
 
 In the following example
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 foo (read_only image2d_t imageA,
@@ -3138,7 +3139,7 @@ work-items in any dimension modulo N is not zero.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 // autovectorize assuming float4 as the
 // basic computation width
@@ -3219,7 +3220,7 @@ a function declared in the `global` or `constant` address space.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 extern constant float4 noise_table[256];
 static constant float4 color_table[256];
@@ -3341,7 +3342,7 @@ address space qualifiers.
 The kernel example below shows what memory operations are not supported on
 built-in types less than 32-bits in size.
 +
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 do_proc (__global char *pA, short b,
@@ -3416,7 +3417,7 @@ directive (prior to any macro replacement), then no macro replacement is
 performed on the directive, and the directive shall have one of the
 following forms whose meanings are described elsewhere:
 
-[source,c]
+[source,opencl_c]
 ----------
 // on-off-switch is one of ON, OFF, or DEFAULT
 #pragma OPENCL FP_CONTRACT on-off-switch
@@ -3490,7 +3491,7 @@ The following predefined macro names are available.
 `+__kernel_exec(X, typen)+` (and `kernel_exec(X, typen)`) ::
     is defined as:
 
-[source,c]
+[source,opencl_c]
 ----------
 __kernel __attribute__((work_group_size_hint(X, 1, 1))) \
     __attribute__((vec_type_hint(typen)))
@@ -3611,7 +3612,7 @@ This attribute specifies a minimum alignment (in bytes) for variables of the
 specified type.
 For example, the declarations:
 
-[source,c]
+[source,opencl_c]
 ----------
 struct S { short f[3]; } __attribute__ ((aligned (8)));
 typedef int more_aligned_int __attribute__ ((aligned (8)));
@@ -3638,7 +3639,7 @@ compiler to align a type to the maximum useful alignment for the target
 machine you are compiling for.
 For example, you could write:
 
-[source,c]
+[source,opencl_c]
 ----------
 struct S { short f[3]; } __attribute__ ((aligned));
 ----------
@@ -3682,7 +3683,7 @@ In the following example, the members of `my_packed_struct` are packed
 closely together, but the internal layout of its `s` member is not packed.
 To do that, struct `my_unpacked_struct` would need to be packed, too.
 
-[source,c]
+[source,opencl_c]
 ----------
 struct my_unpacked_struct
 {
@@ -3729,7 +3730,7 @@ This attribute specifies a minimum alignment for the variable or structure
 field, measured in bytes.
 For example, the declaration:
 +
-[source,c]
+[source,opencl_c]
 ----------
 int x __attribute__ ((aligned (16))) = 0;
 ----------
@@ -3741,7 +3742,7 @@ The alignment value specified must be a power of two.
 You can also specify the alignment of structure fields.
 For example, to create a double-word aligned `int` pair, you could write:
 +
-[source,c]
+[source,opencl_c]
 ----------
 struct foo { int x[2] __attribute__ ((aligned (8))); };
 ----------
@@ -3757,7 +3758,7 @@ compiler to align a variable or field to the maximum useful alignment for
 the target machine you are compiling for.
 For example, you could write:
 +
-[source,c]
+[source,opencl_c]
 ----------
 short array[3] __attribute__ ((aligned));
 ----------
@@ -3792,7 +3793,7 @@ specify a larger value with the aligned attribute.
 Here is a structure in which the field `x` is packed, so that it immediately
 follows a:
 +
-[source,c]
+[source,opencl_c]
 ----------
 struct foo
 {
@@ -3807,7 +3808,7 @@ type body apply to the type.
 +
 For example:
 +
-[source,c]
+[source,opencl_c]
 ----------
 /* a has alignment of 128 */
 __attribute__((aligned(128))) struct A {int i;} a;
@@ -3832,7 +3833,7 @@ The default is `device`.
 +
 For example:
 +
-[source,c]
+[source,opencl_c]
 ----------
 global float4 *p __attribute__ ((endian(host)));
 ----------
@@ -3871,7 +3872,7 @@ The `nosvm` attribute is deprecated, and the compiler can ignore it.
 For basic blocks and control-flow-statements the attribute is placed before
 the structure in question, for example:
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((attr1)) {...}
 
@@ -3916,7 +3917,7 @@ appear immediately before the loop to be affected.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((opencl_unroll_hint(2)))
 while (*s != 0)
@@ -3925,7 +3926,7 @@ while (*s != 0)
 
 The tells the compiler to unroll the above while loop by a factor of 2.
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((opencl_unroll_hint))
 for (int i=0; i<2; i++)
@@ -3937,7 +3938,7 @@ for (int i=0; i<2; i++)
 In the example above, the compiler will determine how much to unroll the
 loop.
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((opencl_unroll_hint(1)))
 for (int i=0; i<32; i++)
@@ -3951,7 +3952,7 @@ The above is an example where the loop should not be unrolled.
 Below are some examples of invalid usage of
 `+__attribute__((opencl_unroll_hint(n)))+`.
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((opencl_unroll_hint(-1)))
 while (...)
@@ -3963,7 +3964,7 @@ while (...)
 The above example is an invalid usage of the loop unroll factor as the loop
 unroll factor is negative.
 
-[source,c]
+[source,opencl_c]
 ----------
 __attribute__((opencl_unroll_hint))
 if (...)
@@ -3975,7 +3976,7 @@ if (...)
 The above example is invalid because the unroll attribute qualifier is used
 on a non-loop construct
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 my_kernel( ... )
@@ -4053,7 +4054,7 @@ in which it was defined.
 If you declare a Block as a variable, you can then use it just as you would
 a function:
 
-[source,c]
+[source,opencl_c]
 ----------
 int multiplier = 7;
 
@@ -4075,7 +4076,7 @@ to a function, except that you use ^ instead of *.
 The Block type fully interoperates with the rest of the C type system.
 The following are valid Block variable declarations:
 
-[source,c]
+[source,opencl_c]
 ----------
 void (^blockReturningVoidWithVoidArgument)(void);
 int (^blockReturningIntWithIntAndCharArguments)(int, char);
@@ -4093,7 +4094,7 @@ You can also create types for Blocks -- doing so is generally considered to
 be best practice when you use a block with a given signature in multiple
 places:
 
-[source,c]
+[source,opencl_c]
 ----------
 typedef float (^MyBlockType)(float, float);
 
@@ -4124,7 +4125,7 @@ is allowed as a function reference.
 
 The following Block literal:
 
-[source,c]
+[source,opencl_c]
 ----------
 ^ void (void) { printf("hello world**\n**"); }
 ----------
@@ -4141,14 +4142,14 @@ void )` argument list may also be omitted.
 
 So:
 
-[source,c]
+[source,opencl_c]
 ----------
 ^ ( void ) { printf("hello world**\n**"); }
 ----------
 
 and:
 
-[source,c]
+[source,opencl_c]
 ----------
 ^ { printf("hello world**\n**"); }
 ----------
@@ -4182,7 +4183,7 @@ variables at global or local `static` scope.
 
 You can also declare a Block as a global literal in program scope.
 
-[source,c]
+[source,opencl_c]
 ----------
 int GlobalInt = 0;
 
@@ -4242,7 +4243,7 @@ are described below.
 
 Example 1:
 
-[source,c]
+[source,opencl_c]
 ----------
 void foo(int *x, int (^bar)(int, int))
 {
@@ -4261,7 +4262,7 @@ void k(global int *x, global int *z)
 
 Example 2:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel
 void k(global int *x, global int *z)
@@ -4277,7 +4278,7 @@ void k(global int *x, global int *z)
 
 Example 3:
 
-[source,c]
+[source,opencl_c]
 ----------
 int GlobalInt = 0;
 int (^getGlobalInt)(void) = ^{ return GlobalInt; }; // legal
@@ -4296,7 +4297,7 @@ void foo()
 
 Example 4:
 
-[source,c]
+[source,opencl_c]
 ----------
 void (^bl0)(void) = ^{
     ...
@@ -4318,7 +4319,7 @@ kernel void k()
 
 Example 5:
 
-[source,c]
+[source,opencl_c]
 ----------
 struct v {
     int arr[2];
@@ -5098,7 +5099,7 @@ If this pragma is used in any other context, the behavior is undefined.
 
 The pragma definition to set `FP_CONTRACT` is:
 
-[source,c]
+[source,opencl_c]
 ----------
 // on-off-switch is one of ON, OFF, or DEFAULT.
 // The DEFAULT value is ON.
@@ -5115,7 +5116,7 @@ The macro names given in the following list must use the values specified.
 These constant expressions are suitable for use in `#if` preprocessing
 directives.
 
-[source,c]
+[source,opencl_c]
 ----------
 #define FLT_DIG         6
 #define FLT_MANT_DIG    24
@@ -5189,7 +5190,7 @@ The macro names given in the following list must use the values specified.
 These constant expressions are suitable for use in `#if` preprocessing
 directives.
 
-[source,c]
+[source,opencl_c]
 ----------
 #define DBL_DIG         15
 #define DBL_MANT_DIG    53
@@ -5402,7 +5403,7 @@ The macro names given in the following list must use the values specified.
 The values shall all be constant expressions suitable for use in `#if`
 preprocessing directives.
 
-[source,c]
+[source,opencl_c]
 ----------
 #define CHAR_BIT        8
 #define CHAR_MAX        SCHAR_MAX
@@ -5521,7 +5522,7 @@ as *mad* or *fma*.
 
 This is equivalent to:
 
-[source,c]
+[source,opencl_c]
 ----------
 gentype t;
 t = clamp ((x - edge0) / (edge1 - edge0), 0, 1);
@@ -5600,7 +5601,7 @@ _p_ * *half_rsqrt*(__p.x__^2^ + __p.y__^2^ + ...)
 The result shall be within 8192 ulps error from the infinitely precise
 result of
 
-[source,c]
+[source,opencl_c]
 ----------
 if (all(p == 0.0f))
   result = p;
@@ -6601,7 +6602,7 @@ initialized using `ATOMIC_VAR_INIT` is initially in an indeterminate state;
 however, the default (zero) initialization for objects with `static` storage
 duration is guaranteed to produce a valid state.
 
-[source,c]
+[source,opencl_c]
 ----------
 #define ATOMIC_VAR_INIT(C value)
 ----------
@@ -6611,7 +6612,7 @@ in program scope in the `global` address space.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 global atomic_int guide = ATOMIC_VAR_INIT(42);
 ----------
@@ -6630,7 +6631,7 @@ operation, constitutes a data-race.
 The `atomic_init` function non-atomically initializes the atomic object
 pointed to by obj to the value value.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer.
 void atomic_init(volatile __global A *obj, C value)
@@ -6643,7 +6644,7 @@ void atomic_init(volatile A *obj, C value)
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 local atomic_int guide;
 if (get_local_id(0) == 0)
@@ -6753,7 +6754,7 @@ The following table lists the enumeration constants:
 --
 The following fence operations are supported.
 
-[source,c]
+[source,opencl_c]
 ----------
 void atomic_work_item_fence(cl_mem_fence_flags flags,
                             memory_order order,
@@ -6840,7 +6841,7 @@ This section specifies each general kind.
 
 [open,refpage='atomic_store',desc='The atomic_store Functions',type='freeform',spec='clang',anchor='atomic_store',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_flag_test_and_set_explicit atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -6911,7 +6912,7 @@ feature.
 
 [open,refpage='atomic_load',desc='The atomic_load Functions',type='freeform',spec='clang',anchor='atomic_load',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_flag_test_and_set_explicit atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -6975,7 +6976,7 @@ feature.
 
 [open,refpage='atomic_exchange',desc='The atomic_exchange Functions',type='freeform',spec='clang',anchor='atomic_exchange',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_flag_test_and_set_explicit atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -7047,7 +7048,7 @@ feature.
 
 [open,refpage='atomic_compare_exchange',desc='The atomic_compare_exchange Functions',type='freeform',spec='clang',anchor='atomic_compare_exchange',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_flag_test_and_set_explicit atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -7326,7 +7327,7 @@ Otherwise, these operations are atomic load operations.
 ====
 The effect of the compare-and-exchange operations is
 
-[source,c]
+[source,opencl_c]
 ----------
 if (memcmp(object, expected, sizeof(*object) == 0)
     memcpy(object, &desired, sizeof(*object));
@@ -7389,7 +7390,7 @@ For *atomic_fetch* and modify functions with *key* = `or`, `xor`, `and`,
 and on atomic type `atomic_uintptr_t`, `M` is `uintptr_t`.
 ====
 
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -7482,7 +7483,7 @@ scope in the `global` address space with the `atomic_flag` type.
 
 Example:
 
-[source,c]
+[source,opencl_c]
 ----------
 global atomic_flag guard = ATOMIC_FLAG_INIT;
 ----------
@@ -7494,7 +7495,7 @@ global atomic_flag guard = ATOMIC_FLAG_INIT;
 
 [open,refpage='atomicFlagTestAndSet',desc='The atomic_flag_test_and_set Functions',type='freeform',spec='clang',anchor='atomic_flag_test_and_set',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_init atomic_load atomic_store atomic_work_item_fence',alias='atomic_flag_test_and_set atomic_flag_test_and_set_explicit']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -7568,7 +7569,7 @@ feature.
 
 [open,refpage='atomic_flag_clear',desc='The atomic_flag_clear Functions',type='freeform',spec='clang',anchor='atomic_flag_clear',xrefs='atomicFunctions atomicTypes atomic_compare_exchange atomic_exchange atomic_fetch_key atomic_flag atomic_flag_clear atomic_flag_test_and_set atomic_flag_test_and_set_explicit atomic_init atomic_load atomic_store atomic_work_item_fence']
 --
-[source,c]
+[source,opencl_c]
 ----------
 // Requires OpenCL C 3.0 or newer and both the __opencl_c_atomic_order_seq_cst
 // and __opencl_c_atomic_scope_device features.
@@ -7950,7 +7951,7 @@ which element of the one or two input vectors the result element gets.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 uint4 mask = (uint4)(3, 2, 1, 0);
 float4 a;
@@ -7972,7 +7973,7 @@ b = shuffle(a, mask);
 
 Examples that are not valid are:
 
-[source,c]
+[source,opencl_c]
 ----------
 uint8 mask;
 short16 a;
@@ -8329,7 +8330,7 @@ floating number with the given precision.
 
 A few examples of printf are given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 float4  f = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
 uchar4 uc = (uchar4)(0xFA, 0xFB, 0xFC, 0xFD);
@@ -8340,7 +8341,7 @@ printf("uc = %#v4hhx\n", uc);
 
 The above two printf calls print the following:
 
-[source,c]
+[source,opencl_c]
 ----------
 f4 = 1.00,2.00,3.00,4.00
 uc = 0xfa,0xfb,0xfc,0xfd
@@ -8350,7 +8351,7 @@ A few examples of valid use cases of printf for the conversion specifier *s*
 are given below.
 The argument value must be a pointer to a literal string.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void my_kernel( ... )
 {
@@ -8361,7 +8362,7 @@ kernel void my_kernel( ... )
 A few examples of invalid use cases of printf for the conversion specifier
 *s* are given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void my_kernel(global char *s, ... )
 {
@@ -8376,7 +8377,7 @@ A few examples of invalid use cases of printf where data types given by the
 vector specifier and length modifier do not match the argument type are
 given below:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void my_kernel(global char *s, ... )
 {
@@ -8479,21 +8480,21 @@ These properties control how elements of an image object are read by
 Samplers can also be declared as global constants in the program source
 using the following syntax.
 
-[source,c]
+[source,opencl_c]
 ----------
 const sampler_t <sampler name> = <value>
 ----------
 
 or
 
-[source,c]
+[source,opencl_c]
 ----------
 constant sampler_t <sampler name> = <value>
 ----------
 
 or
 
-[source,c]
+[source,opencl_c]
 ----------
 __constant sampler_t <sampler_name> = <value>
 ----------
@@ -8568,7 +8569,7 @@ The sampler fields are described in the following table.
 
 *Examples*:
 
-[source,c]
+[source,opencl_c]
 ----------
 const sampler_t samplerA = CLK_NORMALIZED_COORDS_TRUE |
                            CLK_ADDRESS_REPEAT |
@@ -9860,7 +9861,7 @@ an image, the *work_group_barrier*(`CLK_IMAGE_MEM_FENCE`) should be used.
 
 Consider the following example:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 foo(read_write image2d_t img, ... )
@@ -10008,7 +10009,7 @@ is the size of the work-group) elements [a~0~, a~1~, ... a~n-1~] and returns
 
 Consider the following example:
 
-[source,c]
+[source,opencl_c]
 ----------
 void foo(int *p)
 {
@@ -10067,7 +10068,7 @@ and vector data types.
 
 Examples:
 
-[source,c]
+[source,opencl_c]
 ----------
 pipe int4 pipeA; // a pipe with int4 packets
 
@@ -10086,7 +10087,7 @@ specifier is a compilation error.
 
 In the following example
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 foo (read_only pipe fooA_t pipeA,
@@ -10400,7 +10401,7 @@ block:
 
 Below are some examples of how to enqueue a block.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 my_func_A(global int *a, global int *b, global int *c)
@@ -10444,7 +10445,7 @@ my_func_C(global int *a, global int *b, global int *c)
 
 The example below shows how to declare a block literal and enqueue it.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 my_func(global int *a, global int *b)
@@ -10487,7 +10488,7 @@ the `local` or `private` address space.
 
 Example:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 foo(global int *a, local int *lptr, ...)
@@ -10518,7 +10519,7 @@ the enqueued block.
 
 Some examples follow:
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 my_func_A_local_arg1(global int *a, local int *lptr, ...)
@@ -10587,7 +10588,7 @@ If new nd-range work does need to be performed, then evaluate_dp_work_A will
 enqueue a new instance of dp_func_A .
 This process is repeated until all the work is completed.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 dp_func_A(queue_t q, ...)
@@ -10876,7 +10877,7 @@ built-in function.
 The example below shows how events can be used with kernels enqueued to
 multiple device queues.
 
-[source,c]
+[source,opencl_c]
 ----------
 extern void barA_kernel(...);
 extern void barB_kernel(...);
@@ -10914,7 +10915,7 @@ foo(queue_t q0, queue q1, ...)
 The example below shows how the marker command can be used with kernels
 enqueued to a device queue.
 
-[source,c]
+[source,opencl_c]
 ----------
 kernel void
 foo(queue_t q, ...)
@@ -12042,7 +12043,7 @@ For example, *sin*({plusmn}0) = {plusmn}0 shall be interpreted to mean
 * *normalize*(_v_) for which any element in _v_ is infinite shall proceed
      as if the elements in _v_ were replaced as follows:
 +
-[source,c]
+[source,opencl_c]
 ----------
 for (i = 0; i < sizeof(v) / sizeof(v[0]); i++)
    v[i] = isinf(v[i]) ? copysign(1.0, v[i]) : 0.0 * v[i];
@@ -12096,7 +12097,7 @@ for (i = 0; i < sizeof(v) / sizeof(v[0]); i++)
 
 *modf* behaves as though implemented by:
 
-[source,c]
+[source,opencl_c]
 ----------
 gentype modf(gentype value, gentype *iptr)
 {
@@ -12195,7 +12196,7 @@ is obtained.
 This means the image element at location (_i_,_j_,_k_) becomes the image
 element value, where
 
-[source,c]
+[source,opencl_c]
 ----------
 i = address_mode((int)floor(u))
 j = address_mode((int)floor(v))
@@ -12224,7 +12225,7 @@ _w_.
 
 The `clamp` function used in this table is defined as:
 
-[source,c]
+[source,opencl_c]
 ----------
 clamp(a, b, c) = return (a < b) ? b : ((a > c) ? c : a)
 ----------
@@ -12241,7 +12242,7 @@ This 2{times}2 square or 2{times}2{times}2 cube is obtained as follows.
 
 Let
 
-[source,c]
+[source,opencl_c]
 ----------
 i0 = address_mode((int)floor(u - 0.5))
 j0 = address_mode((int)floor(v - 0.5))
@@ -12259,7 +12260,7 @@ floor(x)`.
 
 For a 3D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -12275,7 +12276,7 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 
 For a 2D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -12306,7 +12307,7 @@ When filter mode is `CLK_FILTER_NEAREST`, the image element at location
 (_i_,_j_,_k_) becomes the image element value, with _i_, _j_, and _k_
 computed as
 
-[source,c]
+[source,opencl_c]
 ----------
 u = (s - floor(s)) * w_t
 i = (int)floor(u)
@@ -12339,7 +12340,7 @@ This 2{times}2 square or 2{times}2{times}2 cube is obtained as follows.
 
 Let
 
-[source,c]
+[source,opencl_c]
 ----------
 u = (s - floor(s)) * w_t
 i0 = (int)floor(u - 0.5)
@@ -12375,7 +12376,7 @@ floor(x)`.
 
 For a 3D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -12391,7 +12392,7 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 
 For a 2D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -12422,7 +12423,7 @@ When filter mode is `CLK_FILTER_NEAREST`, the image element at location
 (_i_,_j_,_k_) becomes the image element value, with _i_,_j_ and k computed
 as
 
-[source,c]
+[source,opencl_c]
 ----------
 s' = 2.0f * rint(0.5f * s)
 s' = fabs(s - s')
@@ -12457,7 +12458,7 @@ This 2{times}2 square or 2{times}2{times}2 cube is obtained as follows.
 
 Let
 
-[source,c]
+[source,opencl_c]
 ----------
 s' = 2.0f * rint(0.5f * s)
 s' = fabs(s - s')
@@ -12493,7 +12494,7 @@ floor(x)`.
 
 For a 3D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * (1 - c) * T_i0j0k0
     + a * (1 - b) * (1 - c) * T_i1j0k0
@@ -12509,7 +12510,7 @@ where `T_ijk` is the image element at location (_i_,_j_,_k_) in the 3D image.
 
 For a 2D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * (1 - b) * T_i0j0
     + a * (1 - b) * T_i1j0
@@ -12521,7 +12522,7 @@ where `T_ij` is the image element at location (_i_,_j_) in the 2D image.
 
 For a 1D image, the image element value is found as
 
-[source,c]
+[source,opencl_c]
 ----------
 T = (1 - a) * T_i0
     + a * T_i1
@@ -12841,7 +12842,7 @@ The following is the conversion rule for converting a normalized 8-bit
 unsigned integer sRGB color value to a floating-point linear RGB color value
 using *read_imagef*.
 
-[source,c]
+[source,opencl_c]
 ----------
 // Convert the normalized 8-bit unsigned integer R, G and B channel values
 // to a floating-point value (call it c) as per rules described in section
@@ -12861,7 +12862,7 @@ The following are the conversion rules for converting a linear RGB
 floating-point color value (call it _c_) to a normalized 8-bit unsigned
 integer sRGB value using *write_imagef*.
 
-[source,c]
+[source,opencl_c]
 ----------
 if (c is NaN)
     c = 0.0;

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -13,7 +13,8 @@ Khronos{R} OpenCL Working Group
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-style: github
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 :sectnumoffset: 5
 

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -13,7 +13,8 @@ Khronos{R} OpenCL Working Group
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-style: github
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
 // Various special / math symbols. This is easier to edit with than Unicode.

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -9,7 +9,7 @@ Khronos{R} OpenCL Working Group
 :icons: font
 :toc2:
 :toclevels: 2
-:max-width: 100
+:max-width: 100%
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -11,12 +11,13 @@ Khronos{R} OpenCL Working Group
 // Only one TOC level for the HTML output, two TOC levels for everything else.
 ifdef::backend-html5[:toclevels: 1]
 ifndef::backend-html5[:toclevels: 2]
-:max-width: 100
+:max-width: 100%
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
 :source-highlighter: rouge
-:rouge-style: github
+:source-language: opencl
+:rouge-style: opencl.spec
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
 // Various special / math symbols. This is easier to edit with than Unicode.

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -15,7 +15,8 @@ ifndef::backend-html5[:toclevels: 2]
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-style: github
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 
 // Various special / math symbols. This is easier to edit with than Unicode.

--- a/OpenCL_ICD_Installation.txt
+++ b/OpenCL_ICD_Installation.txt
@@ -13,7 +13,8 @@ Khronos{R} OpenCL Working Group
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-style: github
 :title-logo-image: image:images/OpenCL.png[Logo,pdfwidth=4in,align=right]
 //:title-page-background-image: image:images/Khronos_Dec14.svg["Khronos Logo",pdfwidth=50%,scaledwidth=50%]
 

--- a/OpenCL_ICD_Installation.txt
+++ b/OpenCL_ICD_Installation.txt
@@ -9,7 +9,7 @@ Khronos{R} OpenCL Working Group
 :icons: font
 :toc2:
 :toclevels: 2
-:max-width: 100
+:max-width: 100%
 :numbered:
 :imagewidth: 800
 :fullimagewidth: width="800"

--- a/README.adoc
+++ b/README.adoc
@@ -269,8 +269,9 @@ environment managers below.
 Please read the remainder of this document (other than platform-specific
 parts you don't use) completely before trying to install.
 
-  * Asciidoctor (asciidoctor, version: 1.5.8)
+  * Asciidoctor (asciidoctor, version: 2.0.16)
   * Coderay (coderay, version: 1.1.1)
+  * rouge (rouge, version 3.19.0)
   * ttfunk (ttfunk, version: 1.5.1)
   * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0)
   * Asciidoctor Mathematical (asciidoctor-mathematical, version 0.2.2)
@@ -280,8 +281,8 @@ parts you don't use) completely before trying to install.
     This is cached under `katex/`, and need not be
     installed from github.
 
-Only the `asciidoctor` and `coderay` gems are needed if you don't intend to
-build PDF versions of the spec and supporting documents.
+Only the `asciidoctor`, `coderay`, and `rouge` gems are needed if you don't
+intend to build PDF versions of the spec and supporting documents.
 
 [NOTE]
 .Note
@@ -435,11 +436,12 @@ echo "2.3.3" > ~/.rbenv/version
 # asciidoctor-mathematical also takes in excess of 20 min. to build!
 # The same RUBY_CONFIGURE_OPTS advice above may apply here as well.
 
-gem install asciidoctor -v 1.5.8
+gem install asciidoctor -v 2.0.16
 gem install coderay -v 1.1.1
+gem install rouge -v 3.19.0
 gem install ttfunk -v 1.5.1
 gem install asciidoctor-pdf -v 1.5.0
-MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
+gem install asciidoctor-mathematical -v 0.3.5
 ----
 
 
@@ -646,8 +648,9 @@ The following ruby gems can be installed directly via the `gem install`
 command, once the platform is set up:
 
 ----
-gem install asciidoctor -v 1.5.8
+gem install asciidoctor -v 2.0.16
 gem install coderay -v 1.1.1
+gen install rouge -v 3.19.0
 gem install ttfunk -v 1.5.1
 
 # Required only for pdf builds

--- a/README.adoc
+++ b/README.adoc
@@ -274,7 +274,7 @@ parts you don't use) completely before trying to install.
   * rouge (rouge, version 3.19.0)
   * ttfunk (ttfunk, version: 1.5.1)
   * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0)
-  * Asciidoctor Mathematical (asciidoctor-mathematical, version 0.2.2)
+  * Asciidoctor Mathematical (asciidoctor-mathematical, version 0.3.5)
   * https://github.com/asciidoctor/asciidoctor-mathematical#dependencies[Dependencies
     for asciidoctor-mathematical] (There are a lot of these!)
   * KaTeX distribution (version 0.7.0 from https://github.com/Khan/KaTeX .
@@ -556,7 +556,7 @@ that will require tweaking to get it working.
 Firstly, instead of:
 
 ----
-MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical
+gem install asciidoctor-mathematical
 ----
 
 You should use
@@ -655,7 +655,7 @@ gem install ttfunk -v 1.5.1
 
 # Required only for pdf builds
 gem install asciidoctor-pdf -v 1.5.0
-MATHEMATICAL_SKIP_STRDUP=1 gem install asciidoctor-mathematical -v 0.2.2
+gem install asciidoctor-mathematical -v 0.3.5
 ----
 
 

--- a/api/appendix_b.asciidoc
+++ b/api/appendix_b.asciidoc
@@ -162,7 +162,7 @@ Once the data is loaded into registers, we find that element 0 is at the
 left of the big-endian vector and element 0 is at the right of the
 little-endian vector:
 
-[source,c]
+[source,opencl_c]
 ----
 float x[4];
 float4 v = vload4( 0, x );
@@ -170,14 +170,14 @@ float4 v = vload4( 0, x );
 
 Big-endian:
 
-[source,c]
+[source,opencl]
 ----
 v contains { x[0], x[1], x[2], x[3] }
 ----
 
 Little-endian:
 
-[source,c]
+[source,opencl]
 ----
 v contains { x[3], x[2], x[1], x[0] }
 ----
@@ -202,7 +202,7 @@ is implementation-defined, see section 6.4.4 of OpenCL C specification.)
 
 An example follows:
 
-[source,c]
+[source,opencl_c]
 ----
 float x[4] = { 0.0f, 1.0f, 2.0f, 3.0f };
 float4 v = vload4( 0, x );
@@ -214,7 +214,7 @@ ushort8 z = as_ushort8(v);  // legal, not portable
 
 Big-endian:
 
-[source,c]
+[source,opencl]
 ----
 v contains { 0.0f, 1.0f, 2.0f, 3.0f }
 y contains { 0x00000000, 0x3f800000,
@@ -226,7 +226,7 @@ z.z is 0x3f80
 
 Little-endian:
 
-[source,c]
+[source,opencl]
 ----
 v contains { 3.0f, 2.0f, 1.0f, 0.0f }
 y contains { 0x40400000, 0x40000000,

--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -23,7 +23,7 @@ supplied headers.
 The following application scalar types are provided for application
 convenience.
 
-[source,c]
+[source,opencl]
 ----
 cl_char
 cl_uchar
@@ -49,7 +49,7 @@ application scalar types.
 The following application vector types are provided for application
 convenience.
 
-[source,c]
+[source,opencl]
 ----
 cl_char<n>
 cl_uchar<n>
@@ -112,7 +112,7 @@ Application vector literals may be used in assignments of individual vector
 components.
 Literal usage follows the convention of the underlying application compiler.
 
-[source,c]
+[source,opencl]
 ----
 cl_float2 foo = { .s[1] = 2.0f };
 cl_int8 bar = {{ 2, 4, 6, 8, 10, 12, 14, 16 }};
@@ -127,7 +127,7 @@ The components of application vector types can be addressed using the
 
 For example:
 
-[source,c]
+[source,opencl]
 ----
 foo.s[0] = 1.0f; // Sets the 1st vector component of foo
 pos.s[6] = 2;    // Sets the 7th vector component of bar
@@ -151,7 +151,7 @@ Support of these notations is identified by the `CL_HAS_NAMED_VECTOR_FIELDS`
 preprocessor symbol.
 For example:
 
-[source,c]
+[source,opencl]
 ----
 #ifdef CL_HAS_NAMED_VECTOR_FIELDS
     cl_float4 foo;
@@ -173,7 +173,7 @@ Support of these notations is identified by the `CL_HAS_NAMED_RGBA_VECTOR_FIELDS
 preprocessor symbol.
 For example:
 
-[source,c]
+[source,opencl]
 ----
 #ifdef CL_HAS_NAMED_RGBA_VECTOR_FIELDS
     cl_float4 foo;
@@ -190,7 +190,7 @@ is possible with the OpenCL C language types.
 Attempting to access beyond the number of components for a type also results
 in a failure.
 
-[source,c]
+[source,opencl]
 ----
 foo.xy    // illegal - illegal field name combination
 bar.s1234 // illegal - illegal field name combination
@@ -206,7 +206,7 @@ Support of this notation is identified by the `CL_HAS_HI_LO_VECTOR_FIELDS`
 preprocessor symbol.
 For example:
 
-[source,c]
+[source,opencl]
 ----
 #ifdef CL_HAS_HI_LO_VECTOR_FIELDS
     cl_float4 foo;
@@ -248,7 +248,7 @@ Support of the native vector types is identified by a `+__CL_TYPEN__+`
 preprocessor symbol matching the native type name.
 For example:
 
-[source,c]
+[source,opencl]
 ----
 #ifdef __CL_FLOAT4__ // Check for native cl_float4 type
     cl_float8 foo;

--- a/api/appendix_d.asciidoc
+++ b/api/appendix_d.asciidoc
@@ -10,7 +10,7 @@ The following code describes how to determine if there is overlap between
 the source and destination rectangles specified to {clEnqueueCopyBufferRect}
 provided the source and destination buffers refer to the same buffer object.
 
-[source,c]
+[source,opencl]
 ----
 unsigned int
 check_copy_overlap(const size_t src_origin[],

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1621,7 +1621,7 @@ Note: Under the rules described above, and independent to the previously
 footnoted {cpp} issue, it is known that _x == y == 42_ is a valid final state
 in the following problematic example:
 
-[source,c]
+[source,opencl_c]
 ----
 global atomic_int x = ATOMIC_VAR_INIT(0);
 local atomic_int y = ATOMIC_VAR_INIT(0);
@@ -2148,7 +2148,7 @@ _patch_ version.
 
 These are defined as follows:
 
-[source,c]
+[source,opencl]
 ----
 typedef cl_uint cl_version;
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1707,7 +1707,7 @@ _properties_ argument to {clCreateSubDevices} are given below:
 To partition a device containing 16 compute units into two sub-devices, each
 containing 8 compute units, pass the following in _properties_:
 
-[source,c]
+[source,opencl]
 ----
 { CL_DEVICE_PARTITION_EQUALLY, 8,
   0 } // 0 terminates the property list
@@ -1717,7 +1717,7 @@ To partition a device with four compute units into two sub-devices with one
 sub-device containing 3 compute units and the other sub-device 1 compute
 unit, pass the following in properties argument:
 
-[source,c]
+[source,opencl]
 ----
 { CL_DEVICE_PARTITION_BY_COUNTS,
     3, 1, CL_DEVICE_PARTITION_BY_COUNTS_LIST_END,
@@ -1727,7 +1727,7 @@ unit, pass the following in properties argument:
 To split a device along the outermost cache line (if any), pass the
 following in properties argument:
 
-[source,c]
+[source,opencl]
 ----
 { CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
     CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE,

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5947,7 +5947,7 @@ ignored.
 
 For example, consider the following program source:
 
-[source,c]
+[source,opencl_c]
 ----
 #include <foo.h>
 #include <mydir/myinc.h>
@@ -5965,7 +5965,7 @@ This kernel includes two headers foo.h and mydir/myinc.h.
 The following describes how these headers can be passed as embedded headers
 in program objects:
 
-[source,c]
+[source,opencl]
 ----
 cl_program foo_pg = clCreateProgramWithSource(context,
     1, &foo_header_src, NULL, &err);
@@ -7102,7 +7102,7 @@ include::{generated}/api/version-notes/clSetKernelArg.asciidoc[]
 
 For example, consider the following kernel:
 
-[source,c]
+[source,opencl_c]
 ----
 kernel void image_filter (int n,
                           int m,
@@ -7339,7 +7339,7 @@ either be passed as an argument in the call to that kernel or it must be
 made available to the kernel using {clSetKernelExecInfo}.
 For example, we might pass extra SVM pointers as follows:
 
-[source,c]
+[source,opencl]
 ----
 clSetKernelExecInfo(kernel,
                     CL_KERNEL_EXEC_INFO_SVM_PTRS,
@@ -8464,7 +8464,7 @@ are called; otherwise the behavior is undefined.
 For example, the following code sequence will result in undefined behavior
 of {clReleaseMemObject}.
 
-[source,c]
+[source,opencl]
 ----
 ev1 = clCreateUserEvent(ctx, NULL);
 clEnqueueWriteBuffer(cq, buf1, CL_FALSE, ..., 1, &ev1, NULL);
@@ -8475,7 +8475,7 @@ clSetUserEventStatus(ev1, CL_COMPLETE);
 
 The following code sequence, however, works correctly.
 
-[source,c]
+[source,opencl]
 ----
 ev1 = clCreateUserEvent(ctx, NULL);
 clEnqueueWriteBuffer(cq, buf1, CL_FALSE, ..., 1, &ev1, NULL);

--- a/config/khronos.css
+++ b/config/khronos.css
@@ -131,7 +131,7 @@ meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; wi
 
 html, body { font-size: 100%; }
 
-body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
+body { background: #fff; color: #222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
 a:hover { cursor: pointer; }
 
@@ -180,7 +180,7 @@ div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .
 
 /* Default Link Styles */
 a { color: #0068b0; text-decoration: none; line-height: inherit; }
-a:hover, a:focus { color: #333333; }
+a:hover, a:focus { color: #333; }
 a img { border: none; }
 
 /* Default paragraph styles */
@@ -203,7 +203,7 @@ h5 { font-size: 1.125em; }
 
 h6 { font-size: 1em; }
 
-hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+hr { border: solid #ddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
 
 /* Helpful Typography Defaults */
 em, i { font-style: italic; line-height: inherit; }
@@ -236,20 +236,20 @@ dl dt { margin-bottom: 0.3em; font-weight: bold; }
 dl dd { margin-bottom: 0.75em; }
 
 /* Abbreviations */
-abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #ddd; cursor: help; }
 
 abbr { text-transform: none; }
 
 /* Blockquotes */
-blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
-blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #ddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #365E7A; }
 blockquote cite:before { content: "\2014 \0020"; }
-blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+blockquote cite a, blockquote cite a:visited { color: #365E7A; }
 
-blockquote, blockquote p { line-height: 1.6; color: #333333; }
+blockquote, blockquote p { line-height: 1.6; color: #333; }
 
 /* Microformats */
-.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #ddd; padding: 0.625em 0.75em; }
 .vcard li { margin: 0; display: block; }
 .vcard .fn { font-weight: bold; font-size: 0.9375em; }
 
@@ -262,11 +262,11 @@ blockquote, blockquote p { line-height: 1.6; color: #333333; }
   h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
   h4 { font-size: 1.4375em; } }
 /* Tables */
-table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
-table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
-table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table { background: #fff; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: #eee; font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: #222; text-align: left; }
 table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
-table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #f8f8f8; }
 table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
 
 body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
@@ -278,7 +278,7 @@ a:hover, a:focus { text-decoration: underline; }
 .clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
 .clearfix:after, .float-group:after { clear: both; }
 
-*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: transparent; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
 *:not(pre) > code.nobreak { word-wrap: normal; }
 *:not(pre) > code.nowrap { white-space: nowrap; }
 
@@ -290,7 +290,7 @@ strong strong { font-weight: normal; }
 
 .keyseq { color: #333333; }
 
-kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
 
 .keyseq kbd:first-child { margin-left: 0; }
 
@@ -319,21 +319,21 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 #content:before { content: none; }
 
 #header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
-#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
-#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
-#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #ddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #ddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #ddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #365E7A; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
 #header .details span:first-child { margin-left: -0.125em; }
-#header .details span.email a { color: #333333; }
+#header .details span.email a { color: #333; }
 #header .details br { display: none; }
 #header .details br + span:before { content: "\00a0\2013\00a0"; }
-#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333; }
 #header .details br + span#revremark:before { content: "\00a0|\00a0"; }
 #header #revnumber { text-transform: capitalize; }
 #header #revnumber:after { content: "\00a0"; }
 
-#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #ddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
 
-#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc { border-bottom: 0 solid #ddd; padding-bottom: 0.5em; }
 #toc > ul { margin-left: 0.125em; }
 #toc ul.sectlevel0 > li > a { font-style: italic; }
 #toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
@@ -346,20 +346,20 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 
 @media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
   body.toc2 { padding-left: 15em; padding-right: 0; }
-  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 { margin-top: 0 !important; background-color: #fff; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #ddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
   #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
   #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
   #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
   #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
   body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
-  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #ddd; left: auto; right: 0; } }
 @media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
   #toc.toc2 { width: 20em; }
   #toc.toc2 #toctitle { font-size: 1.375em; }
   #toc.toc2 > ul { font-size: 0.95em; }
   #toc.toc2 ul ul { padding-left: 1.25em; }
   body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
-#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 #content #toc > :first-child { margin-top: 0; }
 #content #toc > :last-child { margin-bottom: 0; }
 
@@ -375,7 +375,7 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
   .sect1 { padding-bottom: 1.25em; } }
 .sect1:last-child { padding-bottom: 0; }
 
-.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+.sect1 + .sect1 { border-top: 0 solid #ddd; }
 
 #content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
 #content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
@@ -397,29 +397,29 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .admonitionblock > table td.icon { text-align: center; width: 80px; }
 .admonitionblock > table td.icon img { max-width: initial; }
 .admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
-.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #ddd; color: #365E7A; }
 .admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
 
-.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 .exampleblock > .content > :first-child { margin-top: 0; }
 .exampleblock > .content > :last-child { margin-bottom: 0; }
 
-.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 .sidebarblock > :first-child { margin-top: 0; }
 .sidebarblock > :last-child { margin-bottom: 0; }
 .sidebarblock > .content > .title { color: black; margin-top: 0; }
 
 .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
 
-.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eee; }
 .sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
 
-.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
 .literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
 @media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
 @media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
 
-.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+.literalblock.output pre { color: #eee; background-color: #264357; }
 
 .listingblock pre.highlightjs { padding: 0; }
 .listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
@@ -440,7 +440,7 @@ table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; lin
 
 table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
 
-pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #ddd; }
 
 pre.pygments .lineno { display: inline-block; margin-right: .25em; }
 
@@ -448,23 +448,23 @@ table.pyhltable .linenodiv { background: none !important; padding-right: 0 !impo
 
 .quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
 .quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
-.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
 .quoteblock blockquote { margin: 0; padding: 0; border: 0; }
 .quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
 .quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
 .quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
-.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #365E7A; }
 .quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
 .quoteblock .quoteblock blockquote:before { display: none; }
 
 .verseblock { margin: 0 1em 0.75em 1em; }
-.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333; font-weight: 300; text-rendering: optimizeLegibility; }
 .verseblock pre strong { font-weight: 400; }
 .verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
 
 .quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
 .quoteblock .attribution br, .verseblock .attribution br { display: none; }
-.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #365E7A; }
 
 .quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
 .quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
@@ -509,9 +509,9 @@ th.valign-middle, td.valign-middle { vertical-align: middle; }
 
 table thead th, table tfoot th { font-weight: bold; }
 
-tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+tbody tr th { display: table-cell; line-height: 1.4; background: #eee; }
 
-tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: #222; font-weight: bold; }
 
 p.tableblock > code:only-child { background: none; padding: 0; }
 
@@ -574,7 +574,7 @@ td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
 .colist > table tr > td:first-of-type img { max-width: initial; }
 .colist > table tr > td:last-of-type { padding: 0.25em 0; }
 
-.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px #fff; -webkit-box-shadow: 0 0 0 1px #ddd; box-shadow: 0 0 0 1px #ddd; }
 
 .imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
 .imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
@@ -699,7 +699,7 @@ b.conum * { color: inherit !important; }
 
 .conum:not([data-value]):empty { display: none; }
 
-h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #ddd; }
 
 .sect1 { padding-bottom: 0; }
 
@@ -711,4 +711,22 @@ code { -webkit-border-radius: 4px; border-radius: 4px; }
 
 p.tableblock.header { color: #6d6e71; }
 
-.literalblock pre, .listingblock pre { background: #eeeeee; }
+.literalblock pre, .listingblock pre { background: #eee; }
+
+/* From https://github.com/KhronosGroup/Vulkan-Docs/pull/901 */
+a code { color: inherit; }
+
+/* From https://github.com/KhronosGroup/Vulkan-Docs/pull/1157 */
+/* Make VUID anchor handles*/
+li > p > a[id^="VUID-"] { visibility: hidden; position: absolute; z-index: 1001; width: 2.2ex; margin-left: -2.2ex; display: block; text-decoration: none !important; text-align: center; font-weight: normal; }
+
+li > p > a[id^="VUID-"]:before { content: "\00A7"; font-size: 1em; display: block; padding-top: 0em; background: #fff; }
+
+li > p:hover > a[id^="VUID-"], li > p > a[id^="VUID-"]:hover { visibility: visible; }
+
+li > p > a[id^="VUID-"].link { color: black; text-decoration: none; }
+
+/* TODO: not quite sure what these two do */
+li > p > a[id^="VUID-"].link:hover { color: black; }
+
+.vuid { color: #4d4d4d; font-family: monospace; }

--- a/config/rouge/lib/rouge/lexers/opencl.rb
+++ b/config/rouge/lib/rouge/lexers/opencl.rb
@@ -5,7 +5,7 @@ module Rouge
   module Lexers
     load_lexer 'cpp.rb'
 
-    class OpencL < Cpp
+    class OpenCL < Cpp
       title "OpenCL"
       desc "The OpenCL standard for heterogeneous computing from the Khronos Group"
 

--- a/config/rouge/lib/rouge/lexers/opencl.rb
+++ b/config/rouge/lib/rouge/lexers/opencl.rb
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    load_lexer 'cpp.rb'
+
+    class OpencL < Cpp
+      title "OpenCL"
+      desc "The OpenCL standard for heterogeneous computing from the Khronos Group"
+
+      tag 'opencl'
+
+      opencl_api_types = %w(
+        cl_double cl_double2 cl_double3 cl_double4 cl_double8 cl_double16
+        cl_float cl_float2 cl_float3 cl_float4 cl_float8 cl_float16
+        cl_short cl_short2 cl_short3 cl_short4 cl_short8 cl_short16
+        cl_int cl_int2 cl_int3 cl_int4 cl_int8 cl_int16
+        cl_long cl_long2 cl_long3 cl_long4 cl_long8 cl_long16 
+        cl_char cl_char2 cl_char3 cl_char4 cl_char8 cl_char16 
+        cl_uchar cl_uchar2 cl_uchar3 cl_uchar4 cl_uchar8 cl_uchar16
+        cl_half cl_half2 cl_half3 cl_half4 cl_half8 cl_half16
+        cl_ushort cl_ushort2 cl_ushort3 cl_ushort4 cl_ushort8 cl_ushort16
+        cl_uint cl_uint2 cl_uint3 cl_uint4 cl_uint8 cl_uint16
+        cl_ulong cl_ulong2 cl_ulong3 cl_ulong4 cl_ulong8 cl_ulong16
+        __cl_float4
+        cl_GLint
+        cl_GLenum
+        cl_GLuint
+        cl_d3d11_device_source_khr
+        cl_d3d11_device_set_khr
+        cl_dx9_media_adapter_type_khr
+        cl_dx9_media_adapter_set_khr
+        cl_d3d10_device_source_khr
+        cl_d3d10_device_set_khr
+        cl_dx9_device_source_intel
+        cl_dx9_device_set_intel
+        cl_accelerator_intel
+        cl_accelerator_type_intel
+        cl_accelerator_info_intel
+        cl_diagnostics_verbose_level
+        cl_va_api_device_source_intel
+        cl_va_api_device_set_intel
+        cl_GLsync
+        CLeglImageKHR
+        CLeglDisplayKHR
+        CLeglSyncKHR
+        cl_egl_image_properties_khr
+        cl_device_partition_property_ext
+        cl_mem_migration_flags_ext
+        cl_image_pitch_info_qcom
+        cl_queue_priority_khr
+        cl_queue_throttle_khr
+        cl_import_properties_arm
+        cl_svm_mem_flags_arm
+        cl_kernel_exec_info_arm
+        cl_device_svm_capabilities_arm
+        cl_gl_context_info
+        cl_gl_object_type
+        cl_gl_texture_info
+        cl_gl_platform_info
+        cl_platform_id
+        cl_device_id
+        cl_context
+        cl_command_queue
+        cl_mem
+        cl_program
+        cl_kernel
+        cl_event
+        cl_sampler
+        cl_bool
+        cl_bitfield
+        cl_properties
+        cl_device_type
+        cl_platform_info
+        cl_device_info
+        cl_device_fp_config
+        cl_device_mem_cache_type
+        cl_device_local_mem_type
+        cl_device_exec_capabilities
+        cl_device_svm_capabilities
+        cl_command_queue_properties
+        cl_device_partition_property
+        cl_device_affinity_domain
+        cl_context_properties
+        cl_context_info
+        cl_queue_properties
+        cl_queue_properties_khr
+        cl_command_queue_info
+        cl_channel_order
+        cl_channel_type
+        cl_mem_flags
+        cl_svm_mem_flags
+        cl_mem_object_type
+        cl_mem_info
+        cl_mem_migration_flags
+        cl_mem_properties
+        cl_image_info
+        cl_buffer_create_type
+        cl_addressing_mode
+        cl_filter_mode
+        cl_sampler_info
+        cl_map_flags
+        cl_pipe_properties
+        cl_pipe_info
+        cl_program_info
+        cl_program_build_info
+        cl_program_binary_type
+        cl_build_status
+        cl_kernel_info
+        cl_kernel_arg_info
+        cl_kernel_arg_address_qualifier
+        cl_kernel_arg_access_qualifier
+        cl_kernel_arg_type_qualifier
+        cl_kernel_work_group_info
+        cl_kernel_sub_group_info
+        cl_event_info
+        cl_command_type
+        cl_profiling_info
+        cl_sampler_properties
+        cl_kernel_exec_info
+        cl_device_unified_shared_memory_capabilities_intel
+        cl_mem_properties_intel
+        cl_mem_alloc_flags_intel
+        cl_mem_info_intel
+        cl_unified_shared_memory_type_intel
+        cl_mem_advice_intel
+        cl_device_atomic_capabilities
+        cl_khronos_vendor_id
+        cl_version
+        cl_version_khr
+        cl_device_device_enqueue_capabilities
+        cl_mipmap_filter_mode_img
+        cl_mem_alloc_flags_img
+        cl_layer_info
+        cl_layer_api_version
+        cl_icd_dispatch
+        cl_device_scheduling_controls_capabilities_arm
+        cl_device_controlled_termination_capabilities_arm
+        cl_command_queue_capabilities_intel
+        cl_device_feature_capabilities_intel
+        cl_device_integer_dot_product_capabilities_khr
+        cl_dx9_surface_info_khr
+        cl_motion_estimation_desc_intel
+        cl_mem_ext_host_ptr
+        cl_mem_ion_host_ptr
+        cl_mem_android_native_buffer_host_ptr
+        cl_image_format
+        cl_image_desc
+        cl_buffer_region
+        cl_name_version
+        cl_name_version_khr
+        cl_device_pci_bus_info_khr
+        cl_queue_family_properties_intel
+        CL_VERSION_MAJOR_MASK_KHR
+        CL_VERSION_MINOR_MASK_KHR
+        CL_VERSION_PATCH_MASK_KHR
+        CL_VERSION_MAJOR_KHR
+        CL_VERSION_MINOR_KHR
+        CL_VERSION_PATCH_KHR
+        CL_MAKE_VERSION_KHR
+        cl_device_integer_dot_product_acceleration_properties_khr
+      )
+
+      # Here are some interesting tokens
+      # https://pygments.org/docs/tokens/ unused in C++ we can reuse
+      # in OpenCL mode:
+      # Comment::Preproc
+      # Keyword.Pseudo
+      # Keyword.Reserved
+      # Literal::String::Regex
+      # Literal::String::Symbol
+      # Name::Attribute
+      # Name.Builtin.Pseudo
+      # Name.Function.Magic
+      # Name.Other
+      # Name.Variable.Magic
+      # Operator.Word
+      # Generic
+      # Generic.Deleted
+      # Generic.Emph
+      # Generic.Error
+      # Generic.Heading
+      # Generic.Inserted
+      # Generic.Output
+      # Generic.Prompt
+      # Generic.Strong
+      # Generic.Subheading
+      # Generic.Traceback
+
+
+      # Insert some specific rules at the beginning of the statement
+      # rule of the C++ lexer
+      prepend :statements do
+        rule %r/(?:#{opencl_api_types.join('|')})\b/,
+             Keyword::Type
+      end
+
+    end
+  end
+end

--- a/config/rouge/lib/rouge/lexers/opencl_c.rb
+++ b/config/rouge/lib/rouge/lexers/opencl_c.rb
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    load_lexer 'cpp.rb'
+
+    class OpenCL_C < Cpp
+      title "OpenCL C"
+      desc "The OpenCL C standard for heterogeneous computing from the Khronos Group"
+
+      tag 'opencl_c'
+
+      opencl_c_data_types = %w(
+        char char2 char3 char4 char8 char16
+        double double2 double3 double4 double8 double16
+        float float2 float3 float4 float8 float16
+        half half2 half3 half4 half8 half16
+        int int2 int3 int4 int8 int16
+        long long2 long3 long4 long8 long16
+        short short2 short3 short4 short8 short16
+        uchar uchar2 uchar3 uchar4 uchar8 uchar16
+        uint uint2 uint3 uint4 uint8 uint16
+        ulong ulong2 ulong3 ulong4 ulong8 ulong16
+        ushort ushort2 ushort3 ushort4 ushort8 ushort16
+        image1d_t
+        image2d_t
+        image3d_t
+        image1d_buffer_t
+        image1d_array_t
+        image2d_array_t
+        image2d_depth_t
+        image2d_array_depth_t
+        sampler_t
+        queue_t
+        ndrange_t
+        clk_event_t
+        reserve_id_t
+        event_t
+        cl_mem_fence_flags
+      )
+
+      # Generic types used in OpenCL pseudo code descriptions
+      opencl_c_generic_types = %w(
+        charn
+        ucharn
+        shortn
+        ushortn
+        intn
+        uintn
+        longn
+        ulongn
+        halfn
+        floatn
+        doublen
+        gentype
+        igentype
+        ugentype
+        sgentype
+      )
+
+      opencl_c_functions = %w(
+        # list of functions used in the spec:
+        as_double4
+        as_float3
+        as_float4
+        as_int4
+        as_short2
+        as_short8
+        as_uint
+        atomic_compare_exchange_strong
+        atomic_compare_exchange_strong_explicit
+        atomic_compare_exchange_weak
+        atomic_compare_exchange_weak_explicit
+        atomic_exchange
+        atomic_exchange_explicit
+        atomic_flag_clear
+        atomic_flag_clear_explicit
+        atomic_flag_test_and_set
+        atomic_flag_test_and_set_explicit
+        atomic_init
+        atomic_load
+        atomic_load_explicit
+        atomic_store
+        atomic_store_explicit
+        atomic_work_item_fence
+        convert_char4_sat
+        convert_float4
+        convert_float4_rtp
+        convert_int4
+        convert_int4_rte
+        convert_int4_sat
+        convert_int4_sat_rte
+        convert_ushort4_sat
+        enqueue_kernel
+        get_default_queue
+        get_global_id
+        get_group_id
+        get_local_id
+        mem_fence
+        ndrange_1D
+        printf
+        read_imagef
+        read_imagei
+        read_imageui
+        read_mem_fence
+        release_event
+        shuffle
+        shuffle2
+        work_group_barrier
+        work_group_scan_inclusive_add
+        write_imagef
+        write_imagei
+        write_imageui
+        write_mem_fence
+      )
+
+      opencl_c_variables = %w(
+        memory_order_acq_rel
+        memory_order_acquire
+        memory_order_relaxed
+        memory_order_release
+        memory_order_seq_cst
+        memory_scope_device
+        memory_scope_sub_group
+        memory_scope_system
+        memory_scope_work_group
+        memory_scope_work_item
+      )
+
+      opencl_c_keywords = %w(
+        __kernel kernel
+        __read_only read_only
+        __read_write read_write
+        __write_only write_only
+        __global global
+        __local local
+        __constant constant
+        __private private
+        uniform
+        pipe
+      )
+
+      # Here are some interesting tokens
+      # https://pygments.org/docs/tokens/ unused in C++ we can reuse
+      # in OpenCL mode:
+      # Comment::Preproc
+      # Keyword.Pseudo
+      # Keyword.Reserved
+      # Literal::String::Regex
+      # Literal::String::Symbol
+      # Name::Attribute
+      # Name.Builtin.Pseudo
+      # Name.Function.Magic
+      # Name.Other
+      # Name.Variable.Magic
+      # Operator.Word
+      # Generic
+      # Generic.Deleted
+      # Generic.Emph
+      # Generic.Error
+      # Generic.Heading
+      # Generic.Inserted
+      # Generic.Output
+      # Generic.Prompt
+      # Generic.Strong
+      # Generic.Subheading
+      # Generic.Traceback
+
+
+      # Insert some specific rules at the beginning of the statement
+      # rule of the C++ lexer
+      prepend :statements do
+        rule %r/(?:#{opencl_c_data_types.join('|')})\b/,
+             Keyword::Type
+        rule %r/(?:#{opencl_c_functions.join('|')})\b/,
+            Name::Function::Magic
+        rule %r/(?:#{opencl_c_generic_types.join('|')})\b/,
+             Keyword::Pseudo
+        rule %r/(?:#{opencl_c_variables.join('|')})\b/,
+             Name::Variable::Magic
+        rule %r/(?:#{opencl_c_keywords.join('|')})\b/,
+             Name::Other
+      end
+
+    end
+  end
+end

--- a/config/rouge/lib/rouge/themes/opencl_spec.rb
+++ b/config/rouge/lib/rouge/themes/opencl_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+# The OpenCL theme used by Khronos in the OpenCL specification
+
+module Rouge
+  module Themes
+    class OpenCLspec < Github
+      name 'opencl.spec'
+
+      # Use mostly :bold versions to be clearer and because :italic
+      # does not work with asciidoctor-pdf
+
+      # opencl_c_generic_types
+      style Keyword::Pseudo,                  :fg => '#445588', :italic => true, :bold => true
+      # opencl_c_functions
+      style Name::Function::Magic,            :fg => '#00c5cd', :bold => true
+      # opencl_c_opencl_keywords
+      style Name::Other,                      :fg => '#ff4500', :bold => true
+      # opencl_c_variables
+      style Name::Variable::Magic,            :fg => '#ffa500', :bold => true
+      # Make the gray comments a little more visible
+      style Comment::Multiline,               :fg => '#555544', :italic => true
+      style Comment::Preproc,                 :fg => '#555555', :bold => true
+      style Comment::Single,                  :fg => '#555544', :italic => true
+      style Comment::Special,                 :fg => '#555555', :italic => true, :bold => true
+      style Comment,                          :fg => '#555544', :italic => true
+    end
+  end
+end

--- a/config/rouge_opencl.rb
+++ b/config/rouge_opencl.rb
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+# Copyright (c) 2011-2021 The Khronos Group, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#puts "Loading rouge_opencl extensions for source code highlighting..."
+
+require 'rouge'
+
+RUBY_ENGINE == 'opal' ? (require 'rouge/lib/rouge/lexers/opencl' ;
+                         require 'rouge/lib/rouge/lexers/opencl_c' ;
+                         require 'rouge/lib/rouge/themes/opencl_spec') \
+                      : (require_relative 'rouge/lib/rouge/lexers/opencl' ;
+                         require_relative 'rouge/lib/rouge/lexers/opencl_c' ;
+                         require_relative 'rouge/lib/rouge/themes/opencl_spec')

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1666,7 +1666,7 @@ is +0 and sin(-0) is -0.
   ** normalize( v ) for which any element in v is infinite shall proceed as
      if the elements in v were replaced as follows:
 +
-[source]
+[source,opencl_c]
 ----
 for( i = 0; i < sizeof(v) / sizeof(v[0] ); i++ )
     v[i] = isinf(v[i] )  ?  copysign(1.0, v[i]) : 0.0 * v [i];
@@ -1738,7 +1738,7 @@ for( i = 0; i < sizeof(v) / sizeof(v[0] ); i++ )
 
 *OpExtInst* *modf* behaves as though implemented by:
 
-[source]
+[source,opencl_c]
 ----
 gentype modf( gentype value, gentype *iptr )
 {

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -28,7 +28,7 @@ and _section 6.13.10_ of the OpenCL 1.2 and OpenCL 2.0 C specifications:
 [cols="1a,1",options="header",]
 |=======================================================================
 |*Function* |*Description*
-|[source,c]
+|[source,opencl_c]
 ----
 void async_work_group_copy_fence(
     cl_mem_fence_flags flags)

--- a/ext/cl_khr_create_command_queue.asciidoc
+++ b/ext/cl_khr_create_command_queue.asciidoc
@@ -39,7 +39,7 @@ extension API.
 
 === New API Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_command_queue clCreateCommandQueueWithPropertiesKHR(
     cl_context context,
@@ -50,7 +50,7 @@ cl_command_queue clCreateCommandQueueWithPropertiesKHR(
 
 === New API Types
 
-[source,c]
+[source,opencl]
 ----
 typedef cl_properties cl_queue_properties_khr;
 ----
@@ -82,7 +82,7 @@ These properties are specified by the _properties_ argument in
 
 The function
 
-[source,c]
+[source,opencl]
 ----
 cl_command_queue clCreateCommandQueueWithPropertiesKHR(
     cl_context context,

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -25,7 +25,7 @@ Direct3D 10.
 [[cl_khr_d3d10_sharing-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromD3D10KHR(cl_platform_id platform,
                                   cl_d3d10_device_source_khr d3d_device_source,
@@ -292,7 +292,7 @@ Direct3D 10 device was created.
 The OpenCL devices corresponding to a Direct3D 10 device or a DXGI device
 may be queried using the function
 indexterm:[clGetDeviceIDsFromD3D10KHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromD3D10KHR(cl_platform_id platform,
                                   cl_d3d10_device_source_khr d3d_device_source,
@@ -408,7 +408,7 @@ termination.
 
 The function
 indexterm:[clCreateFromD3D10BufferKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D10BufferKHR(cl_context context,
                                   cl_mem_flags flags,
@@ -460,7 +460,7 @@ zero.
 
 The function
 indexterm:[clCreateFromD3D10Texture2DKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D10Texture2DKHR(cl_context context,
                                      cl_mem_flags flags,
@@ -525,7 +525,7 @@ zero.
 
 The function
 indexterm:[clCreateFromD3D10Texture3DKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D10Texture3DKHR(cl_context context,
                                      cl_mem_flags flags,
@@ -659,7 +659,7 @@ and _5.3.6_.
 
 The function
 indexterm:[clEnqueueAcquireD3D10ObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueAcquireD3D10ObjectsKHR(cl_command_queue command_queue,
                                        cl_uint num_objects,
@@ -748,7 +748,7 @@ Otherwise it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueReleaseD3D10ObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueReleaseD3D10ObjectsKHR(cl_command_queue command_queue,
                                        cl_uint num_objects,
@@ -911,7 +911,7 @@ There is not a matching CL type, so do we want to support this and map to
 buffer or Texture2D? If so the command might correspond to the 2D / 3D
 versions:
 
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D10Texture1D(cl_context context,
                                   cl_mem_flags flags,

--- a/ext/cl_khr_d3d11_sharing.asciidoc
+++ b/ext/cl_khr_d3d11_sharing.asciidoc
@@ -25,7 +25,7 @@ Direct3D 11.
 [[cl_khr_d3d11_sharing-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromD3D11KHR(cl_platform_id platform,
                                   cl_d3d11_device_source_khr d3d_device_source,
@@ -292,7 +292,7 @@ Direct3D 11 device was created.
 The OpenCL devices corresponding to a Direct3D 11 device or a DXGI device
 may be queried using the function
 indexterm:[clGetDeviceIDsFromD3D11KHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromD3D11KHR(cl_platform_id platform,
                                   cl_d3d11_device_source_khr d3d_device_source,
@@ -408,7 +408,7 @@ termination.
 
 The function
 indexterm:[clCreateFromD3D11BufferKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D11BufferKHR(cl_context context,
                                   cl_mem_flags flags,
@@ -460,7 +460,7 @@ zero.
 
 The function
 indexterm:[clCreateFromD3D11Texture2DKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D11Texture2DKHR(cl_context context,
                                      cl_mem_flags flags,
@@ -525,7 +525,7 @@ zero.
 
 The function
 indexterm:[clCreateFromD3D11Texture3DKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromD3D11Texture3DKHR(cl_context context,
                                      cl_mem_flags flags,
@@ -659,7 +659,7 @@ and _5.3.6_.
 
 The function
 indexterm:[clEnqueueAcquireD3D11ObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueAcquireD3D11ObjectsKHR(cl_command_queue command_queue,
                                        cl_uint num_objects,
@@ -747,7 +747,7 @@ Otherwise it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueReleaseD3D11ObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueReleaseD3D11ObjectsKHR(cl_command_queue command_queue,
                                        cl_uint num_objects,

--- a/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
+++ b/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
@@ -34,7 +34,7 @@ enqueue functions listed in table 6.31."
 
 Then, replace all occurrences of +local void *+ in table 6.31 with +local gentype *+.  For example:
 
-[source,c]
+[source,opencl_c]
 ----
 int enqueue_kernel(queue_t queue,
                    kernel_enqueue_flags_t flags,
@@ -45,7 +45,7 @@ int enqueue_kernel(queue_t queue,
 
 Additionally, replace all occurrences of +local void*+ in table 6.33 with +local gentype *+.  For example:
 
-[source,c]
+[source,opencl_c]
 ----
 uint get_kernel_work_group_size(
                     void (^block)(local gentype *, ...))

--- a/ext/cl_khr_device_uuid.asciidoc
+++ b/ext/cl_khr_device_uuid.asciidoc
@@ -26,7 +26,7 @@ across processes or APIs.
 // 
 // Accepted value for the _param_name_ parameter to *clGetDeviceInfo*:
 // 
-// [source,c]
+// [source,opencl]
 // ----
 // #define CL_DEVICE_UUID_KHR          0x106A
 // #define CL_DRIVER_UUID_KHR          0x106B
@@ -37,7 +37,7 @@ across processes or APIs.
 // 
 // Constants describing the size of the driver and device UUIDs, and the device LUID:
 // 
-// [source,c]
+// [source,opencl]
 // ----
 // #define CL_UUID_SIZE_KHR            16
 // #define CL_LUID_SIZE_KHR            8

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -33,7 +33,7 @@ adapter.
 [[cl_khr_dx9_media_sharing-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromDX9MediaAdapterKHR(
                                     cl_platform_id platform,
@@ -280,7 +280,7 @@ capabilities.
 
 The function
 indexterm:[clGetDeviceIDsFromDX9MediaAdapterKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetDeviceIDsFromDX9MediaAdapterKHR(
                                     cl_platform_id platform,
@@ -387,7 +387,7 @@ Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clCreateFromDX9MediaSurfaceKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromDX9MediaSurfaceKHR(cl_context context,
                                       cl_mem_flags flags,
@@ -420,7 +420,7 @@ CL_ADAPTER_DXVA_KHR.
 If _adapter_type_ is CL_ADAPTER_D3D9_KHR, CL_ADAPTER_D3D9EX_KHR and
 CL_ADAPTER_DXVA_KHR, the _surface_info_ points to the following structure:
 
-[source,c]
+[source,opencl]
 ----
 typedef struct _cl_dx9_surface_info_khr
 {
@@ -501,7 +501,7 @@ CL_IMAGE_DX9_MEDIA_PLANE_KHR as described in _sections 5.4.3_ and _5.3.6_.
 
 The function
 indexterm:[clEnqueueAcquireDX9MediaSurfacesKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueAcquireDX9MediaSurfacesKHR(cl_command_queue command_queue,
                                            cl_uint num_objects,
@@ -592,7 +592,7 @@ Otherwise it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueReleaseDX9MediaSurfacesKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueReleaseDX9MediaSurfacesKHR(cl_command_queue command_queue,
                                            cl_uint num_objects,

--- a/ext/cl_khr_egl_event.asciidoc
+++ b/ext/cl_khr_egl_event.asciidoc
@@ -28,7 +28,7 @@ functionality of creating an EGL sync object from an OpenCL event object.
 [[cl_khr_egl_event-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_event clCreateEventFromEGLSyncKHR(cl_context context,
                                      CLeglSyncKHR sync,
@@ -91,7 +91,7 @@ of the fence command associated with the linked EGL sync object.
 
 The function
 indexterm:[clCreateEventFromEGLSyncKHR]
-[source,c]
+[source,opencl]
 ----
 cl_event clCreateEventFromEGLSyncKHR(cl_context context,
                                      CLeglSyncKHR sync,

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -25,7 +25,7 @@ from EGLImages.
 [[cl_khr_egl_image-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromEGLImageKHR(cl_context context,
                                CLeglDisplayKHR display,
@@ -74,7 +74,7 @@ clCreateImage:
 
 "`The function
 indexterm:[clCreateFromEGLImageKHR]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromEGLImageKHR(cl_context context,
                                CLeglDisplayKHR display,
@@ -194,7 +194,7 @@ released, will result in undefined behavior.
 
 The function
 indexterm:[clEnqueueAcquireEGLObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueAcquireEGLObjectsKHR(cl_command_queue command_queue,
                                      cl_uint num_objects,
@@ -267,7 +267,7 @@ Otherwise it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueReleaseEGLObjectsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueReleaseEGLObjectsKHR(cl_command_queue command_queue,
                                      cl_uint num_objects,

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -42,7 +42,7 @@ the standard asynchronous copy functions unless otherwise stated.
 [cols="1a,1",options="header",]
 |=======================================================================
 |*Function* |*Description*
-|[source,c]
+|[source,opencl_c]
 ----
 event_t async_work_group_copy_2D2D(
     __local gentype *dst,
@@ -96,7 +96,7 @@ built-in function must therefore be encountered by all work-items in a
 work-group executing the kernel with the same argument values;
 otherwise the results are undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 event_t async_work_group_copy_3D3D(
     __local gentype *dst,

--- a/ext/cl_khr_extended_bit_ops.asciidoc
+++ b/ext/cl_khr_extended_bit_ops.asciidoc
@@ -34,7 +34,7 @@ This extension requires OpenCL 1.0.
 
 === New OpenCL C Functions
 
-[source]
+[source,opencl_c]
 ----
 gentype bitfield_insert( gentype base, gentype insert, uint offset, uint count )
 igentype bitfield_extract_signed( gentype base, uint offset, uint count )
@@ -64,7 +64,7 @@ _n_ is 2, 3, 4, 8, or 16.
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype bitfield_insert(
     gentype base, gentype insert,
@@ -82,7 +82,7 @@ If _count_ equals 0, the return value will be equal to _base_.
 
 If _count_ or _offset_ or _offset_ + _count_ is greater than number of bits in `gentype` (for scalar types) or components of `gentype` (for vector types), the result is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 igentype bitfield_extract_signed(
     gentype base,
@@ -100,7 +100,7 @@ If _count_ equals 0, the result is 0.
 
 If the _count_ or _offset_ or _offset_ + _count_ is greater than number of bits in `gentype` (for scalar types) or components of `gentype` (for vector types), the result is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 ugentype bitfield_extract_unsigned(
     gentype base,
@@ -118,7 +118,7 @@ If _count_ equals 0, the result is 0.
 
 If the _count_ or _offset_ or _offset_ + _count_ is greater than number of bits in `gentype` (for scalar types) or components of `gentype` (for vector types), the result is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype bit_reverse(
     gentype base)

--- a/ext/cl_khr_extended_versioning.asciidoc
+++ b/ext/cl_khr_extended_versioning.asciidoc
@@ -57,7 +57,7 @@ This scheme enables two versions to be ordered using the standard C/C++ operator
 Macros are provided to extract individual fields or compose a full version
 from the individual fields.
 
-[source,c]
+[source,opencl]
 ----
 
 typedef cl_uint cl_version_khr;
@@ -87,7 +87,7 @@ typedef cl_uint cl_version_khr;
 This extension adds a structure that can be used to describe a combination of a
 name alongside a version number:
 
-[source,c]
+[source,opencl]
 ----
 #define CL_NAME_VERSION_MAX_NAME_SIZE_KHR 64
 
@@ -105,7 +105,7 @@ storage for a NUL-terminated string whose maximum length is therefore
 
 Accepted value for the _param_name_ parameter to *clGetPlatformInfo*:
 
-[source,c]
+[source,opencl]
 ----
 CL_PLATFORM_NUMERIC_VERSION_KHR
 CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR
@@ -113,7 +113,7 @@ CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR
 
 Accepted value for the _param_name_ parameter to *clGetDeviceInfo*:
 
-[source,c]
+[source,opencl]
 ----
 CL_DEVICE_NUMERIC_VERSION_KHR
 CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -425,7 +425,7 @@ The macro names given in the following list must use the values specified.
 These constant expressions are suitable for use in #if preprocessing
 directives.
 
-[source,c]
+[source,opencl_c]
 ----
 #define HALF_DIG            3
 #define HALF_MANT_DIG       11

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -387,7 +387,7 @@ The macro names given in the following list must use the values specified.
 These constant expressions are suitable for use in #if preprocessing
 directives.
 
-[source,c]
+[source,opencl_c]
 ----
 #define DBL_DIG             15
 #define DBL_MANT_DIG        53

--- a/ext/cl_khr_gl_event.asciidoc
+++ b/ext/cl_khr_gl_event.asciidoc
@@ -33,7 +33,7 @@ the OpenCL context.
 [[cl_khr_gl_event-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_event clCreateEventFromGLsyncKHR(cl_context context,
                                     GLsync sync,
@@ -76,7 +76,7 @@ of the fence command associated with the linked GL sync object.
 
 The function
 indexterm:[clCreateEventFromGLsyncKHR]
-[source,c]
+[source,opencl]
 ----
 cl_event clCreateEventFromGLsyncKHR(cl_context context,
                                     GLsync sync,

--- a/ext/cl_khr_gl_msaa_sharing.asciidoc
+++ b/ext/cl_khr_gl_msaa_sharing.asciidoc
@@ -130,7 +130,7 @@ OpenCL 2.2 specification:*
 *Add the following built-in functions to section 6.13.14.3 -- Built-in Image
 Sampler-less Read Functions:*
 
-[source,c]
+[source,opencl_c]
 ----
 float4 read_imagef(
     image2d_msaa_t image,
@@ -156,7 +156,7 @@ Values returned by *read_imagef* for image objects with
 _image_channel_data_type_ values not specified in the description above are
 undefined.
 
-[source,c]
+[source,opencl_c]
 ----
 int4 read_imagei(image2d_msaa_t image,
                  int2 coord,
@@ -194,7 +194,7 @@ _image_channel_data_type_ set to one of the following values:
 If the _image_channel_data_type_ is not one of the above values, the values
 returned by *read_imageui* are undefined.
 
-[source,c]
+[source,opencl_c]
 ----
 float4 read_imagef(image2d_array_msaa_t image,
                    int4 coord,
@@ -220,7 +220,7 @@ _image_channel_data_type_ values not specified in the description above are
 undefined.
 
 
-[source,c]
+[source,opencl_c]
 ----
 int4 read_imagei(image2d_array_msaa_t image,
                  int4 coord,
@@ -258,7 +258,7 @@ _image_channel_data_type_ set to one of the following values:
 If the _image_channel_data_type_ is not one of the above values, the values
 returned by *read_imageui* are undefined.
 
-[source,c]
+[source,opencl_c]
 ----
 float read_imagef(image2d_msaa_depth_t image,
                   int2 coord,
@@ -279,7 +279,7 @@ Values returned by *read_imagef* for image objects with
 _image_channel_data_type_ values not specified in the description above are
 undefined.
 
-[source,c]
+[source,opencl_c]
 ----
 float read_imagef(image2d_array_msaaa_depth_t image,
                   int4 coord,
@@ -317,7 +317,7 @@ number of samples associated with each pixel in the image is undefined
 *Add the following built-in functions to section 6.13.14.5 -- Built-in Image
 Query Functions:*
 
-[source,c]
+[source,opencl_c]
 ----
 int get_image_width(image2d_msaa_t image)
 
@@ -330,7 +330,7 @@ int get_image_width(image2d_array_msaa_depth_t image)
 
 Return the image width in pixels.
 
-[source,c]
+[source,opencl_c]
 ----
 int get_image_height(image2d_msaa_t image)
 
@@ -343,7 +343,7 @@ int get_image_height(image2d_array_msaa_depth_t image)
 
 Return the image height in pixels.
 
-[source,c]
+[source,opencl_c]
 ----
 int get_image_channel_data_type(image2d_msaa_t image)
 
@@ -356,7 +356,7 @@ int get_image_channel_data_type(image2d_array_msaa_depth_t image)
 
 Return the channel data type.
 
-[source,c]
+[source,opencl_c]
 ----
 int get_image_channel_order(image2d_msaa_t image)
 
@@ -369,7 +369,7 @@ int get_image_channel_order(image2d_array_msaa_depth_t image)
 
 Return the image channel order.
 
-[source,c]
+[source,opencl_c]
 ----
 int2 get_image_dim(image2d_msaa_t image)
 
@@ -384,14 +384,14 @@ Return the 2D image width and height as an int2 type.
 The width is returned in the _x_ component, and the height in the _y_
 component.
 
-[source,c]
+[source,opencl_c]
 ----
 size_t get_image_array_size(image2d_array_msaa_depth_t image)
 ----
 
 Return the number of images in the 2D image array.
 
-[source,c]
+[source,opencl_c]
 ----
 int get_image_num_samples(image2d_msaa_t image)
 

--- a/ext/cl_khr_gl_sharing__context.asciidoc
+++ b/ext/cl_khr_gl_sharing__context.asciidoc
@@ -31,7 +31,7 @@ and buffer object images with OpenCL is required by this extension.
 [[cl_khr_gl_sharing-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_int clGetGLContextInfoKHR(const cl_context_properties *properties,
                              cl_gl_context_info param_name,
@@ -225,7 +225,7 @@ context.
 
 To query the currently corresponding device, use the function
 indexterm:[clGetGLContextInfoKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetGLContextInfoKHR(const cl_context_properties *properties,
                              cl_gl_context_info param_name,

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -55,7 +55,7 @@ destroying the corresponding GL share group or contexts
 
 The function
 indexterm:[clCreateFromGLBuffer]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromGLBuffer(cl_context context,
                             cl_mem_flags flags,
@@ -117,7 +117,7 @@ create a CL 1D image buffer object.
 
 The function
 indexterm:[clCreateFromGLTexture]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromGLTexture(cl_context context,
                              cl_mem_flags flags,
@@ -386,7 +386,7 @@ CL_BGRA, CL_UNORM_INT8
 
 The function
 indexterm:[clCreateFromGLRenderbuffer]
-[source,c]
+[source,opencl]
 ----
 cl_mem clCreateFromGLRenderbuffer(cl_context context,
                                   cl_mem_flags flags,
@@ -464,7 +464,7 @@ The OpenGL object used to create the OpenCL memory object and information
 about the object type i.e. whether it is a texture, renderbuffer or buffer
 object can be queried using the following function.
 indexterm:[clGetGLObjectInfo]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetGLObjectInfo(cl_mem memobj,
                          cl_gl_object_type *gl_object_type,
@@ -494,7 +494,7 @@ Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clGetGLTextureInfo]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetGLTextureInfo(cl_mem memobj,
                           cl_gl_texture_info param_name,
@@ -561,7 +561,7 @@ Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueAcquireGLObjects]
-[source,c]
+[source,opencl]
 ----
 cl_int  clEnqueueAcquireGLObjects(cl_command_queue command_queue,
                                   cl_uint num_objects,
@@ -637,7 +637,7 @@ Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueReleaseGLObjects]
-[source,c]
+[source,opencl]
 ----
 cl_int clEnqueueReleaseGLObjects(cl_command_queue command_queue,
                                  cl_uint num_objects,

--- a/ext/cl_khr_icd.asciidoc
+++ b/ext/cl_khr_icd.asciidoc
@@ -37,7 +37,7 @@ At every OpenCL function call, the ICD Loader infers the vendor ICD function
 to call from the arguments to the function.
 An object is said to be ICD compatible if it is of the following structure:
 
-[source,c]
+[source,opencl]
 ----
 struct _cl_<object>
 {
@@ -216,7 +216,7 @@ continue on to the next.
 [[cl_khr_icd-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_int clIcdGetPlatformIDsKHR(cl_uint num_entries,
                               cl_platform_id *platforms,
@@ -257,7 +257,7 @@ In _section 4.1_, add the following after the description of
 "The list of platforms accessible through the Khronos ICD Loader can be
 obtained using the following function:
 indexterm:[clIcdGetPlatformIDsKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clIcdGetPlatformIDsKHR(cl_uint num_entries,
                               cl_platform_id *platforms,

--- a/ext/cl_khr_il_program.asciidoc
+++ b/ext/cl_khr_il_program.asciidoc
@@ -27,7 +27,7 @@ This functionality described by this extension is a core feature in OpenCL 2.1.
 [[cl_khr_il_program-new-procedures-and-functions]]
 === New Procedures and Functions
 
-[source,c]
+[source,opencl]
 ----
 cl_program clCreateProgramWithILKHR(cl_context context,
                                     const void *il,
@@ -88,7 +88,7 @@ Add to Section 5.8.1: Creating Program Objects:
 "The function
 
 indexterm:[clCreateProgramWithILKHR]
-[source,c]
+[source,opencl]
 ----
 cl_program clCreateProgramWithILKHR(cl_context context,
                                     const void *il,

--- a/ext/cl_khr_integer_dot_product.asciidoc
+++ b/ext/cl_khr_integer_dot_product.asciidoc
@@ -45,7 +45,7 @@ Ayal Zaks, Intel +
 
 Accepted value for the _param_name_ parameter to *clGetDeviceInfo*:
 
-[source,c]
+[source,opencl]
 ----
 
 CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR      (1 << 0)
@@ -63,7 +63,7 @@ This extension defines a number of new functions that operate on vectors
 of integers. The exact function overloads available depend on the features
 supported by the target device.
 
-[source,c]
+[source,opencl_c]
 ----
 uint dot(uchar4 a, uchar4 b);
 int dot(char4 a, char4 b);
@@ -196,7 +196,7 @@ features that cannot otherwise be targeted from application-provided code.
 
 The following built-in functions and preprocessor definitions are added:
 
-[source,c]
+[source,opencl_c]
 ----
 #define cl_khr_integer_dot_product 1
 

--- a/ext/cl_khr_mipmap_image.asciidoc
+++ b/ext/cl_khr_mipmap_image.asciidoc
@@ -145,7 +145,7 @@ The following new built-in functions are added to _section 6.13.14.2_.
 [cols="5a,4",options="header",]
 |=======================================================================
 |*Function* |*Description*
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image2d_t image,
@@ -173,7 +173,7 @@ float read_imagef(
 ----
 | Use the coordinate _coord.xy_ to do an element lookup in the mip-level specified by _lod_ in the 2D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image2d_t image,
@@ -205,7 +205,7 @@ float read_imagef(
 ----
 | Use the gradients to compute the lod and coordinate _coord.xy_ to do an element lookup in the mip-level specified by the computed lod in the 2D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image1d_t image,
@@ -227,7 +227,7 @@ uint4 read_imageui(
 ----
 | Use the coordinate _coord_ to do an element lookup in the mip-level specified by _lod_ in the 1D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image1d_t image,
@@ -252,7 +252,7 @@ uint4 read_imageui(
 ----
 | Use the gradients to compute the lod and coordinate _coord_ to do an element lookup in the mip-level specified by the computed lod in the 1D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image3d_t image,
@@ -274,7 +274,7 @@ uint4 read_imageui(
 ----
 | Use the coordinate _coord.xyz_ to do an element lookup in the mip-level specified by _lod_ in the 3D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image3d_t image,
@@ -299,7 +299,7 @@ uint4 read_imageui(
 ----
 | Use the gradients to compute the lod and coordinate _coord.xyz_ to do an element lookup in the mip-level specified by the computed lod in the 3D image object specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image1d_array_t image,
@@ -321,7 +321,7 @@ uint4 read_imageui(
 ----
 | Use the coordinate _coord.x_ to do an element lookup in the 1D image identified by _coord.x_ and mip-level specified by _lod_ in the 1D image array specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image1d_array_t image,
@@ -346,7 +346,7 @@ uint4 read_imageui(
 ----
 | Use the gradients to compute the lod and coordinate _coord.x_ to do an element lookup in the mip-level specified by the computed lod in the 1D image array specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image2d_array_t image,
@@ -374,7 +374,7 @@ float read_imagef(
 ----
 | Use the coordinate _coord.xy_ to do an element lookup in the 2D image identified by _coord.z_ and mip-level specified by _lod_ in the 2D image array specified by _image_.
 
-|[source,c]
+|[source,opencl_c]
 ----
 float4 read_imagef(
     read_only image2d_array_t image,
@@ -415,7 +415,7 @@ The following new built-in functions are added to _section 6.13.14.4_.
 [cols="1a,1",options="header",]
 |=======================================================================
 |*Function* |*Description*
-|[source,c]
+|[source,opencl_c]
 ----
 void write_imagef(
     write_only image2d_t image,
@@ -447,7 +447,7 @@ _coord.x_ and _coord.y_ are considered to be unnormalized coordinates and must b
 
 The behavior of *write_imagef*, *write_imagei* and *write_imageui* if (_x_, _y_) coordinate values are not in the range (0 .. image width of the mip-level specified by _lod_ – 1, 0 .. image height of the mip-level specified by _lod_ – 1) or _lod_ value exceeds the (number of mip-levels in the image – 1) is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 void write_imagef(
     write_only image1d_t image,
@@ -474,7 +474,7 @@ specified by _lod_ – 1.
 
 The behavior of *write_imagef*, *write_imagei* and *write_imageui* if coordinate value is not in the range (0 .. image width of the mip-level specified by _lod_ – 1) or _lod_ value exceeds the (number of mip-levels in the image – 1), is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 void write_imagef(
     write_only image1d_array_t image,
@@ -500,7 +500,7 @@ _coord.x_ and _coord.y_ are considered to be unnormalized coordinates and must b
 
 The behavior of *write_imagef*, *write_imagei* and *write_imageui* if (_x_, _y_) coordinate values are not in the range (0 .. image width of the mip-level specified by _lod_ – 1, 0 .. image number of layers – 1), respectively or _lod_ value exceeds the (number of mip-levels in the image – 1), is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 void write_imagef(
     write_only image2d_array_t image,
@@ -532,7 +532,7 @@ _coord.x_, _coord.y_ and _coord.z_ are considered to be unnormalized coordinates
 
 The behavior of *write_imagef*, *write_imagei* and *write_imageui* if (_x_, _y, z_) coordinate values are not in the range (0 .. image width of the mip-level specified by _lod_ – 1, 0 .. image height of the mip-level specified by _lod_ – 1, 0 .. image number of layers – 1), respectively or _lod_ value exceeds the (number of mip-levels in the image – 1), is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 void write_imagef(
     write_only image3d_t image,
@@ -566,7 +566,7 @@ The following new built-in functions are added to _section 6.13.14.5_.
 [cols="1a,1",options="header",]
 |=================================
 |*Function* |*Description*
-|[source,c]
+|[source,opencl_c]
 ----
 int get_image_num_mip_levels(
     image1d_t image)

--- a/ext/cl_khr_pci_bus_info.asciidoc
+++ b/ext/cl_khr_pci_bus_info.asciidoc
@@ -42,7 +42,7 @@ This extension requires OpenCL 1.0.
 
 Structure returned by the device info query for `CL_DEVICE_PCI_BUS_INFO_KHR`:
 
-[source,c]
+[source,opencl]
 ----
 typedef struct _cl_device_pci_bus_info_khr {
     cl_uint   pci_domain;
@@ -56,7 +56,7 @@ typedef struct _cl_device_pci_bus_info_khr {
 
 Accepted value for the _param_name_ parameter to *clGetDeviceInfo*:
 
-[source,c]
+[source,opencl]
 ----
 #define CL_DEVICE_PCI_BUS_INFO_KHR  0x410F
 ----

--- a/ext/cl_khr_select_fprounding_mode.asciidoc
+++ b/ext/cl_khr_select_fprounding_mode.asciidoc
@@ -24,7 +24,7 @@ It allows an application to specify the rounding mode for an instruction or grou
 
 With this extension, the rounding mode may be specified using the following *#pragma* in the OpenCL program source:
 
-[source,c]
+[source,opencl_c]
 ----
 #pragma OPENCL SELECT_ROUNDING_MODE <rounding-mode>
 ----
@@ -45,7 +45,7 @@ Except where otherwise documented, the callee functions do not inherit the round
 
 If this extension is enabled, the `\\__ROUNDING_MODE__` preprocessor symbol shall be defined to be one of the following according to the current rounding mode:
 
-[source,c]
+[source,opencl_c]
 ----
 #define __ROUNDING_MODE__ rte
 #define __ROUNDING_MODE__ rtz
@@ -55,7 +55,7 @@ If this extension is enabled, the `\\__ROUNDING_MODE__` preprocessor symbol shal
 
 This is intended to enable remapping `foo()` to `foo_rte()` by the preprocessor by using:
 
-[source,c]
+[source,opencl_c]
 ----
 #define foo foo ## __ROUNDING_MODE__
 ----

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -43,7 +43,7 @@ For all of the extensions described in this section:
 [[extended-subgroups-summary]]
 === Summary of New OpenCL C Functions
 
-[source,c]
+[source,opencl_c]
 ----
 // These functions are available to devices supporting
 // cl_khr_subgroup_extended_types:
@@ -191,14 +191,14 @@ For the functions below, the generic type name `gentype` may be the one of the s
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_elect()
 ----
 | Elects a single work item in the subgroup to perform a task.
 This function will return true (nonzero) for the active work item in the subgroup with the smallest subgroup local ID, and false (zero) for all other active work items in the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_all(
     int predicate )
@@ -207,7 +207,7 @@ int sub_group_non_uniform_all(
 
 Note: This behavior is the same as `sub_group_all` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_any(
     int predicate )
@@ -216,7 +216,7 @@ int sub_group_non_uniform_any(
 
 Note: This behavior is the same as `sub_group_any` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_all_equal(
     gentype value )
@@ -247,7 +247,7 @@ For the `sub_group_non_uniform_broadcast` function, the generic type name `genty
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_broadcast(
     gentype value,
@@ -259,14 +259,14 @@ Behavior is undefined when the value of _index_ is not equivalent for all active
 
 The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_broadcast_first(
     gentype value )
 ----
 | Returns _value_ for the work item with the smallest subgroup local ID among active work items in the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 sub_group_ballot(
     int predicate )
@@ -275,7 +275,7 @@ uint4 sub_group_ballot(
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 The representative bit in the bitfield is set if the work item is active and the _predicate_ is non-zero, and is unset otherwise.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_inverse_ballot(
     uint4 value )
@@ -287,7 +287,7 @@ Behavior is undefined when _value_ is not equivalent for all active work items i
 
 This is a specialized function that may perform better than the equivalent `sub_group_ballot_bit_extract` on some implementations.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_ballot_bit_extract(
     uint4 value,
@@ -298,28 +298,28 @@ The predicate return value will be non-zero if the bit in the bitfield _value_ f
 
 The predicate return value is undefined if the work item with subgroup local ID equal to _index_ is greater than or equal to the size of the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint sub_group_ballot_bit_count(
     uint4 value )
 ----
 | Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint sub_group_ballot_inclusive_scan(
     uint4 value )
 ----
 | Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than or equal to this work item's subgroup local ID.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint sub_group_ballot_exclusive_scan(
     uint4 value )
 ----
 | Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than this work item's subgroup local ID.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint sub_group_ballot_find_lsb(
     uint4 value )
@@ -327,7 +327,7 @@ uint sub_group_ballot_find_lsb(
 | Returns the smallest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
 If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint sub_group_ballot_find_msb(
     uint4 value )
@@ -335,35 +335,35 @@ uint sub_group_ballot_find_msb(
 | Returns the largest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values from all work items in the subgroup.
 If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 get_sub_group_eq_mask()
 ----
 | Generates a bitmask where the bit is set in the bitmask if the bit index equals the subgroup local ID and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 get_sub_group_ge_mask()
 ----
 | Generates a bitmask where the bit is set in the bitmask if the bit index is greater than or equal to the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 get_sub_group_gt_mask()
 ----
 | Generates a bitmask where the bit is set in the bitmask if the bit index is greater than the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 get_sub_group_le_mask()
 ----
 | Generates a bitmask where the bit is set in the bitmask if the bit index is less than or equal to the subgroup local ID and unset otherwise.
 Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
 
-|[source,c]
+|[source,opencl_c]
 ----
 uint4 get_sub_group_lt_mask()
 ----
@@ -391,7 +391,7 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_reduce_add(
     gentype value )
@@ -406,7 +406,7 @@ gentype sub_group_non_uniform_reduce_mul(
 
 Note: This behavior is the same as the *add*, *min*, and *max* reduction built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_inclusive_add(
     gentype value )
@@ -421,7 +421,7 @@ gentype sub_group_non_uniform_scan_inclusive_mul(
 
 Note: This behavior is the same as the *add*, *min*, and *max* inclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_exclusive_add(
     gentype value )
@@ -457,7 +457,7 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_reduce_and(
     gentype value )
@@ -468,7 +468,7 @@ gentype sub_group_non_uniform_reduce_xor(
 ----
 | Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_inclusive_and(
     gentype value )
@@ -479,7 +479,7 @@ gentype sub_group_non_uniform_scan_inclusive_xor(
 ----
 | Returns the result of an inclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_exclusive_and(
     gentype value )
@@ -507,7 +507,7 @@ For these functions, a non-zero _predicate_ argument or return value is logicall
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_reduce_logical_and(
     int predicate )
@@ -518,7 +518,7 @@ int sub_group_non_uniform_reduce_logical_xor(
 ----
 | Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_scan_inclusive_logical_and(
     int predicate )
@@ -529,7 +529,7 @@ int sub_group_non_uniform_scan_inclusive_logical_xor(
 ----
 | Returns the result of an inclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_non_uniform_scan_exclusive_logical_and(
     int predicate )
@@ -563,7 +563,7 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_shuffle(
     gentype value, uint index )
@@ -573,7 +573,7 @@ The shuffle _index_ need not be the same for all work items in the subgroup.
 
 The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_shuffle_xor(
     gentype value, uint mask )
@@ -604,7 +604,7 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_shuffle_up(
     gentype value, uint delta )
@@ -616,7 +616,7 @@ The return value is undefined if the work item with subgroup local ID equal to t
 
 This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_shuffle_down(
     gentype value, uint delta )
@@ -655,7 +655,7 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_clustered_reduce_add(
     gentype value, uint clustersize )
@@ -683,7 +683,7 @@ For the functions below, the generic type name `gentype` may be the one of the s
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_clustered_reduce_and(
     gentype value, uint clustersize )
@@ -707,7 +707,7 @@ For these functions, a non-zero _predicate_ argument or return value is logicall
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 int sub_group_clustered_reduce_logical_and(
     int predicate, uint clustersize )

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -52,7 +52,7 @@ In this situation all sub-group scope functions alias their work-group level equ
 The function
 
 indexterm:[clGetKernelSubGroupInfoKHR]
-[source,c]
+[source,opencl]
 ----
 cl_int clGetKernelSubGroupInfoKHR(cl_kernel kernel,
                                   cl_device_id device,

--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -32,7 +32,7 @@ This extension requires OpenCL 1.0.
 
 === New API Functions
 
-[source]
+[source,opencl]
 ----
 cl_int  clGetKernelSuggestedLocalWorkSizeKHR(
     cl_command_queue command_queue,
@@ -51,7 +51,7 @@ cl_int  clGetKernelSuggestedLocalWorkSizeKHR(
 
 To query a suggested local work size for a kernel object, call the function
 
-[source]
+[source,opencl]
 ----
 cl_int  clGetKernelSuggestedLocalWorkSizeKHR(
     cl_command_queue command_queue,

--- a/ext/cl_khr_terminate_context.asciidoc
+++ b/ext/cl_khr_terminate_context.asciidoc
@@ -81,9 +81,9 @@ Otherwise, context creation fails with error code of CL_INVALID_PROPERTY.
 
 The new function
 indexterm:[clTerminateContextKHR]
-[source,c]
+[source,opencl]
 ----
-cl_int clTerminateContextKHR(cl context context)
+cl_int clTerminateContextKHR(cl_context context)
 ----
 
 terminates all pending work associated with the context and renders all data

--- a/ext/cl_loader_layers.asciidoc
+++ b/ext/cl_loader_layers.asciidoc
@@ -30,7 +30,7 @@ A layer needs to implement and expose those two new entry points in
 a shared library. If one or both of those are missing, the loader will
 discard the layer.
 
-[source,c]
+[source,opencl]
 ----
 cl_int clGetLayerInfo(cl_layer_info  param_name,
                       size_t         param_value_size,
@@ -46,7 +46,7 @@ cl_int clInitLayer(cl_uint                 num_entries,
 [[cl_loader_layers-new-api-types]]
 === New API Types
 
-[source]
+[source,opencl]
 ----
 typedef cl_uint cl_layer_info;
 typedef cl_uint cl_layer_api_version;
@@ -57,7 +57,7 @@ typedef cl_uint cl_layer_api_version;
 
 Accepted as _param_name_ to the function *clGetLayerInfo*:
 
-[source,c]
+[source,opencl]
 ----
 #define CL_LAYER_API_VERSION        0x4240
 ----
@@ -70,7 +70,7 @@ Returned by *clGetLayerInfo* when supplied *CL_LAYER_API_VERSION*
 and the corresponding layer implements version 1.0.0 of the layer
 API:
 
-[source,c]
+[source,opencl]
 ----
 #define CL_LAYER_API_VERSION_100 100
 ----
@@ -93,7 +93,7 @@ OPENCL_LAYERS
 
 [open,refpage='clGetLayerInfo',desc='Query information about an OpenCL layer',type='protos']
 Information concerning a Layer can be obtained with the function:
-[source,c]
+[source,opencl]
 ----
 cl_int clGetLayerInfo(cl_layer_info  param_name,
                       size_t         param_value_size,
@@ -140,7 +140,7 @@ Otherwise, it returns one of the following errors.
 
 [open,refpage='clInitLayer',desc='Initialize an OpenCL layer',type='protos']
 Initialization of a Layer can be achieved with the function:
-[source,c]
+[source,opencl]
 
 ----
 cl_int clInitLayer(cl_uint                 num_entries,

--- a/ext/introduction.asciidoc
+++ b/ext/introduction.asciidoc
@@ -67,7 +67,7 @@ The *#pragma OPENCL EXTENSION* directive controls the behavior of the OpenCL
 compiler with respect to extensions.
 The *#pragma OPENCL EXTENSION* directive is defined as:
 
-[source,c]
+[source,opencl_c]
 ----
 #pragma OPENCL EXTENSION <extension_name> : <behavior>
 #pragma OPENCL EXTENSION all : <behavior>
@@ -115,7 +115,7 @@ previously issued extension directives, but only if the _behavior_ is set to
 
 The initial state of the compiler is as if the directive
 
-[source,c]
+[source,opencl_c]
 ----
 #pragma OPENCL EXTENSION all : disable
 ----
@@ -135,7 +135,7 @@ An extension which adds the extension string `"cl_khr_3d_image_writes"`
 should also add a preprocessor `#define` called *`cl_khr_3d_image_writes`*.
 A kernel can now use this preprocessor `#define` to do something like:
 
-[source,c]
+[source,opencl_c]
 ----
 #ifdef cl_khr_3d_image_writes
     // do something using the extension
@@ -149,7 +149,7 @@ A kernel can now use this preprocessor `#define` to do something like:
 
 The function
 indexterm:[clGetExtensionFunctionAddressForPlatform]
-[source,c]
+[source,opencl]
 ----
 void* clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
                                                const char *funcname)
@@ -193,7 +193,7 @@ sharing extension).
 The following convention must be followed for all extensions affecting the
 host API:
 
-[source,c]
+[source,opencl]
 ----
 #ifndef extension_name
 #define extension_name 1
@@ -215,7 +215,7 @@ where `TAG` can be `KHR`, `EXT` or `vendor-specific`.
 Consider, for example, the *cl_khr_gl_sharing* extension.
 This extension would add the following to cl_gl_ext.h:
 
-[source,c]
+[source,opencl]
 ----
 #ifndef cl_khr_gl_sharing
 #define cl_khr_gl_sharing 1

--- a/scripts/docgenerator.py
+++ b/scripts/docgenerator.py
@@ -218,7 +218,7 @@ class DocOutputGenerator(OutputGenerator):
             index_terms.append(basename)
             write('indexterm:[{}]'.format(','.join(index_terms)), file=fp)
 
-        write('[source,c++]', file=fp)
+        write('[source,opencl]', file=fp)
         write('----', file=fp)
         write(contents, file=fp)
         write('----', file=fp)
@@ -233,7 +233,7 @@ class DocOutputGenerator(OutputGenerator):
             # Asciidoc anchor
             write(self.genOpts.conventions.warning_comment, file=fp)
             write('// Include this no-xref version without cross reference id for multiple includes of same file', file=fp)
-            write('[source,c++]', file=fp)
+            write('[source,opencl]', file=fp)
             write('----', file=fp)
             write(contents, file=fp)
             write('----', file=fp)

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
 
     linkFileName   = args.directory + '/api-dictionary.asciidoc'
     nolinkFileName = args.directory + '/api-dictionary-no-links.asciidoc'
+    typeFileName   = args.directory + '/api-types.txt'
 
     specpath = args.registry
     #specpath = "https://raw.githubusercontent.com/KhronosGroup/OpenCL-Registry/master/xml/cl.xml"
@@ -56,6 +57,7 @@ if __name__ == "__main__":
     nolinkFile = open(nolinkFileName, 'w')
     linkFile.write( GetHeader() )
     nolinkFile.write( GetHeader() )
+    typeFile = open(typeFileName, 'w')
 
     # Generate the API functions dictionaries:
 
@@ -239,6 +241,11 @@ if __name__ == "__main__":
             nolinkFile.write('endif::[]\n')
             nolinkFile.write('\n')
 
+            # Print the type list to a file for custom syntax highlighting.
+            # For this we only care about CL types, not base types.
+            if category != 'basetype':
+                typeFile.write('        ' + name + '\n')
+
             numberOfTypes = numberOfTypes + 1
 
     print('Found ' + str(numberOfTypes) + ' API types.')
@@ -247,7 +254,9 @@ if __name__ == "__main__":
     linkFile.close()
     nolinkFile.write( GetFooter() )
     nolinkFile.close()
+    typeFile.close()
 
     print('Successfully generated file: ' + linkFileName)
     print('Successfully generated file: ' + nolinkFileName)
+    print('Successfully generated file: ' + typeFileName)
 


### PR DESCRIPTION
This PR contains cosmetic updates to the OpenCL specifications.  There should be no content changes.

Specific changes are:

* Switched to the new Khronos stylesheets to fix accessibility issues.
* Switched to the "rouge" source highligher instead of the previous "coderay" source highlighter.  Please note that only the OpenCL API, OpenCL C, OpenCL Extensions, and OpenCL SPIR-V Environment specs were updated.  I have not updated the OpenCL C++ kernel language, the C++ for OpenCL, or any vendor extension specs at this time.
* Added customized rouge source highlighting for OpenCL API types and OpenCL C keywords.  This is easy to further customize, if desired, either by modifying the colors or styles or by adding additional keywords or types.

To more easily review these changes, please view the specs on my GitHub pages, which were built from this branch.  For example:

* https://bashbaug.github.io/OpenCL-Docs/html/OpenCL_API.html
* https://bashbaug.github.io/OpenCL-Docs/pdf/OpenCL_C.pdf