### PR TITLE
Link `cl_khronos_vendor_id` enums to OpenCL 3.0 in cl.xml

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5031,6 +5031,10 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
             <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
         </require>
+        <require comment="cl_khronos_vendor_id">
+            <enum name="CL_KHRONOS_VENDOR_ID_CODEPLAY"/>
+            <enum name="CL_KHRONOS_VENDOR_ID_POCL"/>
+        </require>
         <require comment="cl_platform_info">
             <enum name="CL_PLATFORM_NUMERIC_VERSION"/>
             <enum name="CL_PLATFORM_EXTENSIONS_WITH_VERSION"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4094,6 +4094,9 @@ server's OpenCL/api-docs repository.
             <type name="cl_profiling_info"/>
             <type name="cl_image_format"/>
             <type name="cl_buffer_region"/>
+            <!-- cl_khronos_vendor_id was actually added in OpenCL 3.0, but the
+                 assigned IDs can be used in any OpenCL version. -->
+            <type name="cl_khronos_vendor_id"/>
         </require>
         <require comment="Constants">
             <enum name="CL_CHAR_BIT"/>
@@ -4444,6 +4447,10 @@ server's OpenCL/api-docs repository.
             <enum name="CL_RUNNING"/>
             <enum name="CL_SUBMITTED"/>
             <enum name="CL_QUEUED"/>
+        </require>
+        <require comment="cl_khronos_vendor_id">
+            <enum name="CL_KHRONOS_VENDOR_ID_CODEPLAY"/>
+            <enum name="CL_KHRONOS_VENDOR_ID_POCL"/>
         </require>
         <require comment="Platform APIs">
             <command name="clGetPlatformIDs"/>
@@ -5013,7 +5020,6 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_device_atomic_capabilities"/>
             <type name="cl_device_device_enqueue_capabilities"/>
-            <type name="cl_khronos_vendor_id"/>
             <type name="cl_mem_properties"/>
             <type name="cl_version"/>
             <type name="cl_name_version"/>
@@ -5030,10 +5036,6 @@ server's OpenCL/api-docs repository.
         <require comment="cl_device_device_enqueue_capabilities - bitfield">
             <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
             <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
-        </require>
-        <require comment="cl_khronos_vendor_id">
-            <enum name="CL_KHRONOS_VENDOR_ID_CODEPLAY"/>
-            <enum name="CL_KHRONOS_VENDOR_ID_POCL"/>
         </require>
         <require comment="cl_platform_info">
             <enum name="CL_PLATFORM_NUMERIC_VERSION"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4094,9 +4094,6 @@ server's OpenCL/api-docs repository.
             <type name="cl_profiling_info"/>
             <type name="cl_image_format"/>
             <type name="cl_buffer_region"/>
-            <!-- cl_khronos_vendor_id was actually added in OpenCL 3.0, but the
-                 assigned IDs can be used in any OpenCL version. -->
-            <type name="cl_khronos_vendor_id"/>
         </require>
         <require comment="Constants">
             <enum name="CL_CHAR_BIT"/>
@@ -4449,6 +4446,10 @@ server's OpenCL/api-docs repository.
             <enum name="CL_QUEUED"/>
         </require>
         <require comment="cl_khronos_vendor_id">
+            <!-- The cl_khronos_vendor_id type was added in OpenCL 3.0, but the
+                 concept of assigned vendor IDs has existed since OpenCL 1.0.
+                 These enums can be used in any OpenCL version because the type
+                 used in the API is cl_uint. -->
             <enum name="CL_KHRONOS_VENDOR_ID_CODEPLAY"/>
             <enum name="CL_KHRONOS_VENDOR_ID_POCL"/>
         </require>
@@ -5020,6 +5021,7 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_device_atomic_capabilities"/>
             <type name="cl_device_device_enqueue_capabilities"/>
+            <type name="cl_khronos_vendor_id"/>
             <type name="cl_mem_properties"/>
             <type name="cl_version"/>
             <type name="cl_name_version"/>


### PR DESCRIPTION
See script to check for orphans in https://github.com/KhronosGroup/OpenCL-Docs/pull/730

The type was adding in OpenCL 3.0, the actual enums are independent of a specific OpenCL version, but they're also not part of extensions.  The 3.0 section seems the most natural.