### PR TITLE
add a specification change log

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -12968,6 +12968,10 @@ one of the integers 0, 1, ... h~t~ - 1.
     References are to sections of this specific version, referred to as the
     "`Embedded C Specification`", although other versions exist.
 
+:numbered!:
+
+include::c/appendix_a.asciidoc[]
+
 // This is generatig asciidoctor errors:
 //  OpenCL_C.txt: Failed to load AsciiDoc document - undefined method `+' for nil:NilClass
 // Disabling acknowledgements for now.  We have them in the API spec already.

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -43,3 +43,8 @@ include::env/numerical_compliance.asciidoc[]
 include::env/image_addressing_and_filtering.asciidoc[]
 
 include::env/references.asciidoc[]
+
+:numbered!:
+:leveloffset: 1
+
+include::env/appendix_a.asciidoc[]

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -478,6 +478,7 @@ Changes from *v3.0.5*:
 Changes from *v3.0.6*:
 
   * Removed erroneous condition for {CL_INVALID_KERNEL_ARGS}.
+  * Fixed the spelling of `-cl-no-signed-zeros`.
   * Clarified the table structure in the backwards compatibility appendix.
   * Clarified that `-cl-unsafe-math-optimizations` also implies `-cl-denorms-are-zero`.
   * Added new extensions:

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -462,7 +462,7 @@ conformance process:
 
 The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
 
-Changes in *v3.0.6*:
+Changes from *v3.0.5*:
 
   * Fixed the calculation in "mapping work-items onto an NDRange".
   * Added new extensions:
@@ -475,7 +475,7 @@ Changes in *v3.0.6*:
       ** `cl_khr_subgroup_shuffle_relative`
       ** `cl_khr_subgroup_clustered_reduce`
 
-Changes in *v3.0.7*:
+Changes from *v3.0.6*:
 
   * Removed erroneous condition for {CL_INVALID_KERNEL_ARGS}.
   * Clarified the table structure in the backwards compatibility appendix.
@@ -486,4 +486,42 @@ Changes in *v3.0.7*:
       ** `cl_khr_spirv_extended_debug_info`
       ** `cl_khr_spirv_linkonce_odr`
       ** `cl_khr_suggested_local_work_size`
-  
+
+Changes from *v3.0.7*:
+
+  * Clarified optionality support for double-precision literals.
+  * Removed unnecessary phrase from subgroup mask function descriptions.
+  * Added _input_slice_pitch_ error condition for read and write image APIs.
+  * Added new extension:
+      ** `cl_khr_integer_dot_product`
+
+Changes from *v3.0.8*:
+
+  * Added a missing error condition for {clGetKernelSuggestedLocalWorkSizeKHR}.
+  * Clarified requirements for {CL_DEVICE_DOUBLE_FP_CONFIG} prior to OpenCL 2.0.
+  * Clarified the behavior of ballot operations for remainder subgroups.
+  * Added new extensions:
+      ** `cl_khr_integer_dot_product` (version 2)
+      ** `cl_khr_semaphore` (provisional)
+      ** `cl_khr_external_semaphore` (provisional)
+      ** `cl_khr_external_semaphore_dx_fence` (provisional)
+      ** `cl_khr_external_semaphore_opaque_fd` (provisional)
+      ** `cl_khr_external_semaphore_sync_fd` (provisional)
+      ** `cl_khr_external_semaphore_win32` (provisional)
+      ** `cl_khr_external_memory` (provisional)
+      ** `cl_khr_external_memory_dma_buf` (provisional)
+      ** `cl_khr_external_memory_dx` (provisional)
+      ** `cl_khr_external_memory_opaque_fd` (provisional)
+      ** `cl_khr_external_memory_win32` (provisional)
+
+Changes from *v3.0.9*:
+
+  * Relaxed memory object acquire error checking requirements for OpenGL, EGL, and DirectX interop extensions.
+  * Added a missing error condition for {clGetSemaphoreHandleForTypeKHR}.
+  * Clarified that {clCompileProgram} is valid for programs created from SPIR.
+  * Documented the possible state of a kernel object after a failed call to {clSetKernelArg}.
+  * Added new extensions:
+      ** `cl_khr_async_copy_fence` (final)
+      ** `cl_khr_extended_async_copies` (final)
+      ** `cl_khr_expect_assume`
+      ** `cl_khr_command_buffer` (provisional)

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -6,8 +6,8 @@
 [[changes_to_opencl]]
 = Changes to OpenCL
 
-Changes to the OpenCL API and OpenCL C between successive versions are
-summarized below.
+Changes to the OpenCL API and OpenCL C specifications between successive
+versions are summarized below.
 
 // (Jon) Are these section and table numbers for the current spec, in which
 // case they should turn into asciidoctor xrefs, or to older specs?
