### PR TITLE
Include generated version notes in API reference pages

### DIFF
--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -393,8 +393,10 @@ def emitPage(baseDir, specDir, pi, file):
             logWarn('emitPage:', pageName, 'INCLUDE is None, no page generated')
             return
 
-        # Specification text
-        lines = remapIncludes(file[pi.begin:pi.include + 1], baseDir, specDir)
+        # Specification text from beginning to just before the parameter
+        # section. This covers the description, the prototype, the version
+        # note, and any additional version note text.
+        lines = remapIncludes(file[pi.begin:pi.param], baseDir, specDir)
         specText = ''.join(lines)
 
         if pi.param is not None:

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -395,8 +395,10 @@ def emitPage(baseDir, specDir, pi, file):
 
         # Specification text from beginning to just before the parameter
         # section. This covers the description, the prototype, the version
-        # note, and any additional version note text.
-        lines = remapIncludes(file[pi.begin:pi.param], baseDir, specDir)
+        # note, and any additional version note text. If a parameter section
+        # is absent then go a line beyond the include.
+        remap_end = pi.include + 1 if pi.param is None else pi.param
+        lines = remapIncludes(file[pi.begin:remap_end], baseDir, specDir)
         specText = ''.join(lines)
 
         if pi.param is not None:


### PR DESCRIPTION
Change the range of text copied into the API entry point reference pages so as
to include the generated version notes.

Before: 
![image](https://user-images.githubusercontent.com/2613275/142957542-78f5337b-db03-4123-aa00-44cbebf3f747.png)

After:
![image](https://user-images.githubusercontent.com/2613275/142957492-8b2bb7ec-158b-44af-b7f7-129c882ff5a1.png)


Closes #724