### PR TITLE
Make clGetSemaphoreHandleForTypeKHR return an error when the passed memory region is too small

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -310,6 +310,7 @@ Otherwise, it returns one of the following errors:
 ** if _sema_object_ belongs to a context that is not associated with _device_, or
 ** if _sema_object_ can not be shared with _device_.
 * {CL_INVALID_VALUE} if the requested external semaphore handle type was not specified when _sema_object_ was created.
+* {CL_INVALID_VALUE} if _handle_size_ is less than the size needed to store the returned handle.
 // I don't think this can happen.  This would have been checked when the semaphore was created.
 //    ** if CL_SEMAPHORE_HANDLE_*_KHR is specified as one of the _sema_props_ and
 //    the property CL_SEMAPHORE_HANDLE_*_KHR does not identify a valid external


### PR DESCRIPTION
Use the same error code as clGet*Info commands.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>
Change-Id: Iee17d82052b19c6ddad0db6442799b8b9655a5c1