### PR TITLE
spec source for new extensions

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -100,6 +100,9 @@ include::ext/cl_khr_semaphore.asciidoc[]
 include::ext/cl_khr_external_semaphore.asciidoc[]
 include::ext/cl_khr_external_memory.asciidoc[]
 
+include::ext/cl_khr_command_buffer.asciidoc[]
+include::ext/cl_khr_expect_assume.asciidoc[]
+
 // NOTE: To keep meaningful section numbers, new
 // extension documents should be added above here!
 

--- a/config/rouge/lib/rouge/lexers/opencl.rb
+++ b/config/rouge/lib/rouge/lexers/opencl.rb
@@ -68,6 +68,7 @@ module Rouge
         cl_kernel
         cl_event
         cl_sampler
+        cl_semaphore_khr
         cl_bool
         cl_bitfield
         cl_properties
@@ -140,6 +141,20 @@ module Rouge
         cl_command_queue_capabilities_intel
         cl_device_feature_capabilities_intel
         cl_device_integer_dot_product_capabilities_khr
+        cl_semaphore_properties_khr
+        cl_semaphore_info_khr
+        cl_semaphore_type_khr
+        cl_semaphore_payload_khr
+        cl_external_semaphore_handle_type_khr
+        cl_external_memory_handle_type_khr
+        cl_device_command_buffer_capabilities_khr
+        cl_command_buffer_khr
+        cl_sync_point_khr
+        cl_command_buffer_info_khr
+        cl_command_buffer_state_khr
+        cl_command_buffer_properties_khr
+        cl_ndrange_kernel_command_properties_khr
+        cl_mutable_command_khr
         cl_dx9_surface_info_khr
         cl_motion_estimation_desc_intel
         cl_mem_ext_host_ptr

--- a/config/rouge/lib/rouge/lexers/opencl_c.rb
+++ b/config/rouge/lib/rouge/lexers/opencl_c.rb
@@ -68,6 +68,9 @@ module Rouge
         as_short2
         as_short8
         as_uint
+        async_work_group_copy_fence
+        async_work_group_copy_2D2D
+        async_work_group_copy_3D3D
         atomic_compare_exchange_strong
         atomic_compare_exchange_strong_explicit
         atomic_compare_exchange_weak

--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -339,6 +339,14 @@ declare the following SPIR-V capabilities:
 * *DotProductInput4x8BitKHR* if `CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR` is supported
 * *DotProductInput4x8BitPackedKHR*
 
+==== `cl_khr_expect_assume`
+
+If the OpenCL environment supports the extension `cl_khr_expect_assume`, then the environment must accept modules that declare use of the extension `SPV_KHR_expect_assume` via *OpExtension*.
+
+If the OpenCL environment supports the extension `cl_khr_expect_assume` and use of the SPIR-V extension `SPV_KHR_expect_assume` is declared in the module via *OpExtension*, then the environment must accept modules that declare the following SPIR-V capabilities:
+
+* *ExpectAssumeKHR*
+
 === Embedded Profile Extensions
 
 ==== `cles_khr_int64`

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -3,9 +3,9 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_async_work_group_copy_fence]]
-== Async Work Group Copy Fence (Provisional)
+== Async Work Group Copy Fence
 
-This section describes the *cl_khr_async_work_group_copy_fence* provisional extension.
+This section describes the *cl_khr_async_work_group_copy_fence* extension.
 The extension adds a new built-in function to OpenCL C to establish a memory synchronization ordering of asynchronous copies.
 
 === General information
@@ -16,6 +16,7 @@ The extension adds a new built-in function to OpenCL C to establish a memory syn
 |====
 | *Date*     | *Version* | *Description*
 | 2020-04-21 | 0.9.0     | First assigned version (provisional).
+| 2021-11-10 | 1.0.0     | First non-provisional version.
 |====
 
 [[cl_khr_async_work_group_copy_fence-additions-to-chapter-6-of-the-opencl-specification]]
@@ -54,5 +55,3 @@ work-group executing the kernel with the same argument values;
 otherwise the results are undefined. This rule applies to ND-ranges
 implemented with uniform and non-uniform work-groups.
 |=======================================================================
-
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -161,12 +161,14 @@ typedef cl_uint cl_sync_point_khr;
 // Handle returned on command recording
 typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 
-// Bitfield representing mutable properties of a clCommandNDRangeKernelKHR
-// command
-typedef cl_bitfield cl_ndrange_kernel_command_properties_khr;
+// Mutable properties of a clCommandNDRangeKernelKHR command
+typedef cl_properties cl_ndrange_kernel_command_properties_khr;
 
-// Bitfield representing properties for command-buffer creation.
-typedef cl_bitfield cl_command_buffer_properties_khr;
+// Properties for command-buffer creation
+typedef cl_properties cl_command_buffer_properties_khr;
+
+// Bitfield representing flags for command-buffers
+typedef cl_bitfield cl_command_buffer_flags_khr;
 
 // Enumerated type for use in clGetCommandBufferInfoKHR()
 typedef cl_uint cl_command_buffer_info_khr;
@@ -359,9 +361,9 @@ CL_INVALID_SYNC_POINT_WAIT_LIST_KHR                -1139
 CL_INCOMPATIBLE_COMMAND_QUEUE_KHR                  -1140
 
 // Bitfield to clCreateCommandBufferKHR
-CL_COMMAND_BUFFER_PROPERTIES_KHR                   0x1293
+CL_COMMAND_BUFFER_FLAGS_KHR                        0x1293
 
-// Bits for cl_command_buffer_properties_khr bitfield
+// Bits for cl_command_buffer_flags_khr bitfield
 CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR             (0x1 << 0)
 
 // cl_command_buffer_info_khr queries to clGetCommandBufferInfoKHR
@@ -514,8 +516,8 @@ default values for supported command-buffer properties will be used.
 | *Property Value*
 | *Description*
 
