### PR TITLE
Explain the location of language doc in cl_ext_cxx_for_opencl.

### DIFF
--- a/extensions/cl_ext_cxx_for_opencl.asciidoc
+++ b/extensions/cl_ext_cxx_for_opencl.asciidoc
@@ -49,8 +49,12 @@ This extension requires OpenCL 3.0 with OpenCL C 2.0 support or OpenCL 2.x and
 == Overview
 
 This extension adds support for building programs written using the C++ for
-OpenCL kernel language. It also enables applications to query the version of
-the language supported by the device compiler.
+OpenCL kernel language documented in the *OpenCL-Docs* repository
+(https://github.com/KhronosGroup/OpenCL-Docs)
+with stable versions published in releases of the repository.
+
+This extension also enables applications to query the version of the language
+supported by the device compiler.
 
 == New build option
 


### PR DESCRIPTION
C++ for OpenCL documentation is not published in the Registry
like all other documents and therefore there is a need to explain
where the documentation can be found.