### PR TITLE
fix missing parentheses in compare-and-exchange pseudocode

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7330,10 +7330,11 @@ The effect of the compare-and-exchange operations is
 
 [source,opencl_c]
 ----------
-if (memcmp(object, expected, sizeof(*object) == 0)
+if (memcmp(object, expected, sizeof(*object)) == 0) {
     memcpy(object, &desired, sizeof(*object));
-else
+} else {
     memcpy(expected, object, sizeof(*object));
+}
 ----------
 ====
 


### PR DESCRIPTION
Also adds curly braces, which generates slightly better syntax highlighting.