### PR TITLE
Add doc revision to C++ for OpenCL in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,12 @@ SPECREVISION = $(shell echo `git describe --tags --dirty`)
 SPECREMARK = from git branch: $(shell echo `git symbolic-ref --short HEAD`) \
 	     commit: $(shell echo `git log -1 --format="%H"`)
 endif
-# C++ for OpenCL document revision scheme in aligned with its release date.
+# The C++ for OpenCL document revision scheme is aligned with its release date.
 # Revision naming scheme is as follows:
 # DocRevYYYY.MM,
 # where YYYY corresponds to its release year,
 # MM corresponds to its release month.
-# Example for the release in Dec 2021 the revision is DOCREV2021.12.
+# Example for the release in Dec 2021 the revision is DocRev2021.12.
 # Leave as 'DocRevYYYY.MM-Next' if the doc content does not correspond to any official revision.
 # where DocRevYYYY.MM is the last released revision.
 CXX4OPENCL_DOCREVISION = DocRev2021.12

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 # C++ for OpenCL doc revision scheme in aligned with its release date.
 # Revision naming scheme is as follows:
 # DOCREVYYYY.MM,
-# where YYYY correspomds to its release year,
+# where YYYY corresponds to its release year,
 # MM corresponds to its release month.
 # Example for the release in Dec 2021 the revision is DOCREV2021.12.
 # Leave blank if the doc content does not correspond to any official revision.

--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,13 @@ SPECREMARK = from git branch: $(shell echo `git symbolic-ref --short HEAD`) \
 endif
 # C++ for OpenCL document revision scheme in aligned with its release date.
 # Revision naming scheme is as follows:
-# DOCREVYYYY.MM,
+# DocRevYYYY.MM,
 # where YYYY corresponds to its release year,
 # MM corresponds to its release month.
 # Example for the release in Dec 2021 the revision is DOCREV2021.12.
-# Leave blank if the doc content does not correspond to any official revision.
-CXX4OPENCL_DOCREVISION = DOCREV2021.12
+# Leave as 'DocRevYYYY.MM-Next' if the doc content does not correspond to any official revision.
+# where DocRevYYYY.MM is the last released revision.
+CXX4OPENCL_DOCREVISION = DocRev2021.12
 CXX4OPENCL_DOCREMARK = $(SPECREMARK) \
 			tag: $(SPECREVISION)
 

--- a/Makefile
+++ b/Makefile
@@ -68,20 +68,30 @@ SPECREVISION = $(shell echo `git describe --tags --dirty`)
 SPECREMARK = from git branch: $(shell echo `git symbolic-ref --short HEAD`) \
 	     commit: $(shell echo `git log -1 --format="%H"`)
 endif
+# C++ for OpenCL doc revision scheme in aligned
+# with its release date.
+CXX4OPENCL_DOCREVISION = DOCREV$(shell echo `date +"%Y.%m"`)
+CXX4OPENCL_DOCREMARK = $(SPECREMARK) \
+			tag: $(SPECREVISION)
 
-ATTRIBOPTS_NO_VERSION	= -a revdate="$(SPECDATE)" \
-			  -a revremark="$(SPECREMARK)" \
+COMMONATTRIBOPTS	= -a revdate="$(SPECDATE)" \
 			  -a stem=latexmath \
 			  -a generated=$(GENERATED) \
 			  -a sectnumlevels=5
 
 ATTRIBOPTS   = -a revnumber="$(SPECREVISION)" \
-	       $(ATTRIBOPTS_NO_VERSION)
+	       -a revremark="$(SPECREMARK)" \
+	       $(COMMONATTRIBOPTS)
+
+CXX4OPENCL_ATTRIBOPTS   = -a revnumber="$(CXX4OPENCL_DOCREVISION)" \
+			  -a revremark="$(CXX4OPENCL_DOCREMARK)" \
+			  $(COMMONATTRIBOPTS)
+
 
 ADOCEXTS	      = -r $(CURDIR)/config/sectnumoffset-treeprocessor.rb \
 	-r $(CURDIR)/config/spec-macros.rb \
 	-r $(CURDIR)/config/rouge_opencl.rb
