### PR TITLE
Couple device enqueue and program scope global variables features.

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -161,8 +161,9 @@ share SVM memory with each other and the host process.
 | The OpenCL C compiler supports built-in functions to enqueue additional work
 from the device.
 
-OpenCL C compilers that define the feature macro {opencl_c_device_enqueue}
-must also define the feature macro {opencl_c_generic_address_space}.
+OpenCL C compilers that define the feature macro {opencl_c_device_enqueue} must also
+define {opencl_c_generic_address_space} and {opencl_c_program_scope_global_variables}
+feature macros.
 
 | {opencl_c_generic_address_space}
 | The OpenCL C compiler supports the unnamed generic address space.

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -188,6 +188,7 @@ When device-side enqueue is supported but a replaceable default on-device queue 
 
 OpenCL C compilers supporting device-side enqueue and on-device queues will define the feature macro `+__opencl_c_device_enqueue+`.
 OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_generic_address_space+` because some OpenCL C functions for device-side Enqueue accept pointers to the generic address space.
+OpenCL C compilers that define the feature macro `+__opencl_c_device_enqueue+` must also define the feature macro `+__opencl_c_program_scope_global_variables+` because an implementation of blocks may interact with program scope variables in global address space as part of ABI.
 
 == Pipes
 


### PR DESCRIPTION
Some ABIs (for example, clang blocks ABI) may use program scope variables as part of optimization when generating block constructions for blocks without captures/global blocks. Couple device enqueue and program scope global variables to allow such behaviour.