### PR TITLE
clarify memory_scope_all_devices is an alias for memory_scope_all_svm_devices

### DIFF
--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -445,9 +445,9 @@ Memory Scopes ::
     (memory-ordering constraints only apply to work-items executing in a
     work-group), *memory_scope_device* (memory-ordering constraints only
     apply to work-items executing on a single device) and
-    *memory_scope_all_svm_devices* (memory-ordering constraints only apply
-    to work-items executing across multiple devices and when using shared
-    virtual memory).
+    *memory_scope_all_svm_devices* or equivalently *memory_scope_all_devices*
+    (memory-ordering constraints only apply to work-items executing across
+    multiple devices and when using shared virtual memory).
 
 Modification Order ::
     All modifications to a particular atomic object M occur in some
@@ -639,9 +639,9 @@ Scope inclusion ::
     and *A* and *B* are executed by work-items within the same work-group,
     or (3) if *P* is *memory_scope_device*, and *A* and *B* are executed by
     work-items on the same device, or (4) if *P* is
-    *memory_scope_all_svm_devices*, if *A* and *B* are executed by host
-    threads or by work-items on one or more devices that can share SVM
-    memory with each other and the host process.
+    *memory_scope_all_svm_devices* or *memory_scope_all_devices*, if *A* and *B*
+    are executed by host threads or by work-items on one or more devices that
+    can share SVM memory with each other and the host process.
 
 Sequenced before ::
     A relation between evaluations executed by a single unit of execution.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1188,6 +1188,7 @@ enumeration constant:
     does not have the {CL_MEM_SVM_ATOMICS} flag set will commit to at least
     *memory_scope_device* visibility, with full synchronization of the
     buffer at a queue synchronization point (e.g. an OpenCL event).
+  * *memory_scope_all_devices*: an alias for *memory_scope_all_svm_devices*.
 
 These memory scopes define a hierarchy of visibilities when analyzing the
 ordering constraints of memory operations.

--- a/man/static/enums.txt
+++ b/man/static/enums.txt
@@ -544,7 +544,8 @@ enums - Enumerated types and their permitted values
     `memory_scope_sub_group` +
     `memory_scope_work_group` +
     `memory_scope_device` +
-    `memory_scope_all_svm_devices`
+    `memory_scope_all_svm_devices` +
+    `memory_scope_all_devices`
 |===
 
 


### PR DESCRIPTION
Possible fix for #697?