### PR TITLE
Initial wording for SPIR binary clarification in clCompileProgram.

### DIFF
--- a/ext/cl_khr_spir.asciidoc
+++ b/ext/cl_khr_spir.asciidoc
@@ -90,6 +90,20 @@ For example, if the binary is as described in SPIR version 1.2, then
 Failing to specify these compile options may result in implementation
 defined behavior.`"
 
+*Additions to _section 5.8.5_ -- Separate Compilation and Linking of Programs:*
+
+Replace this error for `clCompileProgram`:
+
+  * {CL_INVALID_OPERATION} if _program_ has no source or IL available, i.e. it
+    has not been created with {clCreateProgramWithSource} or
+    {clCreateProgramWithIL}.
+
+with:
+
+  * {CL_INVALID_OPERATION} if _program_ has no source or IL available, i.e. it
+    has not been created with {clCreateProgramWithSource} or
+    {clCreateProgramWithIL} or {clCreateProgramWithBinary} where `-x spir` is present in _options_.
+
 *Additions to _section 5.9.3_ -- Kernel Object Queries:*
 
 Modify following text in clGetKernelArgInfo from:


### PR DESCRIPTION
Fixes #659.