### PR TITLE
Update Arm copyrights to 2022

### DIFF
--- a/extensions/cl_arm_controlled_kernel_termination.asciidoc
+++ b/extensions/cl_arm_controlled_kernel_termination.asciidoc
@@ -21,7 +21,7 @@ Anastasia Stulova, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2021 Arm Ltd.
+Copyright (c) 2021-2022 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_printf.asciidoc
+++ b/extensions/cl_arm_printf.asciidoc
@@ -24,7 +24,7 @@ Kevin Petit, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2014-2021 Arm Ltd.
+Copyright (c) 2014-2022 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_protected_memory_allocation.asciidoc
+++ b/extensions/cl_arm_protected_memory_allocation.asciidoc
@@ -1,7 +1,3 @@
-// Copyright 2018-2021 The Khronos Group. This work is licensed under a
-// Creative Commons Attribution 4.0 International License; see
-// http://creativecommons.org/licenses/by/4.0/
-
 :data-uri:
 :icons: font
 include::../config/attribs.txt[]
@@ -23,7 +19,7 @@ Kevin Petit, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2021 Arm Ltd.
+Copyright (c) 2021-2022 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_scheduling_controls.asciidoc
+++ b/extensions/cl_arm_scheduling_controls.asciidoc
@@ -20,7 +20,7 @@ Kevin Petit, Arm Ltd.
 
 == Notice
 
-Copyright (c) 2020-2021 Arm Ltd.
+Copyright (c) 2020-2022 Arm Ltd.
 
 == Status
 


### PR DESCRIPTION
One file listed both a Khronos Group and Arm copyright, as this is a vendor
extension I assumed that Arm was the correct choice.  No other vendor extension
has a copyright comment, just the copyright in the text, so I just deleted the
Khronos Group lines.