### PR TITLE
Fix typo in cl.xml

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -873,7 +873,7 @@ server's OpenCL/api-docs repository.
             <unused start="6" end="31"/>
     </enums>
 
-    <enums name="cl_kernel_arg_type_qualifer" vendor="Khronos" type="bitmask">
+    <enums name="cl_kernel_arg_type_qualifier" vendor="Khronos" type="bitmask">
         <enum value="0"             name="CL_KERNEL_ARG_TYPE_NONE"/>
         <enum bitpos="0"            name="CL_KERNEL_ARG_TYPE_CONST"/>
         <enum bitpos="1"            name="CL_KERNEL_ARG_TYPE_RESTRICT"/>


### PR DESCRIPTION
The typo was fixed in the header a while ago, still present in the XML file