### PR TITLE
Add to cl_khr_command_buffer contributors

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -30,6 +30,7 @@ This extension requires OpenCL 1.2 or later.
 ==== Contributors
 
 Ewan Crawford, Codeplay Software Ltd. +
+Gordon Brown, Codeplay Software Ltd. +
 Kenneth Benzie, Codeplay Software Ltd. +
 Alastair Murray, Codeplay Software Ltd. +
 Jack Frankland, Codeplay Software Ltd. +
@@ -39,6 +40,9 @@ Kevin Petit, Arm Ltd. +
 Aharon Abramson, Intel. +
 Ben Ashbaugh, Intel. +
 Boaz Ouriel, Intel. +
+Pekka Jääskeläinen, Tampere University +
+Nikhil Joshi, NVIDIA +
+James Price, Google +
 
 === Overview
 


### PR DESCRIPTION
In an oversight, I missed out some individuals who contributed to the internal extension MR 180 and associated issue 251.

I've gone through the GitLab participants list of both of these and ensured everyone is now present under contributors.

FYI: @nikhiljnv @jrprice @pjaaskel @AerialMantis