### PR TITLE
fixes whitespace error for union generation

### DIFF
--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -942,7 +942,7 @@ class OutputGenerator:
 
         # If prefix was originally non-empty and the param has no elements
         # (e.g. is nothing but text), preserve it.
-        paramdecl = prefix + paramdecl
+        paramdecl = paramdecl + prefix
 
         if aligncol == 0:
             # Squeeze out multiple spaces other than the indentation


### PR DESCRIPTION
fixes #682 

I think the issue here is that the whitespace gets included on the RHS of the generated string instead of on the LHS, so swap the order of the "prefix" and the "paramdecl".