### PR TITLE
Document change from default `master` to `main` branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,12 @@ The most useful parts of this document are the <<intro, Introduction>>,
 Dependencies>>.
 ====
 
+[NOTE]
+.Note
+====
+The default branch of this repository has changed from `master` to `main`.
+====
+
 [[intro]]
 == Introduction
 
@@ -37,7 +43,7 @@ You'll be prompted with a one-time "`click-through`" Contributor's License
 Agreement (CLA) dialog as part of submitting your pull request or other
 contribution to GitHub.
 
-We intend to maintain a linear history on the GitHub `master` branch.
+We intend to maintain a linear history on the GitHub `main` branch.
 
 
 [[repo]]
@@ -142,7 +148,7 @@ take several minutes.
 Most of the reference pages are extracted from the OpenCL API and OpenCL
 C Specifications, although some are static.
 While anyone can generate reference page sets for themselves, Khronos
-publishes them via the `master` branch of the
+publishes them via the `main` branch of the
 https://www.khronos.org/registry/OpenCL/sdk/2.2/docs/man/[OpenCL Registry].
 
 When the OpenCL Specification Editor is updating the published reference

--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Khronos Group. This work is licensed under a
+// Copyright 2017-2022 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -162,7 +162,7 @@ If there is no valid PCI vendor ID defined for the physical device, implementati
 This is a unique identifier greater than the largest PCI vendor ID (`0x10000`) and is representable by a {cl_uint_TYPE}. \
 Khronos vendor IDs are synchronized across APIs by utilizing Vulkan's vk.xml as the central Khronos vendor ID registry. \
 An ID must be reserved here prior to use in OpenCL, regardless of whether a vendor implements Vulkan. \
-Only once the ID has been allotted may it be exposed to OpenCL by proposing a merge request against cl.xml, in the master branch of the OpenCL-Docs project. \
+Only once the ID has been allotted may it be exposed to OpenCL by proposing a merge request against cl.xml, in the `main` branch of the OpenCL-Docs project. \
 The merge must define a new enumerant by adding an `<enum>` tag to the {cl_khronos_vendor_id_TYPE} `<enums>` tag, with the `<value>` attribute set as the acquired Khronos vendor ID. \
 The `<name>` attribute must identify the vendor/adopter, and be of the form `CL_KHRONOS_VENDOR_ID_<vendor>`. \
 ]

--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Khronos Group. This work is licensed under a
+// Copyright 2018-2022 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -223,7 +223,7 @@ CL_ANOTHER_ENUM_KHR   0xYYYY
 The 'New API Enums' section should list any new enumerants added by
 this extension along with the value of the new enumerant.  Until
 values are assigned by the Khronos Registry from the
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/xml/cl.xml[enumerant
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/xml/cl.xml[enumerant
 registry], use a placeholder value, e.g. `0x????`.
 
 Typically, new enumerants have a short description indicating which

--- a/man/static/intro.txt
+++ b/man/static/intro.txt
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Khronos Group Inc.
+// Copyright 2007-2022 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:
@@ -43,7 +43,7 @@ core specification in later revisions of the OpenCL specification.
 == Reference Page Sources
 
 Khronos publishes the OpenCL 3.0 reference pages in the
-https://www.github.com/KhronosGroup/OpenCL-Registry/tree/master/sdk/3.0/docs/[OpenCL-Registry
+https://www.github.com/KhronosGroup/OpenCL-Registry/tree/main/sdk/3.0/docs/[OpenCL-Registry
 repository].
 The sources for these pages are in Asciidoctor format, and are maintained in
 the https://www.github.com/KhronosGroup/OpenCL-Docs[OpenCL-Docs repository].

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2019-2021 The Khronos Group Inc.
+# Copyright 2019-2022 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     typeFileName   = args.directory + '/api-types.txt'
 
     specpath = args.registry
-    #specpath = "https://raw.githubusercontent.com/KhronosGroup/OpenCL-Registry/master/xml/cl.xml"
+    #specpath = "https://raw.githubusercontent.com/KhronosGroup/OpenCL-Registry/main/xml/cl.xml"
 
     print('Generating dictionaries from: ' + specpath)
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright (c) 2013-2021 The Khronos Group Inc.
+Copyright 2013-2022 The Khronos Group Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ machine-readable definition of the API, parameter and member validation
 language incorporated into the Specification and reference pages, and other
 material which is registered by Khronos.
 
-The authoritative public version of cl.xml is maintained in the master
-branch of the Khronos OpenCL-API GitHub repository. The authoritative
+The authoritative public version of cl.xml is maintained in the `main`
+branch of the Khronos OpenCL-Docs GitHub repository. The authoritative
 private version is maintained in the master branch of the member gitlab
 server's OpenCL/api-docs repository.
     </comment>


### PR DESCRIPTION
Merge after using Github's renaming tool.

@bashbaug @ntrevett as discussed in email - once the WG signs off, I will use the Github branch renaming tool to make the default branch 'main', then apply this PR to document the change.