### PR TITLE
Add missing __opencl_c_atomic_scope_device guards

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -7079,7 +7079,8 @@ bool atomic_compare_exchange_strong(
     volatile A *object,
     C *expected, C desired)
 
-// Requires OpenCL C 3.0 or newer.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 bool atomic_compare_exchange_strong_explicit(
     volatile __global A *object,
     __global C *expected,
@@ -7117,8 +7118,9 @@ bool atomic_compare_exchange_strong_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
-// opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and
+// __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_strong_explicit(
     volatile A *object,
     C *expected,
@@ -7208,7 +7210,8 @@ bool atomic_compare_exchange_weak(
     volatile A *object,
     C *expected, C desired)
 
-// Requires OpenCL C 3.0 or newer.
+// Requires OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
+// feature.
 bool atomic_compare_exchange_weak_explicit(
     volatile __global A *object,
     __global C *expected,
@@ -7246,8 +7249,9 @@ bool atomic_compare_exchange_weak_explicit(
     memory_order success,
     memory_order failure)
 
-// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and the
-// opencl_c_generic_address_space feature.
+// Requires OpenCL C 2.0, or OpenCL C 3.0 or newer and both the
+// __opencl_c_generic_address_space and
+// __opencl_c_atomic_scope_device features.
 bool atomic_compare_exchange_weak_explicit(
     volatile A *object,
     C *expected,


### PR DESCRIPTION
The OpenCL 3.0 specification states that:

>   functions that do not have memory_scope argument have the same
>   semantics as the corresponding functions with the memory_scope
>   argument set to memory_scope_device.

and that memory_scope_device requires:

>   [...] OpenCL C 3.0 or newer and the __opencl_c_atomic_scope_device
>   feature.

The fix for issue #357 added the `__opencl_c_atomic_scope_device`
feature macro to most atomic builtin functions that do not take a
scope argument, but not for the scope-less overloads of
atomic_compare_exchange_strong/weak_explicit.