### PR TITLE
Fix trivial typo for image_slice_pitch.

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1861,7 +1861,7 @@ include::{generated}/api/version-notes/clCreateImage3D.asciidoc[]
     If _image_row_pitch_ is not 0, it must be a multiple of the image element
     size in bytes.
   * _image_slice_pitch_ is the size in bytes of each 2D slice in the 3D image.
-     This be be 0 if _host_ptr_ is `NULL` and can be 0 or {geq}
+     This must be 0 if _host_ptr_ is `NULL` and can be 0 or {geq}
      _image_row_pitch_ {times} _image_height_ if _host_ptr_ is not `NULL`.
      If _host_ptr_ is not `NULL` and _image_slice_pitch_ is 0,
      _image_slice_pitch_ is calculated as _image_row_pitch_ {times}


### PR DESCRIPTION
Only effects clCreateImage3D.