### PR TITLE
Clarify that clustered subgroup operations may lead to undefined behaviour

### DIFF
--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -642,7 +642,7 @@ This section describes arithmetic operations that are performed on a subset of w
 A cluster is described by a specified cluster size.
 Work items in a subgroup are assigned to clusters such that for cluster size _n_, the _n_ work items in the subgroup with the smallest subgroup local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest subgroup local IDs are assigned to the next cluster, and so on.
 The specified cluster size must be an integer constant expression that is a power-of-two, otherwise the behaviour is undefined.
-Behavior is undefined if the specified cluster size is greater than the maximum size of a subgroup within the dispatch.
+Behavior is undefined if the specified cluster size is not an integer constant expression, is not a power-of-two, or is greater than the maximum size of a subgroup within the dispatch.
 
 ===== Arithmetic Operations
 

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -641,7 +641,6 @@ This extension adds support for clustered reductions that operate on a subset of
 This section describes arithmetic operations that are performed on a subset of work items in a subgroup, referred to as a cluster.
 A cluster is described by a specified cluster size.
 Work items in a subgroup are assigned to clusters such that for cluster size _n_, the _n_ work items in the subgroup with the smallest subgroup local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest subgroup local IDs are assigned to the next cluster, and so on.
-The specified cluster size must be an integer constant expression that is a power-of-two, otherwise the behaviour is undefined.
 Behavior is undefined if the specified cluster size is not an integer constant expression, is not a power-of-two, or is greater than the maximum size of a subgroup within the dispatch.
 
 ===== Arithmetic Operations

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -641,7 +641,7 @@ This extension adds support for clustered reductions that operate on a subset of
 This section describes arithmetic operations that are performed on a subset of work items in a subgroup, referred to as a cluster.
 A cluster is described by a specified cluster size.
 Work items in a subgroup are assigned to clusters such that for cluster size _n_, the _n_ work items in the subgroup with the smallest subgroup local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest subgroup local IDs are assigned to the next cluster, and so on.
-The specified cluster size must be an integer constant expression that is a power-of-two.
+The specified cluster size must be an integer constant expression that is a power-of-two, otherwise the behaviour is undefined.
 Behavior is undefined if the specified cluster size is greater than the maximum size of a subgroup within the dispatch.
 
 ===== Arithmetic Operations


### PR DESCRIPTION
... when the cluster size is not an integer constant that is a power of two.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>
Change-Id: I0116b75808c7fe5df7146a33f6b36698f2c4e6b7