### PR TITLE
Fix parameter description of command-buffer API

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -997,8 +997,8 @@ complete. If the _sync_point_wait_list_ and the _sync_point_ arguments are not
 `NULL`, the _sync_point_ argument should not refer to an element of the
 _sync_point_wait_list_ array.
 
-_mutable_handle_ may be `NULL`, however the command will still be mutable if
-_command_buffer_ was created with `CL_MUTABLE_MEM_COMMANDS_ENABLE_KHR`.
+_mutable_handle_ Returns a handle to the command. Handle is unused by
+this extension and must be passed as `NULL`.
 
 *clCommandCopyBufferRectKHR* returns `CL_SUCCESS` if the function is executed
 successfully. Otherwise, it returns the errors defined by


### PR DESCRIPTION
The `clCommandCopyBufferRectKHR` entry-point defined by `cl_khr_command_buffer` has an incorrect description for parameter `mutable_handle`.

It should be identical to the `mutable_handle` descriptions for all the other command recording entry-points in the extension.