### PR TITLE
[NFC] Collocate atomic instructions requirements

### DIFF
--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -47,6 +47,10 @@ For all *Atomic Instructions*:
     or *CrossWorkgroup* _Storage Classes_.  Note that an *Atomic Instruction*
     on a pointer to the *Function* _Storage Class_ is valid, but does not
     have defined behavior.
+  * For OpenCL environments that support and declare the *GenericPointer*
+    capability, the _Pointer_ operand may be a pointer to the *Generic* 
+    _Storage Class_, however behavior is still undefined if the *Generic*
+    pointer represents a pointer to the *Function* _Storage Class_.
 
 Recursion is not supported.
 The static function call graph for an entry point must not contain cycles.
@@ -161,9 +165,3 @@ And, the memory-order constraint in _Memory Semantics_ must be one of:
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices
        supporting {CL_DEVICE_ATOMIC_ORDER_SEQ_CST} in
        {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES}.
-
-For OpenCL environments that support and declare the *GenericPointer*
-capability, the _Pointer_ operand to all *Atomic Instructions* may be
-a pointer to the *Generic* _Storage Class_, however behavior is still
-undefined if the *Generic* pointer represents a pointer to the
-*Function* _Storage Class_.


### PR DESCRIPTION
This change collocates storage class requirements for atomic instructions pointer argument to make it easier to find/read. No functional changes intended.