@@ -457,3 +457,20 @@ test suite that the device has fully passed in accordance with the official
 conformance process:
 
   * {CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED}
+
+== Summary of changes from OpenCL 3.0
+
+The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
+
+Changes in *v3.0.6*:
+
+  * Fixed the calculation in "mapping work-items onto an NDRange".
+  * Added new extensions:
+      ** `cl_khr_extended_versioning`
+      ** `cl_khr_subgroup_extended_types`
+      ** `cl_khr_subgroup_non_uniform_vote`
+      ** `cl_khr_subgroup_ballot`
+      ** `cl_khr_subgroup_non_uniform_arithmetic`
+      ** `cl_khr_subgroup_shuffle`
+      ** `cl_khr_subgroup_shuffle_relative`
+      ** `cl_khr_subgroup_clustered_reduce`

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -474,3 +474,16 @@ Changes in *v3.0.6*:
       ** `cl_khr_subgroup_shuffle`
       ** `cl_khr_subgroup_shuffle_relative`
       ** `cl_khr_subgroup_clustered_reduce`
+
+Changes in *v3.0.7*:
+
+  * Removed erroneous condition for {CL_INVALID_KERNEL_ARGS}.
+  * Clarified the table structure in the backwards compatibility appendix.
+  * Clarified that `-cl-unsafe-math-optimizations` also implies `-cl-denorms-are-zero`.
+  * Added new extensions:
+      ** `cl_khr_extended_bit_ops`
+      ** `cl_khr_pci_bus_info`
+      ** `cl_khr_spirv_extended_debug_info`
+      ** `cl_khr_spirv_linkonce_odr`
+      ** `cl_khr_suggested_local_work_size`
+  

--- a/c/appendix_a.asciidoc
+++ b/c/appendix_a.asciidoc
@@ -13,7 +13,7 @@ summarized below.
 
 The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
 
-Changes in *v3.0.6*:
+Changes from *v3.0.5*:
 
   * Clarified that `memory_scope_all_devices` is supported only for OpenCL C 3.0 or newer.
   * Defined ULP overflow leniency.
@@ -22,7 +22,7 @@ Changes in *v3.0.6*:
   * Clarified relationship between optional core features and extensions.
   * Deprecated the `+__OPENCL_C_VERSION__+` predefined macro and clarified possible values of the macro for different versions of OpenCL.
 
-Changes in *v3.0.7*:
+Changes from *v3.0.6*:
 
   * Clarified the argument to *vec_step* is not evaluated.
   * Improved description for pipe specifier.
@@ -33,3 +33,7 @@ Changes in *v3.0.7*:
   * Fixed several bugs and formatting in the fast math ULP tables.
   * Clarified the behavior of *work_group_broadcast*.
   * Clarified the minimum OpenCL C version for the `opencl_unroll_hint` attribute.
+
+Changes from *v3.0.7*:
+
+  * Clarified optionality support for double-precision literals.

--- a/c/appendix_a.asciidoc
+++ b/c/appendix_a.asciidoc
@@ -26,7 +26,6 @@ Changes from *v3.0.6*:
 
   * Clarified the argument to *vec_step* is not evaluated.
   * Improved description for pipe specifier.
-  * Fixed spelling of `-cl-no-signed-zeros`.
   * Fixed parameter name in *work_group_broadcast* description.
   * Clarified that the size of a pipe is implementation-defined.
   * Moved descriptions of the identify value for exclusive scans.

--- a/c/appendix_a.asciidoc
+++ b/c/appendix_a.asciidoc
@@ -1,0 +1,23 @@
+// Copyright 2017-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[appendix]
+[[changes_to_opencl]]
+= Changes to OpenCL
+
+Changes to the OpenCL C specifications between successive versions are
+summarized below.
+
+== Summary of changes from OpenCL 3.0
+
+The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
+
+Changes in *v3.0.6*:
+
+  * Clarified that `memory_scope_all_devices` is supported only for OpenCL C 3.0 or newer.
+  * Defined ULP overflow leniency.
+  * Removed a confusing phrase about kernel argument pointer types.
+  * Clarified usage of feature test macros pre-OpenCL C 3.0.
+  * Clarified relationship between optional core features and extensions.
+  * Deprecated the `+__OPENCL_C_VERSION__+` predefined macro and clarified possible values of the macro for different versions of OpenCL.

--- a/c/appendix_a.asciidoc
+++ b/c/appendix_a.asciidoc
@@ -21,3 +21,15 @@ Changes in *v3.0.6*:
   * Clarified usage of feature test macros pre-OpenCL C 3.0.
   * Clarified relationship between optional core features and extensions.
   * Deprecated the `+__OPENCL_C_VERSION__+` predefined macro and clarified possible values of the macro for different versions of OpenCL.
