### PR TITLE
Fix clGetLayerInfo signature.

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4001,8 +4001,8 @@ server's OpenCL/api-docs repository.
         </command>
         <command>
             <proto><type>cl_int</type>                                  <name>clGetLayerInfo</name></proto>
-            <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param><type>cl_layer_info</type>                           <name>param_name</name></param>
+            <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>


### PR DESCRIPTION
The first two parameters were swapped. See: https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_loader_layers.asciidoc
I discovered this while trying to build the layers from the generated extension headers.