### PR TITLE
Reserve additional MR 193 enum

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1668,8 +1668,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
-            <unused start="0x12AB" end="0x12B0" comment="Used by future command-buffer extensions"/>
-            <unused start="0x12B1" end="0x1FFF" comment="Reserved for core API tokens"/>
+            <unused start="0x12AB" end="0x12B1" comment="Used by future command-buffer extensions"/>
+            <unused start="0x12B2" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
     <enums start="0x2000" end="0x201F" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">


### PR DESCRIPTION
After revision 8 of internal MR 193 we need to reserve another enum value, `0x12B1`. Apologies for following quite quickly after a previous reservation for the same internal MR in https://github.com/KhronosGroup/OpenCL-Docs/pull/747