### PR TITLE
Define upcoming FPGA extension in XML to avoid creation of orphan enums

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2102,9 +2102,11 @@ server's OpenCL/api-docs repository.
         <enum value="0x4211"        name="CL_DEVICE_MAX_HOST_READ_PIPES_INTEL"/>
         <enum value="0x4212"        name="CL_DEVICE_MAX_HOST_WRITE_PIPES_INTEL"/>
         <enum value="0x4213"        name="CL_MEM_CHANNEL_INTEL"/>
-        <enum value="0x4214"        name="CL_COMMAND_READ_HOST_PIPE_INTEL_FPGA"/>
-        <enum value="0x4215"        name="CL_COMMAND_WRITE_HOST_PIPE_INTEL_FPGA"/>
-            <unused start="0x4216" end="0x421F"/>
+        <enum value="0x4214"        name="CL_COMMAND_READ_HOST_PIPE_INTEL"/>
+        <enum value="0x4215"        name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"/>
+        <enum value="0x4216"        name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"/>
+        <enum value="0x4217"        name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"/>
+            <unused start="0x4218" end="0x421F"/>
     </enums>
 
     <enums start="0x4220" end="0x422F" name="enums.4220" vendor="IMG">
@@ -4063,6 +4065,30 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>             <name>num_entries</name></param>
             <param><type>VAImageFormat</type>*      <name>va_api_formats</name></param>
             <param><type>cl_uint</type>*            <name>num_surface_formats</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>              <name>clEnqueueReadHostPipeINTEL</name></proto>
+            <param><type>cl_command_queue</type>    <name>command_queue</name></param>
+            <param><type>cl_program</type>          <name>program</name></param>
+            <param>const <type>char</type>*         <name>pipe_symbol</name></param>
+            <param><type>cl_bool</type>             <name>blocking_read</name></param>
+            <param><type>void</type>*               <name>ptr</name></param>
+            <param><type>size_t</type>              <name>size</name></param>
+            <param><type>cl_uint</type>             <name>num_events_in_wait_list</name></param>
+            <param>const <type>cl_event</type>*     <name>event_wait_list</name></param>
+            <param><type>cl_event</type>*           <name>event</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>              <name>clEnqueueWriteHostPipeINTEL</name></proto>
+            <param><type>cl_command_queue</type>    <name>command_queue</name></param>
+            <param><type>cl_program</type>          <name>program</name></param>
+            <param>const <type>char</type>*         <name>pipe_symbol</name></param>
+            <param><type>cl_bool</type>             <name>blocking_write</name></param>
+            <param><type>void</type>*               <name>ptr</name></param>
+            <param><type>size_t</type>              <name>size</name></param>
+            <param><type>cl_uint</type>             <name>num_events_in_wait_list</name></param>
+            <param>const <type>cl_event</type>*     <name>event_wait_list</name></param>
+            <param><type>cl_event</type>*           <name>event</name></param>
         </command>
     </commands>
 
@@ -6942,6 +6968,23 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
                 <enum name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
                 <enum name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
+            </require>
+        </extension>
+        <extension name="cl_intel_program_scope_host_pipe" supported="opencl">
+            <require>
+                <type name="CL/cl.h"/>
+            </require>
+            <require comment="clGetEventInfo response when param_name is CL_EVENT_COMMAND_TYPE">
+                <enum name="CL_COMMAND_READ_HOST_PIPE_INTEL"/>
+                <enum name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"/>
+            </require>
+            <require comment="clGetProgramInfo param_name">
+                <enum name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"/>
+                <enum name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"/>
+            </require>
+            <require>
+                <command name="clEnqueueReadHostPipeINTEL"/>
+                <command name="clEnqueueWriteHostPipeINTEL"/>
             </require>
         </extension>
     </extensions>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4084,7 +4084,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_program</type>          <name>program</name></param>
             <param>const <type>char</type>*         <name>pipe_symbol</name></param>
             <param><type>cl_bool</type>             <name>blocking_write</name></param>
-            <param><type>void</type>*               <name>ptr</name></param>
+            <param>const <type>void</type>*               <name>ptr</name></param>
             <param><type>size_t</type>              <name>size</name></param>
             <param><type>cl_uint</type>             <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*     <name>event_wait_list</name></param>


### PR DESCRIPTION
Test built headers using https://github.com/KhronosGroup/OpenCL-Headers/pull/161