### PR TITLE
Rename cl_intel_thread_local_exec to cl_intel_exec_by_local_thread

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5560,7 +5560,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"/>
             </require>
         </extension>
-        <extension name="cl_intel_thread_local_exec" supported="opencl">
+        <extension name="cl_intel_exec_by_local_thread" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
                 <type name="CL/cl_platform.h"/>


### PR DESCRIPTION
cl_intel_exec_by_local_thread is the correct extension name.