-ADOCOPTS_NO_VERSION   = -d book $(ATTRIBOPTS_NO_VERSION) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
+CXX4OPENCL_ADOCOPTS   = -d book $(CXX4OPENCL_ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
 ADOCCOMMONOPTS	      = -a apispec="$(CURDIR)/api" \
 			-a config="$(CURDIR)/config" \
 			-a cspec="$(CURDIR)/c" \
@@ -352,14 +362,14 @@ CXX4OPENCLDOCSRC = $(CXX4OPENCLDOC).txt $(GENDEPENDS) \
 cxx4openclhtml: $(HTMLDIR)/$(CXX4OPENCLDOC).html $(CXX4OPENCLDOCSRC)
 
 $(HTMLDIR)/$(CXX4OPENCLDOC).html: $(CXX4OPENCLDOCSRC) $(KATEXINST)
-	$(QUIET)$(ASCIIDOCTOR) -b html5 $(ADOCOPTS_NO_VERSION) $(ADOCHTMLOPTS) -o $@ $(CXX4OPENCLDOC).txt
+	$(QUIET)$(ASCIIDOCTOR) -b html5 $(CXX4OPENCL_ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(CXX4OPENCLDOC).txt
 
 cxx4openclpdf: $(PDFDIR)/$(CXX4OPENCLDOC).pdf $(CXX4OPENCLDOCSRC)
 
 $(PDFDIR)/$(CXX4OPENCLDOC).pdf: $(CXX4OPENCLDOCSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
-	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS_NO_VERSION) $(ADOCPDFOPTS) -o $@ $(CXX4OPENCLDOC).txt
+	$(QUIET)$(ASCIIDOCTOR) -b pdf $(CXX4OPENCL_ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CXX4OPENCLDOC).txt
 ifndef GS_EXISTS
 	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
 else

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,14 @@ SPECREVISION = $(shell echo `git describe --tags --dirty`)
 SPECREMARK = from git branch: $(shell echo `git symbolic-ref --short HEAD`) \
 	     commit: $(shell echo `git log -1 --format="%H"`)
 endif
-# C++ for OpenCL doc revision scheme in aligned
-# with its release date.
-CXX4OPENCL_DOCREVISION = DOCREV$(shell echo `date +"%Y.%m"`)
+# C++ for OpenCL doc revision scheme in aligned with its release date.
+# Revision naming scheme is as follows:
+# DOCREVYYYY.MM,
+# where YYYY correspomds to its release year,
+# MM corresponds to its release month.
+# Example for the release in Dec 2021 the revision is DOCREV2021.12.
+# Leave blank if the doc content does not correspond to any official revision.
+CXX4OPENCL_DOCREVISION = DOCREV2021.12
 CXX4OPENCL_DOCREMARK = $(SPECREMARK) \
 			tag: $(SPECREVISION)
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ SPECREVISION = $(shell echo `git describe --tags --dirty`)
 SPECREMARK = from git branch: $(shell echo `git symbolic-ref --short HEAD`) \
 	     commit: $(shell echo `git log -1 --format="%H"`)
 endif
-# C++ for OpenCL doc revision scheme in aligned with its release date.
+# C++ for OpenCL document revision scheme in aligned with its release date.
 # Revision naming scheme is as follows:
 # DOCREVYYYY.MM,
 # where YYYY corresponds to its release year,


### PR DESCRIPTION
With the addition of C++ for OpenCL 2021, we will now end up with 2 language versions defined in the same document.

Hence we need some way to reference the document independent from the language versions.

This change adds the versioning of the document taken from its publishing date. For example, document published in Dec this year will have a version:

DOCREV2021.12

Listed in the front page.

Then  if we need to reference it to describe the semantics of C++ for OpenCL 1.0 and C++ for OpenCL 2021, we can do something like:

> C++ for OpenCL DOCREV2021.12: s2.3.3 by default implicit object parameter is in generic address space for v1.0 and in private address space for v2021.

While this is a bit longer than what we used to do with OpenCL C or C and C++, it can allow uniquely identify the document that explains semantics for multiple language versions.