-| *CL_COMMAND_BUFFER_PROPERTIES_KHR*
-| `cl_command_buffer_properties_khr`
+| *CL_COMMAND_BUFFER_FLAGS_KHR*
+| `cl_command_buffer_flags_khr`
 | This is a bitfield and can be set to a combination of the following values:
 
   `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` - Allow multiple instances of the

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -1,0 +1,1875 @@
+// Copyright 2018-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_khr_command_buffer]]
+== Command Buffers (Provisional)
+
+This extension adds the ability to record and replay buffers of OpenCL commands.
+
+=== General Information
+
+==== Name Strings
+
+`cl_khr_command_buffer`
+
+==== Version History
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2021-11-10 | 0.9.0     | First assigned version (provisional).
+|====
+
+=== Dependencies
+
+This extension is written against the OpenCL Specification version 3.0.6.
+
+This extension requires OpenCL 1.2 or later.
+
+==== Contributors
+
+Ewan Crawford, Codeplay Software Ltd. +
+Kenneth Benzie, Codeplay Software Ltd. +
+Alastair Murray, Codeplay Software Ltd. +
+Jack Frankland, Codeplay Software Ltd. +
+Balaji Calidas, Qualcomm Technologies Inc. +
+Joshua Kelly, Qualcomm Technologies, Inc. +
+Kevin Petit, Arm Ltd. +
+Aharon Abramson, Intel. +
+Ben Ashbaugh, Intel. +
+Boaz Ouriel, Intel. +
+
+=== Overview
+
+Command-buffers enable a reduction in overhead when enqueuing the same
+workload multiple times. By separating the command-queue setup from dispatch,
+the ability to replay a set of previously created commands is introduced.
+
+Device-side _cl_sync_point_khr_ synchronization-points can be used within
+command-buffers to define command dependencies. This allows the commands of a
+command-buffer to execute out-of-order on a single <<compatible, compatible>>
+command-queue. The command-buffer itself has no inherent in-order/out-of-order
+property, this ordering is inferred from the command-queue used on command
+recording. Out-of-order enqueues without event dependencies of both regular
+commands, such as *clEnqueueFillBuffer*, and command-buffers are allowed to
+execute concurrently, and it is up to the user to express any dependencies using
+events.
+
+The command-queues a command-buffer will be executed on can be set on replay via
+parameters to *clEnqueueCommandBufferKHR*, provided they are
+<<compatible, compatible>> with the command-queues used on command-buffer
+recording.
+
+==== Background
+
+On embedded devices where building a command stream accounts for a significant
+expenditure of resources and where workloads are often required to be pipelined,
+a solution that minimizes driver overhead can significantly improve the
+utilization of accelerators by removing a bottleneck in repeated command stream
+generation.
+
+An additional motivator is lowering task execution latency, as devices can be
+kept occupied with work by repeated submissions, without having to wait on
+the host to construct commands again for a similar workload.
+
+==== Rationale
+
+The command-buffer abstraction over the generation of command streams is a
+proven approach which facilitates a significant reduction in driver overhead in
+existing real-world applications with repetitive pipelined workloads which are
+built on top of Vulkan, DirectX 12, and Metal.
+
+A primary goal is for a command-buffer to avoid any interaction with
+application code after being enqueued until all recorded commands have
+completed. As such, any command which; maps or migrates memory objects; reads
+or writes memory objects; or enqueues a native kernel, is not available for
+command-buffer recording. Finally commands recorded into a command buffer do
+not wait for or return event objects, these are instead replaced with
+device-side synchronization-point identifiers which enable out-of-order
+execution when enqueued on <<compatible, compatible>> command-queues.
+
+Adding new entry-points for individual commands, rather than recording existing
+command-queue APIs with begin/end markers was a design decision made for the
+following reasons:
+
+* Individually specified entry points makes it clearer to the user what's
+  supported, as opposed to adding a large number of error conditions
+  throughout the specification with all the restrictions.
+
+* Prevents code forking in existing entry points for the implementer, as
+  otherwise separate paths in each entry point need to be maintained for both
+  the recording and normal cases.
+
+* Allows the definition of a new device-side synchronization primitive rather
+  than overloading `cl_event`. As use of `cl_event` in individual commands
+  allows host interaction from callback and user-events, as well as introducing
+  complexities when a command-buffer is enqueued multiple times regarding
+  profiling and execution status.
+
+* New entry points facilitate returning handles to individual commands, allowing
+  those commands to be modified between enqueues of the command buffer. Not all
+  command handles are used in this extension, but providing them facilitates
+  other extensions layered on top to take advantage of them to provide additional
+  mutable functionality.
+
+==== Simultaneous Use
+
+The optional simultaneous use capability was added to the extension so that
+vendors can support pipelined workflows, where command-buffers are repeatedly
+enqueued without blocking in user code. However, simultaneous use may result in
+command-buffers being more expensive to enqueue than in a sequential model, so
+the capability is optional to enable optimizations on command-buffer recording.
+
+=== Interactions with Other Extensions
+
+All command recording entry-points return a mutable-command handle for
+modifying the command between enqueues of the command-buffer. However,
+functionality for mutating commands is not supported by this
+extension. These are provided for other extensions layered on top to use,
+such as `cl_khr_mutable_dispatch`.
+
+Only a single command-queue specified on creation of a command-buffer can
+be used for recording commands to in this `cl_khr_command_buffer` extension.
+The `cl_khr_heterogeneous_replay` extension allows commands to be recorded across
+multiple queues in the same command-buffer, providing replay of heterogeneous
+task graphs.
+
+=== New Types
+
+====  Command Buffer Types
+
+Bitfield for querying command-buffer capabilities of an OpenCL device with
+*clGetDeviceInfo*, see <<command-buffer-queries, device queries table>>:
+[source,c]
+----
+typedef cl_bitfield cl_device_command_buffer_capabilities_khr
+----
+
+Types describing <<command-buffers, command-buffers>>:
+
+[source,c]
+----
+// Returned by clCreateCommandBufferKHR()
+typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
+
+// Unique ID to a device-side synchronization-point used to describe the
+// ordering of commands when recording a command-buffer. Valid for use
+// only within the same command-buffer during recording.
+typedef cl_uint cl_sync_point_khr;
+
+// Handle returned on command recording
+typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
+
+// Bitfield representing mutable properties of a clCommandNDRangeKernelKHR
+// command
+typedef cl_bitfield cl_ndrange_kernel_command_properties_khr;
+
+// Bitfield representing properties for command-buffer creation.
+typedef cl_bitfield cl_command_buffer_properties_khr;
+
+// Enumerated type for use in clGetCommandBufferInfoKHR()
+typedef cl_uint cl_command_buffer_info_khr;
+
+// Return type for CL_COMMAND_BUFFER_STATE_KHR in clGetCommandBufferInfoKHR()
+typedef cl_uint cl_command_buffer_state_khr;
+----
+
+=== New API Functions
+
+Command-buffer entry points from <<command-buffers, Section 5.X>>:
+[source,c]
+----
+cl_command_buffer_khr clCreateCommandBufferKHR(
+    cl_uint num_queues,
+    const cl_command_queue* queues,
+    const cl_command_buffer_properties_khr* properties,
+    cl_int* errcode_ret);
+
+cl_int clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer);
+
+cl_int clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer);
+
+cl_int clFinalizeCommandBufferKHR(cl_command_buffer_khr command_buffer);
+
+cl_int clEnqueueCommandBufferKHR(
+    cl_uint num_queues,
+    cl_command_queue* queues,
+    cl_command_buffer_khr command_buffer,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+
+cl_int clCommandBarrierWithWaitListKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandCopyBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandCopyBufferRectKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    size_t src_row_pitch,
+    size_t src_slice_pitch,
+    size_t dst_row_pitch,
+    size_t dst_slice_pitch,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandCopyBufferToImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_image,
+    size_t src_offset,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandCopyImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem dst_image,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandCopyImageToBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem dst_buffer,
+    const size_t* src_origin,
+    const size_t* region,
+    size_t dst_offset,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandFillBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    const void* pattern,
+    size_t pattern_size,
+    size_t offset,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandFillImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem image,
+    const void* fill_color,
+    const size_t* origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clCommandNDRangeKernelKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    const cl_ndrange_kernel_command_properties_khr* properties,
+    cl_kernel kernel,
+    cl_uint work_dim,
+    const size_t* global_work_offset,
+    const size_t* global_work_size,
+    const size_t* local_work_size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+
+cl_int clGetCommandBufferInfoKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_buffer_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+----
+
+
+=== New API Enums
+
+Enums for querying device command-buffer capabilities with
+*clGetDeviceInfo*, see <<command-buffer-queries, device queries table>>:
+
+[source,c]
+----
+// Accepted values for the param_name parameter to clGetDeviceInfo
+CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR              0x12A9
+CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR 0x12AA
+
+// Bits for cl_device_command_buffer_capabilities_khr bitfield
+CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR        (0x1 << 0)
+CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR  (0x1 << 1)
+CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR     (0x1 << 2)
+CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR         (0x1 << 3)
+
+// Values for cl_command_buffer_state_khr
+CL_COMMAND_BUFFER_STATE_RECORDING_KHR              0x0
+CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR             0x1
+CL_COMMAND_BUFFER_STATE_PENDING_KHR                0x2
+CL_COMMAND_BUFFER_STATE_INVALID_KHR                0x3
+----
+
+Enums for base <<command-buffer, command-buffers>> functionality:
+
+[source,c]
+----
+// Error codes
+CL_INVALID_COMMAND_BUFFER_KHR                      -1138
+CL_INVALID_SYNC_POINT_WAIT_LIST_KHR                -1139
+CL_INCOMPATIBLE_COMMAND_QUEUE_KHR                  -1140
+
+// Bitfield to clCreateCommandBufferKHR
+CL_COMMAND_BUFFER_PROPERTIES_KHR                   0x1293
+
+// Bits for cl_command_buffer_properties_khr bitfield
+CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR             (0x1 << 0)
+
+// cl_command_buffer_info_khr queries to clGetCommandBufferInfoKHR
+CL_COMMAND_BUFFER_INFO_QUEUES_KHR                  0x1294
+CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR              0x1295
+CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR         0x1296
+CL_COMMAND_BUFFER_INFO_STATE_KHR                   0x1297
+CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR        0x1298
+
+// cl_event command-buffer enqueue command type
+CL_COMMAND_COMMAND_BUFFER_KHR                      0x12A8
+----
+
+=== Modifications to section 4.2 of the OpenCL API Specification
+
+Add to *Table 5*, _Device Queries_, of section 4.2:
+[[command-buffer-queries]]
+[cols="1,1,4",options="header"]
+|====
+| cl_device_info
+| Return Type
+| Description
+
+| `CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR`
+| `cl_device_command_buffer_capabilities_khr`
+| Describes device command-buffer capabilities, encoded as bits in a bitfield.
+  Supported capabilities are:
+
+  `CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR` Device supports the ability
+  to record commands that execute kernels which contain printf calls.
+
+  `CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR` Device supports the
+  ability to record commands that execute kernels which contain device-side
+  kernel-enqueue calls.
+
+  `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR` Device supports the
+  command-buffers having a <<pending_count, Pending Count>> that exceeds 1.
+
+  `CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR` Device supports the ability
+  to record command-buffers to out-of-order command-queues.
+
+| `CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR`
+| `cl_command_queue_properties`
+| Bitmask of the minimum properties with which a command-queue must be created
+  to allow a command-buffer to be executed on it. It is valid for a
+  command-queue to be created with extra properties in addition to this
+  base requirement and still be compatible with command-buffer execution.
+|====
+
+[[command-buffers]]
+=== Add new section "Section 5.X - Command Buffers" to OpenCL API Specification
+
+A _command-buffer_ object represents a series of operations to be enqueued
+on one or more command-queues without any application code interaction.
+Grouping the operations together allows efficient enqueuing of repetitive
+operations, as well as enabling driver optimizations.
+
+Command-buffers are _sequential use_ by default, but may also be set to
+_simultaneous use_ on creation if the device optionally supports this
+capability. A sequential use command-buffer must have a <<pending_count,
+Pending Count>> of 0 or 1. The simultaneous use capability removes this
+restriction and allows command-buffers to have a <<pending_count, Pending
+Count>> greater than 1.
+
+[[compatible]]
+Command-buffers are created using an ordered list of command-queues that
+commands are recorded to and execute on by default. These command-queues can be
+replaced on command-buffer enqueue with different command-queues, provided for
+each element in the replacement list the substitute command-queue is compatible
+with the command-queue used on command-buffer creation. Where a _compatible_
+command-queue is defined as a command-queue with identical properties targeting
+the same device and in the same OpenCL context.
+
+
+==== Add new section "Section 5.X.1 - Command Buffer Lifecycle"
+
+A command-buffer is always in one of the following states:
+
+[[recording]]
+Recording:: Initial state of a command-buffer on creation, where commands can be
+recorded to the command-buffer.
+
+[[executable]]
+Executable:: State after command recording has finished with
+*clFinalizeCommandBufferKHR* and the command-buffer may be enqueued.
+
+[[pending]]
+Pending:: Once a command-buffer has been enqueued to a command-queue it enters
+the Pending state until completion, at which point it moves back to the
+<<executable, Executable>> state.
+
+[[invalid]]
+Invalid:: A command-buffer can enter the Invalid state if a resource that was
+used in a command has been modified or freed. The only valid operation to
+perform on a command-buffer in the Invalid state is to call
+*clReleaseCommandBufferKHR* for each of the reference counts the application
+owns.
+
+image::images/commandbuffer_lifecycle.svg[align="center", title="Lifecycle of a command-buffer."]
+
+[[pending_count]]
+The Pending Count is the number of copies of the command
+buffer in the <<pending, Pending>> state. By default a command-buffer's Pending
+Count must be 0 or 1. If the command-buffer was created with
+`CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` then the command-buffer may have a
+Pending Count greater than 1.
+
+==== Add new section "Section 5.X.2 - Creating Command Buffer Objects"
+
+The function
+indexterm:[clCreateCommandBufferKHR]
+[source,c]
+----
+cl_command_buffer clCreateCommandBufferKHR(
+    cl_uint num_queues,
+    const cl_command_queue* queues,
+    const cl_command_buffer_properties_khr* properties,
+    cl_int* errcode_ret);
+----
+Is used to create a command-buffer that can record commands to the specified
+queues.
+
+[NOTE]
+====
+Upon creation the command-buffer is defined as being in the
+<<recording, Recording>> state, in order for the command-buffer to be enqueued
+it must first be finalized using *clFinalizeCommandBufferKHR* after which no
+further commands can be recorded. A command-buffer is submitted for execution
+on command-queues with a call to *clEnqueueCommandBufferKHR*.
+====
+
+_num_queues_ The number of command-queues listed in _queues_. This extension
+only supports a single command-queue, so this **must** be one.
+
+_queues_  Is a pointer to a command-queue that the command-buffer commands will
+be recorded to. _queues_ must be a non-`NULL` value.
+
+_properties_  Specifies a list of properties for the command-buffer and their
+corresponding values. Each property name is immediately followed by the
+corresponding desired value. The list is terminated with 0.
+The list of supported properties is described in the table below. If a
+supported property and its value is not specified in properties, its
+default value will be used. _properties_ can be `NULL` in which case the
+default values for supported command-buffer properties will be used.
+
+.*clCreateCommandBufferKHR* properties
+[cols=",,",options="header",]
+|====
+| *Recording Properties*
+| *Property Value*
+| *Description*
+
+| *CL_COMMAND_BUFFER_PROPERTIES_KHR*
+| `cl_command_buffer_properties_khr`
+| This is a bitfield and can be set to a combination of the following values:
+
+  `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` - Allow multiple instances of the
+  command-buffer to be submitted to the device for execution. If set, devices
+  must support `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR`.
+|====
+
+_errcode_ret_ Returns an appropriate error code. If _errcode_ret_ is `NULL`, no
+error code is returned.
+
+*clCreateCommandBufferKHR* returns a valid non-zero command-buffer and
+_errcode_ret_ is set to `CL_SUCCESS` if the command-buffer is created
+successfully. Otherwise, it returns a `NULL` value with one of the following
+error values returned in _errcode_ret_:
+
+* `CL_INVALID_COMMAND_QUEUE` if any command-queue in _queues_ is not a valid
+  command-queue.
+
+* `CL_INCOMPATIBLE_COMMAND_QUEUE_KHR` if any command-queue in _queues_ is an
+  out-of-order command-queue and the device associated with the command-queue
+  does not support the `CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR`
+  capability.
+
+* `CL_INCOMPATIBLE_COMMAND_QUEUE_KHR` if the properties of any command-queue in
+  _queues_ does not contain the minimum properties specified by
+  `CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR`.
+
+* `CL_INVALID_CONTEXT` if all the command-queues in _queues_ do not have the
+  same OpenCL context.
+
+* `CL_INVALID_VALUE` if _num_queues_ is not one.
+
+* `CL_INVALID_VALUE` if _queues_ is `NULL`.
+
+* `CL_INVALID_VALUE` if values specified in _properties_ are not valid, or if
+  the same property name is specified more than once.
+
+* `CL_INVALID_PROPERTY` if values specified in _properties_ are valid but are
+  not supported by all the devices associated with command-queues in _queues_.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources
+  required by the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources
+  required by the OpenCL implementation on the host.
+
+The function
+indexterm:[clRetainCommandBufferKHR]
+[source,c]
+----
+cl_int clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer)
+----
+Increments the _command_buffer_ reference count.
+
+[NOTE]
+====
+A command-buffer object updates the reference count for objects such as
+buffers, images, and kernels used as parameters for commands recorded to the
+command-buffer.
+
+For example, recording a ND-range kernel via *clCommandNDRangeKernel* into a
+command-buffer and then releasing the kernel object will still allow continued
+safe use of the command-buffer. As the reference count of the kernel object
+will have been incremented when the command was recorded, and then on
+command-buffer release the kernel reference count will be decremented. If at
+that point the kernel reference count reaches 0, the kernel object will be
+freed.
+====
+
+_command_buffer_ Specifies the command-buffer to retain.
+
+*clRetainCommandBufferKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by
+  the OpenCL implementation on the host.
+
+The function
+indexterm:[clReleaseCommandBufferKHR]
+[source,c]
+----
+cl_int clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer)
+----
+Decrements the _command_buffer_ reference count.
+
+[NOTE]
+====
+After the _command_buffer_ reference count becomes zero and has finished
+execution, the command-buffer is deleted.
+====
+
+_command_buffer_ Specifies the command-buffer to release.
+
+*clReleaseCommandBufferKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources
+  required by the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources
+  required by the OpenCL implementation on the host.
+
+==== Add new section "Section 5.X.2 - Enqueuing a Command Buffer"
+
+The function
+indexterm:[clFinalizeCommandBufferKHR]
+[source,c]
+----
+cl_int clFinalizeCommandBufferKHR(cl_command_buffer_khr command_buffer);
+----
+Finalizes command recording ready for enqueuing the command-buffer on a
+command-queue.
+
+[NOTE]
+====
+*clFinalizeCommandBufferKHR* places the command-buffer in the
+<<executable, Executable>> state where commands can no longer be recorded, at
+this point the command-buffer is ready to be enqueued.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+*clFinalizeCommandBufferKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required
+  by the OpenCL implementation on the host.
+
+The function
+indexterm:[clEnqueueCommandBufferKHR]
+[source,c]
+----
+cl_int clEnqueueCommandBufferKHR(
+    cl_uint num_queues,
+    cl_command_queue* queues,
+    cl_command_buffer_khr command_buffer,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event);
+----
+Enqueues a command-buffer to execute on command-queues specified by _queues_,
+or on default command-queues used during recording if _queues_ is empty.
+
+[NOTE]
+====
+To enqueue a command-buffer it must be in a <<executable, Executable>> state,
+see *clFinalizeCommandBufferKHR*.
+====
+
+_num_queues_ The number of command-queues listed in _queues_.
+
+_queues_  A pointer to an ordered list of command-queues
+<<compatible, compatible>> with the command-queues used on recording. _queues_
+can be `NULL` in which case the default command-queues used on command-buffer
+creation are used and _num_queues_ must be 0.
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_event_wait_list_, _num_events_in_wait_list_ Specify events that need to
+complete before this particular command can be executed. If
+_event_wait_list_ is `NULL`, then this particular command does not wait
+on any event to complete. If _event_wait_list_ is `NULL`,
+_num_events_in_wait_list_ must be 0. If event_wait_list is not `NULL`,
+the list of events pointed to by _event_wait_list_ must be valid and
+_num_events_in_wait_list_ must be greater than 0. The events specified
+in _event_wait_list_ act as synchronization points. The context associated
+with events in _event_wait_list_ and command_queue must be the same. The memory
+associated with _event_wait_list_ can be reused or freed after the function
+returns.
+
+_event_ Returns an event object that identifies this command and
+can be used to query for profiling information or queue a wait for this
+particular command to complete. _event_ can be `NULL` in which case it will not
+be possible for the application to wait on this command or query it for
+profiling information.
+
+*clEnqueueCommandBufferKHR* returns `CL_SUCCESS` if the command-buffer
+execution was successfully queued, or one of the errors below:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has not been finalized.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ was not created with the
+  `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` flag and is in the <<pending,
+  Pending>> state.
+
+* `CL_INVALID_VALUE` if _queues_ is `NULL` and _num_queues_ is > 0, or _queues_
+  is not `NULL` and _num_queues_ is 0.
+
+* `CL_INVALID_VALUE` if _num_queues_ is > 0 and not the same value as
+  _num_queues_ set on _command_buffer_ creation.
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not a valid command-queue.
+
+* `CL_INCOMPATIBLE_COMMAND_QUEUE_KHR` if any element of _queues_ is not
+  <<compatible, compatible>>  with the command-queue set on _command_buffer_
+  creation at the same list index.
+
+* `CL_INVALID_CONTEXT` if any element of _queues_ does not have the same
+  context as the command-queue set on _command_buffer_ creation at the same list
+  index.
+
+* `CL_INVALID_CONTEXT` if context associated with _command_buffer_ and
+  events in _event_wait_list_ are not the same.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to queue the execution instance of
+  _command_buffer_ on the command-queues because of insufficient resources
+  needed to execute _command_buffer_.
+
+* `CL_INVALID_EVENT_WAIT_LIST` if _event_wait_list_ is `NULL` and
+  _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL`
+  and _num_events_in_wait_list_ is 0, or if event objects in
+  _event_wait_list_ are not valid events.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required
+  by the OpenCL implementation on the host.
+
+==== Add new section "Section 5.X.3 - Recording Commands to a Command Buffer"
+
+The function
+indexterm:[clCommandBarrierWithWaitListKHR]
+[source,c]
+----
+cl_int clCommandBarrierWithWaitListKHR(
+      cl_command_buffer_khr command_buffer,
+      cl_command_queue command_queue,
+      cl_uint num_sync_points_in_wait_list,
+      const cl_sync_point_khr* sync_point_wait_list,
+      cl_sync_point_khr* sync_point,
+      cl_mutable_command_khr* mutable_handle);
+----
+Records a barrier operation used as a synchronization point.
+
+[NOTE]
+====
+*clCommandBarrierWithWaitListKHR* Waits for either a list of
+synchronization-points to complete, or if the list is empty it waits for all
+commands previously recorded in _command_buffer_ to complete before it
+completes. This command blocks command execution, that is, any following
+commands recorded after it do not execute until it completes.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+If _sync_point_wait_list_ is `NULL`, then this particular command
+waits until all previous recorded commands to _command_queue_ have
+completed.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this barrier command later on. _sync_point_ can be `NULL` in
+which case it will not be possible for the application to record a wait
+for this command to complete. If the _sync_point_wait_list_ and the
+_sync_point_ arguments are not `NULL`, the _sync_point_ argument
+should not refer to an element of the _sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandBarrierWithWaitListKHR* returns `CL_SUCCESS` if the function is
+executed successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_ and
+  _command_buffer_ is not the same.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by
+  the OpenCL implementation on the host.
+
+The function
+indexterm:[clCommandCopyBufferKHR]
+[source,c]
+----
+cl_int clCommandCopyBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    size_t src_offset,
+    size_t dst_offset,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to copy from one buffer object to another.
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_src_buffer_, _dst_buffer_, _src_offset_, _dst_offset_, _size_ Refer to
+*clEnqueueCopyBuffer*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandCopyBufferKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueCopyBuffer* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, _src_buffer_, and _dst_buffer_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandCopyBufferRectKHR]
+[source,c]
+----
+cl_int clCommandCopyBufferRectKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_buffer,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    size_t src_row_pitch,
+    size_t src_slice_pitch,
+    size_t dst_row_pitch,
+    size_t dst_slice_pitch,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to copy a rectangular region from a buffer object to another
+buffer object.
+
+[NOTE]
+====
+*clCommandCopyBufferRectKHR* records a command to copy a 2D or 3D rectangular
+region from the buffer object identified by _src_buffer_ to a 2D or 3D region
+in the buffer object identified by _dst_buffer_. Copying begins at the source
+offset and destination offset which are computed as described in the
+description for _src_origin_ and _dst_origin_.
+
+Each byte of the region's width is copied from the source offset to the
+destination offset. After copying each width, the source and destination
+offsets are incremented by their respective source and destination row
+pitches. After copying each 2D rectangle, the source and destination offsets
+are incremented by their respective source and destination slice pitches.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_src_origin_, _dst_origin_, _region_, _src_row_pitch_, _src_slice_pitch_,
+_dst_row_pitch_, _dst_slice_pitch_ Refer to *clEnqueueCopyBufferRect*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ may be `NULL`, however the command will still be mutable if
+_command_buffer_ was created with `CL_MUTABLE_MEM_COMMANDS_ENABLE_KHR`.
+
+*clCommandCopyBufferRectKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueCopyBufferRect* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, _src_buffer_, and _dst_buffer_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandCopyBufferToImageKHR]
+[source,c]
+----
+cl_int clCommandCopyBufferToImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_buffer,
+    cl_mem dst_image,
+    size_t src_offset,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to copy a buffer object to an image object.
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_src_buffer_, _dst_image_, _src_offset_, _dst_origin_, _region_ Refer to
+*clEnqueueCopyBufferToImage*
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandCopyBufferToImageKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueCopyBufferToImage* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, _src_buffer_, and _dst_image_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandCopyImageKHR]
+[source,c]
+----
+cl_int clCommandCopyImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem dst_image,
+    const size_t* src_origin,
+    const size_t* dst_origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to copy image objects.
+
+[NOTE]
+====
+It is currently a requirement that the _src_image_ and _dst_image_ image
+memory objects for *clCommandCopyImageKHR* must have the exact same image
+format, i.e. the cl_image_format descriptor specified when _src_image_ and
+_dst_image_ are created must match.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_src_image_, _dst_image_, _src_origin_, _dst_origin_, _region_ Refer to
+*clEnqueueCopyImage*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandCopyImageKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueCopyImage* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, _src_image_, and _dst_image_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandCopyImageToBufferKHR]
+[source,c]
+----
+cl_int clCommandCopyImageToBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem src_image,
+    cl_mem  dst_buffer,
+    const size_t* src_origin,
+    const size_t* region,
+    size_t dst_offset,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to copy an image object to a buffer object.
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_src_image_, _dst_buffer_, _src_origin_, _region_, _dst_offset_
+Refer to *clEnqueueCopyImageToBuffer*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandCopyImageToBufferKHR* returns `CL_SUCCESS` if the function is
+executed successfully. Otherwise, it returns the errors defined by
+*clEnqueueCopyImageToBuffer* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, _src_image_, and _dst_buffer_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandFillBufferKHR]
+[source,c]
+----
+cl_int clCommandFillBufferKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem buffer,
+    const void* pattern,
+    size_t pattern_size,
+    size_t offset,
+    size_t size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to fill a buffer object with a pattern of a given pattern
+size.
+
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the _cl_mem_flags_ argument
+value specified when _buffer_ is created is ignored by
+*clCommandFillBufferKHR*.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_buffer_, _pattern_, _pattern_size_, _offset_, _size_ Refer to
+*clEnqueueFillBuffer*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandFillBufferKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueFillBuffer* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, and _buffer_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandFillImageKHR]
+[source,c]
+----
+cl_int clCommandFillImageKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    cl_mem image,
+    const void* fill_color,
+    const size_t* origin,
+    const size_t* region,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to fill an image object with a specified color.
+
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the _cl_mem_flags_ argument
+value specified when image is created is ignored by *clCommandFillImageKHR*.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_image_, _fill_color_, _origin_, _region_ Refer to *clEnqueueFillImage*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandFillImageKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueFillImage* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, and _image_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+The function
+indexterm:[clCommandNDRangeKernelKHR]
+[source,c]
+----
+cl_int clCommandNDRangeKernelKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_queue command_queue,
+    const cl_ndrange_kernel_command_properties_khr* properties,
+    cl_kernel kernel,
+    cl_uint work_dim,
+    const size_t* global_work_offset,
+    const size_t* global_work_size,
+    const size_t* local_work_size,
+    cl_uint num_sync_points_in_wait_list,
+    const cl_sync_point_khr* sync_point_wait_list,
+    cl_sync_point_khr* sync_point,
+    cl_mutable_command_khr* mutable_handle);
+----
+Records a command to execute a kernel on a device.
+
+[NOTE]
+====
+The work-group size to be used for _kernel_ can also be specified in the
+program source using the
+`+__attribute__((reqd_work_group_size(X, Y, Z)))+` qualifier. In this case the
+size of work group specified by _local_work_size_ must match the value
+specified by the `reqd_work_group_size` `+__attribute__+` qualifier.
+
+These work-group instances are executed in parallel across multiple compute
+units or concurrently on the same compute unit.
+
+Each work-item is uniquely identified by a global identifier. The global ID,
+which can be read inside the kernel, is computed using the value given by
+_global_work_size_ and _global_work_offset_. In addition, a work-item is
+also identified within a work-group by a unique local ID. The local ID,
+which can also be read by the kernel, is computed using the value given by
+_local_work_size_. The starting local ID is always (0, 0, ... 0).
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_command_queue_ Specifies the command-queue the command will be recorded to.
+Parameter is unused by this extension as only a single command-queue is
+supported and **must** be `NULL`.
+
+_properties_ Specifies a list of properties for the kernel command and their
+corresponding values. Each property name is immediately followed by the
+corresponding desired value. The list is terminated with 0. If no properties are
+required, _properties_ may be `NULL`. This extension does not define any
+properties.
+
+_kernel_ A valid kernel object.
+
+_work_dim_, _global_work_offset_, _global_work_size_, _local_work_size_ Refer
+to *clEnqueueNDRangeKernel*.
+
+_sync_point_wait_list_, _num_sync_points_in_wait_list_ Specify
+synchronization-points that need to complete before this
+particular command can be executed.
+
+If _sync_point_wait_list_ is `NULL`, _num_sync_points_in_wait_list_
+must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
+synchronization-points pointed to by _sync_point_wait_list_ must be
+valid and _num_sync_points_in_wait_list_ must be greater than 0.
+The synchronization-points specified in _sync_point_wait_list_ are
+*device side* synchronization-points. The command-buffer associated
+with synchronization-points in _sync_point_wait_list_ must be the same
+as _command_buffer_. The memory associated with _sync_point_wait_list_
+can be reused or freed after the function returns.
+
+_sync_point_ Returns a synchronization-point ID that identifies this particular
+command. Synchronization-point objects are unique and can be used to
+identify this command later on. _sync_point_ can be `NULL` in which case it
+will not be possible for the application to record a wait for this command to
+complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
+`NULL`, the _sync_point_ argument should not refer to an element of the
+_sync_point_wait_list_ array.
+
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
+
+*clCommandNDRangeKernelKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns the errors defined by
+*clEnqueueNDRangeKernel* except:
+
+`CL_INVALID_COMMAND_QUEUE` is replaced with:
+
+* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not `NULL`.
+
+`CL_INVALID_CONTEXT` is replaced with:
+
+* `CL_INVALID_CONTEXT` if the context associated with _command_queue_,
+  _command_buffer_, and _kernel_ are not the same.
+
+`CL_INVALID_EVENT_WAIT_LIST` is replaced with:
+
+* `CL_INVALID_SYNC_POINT_WAIT_LIST_KHR` if _sync_point_wait_list_ is `NULL` and
+  _num_sync_points_in_wait_list_ is > 0, or _sync_point_wait_list_ is not
+  `NULL` and _num_sync_points_in_wait_list_ is 0, or if
+  synchronization-point objects in _sync_point_wait_list_ are not valid
+  synchronization-points.
+
+New errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_VALUE` if values specified in _properties_ are not valid
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has been finalized.
+
+* `CL_INVALID_VALUE` if _mutable_handle_ is not `NULL`.
+
+* `CL_INVALID_OPERATION` if the device associated with _command_queue_ does not
+  support `CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR` and _kernel_ contains
+  a printf call.
+
+* `CL_INVALID_OPERATION` if the device associated with _command_queue_ does not
+  support `CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR` and _kernel_
+  contains a kernel-enqueue call.
+
+==== Add new section "Section 5.X.4 - Command Buffer Queries"
+
+The function
+indexterm:[clGetCommandBufferInfoKHR]
+[source,c]
+----
+cl_int clGetCommandBufferInfoKHR(
+    cl_command_buffer_khr command_buffer,
+    cl_command_buffer_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+----
+Queries information about a command-buffer.
+
+_command_buffer_ Specifies the command-buffer being queried.
+
+_param_name_ Specifies the information to query.
+
+_param_value_size_ Specifies the size in bytes of memory pointed to by
+_param_value_. This size must be ≥ size of return type as described in the table
+below. If _param_value_ is `NULL`, it is ignored.
+
+_param_value_ A pointer to memory where the appropriate result being queried is
+returned. If _param_value_ is `NULL`, it is ignored.
+
+_param_value_size_ret_ Returns the actual size in bytes of data being queried by
+_param_value_. If _param_value_size_ret_ is `NULL`, it is ignored.
+
+The list of supported _param_name_ values and the information returned in
+_param_value_ by *clGetCommandBufferInfoKHR* is described in the table below.
+
+.*clGetCommandBufferInfoKHR* values
+[cols=",,",options="header",]
+|====
+| *cl_command_buffer_info_khr*
+| *Return Type*
+| *Description*
+
+| *CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR*
+| cl_uint
+| The number of command-queues specified when _command_buffer_ was created.
+
+| *CL_COMMAND_BUFFER_INFO_QUEUES_KHR*
+| cl_command_queue[]
+| Return the list of command-queues specified when the _command_buffer_ was
+  created.
+
+| *CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR*
+| cl_uint
+| Return the _command_buffer_ reference count.
+
+  The reference count returned with `CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR`
+  should be considered immediately stale. It is provided for identifying
+  memory leaks.
+
+| *CL_COMMAND_BUFFER_INFO_STATE_KHR*
+| cl_command_buffer_state_khr
+| Return the state of _command_buffer_.
+
+  `CL_COMMAND_BUFFER_STATE_RECORDING_KHR` is returned when _command_buffer_ has
+  not been finalized.
+
+  `CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR` is returned when _command_buffer_
+  has been finalized and there is not a <<pending, Pending>> instance of
+  _command_buffer_ awaiting completion on a command_queue.
+
+  `CL_COMMAND_BUFFER_STATE_PENDING_KHR` is returned when an instance of
+  _command_buffer_ has been enqueued for execution but not yet completed.
+
+  `CL_COMMAND_BUFFER_STATE_INVALID_KHR` is returned when _command_buffer_ is
+  in an <<invalid, Invalid>> state.
+
+| *CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR*
+| cl_command_buffer_properties_khr[]
+| Return the _properties_ argument specified in *clCreateCommandBufferKHR*.
+
+  If the _properties_ argument specified in *clCreateCommandBufferKHR* used to
+  create _command_buffer_ was not `NULL`, the implementation must return the
+  values specified in the properties argument.
+
+  If the _properties_ argument specified in *clCreateCommandBufferKHR* used to
+  create _command_buffer_ was `NULL`, the implementation may return either a
+  _param_value_size_ret_ of 0 (i.e. there is are no properties to be returned),
+  or the implementation may return a property value of 0 (where 0 is used to
+  terminate the properties list).
+
+|====
+
+*clGetCommandBufferInfoKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_VALUE` if _param_name_ is not one of the supported values
+  or if size in bytes specified by _param_value_size_ is less than size of
+  return type and _param_value_ is not a `NULL` value.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by
+  the OpenCL implementation on the host.
+
+=== Modifications to section 5.11 of the OpenCL API Specification
+
+In the opening paragraph add *clEnqueueCommandBufferKHR* to list of commands that
+can return an event object.
+
+Add to Table 37, _Event Command Types_:
+[cols=",",options="header"]
+|====
+| Events Created By
+| Event Command Type
+
+| `clEnqueueCommandBufferKHR`
+| `CL_COMMAND_COMMAND_BUFFER_KHR`
+|====
+
+=== Sample Code
+
+[source,cpp]
+----
+  #define CL_CHECK(ERROR)                             \
+    if (ERROR) {                                      \
+      std::cerr << "OpenCL error: " << ERROR << "\n"; \
+      return ERROR;                                   \
+    }
+
+  int main() {
+    cl_platform_id platform;
+    CL_CHECK(clGetPlatformIDs(1, &platform, nullptr));
+    cl_device_id device;
+    CL_CHECK(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, nullptr));
+
+    cl_int error;
+    cl_context context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &error);
+    CL_CHECK(error);
+
+    const char* code = R"OpenCLC(
+  kernel void vector_addition(global int* tile1, global int* tile2,
+                              global int* res) {
+    size_t index = get_global_id(0);
+    res[index] = tile1[index] + tile2[index];
+  }
+  )OpenCLC";
+    const size_t length = std::strlen(code);
+
+    cl_program program =
+        clCreateProgramWithSource(context, 1, &code, &length, &error);
+    CL_CHECK(error);
+
+    cl_kernel kernel = clCreateKernel(program, "vector_addition", &error);
+    CL_CHECK(error);
+
+    constexpr size_t frame_count = 60;
+    constexpr size_t frame_elements = 1024;
+    constexpr size_t frame_size = frame_elements * sizeof(cl_int);
+
+    constexpr size_t tile_count = 16;
+    constexpr size_t tile_elements = frame_elements / tile_count;
+    constexpr size_t tile_size = tile_elements * sizeof(cl_int);
+
+    cl_mem buffer_tile1 =
+        clCreateBuffer(context, CL_MEM_READ_ONLY, tile_size, nullptr, &error);
+    CL_CHECK(error);
+    cl_mem buffer_tile2 =
+        clCreateBuffer(context, CL_MEM_READ_ONLY, tile_size, nullptr, &error);
+    CL_CHECK(error);
+    cl_mem buffer_res =
+        clCreateBuffer(context, CL_MEM_WRITE_ONLY, tile_size, nullptr, &error);
+    CL_CHECK(error);
+
+    CL_CHECK(clSetKernelArg(kernel, 0, sizeof(buffer_tile1), &buffer_tile1));
+    CL_CHECK(clSetKernelArg(kernel, 1, sizeof(buffer_tile2), &buffer_tile2));
+    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(buffer_res), &buffer_res));
+
+    cl_command_queue command_queue =
+      clCreateCommandQueue(context, device,
+                           CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &error);
+    CL_CHECK(error);
+
+    cl_command_buffer_khr command_buffer =
+        clCreateCommandBufferKHR(1, &command_queue, nullptr, &error);
+    CL_CHECK(error);
+
+    cl_mem buffer_src1 =
+        clCreateBuffer(context, CL_MEM_READ_ONLY, frame_size, nullptr, &error);
+    CL_CHECK(error);
+    cl_mem buffer_src2 =
+        clCreateBuffer(context, CL_MEM_READ_ONLY, frame_size, nullptr, &error);
+    CL_CHECK(error);
+    cl_mem buffer_dst =
+        clCreateBuffer(context, CL_MEM_WRITE_ONLY, frame_size, nullptr, &error);
+    CL_CHECK(error);
+
+    cl_sync_point_khr tile_sync_point = 0;
+    for (size_t tile_index = 0; tile_index < tile_count; tile_index++) {
+      std::array<cl_sync_point_khr, 2> copy_sync_points;
+      CL_CHECK(clCommandCopyBufferKHR(command_buffer,
+          command_queue, buffer_src1, buffer_tile1, tile_index * tile_size, 0,
+          tile_size, tile_sync_point ? 1 : 0,
+          tile_sync_point ? &tile_sync_point : nullptr, &copy_sync_points[0]),
+          nullptr);
+      CL_CHECK(clCommandCopyBufferKHR(command_buffer,
+          command_queue, buffer_src2, buffer_tile2, tile_index * tile_size, 0,
+          tile_size, tile_sync_point ? 1 : 0,
+          tile_sync_point ? &tile_sync_point : nullptr, &copy_sync_points[1]),
+          nullptr);
+
+      cl_sync_point_khr nd_sync_point;
+      CL_CHECK(clCommandNDRangeKernelKHR(command_buffer,
+          command_queue, nullptr, kernel, 1, nullptr, &tile_elements, nullptr,
+          copy_sync_points.size(), copy_sync_points.data(), &nd_sync_point,
+          nullptr));
+
+      CL_CHECK(clCommandCopyBufferKHR(command_buffer,
+          command_queue, buffer_res, buffer_dst, 0, tile_index * tile_size,
+          tile_size, 1, &nd_sync_point, &tile_sync_point, nullptr));
+    }
+
+    CL_CHECK(clFinalizeCommandBufferKHR(command_buffer));
+
+    std::random_device random_device;
+    std::mt19937 random_engine{random_device()};
+    std::uniform_int_distribution<cl_int> random_distribution{
+        0, std::numeric_limits<cl_int>::max() / 2};
+    auto random_generator = [&]() { return random_distribution(random_engine); };
+
+    for (size_t frame_index = 0; frame_index < frame_count; frame_index++) {
+      std::array<cl_event, 2> write_src_events;
+      std::vector<cl_int> src1(frame_elements);
+      std::generate(src1.begin(), src1.end(), random_generator);
+      CL_CHECK(clEnqueueWriteBuffer(command_queue, buffer_src1, CL_FALSE, 0,
+                                    frame_size, src1.data(), 0, nullptr,
+                                    &write_src_events[0]));
+      std::vector<cl_int> src2(frame_elements);
+      std::generate(src2.begin(), src2.end(), random_generator);
+      CL_CHECK(clEnqueueWriteBuffer(command_queue, buffer_src2, CL_FALSE, 0,
+                                    frame_size, src2.data(), 0, nullptr,
+                                    &write_src_events[1]));
+
+      CL_CHECK(clEnqueueCommandBufferKHR(0, NULL, command_buffer, 2,
+                                         write_src_events.data(), nullptr));
+
+      CL_CHECK(clFinish(command_queue));
+
+      CL_CHECK(clReleaseEvent(write_src_event[0]));
+      CL_CHECK(clReleaseEvent(write_src_event[1]));
+    }
+
+    CL_CHECK(clReleaseCommandBufferKHR(command_buffer));
+    CL_CHECK(clReleaseCommandQueue(command_queue));
+
+    CL_CHECK(clReleaseMemObject(buffer_src1));
+    CL_CHECK(clReleaseMemObject(buffer_src2));
+    CL_CHECK(clReleaseMemObject(buffer_dst));
+
+    CL_CHECK(clReleaseMemObject(buffer_tile1));
+    CL_CHECK(clReleaseMemObject(buffer_tile2));
+    CL_CHECK(clReleaseMemObject(buffer_res));
+
+    CL_CHECK(clReleaseKernel(kernel));
+    CL_CHECK(clReleaseProgram(program));
+    CL_CHECK(clReleaseContext(context));
+
+    return 0;
+  }
+----
+
+=== Issues
+
+. Introduce a `clCloneCommandBufferKHR` entry-point for cloning a
+  command-buffer.
++
+--
+*UNRESOLVED*
+--
+. Enable detached command-buffer execution, where command-buffers are executed
+  on their own internal queue to prevent locking user created queues for the
+  duration of their execution.
++
+--
+*UNRESOLVED*
+--
+
+NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -21,7 +21,7 @@ This extension adds the ability to record and replay buffers of OpenCL commands.
 | 2021-11-10 | 0.9.0     | First assigned version (provisional).
 |====
 
-=== Dependencies
+==== Dependencies
 
 This extension is written against the OpenCL Specification version 3.0.6.
 

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -82,7 +82,7 @@ built on top of Vulkan, DirectX 12, and Metal.
 
 A primary goal is for a command-buffer to avoid any interaction with
 application code after being enqueued until all recorded commands have
-completed. As such, any command which; maps or migrates memory objects; reads
+completed. As such, any command which maps or migrates memory objects; reads
 or writes memory objects; or enqueues a native kernel, is not available for
 command-buffer recording. Finally commands recorded into a command buffer do
 not wait for or return event objects, these are instead replaced with
@@ -521,6 +521,8 @@ default values for supported command-buffer properties will be used.
   `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` - Allow multiple instances of the
   command-buffer to be submitted to the device for execution. If set, devices
   must support `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR`.
+  
+  The default value of this property is `0`.
 |====
 
 _errcode_ret_ Returns an appropriate error code. If _errcode_ret_ is `NULL`, no

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -1634,13 +1634,9 @@ _param_value_ by *clGetCommandBufferInfoKHR* is described in the table below.
 | Return the list of command-queues specified when the _command_buffer_ was
   created.
 
-| *CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR*
+| *CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR* footnote:[{fn-reference-count-usage}]
 | cl_uint
 | Return the _command_buffer_ reference count.
-
-  The reference count returned with `CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR`
-  should be considered immediately stale. It is provided for identifying
-  memory leaks.
 
 | *CL_COMMAND_BUFFER_STATE_KHR*
 | cl_command_buffer_state_khr

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -365,11 +365,11 @@ CL_COMMAND_BUFFER_PROPERTIES_KHR                   0x1293
 CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR             (0x1 << 0)
 
 // cl_command_buffer_info_khr queries to clGetCommandBufferInfoKHR
-CL_COMMAND_BUFFER_INFO_QUEUES_KHR                  0x1294
-CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR              0x1295
-CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR         0x1296
-CL_COMMAND_BUFFER_INFO_STATE_KHR                   0x1297
-CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR        0x1298
+CL_COMMAND_BUFFER_QUEUES_KHR                       0x1294
+CL_COMMAND_BUFFER_NUM_QUEUES_KHR                   0x1295
+CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR              0x1296
+CL_COMMAND_BUFFER_STATE_KHR                        0x1297
+CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR             0x1298
 
 // cl_event command-buffer enqueue command type
 CL_COMMAND_COMMAND_BUFFER_KHR                      0x12A8
@@ -1623,16 +1623,16 @@ _param_value_ by *clGetCommandBufferInfoKHR* is described in the table below.
 | *Return Type*
 | *Description*
 
-| *CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR*
+| *CL_COMMAND_BUFFER_NUM_QUEUES_KHR*
 | cl_uint
 | The number of command-queues specified when _command_buffer_ was created.
 
-| *CL_COMMAND_BUFFER_INFO_QUEUES_KHR*
+| *CL_COMMAND_BUFFER_QUEUES_KHR*
 | cl_command_queue[]
 | Return the list of command-queues specified when the _command_buffer_ was
   created.
 
-| *CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR*
+| *CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR*
 | cl_uint
 | Return the _command_buffer_ reference count.
 
@@ -1640,7 +1640,7 @@ _param_value_ by *clGetCommandBufferInfoKHR* is described in the table below.
   should be considered immediately stale. It is provided for identifying
   memory leaks.
 
-| *CL_COMMAND_BUFFER_INFO_STATE_KHR*
+| *CL_COMMAND_BUFFER_STATE_KHR*
 | cl_command_buffer_state_khr
 | Return the state of _command_buffer_.
 
@@ -1657,7 +1657,7 @@ _param_value_ by *clGetCommandBufferInfoKHR* is described in the table below.
   `CL_COMMAND_BUFFER_STATE_INVALID_KHR` is returned when _command_buffer_ is
   in an <<invalid, Invalid>> state.
 
-| *CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR*
+| *CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR*
 | cl_command_buffer_properties_khr[]
 | Return the _properties_ argument specified in *clCreateCommandBufferKHR*.
 

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -141,14 +141,14 @@ task graphs.
 
 Bitfield for querying command-buffer capabilities of an OpenCL device with
 *clGetDeviceInfo*, see <<command-buffer-queries, device queries table>>:
-[source,c]
+[source]
 ----
 typedef cl_bitfield cl_device_command_buffer_capabilities_khr
 ----
 
 Types describing <<command-buffers, command-buffers>>:
 
-[source,c]
+[source]
 ----
 // Returned by clCreateCommandBufferKHR()
 typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
@@ -178,7 +178,7 @@ typedef cl_uint cl_command_buffer_state_khr;
 === New API Functions
 
 Command-buffer entry points from <<command-buffers, Section 5.X>>:
-[source,c]
+[source]
 ----
 cl_command_buffer_khr clCreateCommandBufferKHR(
     cl_uint num_queues,
@@ -330,7 +330,7 @@ cl_int clGetCommandBufferInfoKHR(
 Enums for querying device command-buffer capabilities with
 *clGetDeviceInfo*, see <<command-buffer-queries, device queries table>>:
 
-[source,c]
+[source]
 ----
 // Accepted values for the param_name parameter to clGetDeviceInfo
 CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR              0x12A9
@@ -351,7 +351,7 @@ CL_COMMAND_BUFFER_STATE_INVALID_KHR                0x3
 
 Enums for base <<command-buffer, command-buffers>> functionality:
 
-[source,c]
+[source]
 ----
 // Error codes
 CL_INVALID_COMMAND_BUFFER_KHR                      -1138
@@ -473,7 +473,7 @@ Pending Count greater than 1.
 
 The function
 indexterm:[clCreateCommandBufferKHR]
-[source,c]
+[source]
 ----
 cl_command_buffer clCreateCommandBufferKHR(
     cl_uint num_queues,
@@ -564,7 +564,7 @@ error values returned in _errcode_ret_:
 
 The function
 indexterm:[clRetainCommandBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clRetainCommandBufferKHR(cl_command_buffer_khr command_buffer)
 ----
@@ -601,7 +601,7 @@ successfully. Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clReleaseCommandBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clReleaseCommandBufferKHR(cl_command_buffer_khr command_buffer)
 ----
@@ -631,7 +631,7 @@ successfully. Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clFinalizeCommandBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clFinalizeCommandBufferKHR(cl_command_buffer_khr command_buffer);
 ----
@@ -661,7 +661,7 @@ successfully. Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clEnqueueCommandBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clEnqueueCommandBufferKHR(
     cl_uint num_queues,
@@ -757,7 +757,7 @@ execution was successfully queued, or one of the errors below:
 
 The function
 indexterm:[clCommandBarrierWithWaitListKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandBarrierWithWaitListKHR(
       cl_command_buffer_khr command_buffer,
@@ -842,7 +842,7 @@ executed successfully. Otherwise, it returns one of the following errors:
 
 The function
 indexterm:[clCommandCopyBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandCopyBufferKHR(
     cl_command_buffer_khr command_buffer,
@@ -925,7 +925,7 @@ New errors:
 
 The function
 indexterm:[clCommandCopyBufferRectKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandCopyBufferRectKHR(
     cl_command_buffer_khr command_buffer,
@@ -1028,7 +1028,7 @@ New errors:
 
 The function
 indexterm:[clCommandCopyBufferToImageKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandCopyBufferToImageKHR(
     cl_command_buffer_khr command_buffer,
@@ -1111,7 +1111,7 @@ New errors:
 
 The function
 indexterm:[clCommandCopyImageKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandCopyImageKHR(
     cl_command_buffer_khr command_buffer,
@@ -1202,7 +1202,7 @@ New errors:
 
 The function
 indexterm:[clCommandCopyImageToBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandCopyImageToBufferKHR(
     cl_command_buffer_khr command_buffer,
@@ -1285,7 +1285,7 @@ New errors:
 
 The function
 indexterm:[clCommandFillBufferKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandFillBufferKHR(
     cl_command_buffer_khr command_buffer,
@@ -1377,7 +1377,7 @@ New errors:
 
 The function
 indexterm:[clCommandFillImageKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandFillImageKHR(
     cl_command_buffer_khr command_buffer,
@@ -1465,7 +1465,7 @@ New errors:
 
 The function
 indexterm:[clCommandNDRangeKernelKHR]
-[source,c]
+[source]
 ----
 cl_int clCommandNDRangeKernelKHR(
     cl_command_buffer_khr command_buffer,
@@ -1588,7 +1588,7 @@ New errors:
 
 The function
 indexterm:[clGetCommandBufferInfoKHR]
-[source,c]
+[source]
 ----
 cl_int clGetCommandBufferInfoKHR(
     cl_command_buffer_khr command_buffer,
@@ -1706,7 +1706,7 @@ Add to Table 37, _Event Command Types_:
 
 === Sample Code
 
-[source,cpp]
+[source]
 ----
   #define CL_CHECK(ERROR)                             \
     if (ERROR) {                                      \

--- a/ext/cl_khr_expect_assume.asciidoc
+++ b/ext/cl_khr_expect_assume.asciidoc
@@ -60,6 +60,7 @@ kernel void test(global int* dst, global int* src)
 #endif
 
     // Tell the compiler that the source value is non-negative.
+    // Behavior is undefined if the source value is actually negative.
 #if __has_builtin(__builtin_assume)
     __builtin_assume(value >= 0);
 #endif

--- a/ext/cl_khr_expect_assume.asciidoc
+++ b/ext/cl_khr_expect_assume.asciidoc
@@ -42,7 +42,7 @@ Please refer to the OpenCL SPIR-V Environment Specification that describes how t
 Although this extension does not formally extend OpenCL C, the ability to provide _expect_ and _assume_ information is supported by many OpenCL C compiler tool chains.
 The sample code below describes how to test for and provide _expect_ and _assume_ information to compilers based on Clang:
 
-[source,c]
+[source,opencl_c]
 ----
 // __has_builtin is an optional compiler feature that is supported by Clang.
 // If this feature is not supported, we will assume the builtin is not present.

--- a/ext/cl_khr_expect_assume.asciidoc
+++ b/ext/cl_khr_expect_assume.asciidoc
@@ -1,0 +1,69 @@
+// Copyright 2017-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_khr_expect_assume]]
+== Kernel Optimization Hints
+
+This extension adds mechanisms to provide information to the compiler that may improve the performance of some kernels.
+Specifically, this extension adds the ability to:
+
+* Tell the compiler the _expected_ value of a variable.
+* Allow the compiler to _assume_ a condition is true.
+
+These functions are not required for functional correctness.
+
+The initial version of this extension extends the OpenCL SPIR-V environment to support new instructions for offline compilation tool chains.
+Similar functionality may be provided by some OpenCL C online compilation tool chains, but formal support in OpenCL C is not required by the initial version of the extension.
+
+=== General information
+
+==== Name Strings
+
+`cl_khr_expect_assume`
+
+==== Version History
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2021-11-10 | 1.0.0     | First assigned version.
+|====
+
+==== Dependencies
+
+This extension is written against the OpenCL Specifications Version V3.0.8.
+
+The initial version of this extension extends the OpenCL SPIR-V environment to support new instructions.
+Please refer to the OpenCL SPIR-V Environment Specification that describes how this extension modifies the OpenCL SPIR-V environment.
+
+=== Sample Code
+
+Although this extension does not formally extend OpenCL C, the ability to provide _expect_ and _assume_ information is supported by many OpenCL C compiler tool chains.
+The sample code below describes how to test for and provide _expect_ and _assume_ information to compilers based on Clang:
+
+[source,c]
+----
+// __has_builtin is an optional compiler feature that is supported by Clang.
+// If this feature is not supported, we will assume the builtin is not present.
+#ifndef __has_builtin
+#define __has_builtin(x)    0
+#endif
+
+kernel void test(global int* dst, global int* src)
+{
+    int value = src[get_global_id(0)];
+
+    // Tell the compiler that the most likely source value is zero.
+#if __has_builtin(__builtin_expect)
+    value = __builtin_expect(value, 0);
+#endif
+
+    // Tell the compiler that the source value is non-negative.
+#if __has_builtin(__builtin_assume)
+    __builtin_assume(value >= 0);
+#endif
+
+    dst[get_global_id(0)] = value % 4;
+}
+----

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -3,9 +3,9 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_extended_async_copies]]
-== Extended Async Copies (Provisional)
+== Extended Async Copies
 
-This section describes the *cl_khr_extended_async_copies* provisional extension.
+This section describes the *cl_khr_extended_async_copies* extension.
 This extension augments built-in asynchronous copy functions to OpenCL C
 to support more patterns:
 
@@ -20,6 +20,8 @@ to support more patterns:
 |====
 | *Date*     | *Version* | *Description*
 | 2020-04-21 | 0.9.0     | First assigned version (provisional).
+| 2020-09-06 | 0.9.1     | Elements-based proposal update.
+| 2021-11-10 | 1.0.0     | First non-provisional version.
 |====
 
 [[cl_khr_extended_async_copies-additions-to-chapter-6-of-the-opencl-specification]]
@@ -33,11 +35,11 @@ Note that *async_work_group_strided_copy* is a special case of
 *async_work_group_copy_2D2D*, namely one which copies a single column to a
 single line or vice versa.
 For example: +
-`async_work_group_strided_copy(dst, src, num_gentypes, src_stride)` is equal to +
-`async_work_group_copy_2D2D(dst, src, 1, num_gentypes, src_stride-1, 1)`
+`async_work_group_strided_copy(dst, src, num_gentypes, src_stride, event)` is equal to
+`async_work_group_copy_2D2D(dst, 0, src, 0, sizeof(gentype), 1, num_gentypes, src_stride, 1, event)`
 
-These new built-in functions support the same `gentype` generic type names as
-the standard asynchronous copy functions unless otherwise stated.
+These new built-in functions support arbitrary `gentype`-based buffers by
+casting pointers to `void *`.
 
 [cols="1a,1",options="header",]
 |=======================================================================
@@ -45,34 +47,49 @@ the standard asynchronous copy functions unless otherwise stated.
 |[source,opencl_c]
 ----
 event_t async_work_group_copy_2D2D(
-    __local gentype *dst,
-    const __global gentype *src,
+    __local void *dst,
+    size_t dst_offset,
+    const __global void *src,
+    size_t src_offset,
+    size_t num_bytes_per_element,
     size_t num_elements_per_line,
     size_t num_lines,
-    size_t src_stride,
-    size_t dst_stride,
+    size_t src_total_line_length,
+    size_t dst_total_line_length,
     event_t event)
 
 event_t async_work_group_copy_2D2D(
-    __global gentype *dst,
-    const __local gentype *src,
+    __global void *dst,
+    size_t dst_offset,
+    const __local void *src,
+    size_t src_offset,
+    size_t num_bytes_per_element,
     size_t num_elements_per_line,
     size_t num_lines,
-    size_t src_stride,
-    size_t dst_stride,
+    size_t src_total_line_length,
+    size_t dst_total_line_length,
     event_t event)
 ----
-| Perform an asynchronous copy of _num_lines_ lines from _src_ to _dst_.  Each line
-contains _num_elements_per_line_ `gentype` elements.  After each line of
-transfer, _src_ address is incremented by
-(_src_stride_ + _num_elements_per_line_) `gentype` elements,
-_dst_ address is incremented by
-(_dst_stride_ + _num_elements_per_line_) `gentype` elements
+| Perform an async copy of (_num_elements_per_line_ * _num_lines_) elements
+of size _num_bytes_per_element_ from
+(_src_ + (_src_offset_ * _num_bytes_per_element_)) to
+(_dst_ + (_dst_offset_ * _num_bytes_per_element_)). All pointer arithmetic
+is performed with implicit casting to `char *` by the implementation.
+Each line contains _num_elements_per_line_ elements of size
+_num_bytes_per_element_.
+After each line of transfer, _src_ address is incremented by
+_src_total_line_length_ elements
+(aka _src_total_line_length_ * _num_bytes_per_element_ bytes),
+_dst_ address is incremented by _dst_total_line_length_ elements
+(aka _dst_total_line_length_ * _num_bytes_per_element_ bytes),
 for the next line of transfer.
 
-For these functions, the stride describes the number of elements between
-the *end* of the current line and the *beginning* of the next line, i.e.,
-without overlap.
+All _src_offset_, _dst_offset_, _src_total_line_length_
+and _dst_total_line_length_ values are expressed in elements.
+
+Both _src_total_line_length_ and _dst_total_line_length_ describe
+the number of elements between the *beginning* of the current line
+and the *beginning* of the next line.
 
 Returns an event object that can be used by *wait_group_events* to wait
 for the async copy to finish.  The _event_ argument can also be used to
@@ -91,6 +108,15 @@ _num_elements_per_line_ or _src_stride_ or _dst_stride_ values cause
 the _src_ or _dst_ addresses to exceed the upper bounds of the address
 space during the copy.
 
+The behavior of *async_work_group_copy_2D2D* is undefined if the
+_src_total_line_length_ or _dst_total_line_length_ or _src_offset_
+or _dst_offset_ values cause the _src_ or _dst_ addresses to exceed
+the upper bounds of the address space during the copy.
+
+The behavior of *async_work_group_copy_2D2D* is undefined if the
+_src_total_line_length_ or _dst_total_line_length_ values are smaller
+than _num_elements_per_line_, i.e. overlapping of lines is undefined.
+
 The async copy is performed by all work-items in a work-group and this
 built-in function must therefore be encountered by all work-items in a
 work-group executing the kernel with the same argument values;
@@ -99,39 +125,62 @@ otherwise the results are undefined.
 |[source,opencl_c]
 ----
 event_t async_work_group_copy_3D3D(
-    __local gentype *dst,
-    const __global gentype *src,
+    __local void *dst,
+    size_t dst_offset,
+    const __global void *src,
+    size_t src_offset,
+    size_t num_bytes_per_element,
     size_t num_elements_per_line,
     size_t num_lines,
-    size_t src_line_stride,
-    size_t dst_line_stride,
     size_t num_planes,
-    size_t src_plane_stride,
-    size_t dst_plane_stride,
+    size_t src_total_line_length,
+    size_t src_total_plane_area,
+    size_t dst_total_line_length,
+    size_t dst_total_plane_area,
     event_t event)
 
 event_t async_work_group_copy_3D3D(
-    __global gentype *dst,
-    const __local gentype *src,
+    __global void *dst,
+    size_t dst_offset,
+    const __local void *src,
+    size_t src_offset,
+    size_t num_bytes_per_element,
     size_t num_elements_per_line,
     size_t num_lines,
-    size_t src_line_stride,
-    size_t dst_line_stride,
     size_t num_planes,
-    size_t src_plane_stride,
-    size_t dst_plane_stride,
+    size_t src_total_line_length,
+    size_t src_total_plane_area,
+    size_t dst_total_line_length,
+    size_t dst_total_plane_area,
     event_t event)
 ----
-| Perform an async copy of _num_planes_ times _num_lines_ lines from _src_ to
-_dst_ arranged in _num_planes_ planes.  Each plane contains _num_lines_
-lines.  Each line contains _num_elements_per_line_ `gentype` elements.
+| Perform an async copy of
+((_num_elements_per_line_ * _num_lines_) * _num_planes_) elements
+of size _num_bytes_per_element_ from
+(_src_ + (_src_offset_ * _num_bytes_per_element_)) to
+(_dst_ + (_dst_offset_ * _num_bytes_per_element_)),
+arranged in _num_planes_ planes. All pointer arithmetic
+is performed with implicit casting to `char *` by the implementation.
+Each plane contains _num_lines_ lines.
+Each line contains _num_elements_per_line_ elements.
 After each line of transfer, _src_ address is incremented by
-(_src_line_stride_ + _num_elements_per_line_) `gentype` elements, _dst_
-address is incremented by (_dst_line_stride_ + _num_elements_per_line_)
-`gentype` elements for the next line of transfer.  For the last line of a
-plane, an additional _src_plane_stride_ `gentype` elements is added to
-_src_ address, and an additional _dst_plane_stride_ `gentype` elements is
-added to _dst_ address.
+_src_total_line_length_ elements
+(aka _src_total_line_length_ * _num_bytes_per_element_ bytes),
+_dst_ address is incremented by _dst_total_line_length_ elements
+(aka _dst_total_line_length_ * _num_bytes_per_element_ bytes),
+for the next line of transfer.
+
+All _src_offset_, _dst_offset_, _src_total_line_length_,
+_dst_total_line_length_, _src_total_plane_area_ and
+_dst_total_plane_area_ values are expressed in elements.
+
+Both _src_total_line_length_ and _dst_total_line_length_ describe
+the number of elements between the *beginning* of the current line
+and the *beginning* of the next line.
+
+Both _src_total_plane_area_ and _dst_total_plane_area_ describe
+the number of elements between the *beginning* of the current plane
+and the *beginning* of the next plane.
 
 Returns an event object that can be used by *wait_group_events* to wait
 for the async copy to finish.  The _event_ argument can also be used to
@@ -145,10 +194,19 @@ argument will be returned.
 This function does not perform any implicit synchronization of source
 data such as using a *barrier* before performing the copy.
 
-The behavior of *async_work_group_copy_3D3D* is undefined if any of
-_num_elements_per_line_, _src_line_stride_, _dst_line_stride_,
-_src_plane_stride_ or _dst_plane_stride_ values cause the _src_ or _dst_
-addresses to exceed the upper bounds of the address space during the copy.
+The behavior of *async_work_group_copy_3D3D* is undefined if the
+_src_total_size_ or _dst_total_size_ or _src_offset_
+or _dst_offset_ values cause the _src_ or _dst_ addresses to exceed
+the upper bounds of the address space during the copy.
+
+The behavior of *async_work_group_copy_3D3D* is undefined if the
+_src_total_line_length_ or _dst_total_line_length_ values are smaller
+than _num_elements_per_line_, i.e. overlapping of lines is undefined.
+
+The behavior of *async_work_group_copy_3D3D* is undefined if
+_src_total_plane_area_ is smaller than (_num_lines_ * _src_total_line_length_),
+or _dst_total_plane_area_ is smaller than (_num_lines_ * _dst_total_line_length_),
+i.e. overlapping of planes is undefined.
 
 The async copy is performed by all work-items in a work-group and this
 built-in function must therefore be encountered by all work-items in a
@@ -156,5 +214,3 @@ work-group executing the kernel with the same argument values;
 otherwise the results are undefined.
 
 |=======================================================================
-
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -20,7 +20,7 @@ to support more patterns:
 |====
 | *Date*     | *Version* | *Description*
 | 2020-04-21 | 0.9.0     | First assigned version (provisional).
-| 2020-09-06 | 0.9.1     | Elements-based proposal update.
+| 2021-09-06 | 0.9.1     | Elements-based proposal update.
 | 2021-11-10 | 1.0.0     | First non-provisional version.
 |====
 
@@ -74,22 +74,22 @@ event_t async_work_group_copy_2D2D(
 of size _num_bytes_per_element_ from
 (_src_ + (_src_offset_ * _num_bytes_per_element_)) to
 (_dst_ + (_dst_offset_ * _num_bytes_per_element_)). All pointer arithmetic
-is performed with implicit casting to `char *` by the implementation.
+is performed with implicit casting to `char*` by the implementation.
 Each line contains _num_elements_per_line_ elements of size
 _num_bytes_per_element_.
 After each line of transfer, _src_ address is incremented by
 _src_total_line_length_ elements
-(aka _src_total_line_length_ * _num_bytes_per_element_ bytes),
+(i.e. _src_total_line_length_ * _num_bytes_per_element_ bytes),
 _dst_ address is incremented by _dst_total_line_length_ elements
-(aka _dst_total_line_length_ * _num_bytes_per_element_ bytes),
+(i.e. _dst_total_line_length_ * _num_bytes_per_element_ bytes),
 for the next line of transfer.
 
 All _src_offset_, _dst_offset_, _src_total_line_length_
 and _dst_total_line_length_ values are expressed in elements.
 
 Both _src_total_line_length_ and _dst_total_line_length_ describe
-the number of elements between the *beginning* of the current line
-and the *beginning* of the next line.
+the number of elements between the beginning of the current line
+and the beginning of the next line.
 
 Returns an event object that can be used by *wait_group_events* to wait
 for the async copy to finish.  The _event_ argument can also be used to
@@ -160,14 +160,14 @@ of size _num_bytes_per_element_ from
 (_src_ + (_src_offset_ * _num_bytes_per_element_)) to
 (_dst_ + (_dst_offset_ * _num_bytes_per_element_)),
 arranged in _num_planes_ planes. All pointer arithmetic
-is performed with implicit casting to `char *` by the implementation.
+is performed with implicit casting to `char*` by the implementation.
 Each plane contains _num_lines_ lines.
 Each line contains _num_elements_per_line_ elements.
 After each line of transfer, _src_ address is incremented by
 _src_total_line_length_ elements
-(aka _src_total_line_length_ * _num_bytes_per_element_ bytes),
+(i.e. _src_total_line_length_ * _num_bytes_per_element_ bytes),
 _dst_ address is incremented by _dst_total_line_length_ elements
-(aka _dst_total_line_length_ * _num_bytes_per_element_ bytes),
+(i.e. _dst_total_line_length_ * _num_bytes_per_element_ bytes),
 for the next line of transfer.
 
 All _src_offset_, _dst_offset_, _src_total_line_length_,
@@ -175,12 +175,12 @@ _dst_total_line_length_, _src_total_plane_area_ and
 _dst_total_plane_area_ values are expressed in elements.
 
 Both _src_total_line_length_ and _dst_total_line_length_ describe
-the number of elements between the *beginning* of the current line
-and the *beginning* of the next line.
+the number of elements between the beginning of the current line
+and the beginning of the next line.
 
 Both _src_total_plane_area_ and _dst_total_plane_area_ describe
-the number of elements between the *beginning* of the current plane
-and the *beginning* of the next plane.
+the number of elements between the beginning of the current plane
+and the beginning of the next plane.
 
 Returns an event object that can be used by *wait_group_events* to wait
 for the async copy to finish.  The _event_ argument can also be used to

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -19,11 +19,15 @@
 
 | <<cl_khr_async_work_group_copy_fence,cl_khr_async_work_group_copy_fence>>
 | Asynchronous Copy Fences
-| Provisional Extension
+| Extension
 
 | <<cl_khr_byte_addressable_store,cl_khr_byte_addressable_store>>
 | Read and write from 8-bit and 16-bit pointers
 | Core Feature in OpenCL 1.1
+
+| <<cl_khr_command_buffer,cl_khr_command_buffer>>
+| Record and Replay Commands
+| Provisional Extension
 
 | <<cl_khr_create_command_queue,cl_khr_create_command_queue>>
 | API to Create Command Queues with Properties
@@ -63,7 +67,7 @@
 
 | <<cl_khr_extended_async_copies,cl_khr_extended_async_copies>>
 | 2D and 3D Async Copies
-| Provisional Extension
+| Extension
 
 | <<cl_khr_extended_bit_ops,cl_khr_extended_bit_ops>>
 | Bit Insert, Extract, and Reverse Operations
@@ -92,6 +96,10 @@
 | <<cl_khr_external_memory,cl_khr_external_memory_win32>>
 | NT Handle External Memory Handles
 | Provisional Extension
+
+| <<cl_khr_expect_assume,cl_khr_expect_assume>>
+| Kernel Optimization Hints
+| Extension
 
 | <<cl_khr_external_semaphore,cl_khr_external_semaphore>>
 | Common Functionality for External Semaphore Sharing

--- a/images/commandbuffer_lifecycle.svg
+++ b/images/commandbuffer_lifecycle.svg
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="224.63503mm"
+   height="92.592918mm"
+   viewBox="0 0 224.63503 92.592918"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="commandbuffer_lifecycle.svg"
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <rect
+       x="734.50713"
+       y="176.00737"
+       width="180"
+       height="70"
+       id="rect17769" />
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5571"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5569"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3457"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:collect="always">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3455"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1404"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1402"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path968"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1246"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1244"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path971"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1246-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1244-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1246-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1244-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1246-68"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1244-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1246-68-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1244-3-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path968-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="277.18585"
+     inkscape:cy="139.30003"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:measure-start="245,915"
+     inkscape:measure-end="570,915"
+     showguides="false"
+     fit-margin-left="1"
+     fit-margin-top="1"
+     fit-margin-right="1"
+     fit-margin-bottom="1"
+     inkscape:window-width="1920"
+     inkscape:window-height="986"
+     inkscape:window-x="-11"
+     inkscape:window-y="-11"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid907"
+       originx="3.8383438"
+       originy="-212.72305" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(3.8383438,8.3159637)">
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.385025;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect815-1-4-3-6-1-68-2-5-2"
+       width="63.499996"
+       height="7.9375005"
+       x="79.375"
+       y="9.1484861" />
+    <text
+       id="text823-4-2-9-4-7-9-2-0"
+       y="14.440153"
+       x="107.94999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       xml:space="preserve"><tspan
+         id="tspan825-6-0-2-5-6-26-4-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875"
+         y="14.440153"
+         x="107.94999"
+         sodipodi:role="line">Recording</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.385025;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect815-1-4-3-6-1-68-2-5-7"
+       width="63.499996"
+       height="7.9375005"
+       x="79.375"
+       y="70.002655" />
+    <text
+       id="text823-4-2-9-4-7-9-2-7"
+       y="75.294319"
+       x="105.83331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       xml:space="preserve"><tspan
+         id="tspan825-6-0-2-5-6-26-4-0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875"
+         y="75.294319"
+         x="105.83331"
+         sodipodi:role="line">Pending</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.385025;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect815-1-4-3-6-1-68-2-5-1"
+       width="63.499996"
+       height="7.9375005"
+       x="156.10417"
+       y="35.606819" />
+    <text
+       id="text823-4-2-9-4-7-9-2-9"
+       y="40.898487"
+       x="179.91667"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       xml:space="preserve"><tspan
+         id="tspan825-6-0-2-5-6-26-4-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875"
+         y="40.898487"
+         x="179.91667"
+         sodipodi:role="line">Executable</tspan></text>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.385025;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect815-1-4-3-6-1-68-2-5-9"
+       width="63.499996"
+       height="7.9375005"
+       x="-2.6458311"
+       y="35.984749" />
+    <text
+       id="text823-4-2-9-4-7-9-2-6"
+       y="41.010792"
+       x="30.06638"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       xml:space="preserve"><tspan
+         id="tspan825-6-0-2-5-6-26-4-93"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875"
+         y="41.010792"
+         x="30.06638"
+         sodipodi:role="line">Invalid</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       x="108.47915"
+       y="-4.0996227"
+       id="text905"><tspan
+         sodipodi:role="line"
+         id="tspan903"
+         x="108.47915"
+         y="-4.0996227"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875">Create</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.422801px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1246)"
+       d="m 177.27083,43.54432 c -2.79922,12.859947 -15.004,22.291809 -34.39583,29.104166"
+       id="path928"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.387311px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1246-68)"
+       d="m 142.875,70.002653 c 2.5839,-11.690866 13.84985,-20.265278 31.75,-26.458333"
+       id="path928-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.335421px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker1246-68-6)"
+       d="m 142.875,11.79432 c 11.69087,1.937925 20.26528,10.387387 26.45833,23.8125"
+       id="path928-3-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.451156;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.80462, 1.80462;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Mstart)"
+       d="m 61.912501,43.015153 c 26.920388,0 44.155759,0.610807 49.212499,26.9875"
+       id="path928-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.389628;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.55851, 1.55851;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Mstart-4)"
+       d="m 62.153727,37.313648 c 26.788426,0 43.939313,-0.457812 48.971273,-20.227662"
+       id="path928-9-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.39687496px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker3457)"
+       d="M 108.47917,-2.1152472 V 7.8066273"
+       id="path3447"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       x="161.39583"
+       y="19.731819"
+       id="text905-5-4"><tspan
+         sodipodi:role="line"
+         id="tspan903-4-1"
+         x="161.39583"
+         y="19.731819"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.396875">Finalize</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       x="177.80003"
+       y="65.24015"
+       id="text905-5-4-3"><tspan
+         sodipodi:role="line"
+         id="tspan903-4-1-1"
+         x="177.80003"
+         y="65.24015"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875">Enqueue</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       x="136.83919"
+       y="56.773487"
+       id="text905-5-4-3-1"><tspan
+         sodipodi:role="line"
+         id="tspan903-4-1-1-9"
+         x="137.58333"
+         y="56.773487"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875">Completion </tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.394664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.57866, 1.57866;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker5571)"
+       d="M 156.10417,39.953502 H 61.912498"
+       id="path5557"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.396875"
+       x="74.744797"
+       y="50.139965"
+       id="text905-6-3-4"><tspan
+         sodipodi:role="line"
+         x="74.744797"
+         y="50.139965"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.396875"
+         id="tspan3709-2-2">Invalidate</tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,-3.8383438,-8.3159637)"
+       id="text17767"
+       style="fill:black;fill-opacity:1;line-height:1.25;stroke:none;font-family:sans-serif;font-style:normal;font-weight:normal;font-size:40px;white-space:pre;shape-inside:url(#rect17769)" />
+  </g>
+</svg>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6809,7 +6809,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetContentSizeBufferPoCL"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer" comment="in sync with rev 29" supported="opencl">
+        <extension name="cl_khr_command_buffer" comment="in sync with version 0.9.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1644,11 +1644,11 @@ server's OpenCL/api-docs repository.
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
             <unused start="0x1290" end="0x1292" comment="Reserved for MR179"/>
         <enum value="0x1293"             name="CL_COMMAND_BUFFER_PROPERTIES_KHR"/>
-        <enum value="0x1294"             name="CL_COMMAND_BUFFER_INFO_QUEUES_KHR"/>
-        <enum value="0x1295"             name="CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR"/>
-        <enum value="0x1296"             name="CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR"/>
-        <enum value="0x1297"             name="CL_COMMAND_BUFFER_INFO_STATE_KHR"/>
-        <enum value="0x1298"             name="CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR"/>
+        <enum value="0x1294"             name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
+        <enum value="0x1295"             name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
+        <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
+        <enum value="0x1297"             name="CL_COMMAND_BUFFER_STATE_KHR"/>
+        <enum value="0x1298"             name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
             <unused start="0x1299" end="0x12A7" comment="Used by future command-buffer extensions"/>
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
@@ -6843,11 +6843,11 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
             </require>
             <require comment="cl_command_buffer_info_khr">
-               <enum name="CL_COMMAND_BUFFER_INFO_QUEUES_KHR"/>
-               <enum name="CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR"/>
-               <enum name="CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR"/>
-               <enum name="CL_COMMAND_BUFFER_INFO_STATE_KHR"/>
-               <enum name="CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_STATE_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
             </require>
             <require comment="cl_command_buffer_state_khr">
                <enum name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -239,8 +239,9 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_sync_point_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_info_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_state_khr</name>;</type>
-        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_properties_khr</name>;</type>
-        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>      <name>cl_command_buffer_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_flags_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>      <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
         <type category="define">typedef struct _cl_mutable_command_khr* <name>cl_mutable_command_khr</name>;</type>
 
             <comment>Structure types</comment>
@@ -1251,7 +1252,7 @@ server's OpenCL/api-docs repository.
             <unused start="6" end="31"/>
     </enums>
 
-    <enums name="cl_command_buffer_properties_khr" vendor="Khronos" type="bitmask">
+    <enums name="cl_command_buffer_flags_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
             <unused start="1" end="2" comment="Used by future command-buffer extensions"/>
             <unused start="2" end="31"/>
@@ -1643,7 +1644,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x1284"        name="CL_PROFILING_COMMAND_COMPLETE"/>
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
             <unused start="0x1290" end="0x1292" comment="Reserved for MR179"/>
-        <enum value="0x1293"             name="CL_COMMAND_BUFFER_PROPERTIES_KHR"/>
+        <enum value="0x1293"             name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
         <enum value="0x1294"             name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
         <enum value="0x1295"             name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
         <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
@@ -6820,6 +6821,7 @@ server's OpenCL/api-docs repository.
                 <type name="cl_command_buffer_info_khr"/>
                 <type name="cl_command_buffer_state_khr"/>
                 <type name="cl_command_buffer_properties_khr"/>
+                <type name="cl_command_buffer_flags_khr"/>
                 <type name="cl_ndrange_kernel_command_properties_khr"/>
                 <type name="cl_mutable_command_khr"/>
             </require>
@@ -6834,7 +6836,9 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR"/>
             </require>
             <require comment="cl_command_buffer_properties_khr">
-               <enum name="CL_COMMAND_BUFFER_PROPERTIES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
+            </require>
+            <require comment="cl_command_buffer_flags_khr">
                <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
             </require>
             <require comment="Error codes">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -234,6 +234,14 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_ulong</type>         <name>cl_semaphore_payload_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_external_semaphore_handle_type_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_external_memory_handle_type_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_command_buffer_capabilities_khr</name>;</type>
+        <type category="define">typedef struct _cl_command_buffer_khr* <name>cl_command_buffer_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_sync_point_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_info_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_state_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
+        <type category="define">typedef struct _cl_mutable_command_khr* <name>cl_mutable_command_khr</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
@@ -625,7 +633,11 @@ server's OpenCL/api-docs repository.
             <unused start="-1126" end="-1137"/>
     </enums>
 
-    <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="Reserved for MR180">
+    <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="For cl_khr_command_buffer related extensions">
+        <enum value="-1138"         name="CL_INVALID_COMMAND_BUFFER_KHR"/>
+        <enum value="-1139"         name="CL_INVALID_SYNC_POINT_WAIT_LIST_KHR"/>
+        <enum value="-1140"         name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
+            <unused start="-1141" end="-1141" comment="Used by future command-buffer extensions"/>
     </enums>
 
     <enums start="-1142" end="-1142" name="ErrorCodes.1142" vendor="Khronos" comment="For cl_khr_semaphore">
@@ -633,6 +645,7 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums start="-1143" end="-1153" name="ErrorCodes.1143" vendor="VeriSilicon" comment="Reserved for VeriSilicon extensions">
+            <unused start="-1143" end="-1153"/>
     </enums>
 
     <enums start="-1154" end="-9999" name="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
@@ -1229,6 +1242,28 @@ server's OpenCL/api-docs repository.
             <unused start="2" end="9999"/>
     </enums>
 
+    <enums name="cl_device_command_buffer_capabilities_khr " vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
+        <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
+        <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
+        <enum bitpos="3"            name="CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR"/>
+            <unused start="4" end="6" comment="Used by future command-buffer extensions"/>
+            <unused start="6" end="31"/>
+    </enums>
+
+    <enums name="cl_command_buffer_properties_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
+            <unused start="1" end="2" comment="Used by future command-buffer extensions"/>
+            <unused start="2" end="31"/>
+    </enums>
+
+    <enums name="cl_command_buffer_state_khr" vendor="Khronos">
+        <enum value="0"            name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>
+        <enum value="1"            name="CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR"/>
+        <enum value="2"            name="CL_COMMAND_BUFFER_STATE_PENDING_KHR"/>
+        <enum value="3"            name="CL_COMMAND_BUFFER_STATE_INVALID_KHR"/>
+    </enums>
+
     <enums start="0x10000" end="0x1FFFF" name="cl_khronos_vendor_id" vendor="Khronos">
         <comment>
             In order to synchronize vendor IDs across Khronos APIs, Vulkan's vk.xml
@@ -1608,7 +1643,17 @@ server's OpenCL/api-docs repository.
         <enum value="0x1284"        name="CL_PROFILING_COMMAND_COMPLETE"/>
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
             <unused start="0x1290" end="0x1292" comment="Reserved for MR179"/>
-            <unused start="0x1293" end="0x12AE" comment="Reserved for MR180"/>
+        <enum value="0x1293"             name="CL_COMMAND_BUFFER_PROPERTIES_KHR"/>
+        <enum value="0x1294"             name="CL_COMMAND_BUFFER_INFO_QUEUES_KHR"/>
+        <enum value="0x1295"             name="CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR"/>
+        <enum value="0x1296"             name="CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR"/>
+        <enum value="0x1297"             name="CL_COMMAND_BUFFER_INFO_STATE_KHR"/>
+        <enum value="0x1298"             name="CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR"/>
+            <unused start="0x1299" end="0x12A7" comment="Used by future command-buffer extensions"/>
+        <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
+        <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
+        <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
+            <unused start="0x12AB" end="0x12AE" comment="Used by future command-buffer extensions"/>
             <unused start="0x12AF" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
@@ -2853,6 +2898,168 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                           <name>host_ptr</name></param>
             <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
         </command>
+        <command>
+            <proto><type>cl_command_buffer_khr</type>                    <name>clCreateCommandBufferKHR</name></proto>
+            <param><type>cl_uint</type>                                  <name>num_queues</name></param>
+            <param>const <type>cl_command_queue</type>*                  <name>queues</name></param>
+            <param>const <type>cl_command_buffer_properties_khr</type>*  <name>properties</name></param>
+            <param><type>cl_int</type>*                                  <name>errcode_ret</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clFinalizeCommandBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clRetainCommandBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clReleaseCommandBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clEnqueueCommandBufferKHR</name></proto>
+            <param><type>cl_uint</type>                   <name>num_queues</name></param>
+            <param><type>cl_command_queue</type>*         <name>queues</name></param>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_uint</type>                   <name>num_events_in_wait_list</name></param>
+            <param>const <type>cl_event</type>*           <name>event_wait_list</name></param>
+            <param><type>cl_event</type>*                 <name>event</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandBarrierWithWaitListKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandCopyBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>src_buffer</name></param>
+            <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
+            <param><type>size_t</type>                    <name>src_offset</name></param>
+            <param><type>size_t</type>                    <name>dst_offset</name></param>
+            <param><type>size_t</type>                    <name>size</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandCopyBufferRectKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>src_buffer</name></param>
+            <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
+            <param>const <type>size_t</type>*             <name>src_origin</name></param>
+            <param>const <type>size_t</type>*             <name>dst_origin</name></param>
+            <param>const <type>size_t</type>*             <name>region</name></param>
+            <param><type>size_t</type>                    <name>src_row_pitch</name></param>
+            <param><type>size_t</type>                    <name>src_slice_pitch</name></param>
+            <param><type>size_t</type>                    <name>dst_row_pitch</name></param>
+            <param><type>size_t</type>                    <name>dst_slice_pitch</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandCopyBufferToImageKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>src_buffer</name></param>
+            <param><type>cl_mem</type>                    <name>dst_image</name></param>
+            <param><type>size_t</type>                    <name>src_offset</name></param>
+            <param>const <type>size_t</type>*             <name>dst_origin</name></param>
+            <param>const <type>size_t</type>*             <name>region</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandCopyImageKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>src_image</name></param>
+            <param><type>cl_mem</type>                    <name>dst_image</name></param>
+            <param>const <type>size_t</type>*             <name>src_origin</name></param>
+            <param>const <type>size_t</type>*             <name>dst_origin</name></param>
+            <param>const <type>size_t</type>*             <name>region</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandCopyImageToBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>src_image</name></param>
+            <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
+            <param>const <type>size_t</type>*             <name>src_origin</name></param>
+            <param>const <type>size_t</type>*             <name>region</name></param>
+            <param><type>size_t</type>                    <name>dst_offset</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandFillBufferKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>buffer</name></param>
+            <param>const <type>void</type>*               <name>pattern</name></param>
+            <param><type>size_t</type>                    <name>pattern_size</name></param>
+            <param><type>size_t</type>                    <name>offset</name></param>
+            <param><type>size_t</type>                    <name>size</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                    <name>clCommandFillImageKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param><type>cl_mem</type>                    <name>image</name></param>
+            <param>const <type>void</type>*               <name>fill_color</name></param>
+            <param>const <type>size_t</type>*             <name>origin</name></param>
+            <param>const <type>size_t</type>*             <name>region</name></param>
+            <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                                     <name>clCommandNDRangeKernelKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>                      <name>command_buffer</name></param>
+            <param><type>cl_command_queue</type>                           <name>command_queue</name></param>
+            <param>const <type>cl_ndrange_kernel_command_properties_khr</type>*  <name>properties</name></param>
+            <param><type>cl_kernel</type>                                  <name>kernel</name></param>
+            <param><type>cl_uint</type>                                    <name>work_dim</name></param>
+            <param>const <type>size_t</type>*                              <name>global_work_offset</name></param>
+            <param>const <type>size_t</type>*                              <name>global_work_size</name></param>
+            <param>const <type>size_t</type>*                              <name>local_work_size</name></param>
+            <param><type>cl_uint</type>                                    <name>num_sync_points_in_wait_list</name></param>
+            <param>const <type>cl_sync_point_khr</type>*                   <name>sync_point_wait_list</name></param>
+            <param><type>cl_sync_point_khr</type>*                         <name>sync_point</name></param>
+            <param><type>cl_mutable_command_khr</type>*                    <name>mutable_handle</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                     <name>clGetCommandBufferInfoKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>      <name>command_buffer</name></param>
+            <param><type>cl_command_buffer_info_khr</type> <name>param_name</name></param>
+            <param><type>size_t</type>                     <name>param_value_size</name></param>
+            <param><type>void</type>*                      <name>param_value</name></param>
+            <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
+        </command>
+
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                     <name>clSetContentSizeBufferPoCL</name></proto>
             <param><type>cl_mem</type>                     <name>buffer</name></param>
@@ -6600,6 +6807,73 @@ server's OpenCL/api-docs repository.
         <extension name="cl_pocl_content_size" supported="opencl">
             <require>
                 <command name="clSetContentSizeBufferPoCL"/>
+            </require>
+        </extension>
+        <extension name="cl_khr_command_buffer" comment="in sync with rev 29" supported="opencl">
+            <require>
+                <type name="CL/cl.h"/>
+            </require>
+            <require>
+                <type name="cl_device_command_buffer_capabilities_khr"/>
+                <type name="cl_command_buffer_khr"/>
+                <type name="cl_sync_point_khr"/>
+                <type name="cl_command_buffer_info_khr"/>
+                <type name="cl_command_buffer_state_khr"/>
+                <type name="cl_command_buffer_properties_khr"/>
+                <type name="cl_ndrange_kernel_command_properties_khr"/>
+                <type name="cl_mutable_command_khr"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
+                <enum name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
+            </require>
+            <require comment="cl_device_command_buffer_capabilities_khr - bitfield">
+                <enum name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
+                <enum name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
+                <enum name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
+                <enum name="CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR"/>
+            </require>
+            <require comment="cl_command_buffer_properties_khr">
+               <enum name="CL_COMMAND_BUFFER_PROPERTIES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
+            </require>
+            <require comment="Error codes">
+                <enum name="CL_INVALID_COMMAND_BUFFER_KHR"/>
+                <enum name="CL_INVALID_SYNC_POINT_WAIT_LIST_KHR"/>
+                <enum name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
+            </require>
+            <require comment="cl_command_buffer_info_khr">
+               <enum name="CL_COMMAND_BUFFER_INFO_QUEUES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_INFO_NUM_QUEUES_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_INFO_REFERENCE_COUNT_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_INFO_STATE_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_INFO_PROPERTIES_ARRAY_KHR"/>
+            </require>
+            <require comment="cl_command_buffer_state_khr">
+               <enum name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_STATE_PENDING_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_STATE_INVALID_KHR"/>
+            </require>
+            <require comment="cl_command_type">
+                <enum name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
+            </require>
+            <require>
+                <command name="clCreateCommandBufferKHR"/>
+                <command name="clFinalizeCommandBufferKHR"/>
+                <command name="clRetainCommandBufferKHR"/>
+                <command name="clReleaseCommandBufferKHR"/>
+                <command name="clEnqueueCommandBufferKHR"/>
+                <command name="clCommandBarrierWithWaitListKHR"/>
+                <command name="clCommandCopyBufferKHR"/>
+                <command name="clCommandCopyBufferRectKHR"/>
+                <command name="clCommandCopyBufferToImageKHR"/>
+                <command name="clCommandCopyImageKHR"/>
+                <command name="clCommandCopyImageToBufferKHR"/>
+                <command name="clCommandFillBufferKHR"/>
+                <command name="clCommandFillImageKHR"/>
+                <command name="clCommandNDRangeKernelKHR"/>
+                <command name="clGetCommandBufferInfoKHR"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
This PR contains the spec source for the following new extensions:

* `cl_khr_async_copy_fence` (was provisional, now final)
* `cl_khr_extended_async_copies` (was provisional, now final)
* `cl_khr_expect_assume`
* `cl_khr_command_buffer` (provisional)