+
+Changes in *v3.0.7*:
+
+  * Clarified the argument to *vec_step* is not evaluated.
+  * Improved description for pipe specifier.
+  * Fixed spelling of `-cl-no-signed-zeros`.
+  * Fixed parameter name in *work_group_broadcast* description.
+  * Clarified that the size of a pipe is implementation-defined.
+  * Moved descriptions of the identify value for exclusive scans.
+  * Fixed several bugs and formatting in the fast math ULP tables.
+  * Clarified the behavior of *work_group_broadcast*.
+  * Clarified the minimum OpenCL C version for the `opencl_unroll_hint` attribute.

--- a/env/appendix_a.asciidoc
+++ b/env/appendix_a.asciidoc
@@ -13,7 +13,7 @@ versions are summarized below.
 
 The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
 
-Changes in *v3.0.6*:
+Changes from *v3.0.5*:
 
   * Clarified subgroup barrier behavior in non-uniform control flow.
   * Added required alignment of types.
@@ -26,7 +26,7 @@ Changes in *v3.0.6*:
       ** `cl_khr_subgroup_shuffle_relative`
       ** `cl_khr_subgroup_clustered_reduce`
 
-Changes in *v3.0.7*:
+Changes from *v3.0.6*:
 
   * Explicitly say that *OpTypeSampledImage* may be used in an OpenCL environment.
   * Added the required type for SPIR-V built-in variables.
@@ -36,3 +36,6 @@ Changes in *v3.0.7*:
       ** `cl_khr_spirv_extended_debug_info`
       ** `cl_khr_spirv_linkonce_odr`
 
+Changes from *v3.0.8*:
+
+  * Clarified that some OpenCL `khr` extensions also require SPIR-V extensions.

--- a/env/appendix_a.asciidoc
+++ b/env/appendix_a.asciidoc
@@ -1,0 +1,29 @@
+// Copyright 2017-2021 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[appendix]
+[[changes_to_opencl]]
+= Changes to OpenCL
+
+Changes to the OpenCL SPIR-V Environment specifications between successive
+versions are summarized below.
+
+== Summary of changes from OpenCL 3.0
+
+The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
+
+Changes in *v3.0.6*:
+
+  * Clarified subgroup barrier behavior in non-uniform control flow.
+  * Added required alignment of types.
+  * Added new extensions:
+      ** `cl_khr_extended_versioning`
+      ** `cl_khr_subgroup_extended_types`
+      ** `cl_khr_subgroup_non_uniform_vote`
+      ** `cl_khr_subgroup_ballot`
+      ** `cl_khr_subgroup_non_uniform_arithmetic`
+      ** `cl_khr_subgroup_shuffle`
+      ** `cl_khr_subgroup_shuffle_relative`
+      ** `cl_khr_subgroup_clustered_reduce`
+

--- a/env/appendix_a.asciidoc
+++ b/env/appendix_a.asciidoc
@@ -18,7 +18,6 @@ Changes in *v3.0.6*:
   * Clarified subgroup barrier behavior in non-uniform control flow.
   * Added required alignment of types.
   * Added new extensions:
-      ** `cl_khr_extended_versioning`
       ** `cl_khr_subgroup_extended_types`
       ** `cl_khr_subgroup_non_uniform_vote`
       ** `cl_khr_subgroup_ballot`
@@ -26,4 +25,14 @@ Changes in *v3.0.6*:
       ** `cl_khr_subgroup_shuffle`
       ** `cl_khr_subgroup_shuffle_relative`
       ** `cl_khr_subgroup_clustered_reduce`
+
+Changes in *v3.0.7*:
+
+  * Explicitly say that *OpTypeSampledImage* may be used in an OpenCL environment.
+  * Added the required type for SPIR-V built-in variables.
+  * Fixed several bugs and formatting in the fast math ULP tables.
+  * Added new extensions:
+      ** `cl_khr_extended_bit_ops`
+      ** `cl_khr_spirv_extended_debug_info`
+      ** `cl_khr_spirv_linkonce_odr`
 


### PR DESCRIPTION
fixes #707 

This PR adds a specification "change log" for published revisions of the OpenCL 3.0 specifications.  I did this by adding an appendix to the OpenCL C and OpenCL SPIR-V Environment specifications and by adding to the existing appendix in the OpenCL API specification.

I've documented most of the extension changes in the OpenCL API specification appendix for now, but I'm not entirely sure if that makes the most sense.  It's easy to move these to an appendix in the extension spec if desired, though I get nervous spreading information around too many places.  By this same logic I suppose the OpenCL SPIR-V Environment changes could be merged into the API spec also, if desired.