### PR TITLE
Clarify clGetKernelSubGroupInfo error codes

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7786,8 +7786,10 @@ Otherwise, it returns one of the following errors:
     the <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table
     and _param_value_ is not `NULL`.
   * {CL_INVALID_VALUE} if _param_name_ is
-    {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE} and the size in bytes specified by
-    _input_value_size_ is not valid or if _input_value_ is `NULL`.
+    {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE},
+    {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE} or
+    {CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT} and the size in bytes specified
+    by _input_value_size_ is not valid or if _input_value_ is `NULL`.
   * {CL_INVALID_KERNEL} if _kernel_ is a not a valid kernel object.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.


### PR DESCRIPTION
Return `CL_INVALID_VALUE` for any query to `clGetKernelSubGroupInfo`
that takes an input value that is `NULL` or has an invalid size.