### PR TITLE
Reserve two enums for internal MR 193

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1668,8 +1668,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
-            <unused start="0x12AB" end="0x12AE" comment="Used by future command-buffer extensions"/>
-            <unused start="0x12AF" end="0x1FFF" comment="Reserved for core API tokens"/>
+            <unused start="0x12AB" end="0x12B0" comment="Used by future command-buffer extensions"/>
+            <unused start="0x12B1" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
     <enums start="0x2000" end="0x201F" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">


### PR DESCRIPTION
Reserve enums `0x12AF` & `0x12B0` for use in internal MR 193 which currently has a couple of placeholder values that need filled in.