### PR TITLE
Consistently mark enumerant names

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1438,16 +1438,28 @@ server's OpenCL/api-docs repository.
         <enum value="0x1074"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR"/>
         <enum value="0x1075"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
             <unused start="0x1076" end="0x107F" comment="Reserved for cl_device_info"/>
+    </enums>
+
+    <enums start="0x1080" end="0x1083" name="cl_context_info" vendor="Khronos">
         <enum value="0x1080"        name="CL_CONTEXT_REFERENCE_COUNT"/>
         <enum value="0x1081"        name="CL_CONTEXT_DEVICES"/>
         <enum value="0x1082"        name="CL_CONTEXT_PROPERTIES"/>
         <enum value="0x1083"        name="CL_CONTEXT_NUM_DEVICES"/>
+    </enums>
+
+    <enums start="0x1084" end="0x1085" name="cl_context_properties" vendor="Khronos">
         <enum value="0x1084"        name="CL_CONTEXT_PLATFORM"/>
         <enum value="0x1085"        name="CL_CONTEXT_INTEROP_USER_SYNC"/>
+    </enums>
+
+    <enums start="0x1086" end="0x108F" name="cl_device_partition_property" vendor="Khronos">
         <enum value="0x1086"        name="CL_DEVICE_PARTITION_EQUALLY"/>
         <enum value="0x1087"        name="CL_DEVICE_PARTITION_BY_COUNTS"/>
         <enum value="0x1088"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN"/>
             <unused start="0x1089" end="0x108F" comment="Reserved for cl_device_partition_property"/>
+    </enums>
+
+    <enums start="0x1090" end="0x109F" name="cl_command_queue_info" vendor="Khronos">
         <enum value="0x1090"        name="CL_QUEUE_CONTEXT"/>
         <enum value="0x1091"        name="CL_QUEUE_DEVICE"/>
         <enum value="0x1092"        name="CL_QUEUE_REFERENCE_COUNT"/>
@@ -1458,7 +1470,13 @@ server's OpenCL/api-docs repository.
         <enum value="0x1097"        name="CL_QUEUE_THROTTLE_KHR"/>
         <enum value="0x1098"        name="CL_QUEUE_PROPERTIES_ARRAY"/>
             <unused start="0x1099" end="0x109F" comment="Reserved for cl_command_queue_info"/>
+    </enums>
+
+    <enums start="0x10A0" end="0x10AF" name="enums.10A0" vendor="Khronos">
             <unused start="0x10A0" end="0x10AF" comment="Reserved for core API tokens"/>
+    </enums>
+
+    <enums start="0x10B0" end="0x10CF" name="cl_channel_order" vendor="Khronos">
         <enum value="0x10B0"        name="CL_R"/>
         <enum value="0x10B1"        name="CL_A"/>
         <enum value="0x10B2"        name="CL_RG"/>
@@ -1480,6 +1498,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10C2"        name="CL_sBGRA"/>
         <enum value="0x10C3"        name="CL_ABGR"/>
             <unused start="0x10C4" end="0x10CF" comment="Reserved for cl_channel_order"/>
+    </enums>
+
+    <enums start="0x10D0" end="0x10EF" name="cl_channel_type" vendor="Khronos">
         <enum value="0x10D0"        name="CL_SNORM_INT8"/>
         <enum value="0x10D1"        name="CL_SNORM_INT16"/>
         <enum value="0x10D2"        name="CL_UNORM_INT8"/>
@@ -1498,6 +1519,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10DF"        name="CL_UNORM_INT24"/>
         <enum value="0x10E0"        name="CL_UNORM_INT_101010_2"/>
             <unused start="0x10E1" end="0x10EF" comment="Reserved for cl_channel_type"/>
+    </enums>
+
+    <enums start="0x10F0" end="0x10FF" name="cl_mem_object_type" vendor="Khronos">
         <enum value="0x10F0"        name="CL_MEM_OBJECT_BUFFER"/>
         <enum value="0x10F1"        name="CL_MEM_OBJECT_IMAGE2D"/>
         <enum value="0x10F2"        name="CL_MEM_OBJECT_IMAGE3D"/>
@@ -1507,6 +1531,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10F6"        name="CL_MEM_OBJECT_IMAGE1D_BUFFER"/>
         <enum value="0x10F7"        name="CL_MEM_OBJECT_PIPE"/>
             <unused start="0x10F8" end="0x10FF" comment="Reserved for cl_mem_object_type"/>
+    </enums>
+
+    <enums start="0x1100" end="0x110F" name="cl_mem_info" vendor="Khronos">
         <enum value="0x1100"        name="CL_MEM_TYPE"/>
         <enum value="0x1101"        name="CL_MEM_FLAGS"/>
         <enum value="0x1102"        name="CL_MEM_SIZE"/>
@@ -1519,6 +1546,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x1109"        name="CL_MEM_USES_SVM_POINTER"/>
         <enum value="0x110A"        name="CL_MEM_PROPERTIES"/>
             <unused start="0x110B" end="0x110F" comment="Reserved for cl_mem_info"/>
+    </enums>
+
+    <enums start="0x1110" end="0x111F" name="cl_image_info" vendor="Khronos">
         <enum value="0x1110"        name="CL_IMAGE_FORMAT"/>
         <enum value="0x1111"        name="CL_IMAGE_ELEMENT_SIZE"/>
         <enum value="0x1112"        name="CL_IMAGE_ROW_PITCH"/>
@@ -1531,19 +1561,31 @@ server's OpenCL/api-docs repository.
         <enum value="0x1119"        name="CL_IMAGE_NUM_MIP_LEVELS"/>
         <enum value="0x111A"        name="CL_IMAGE_NUM_SAMPLES"/>
             <unused start="0x111B" end="0x111F" comment="Reserved for cl_image_info"/>
+    </enums>
+
+    <enums start="0x1120" end="0x112F" name="cl_pipe_info" vendor="Khronos">
         <enum value="0x1120"        name="CL_PIPE_PACKET_SIZE"/>
         <enum value="0x1121"        name="CL_PIPE_MAX_PACKETS"/>
         <enum value="0x1122"        name="CL_PIPE_PROPERTIES"/>
             <unused start="0x1123" end="0x112F" comment="Reserved for cl_pipe_info"/>
+    </enums>
+
+    <enums start="0x1130" end="0x113F" name="cl_addressing_mode" vendor="Khronos">
         <enum value="0x1130"        name="CL_ADDRESS_NONE"/>
         <enum value="0x1131"        name="CL_ADDRESS_CLAMP_TO_EDGE"/>
         <enum value="0x1132"        name="CL_ADDRESS_CLAMP"/>
         <enum value="0x1133"        name="CL_ADDRESS_REPEAT"/>
         <enum value="0x1134"        name="CL_ADDRESS_MIRRORED_REPEAT"/>
             <unused start="0x1135" end="0x113F" comment="Reserved for cl_addressing_mode"/>
+    </enums>
+
+    <enums start="0x1140" end="0x114F" name="cl_filter_mode" vendor="Khronos">
         <enum value="0x1140"        name="CL_FILTER_NEAREST"/>
         <enum value="0x1141"        name="CL_FILTER_LINEAR"/>
             <unused start="0x1142" end="0x114F" comment="Reserved for cl_filter_mode"/>
+    </enums>
+
+    <enums start="0x1150" end="0x115F" name="cl_sampler_info" vendor="Khronos">
         <enum value="0x1150"        name="CL_SAMPLER_REFERENCE_COUNT"/>
         <enum value="0x1151"        name="CL_SAMPLER_CONTEXT"/>
         <enum value="0x1152"        name="CL_SAMPLER_NORMALIZED_COORDS"/>
@@ -1557,6 +1599,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x1157"        name="CL_SAMPLER_LOD_MAX_KHR"/>
         <enum value="0x1158"        name="CL_SAMPLER_PROPERTIES"/>
             <unused start="0x1159" end="0x115F" comment="Reserved for cl_sampler_info"/>
+    </enums>
+
+    <enums start="0x1160" end="0x117F" name="cl_program_info" vendor="Khronos">
         <enum value="0x1160"        name="CL_PROGRAM_REFERENCE_COUNT"/>
         <enum value="0x1161"        name="CL_PROGRAM_CONTEXT"/>
         <enum value="0x1162"        name="CL_PROGRAM_NUM_DEVICES"/>
@@ -1571,6 +1616,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x116A"        name="CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT"/>
         <enum value="0x116B"        name="CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT"/>
             <unused start="0x116C" end="0x117F" comment="Reserved for cl_program_info"/>
+    </enums>
+
+    <enums start="0x1180" end="0x118F" name="cl_program_build_info" vendor="Khronos">
             <unused start="0x1180" comment="Reserved for cl_program_build_info"/>
         <enum value="0x1181"        name="CL_PROGRAM_BUILD_STATUS"/>
         <enum value="0x1182"        name="CL_PROGRAM_BUILD_OPTIONS"/>
@@ -1578,45 +1626,72 @@ server's OpenCL/api-docs repository.
         <enum value="0x1184"        name="CL_PROGRAM_BINARY_TYPE"/>
         <enum value="0x1185"        name="CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE"/>
             <unused start="0x1186" end="0x118F" comment="Reserved for cl_program_build_info"/>
+    </enums>
+
+    <enums start="0x1190" end="0x1195" name="cl_kernel_info" vendor="Khronos">
         <enum value="0x1190"        name="CL_KERNEL_FUNCTION_NAME"/>
         <enum value="0x1191"        name="CL_KERNEL_NUM_ARGS"/>
         <enum value="0x1192"        name="CL_KERNEL_REFERENCE_COUNT"/>
         <enum value="0x1193"        name="CL_KERNEL_CONTEXT"/>
         <enum value="0x1194"        name="CL_KERNEL_PROGRAM"/>
         <enum value="0x1195"        name="CL_KERNEL_ATTRIBUTES"/>
+    </enums>
+
+    <enums start="0x1196" end="0x119A" name="cl_kernel_arg_info" vendor="Khronos">
         <enum value="0x1196"        name="CL_KERNEL_ARG_ADDRESS_QUALIFIER"/>
         <enum value="0x1197"        name="CL_KERNEL_ARG_ACCESS_QUALIFIER"/>
         <enum value="0x1198"        name="CL_KERNEL_ARG_TYPE_NAME"/>
         <enum value="0x1199"        name="CL_KERNEL_ARG_TYPE_QUALIFIER"/>
         <enum value="0x119A"        name="CL_KERNEL_ARG_NAME"/>
+    </enums>
+
+    <enums start="0x119B" end="0x119F" name="cl_kernel_arg_address_qualifier" vendor="Khronos">
         <enum value="0x119B"        name="CL_KERNEL_ARG_ADDRESS_GLOBAL"/>
         <enum value="0x119C"        name="CL_KERNEL_ARG_ADDRESS_LOCAL"/>
         <enum value="0x119D"        name="CL_KERNEL_ARG_ADDRESS_CONSTANT"/>
         <enum value="0x119E"        name="CL_KERNEL_ARG_ADDRESS_PRIVATE"/>
             <unused start="0x119F" comment="Reserved for cl_kernel_arg_address_qualifier"/>
+    </enums>
+
+    <enums start="0x11A0" end="0x11AF" name="cl_kernel_arg_access_qualifier" vendor="Khronos">
         <enum value="0x11A0"        name="CL_KERNEL_ARG_ACCESS_READ_ONLY"/>
         <enum value="0x11A1"        name="CL_KERNEL_ARG_ACCESS_WRITE_ONLY"/>
         <enum value="0x11A2"        name="CL_KERNEL_ARG_ACCESS_READ_WRITE"/>
         <enum value="0x11A3"        name="CL_KERNEL_ARG_ACCESS_NONE"/>
             <unused start="0x11A4" end="0x11AF" comment="Reserved for cl_kernel_arg_access_qualifier"/>
+    </enums>
+
+    <enums start="0x11B0" end="0x11B6" name="cl_kernel_work_group_info" vendor="Khronos">
         <enum value="0x11B0"        name="CL_KERNEL_WORK_GROUP_SIZE"/>
         <enum value="0x11B1"        name="CL_KERNEL_COMPILE_WORK_GROUP_SIZE"/>
         <enum value="0x11B2"        name="CL_KERNEL_LOCAL_MEM_SIZE"/>
         <enum value="0x11B3"        name="CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE"/>
         <enum value="0x11B4"        name="CL_KERNEL_PRIVATE_MEM_SIZE"/>
         <enum value="0x11B5"        name="CL_KERNEL_GLOBAL_WORK_SIZE"/>
+    </enums>
+
+    <enums start="0x11B6" end="0x11B7" name="cl_kernel_exec_info " vendor="Khronos">
         <enum value="0x11B6"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS"/>
         <enum value="0x11B7"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM"/>
+    </enums>
+
+    <enums start="0x11B8" end="0x11CF" name="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x11B8"        name="CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT"/>
         <enum value="0x11B9"        name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
         <enum value="0x11BA"        name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
             <unused start="0x11BB" end="0x11CF" comment="Reserved for cl_kernel_info / cl_kernel_work_group_info / cl_kernel_exec_info / cl_kernel_sub_group_info"/>
+    </enums>
+
+    <enums start="0x11D0" end="0x11EF" name="cl_event_info" vendor="Khronos">
         <enum value="0x11D0"        name="CL_EVENT_COMMAND_QUEUE"/>
         <enum value="0x11D1"        name="CL_EVENT_COMMAND_TYPE"/>
         <enum value="0x11D2"        name="CL_EVENT_REFERENCE_COUNT"/>
         <enum value="0x11D3"        name="CL_EVENT_COMMAND_EXECUTION_STATUS"/>
         <enum value="0x11D4"        name="CL_EVENT_CONTEXT"/>
             <unused start="0x11D5" end="0x11EF" comment="Reserved for cl_event_info"/>
+    </enums>
+
+    <enums start="0x11F0" end="0x121F" name="cl_command_type" vendor="Khronos">
         <enum value="0x11F0"        name="CL_COMMAND_NDRANGE_KERNEL"/>
         <enum value="0x11F1"        name="CL_COMMAND_TASK"/>
         <enum value="0x11F2"        name="CL_COMMAND_NATIVE_KERNEL"/>
@@ -1648,33 +1723,57 @@ server's OpenCL/api-docs repository.
         <enum value="0x120C"        name="CL_COMMAND_SVM_MAP"/>
         <enum value="0x120D"        name="CL_COMMAND_SVM_UNMAP"/>
         <enum value="0x120E"        name="CL_COMMAND_SVM_MIGRATE_MEM"/>
-            <unused start="0x120F" end="0x121F" comment="Reserved for cl_command_types"/>
+            <unused start="0x120F" end="0x121F" comment="Reserved for cl_command_type"/>
+    </enums>
+
+    <enums start="0x1220" end="0x127F" name="cl_buffer_create_type" vendor="Khronos">
         <enum value="0x1220"        name="CL_BUFFER_CREATE_TYPE_REGION"/>
             <unused start="0x1221" end="0x127F" comment="Reserved for cl_buffer_create_type"/>
+    </enums>
+
+    <enums start="0x1280" end="0x128F" name="cl_profiling_info" vendor="Khronos">
         <enum value="0x1280"        name="CL_PROFILING_COMMAND_QUEUED"/>
         <enum value="0x1281"        name="CL_PROFILING_COMMAND_SUBMIT"/>
         <enum value="0x1282"        name="CL_PROFILING_COMMAND_START"/>
         <enum value="0x1283"        name="CL_PROFILING_COMMAND_END"/>
         <enum value="0x1284"        name="CL_PROFILING_COMMAND_COMPLETE"/>
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
+    </enums>
+
+    <enums start="0x1290" end="0x1292" name="enums.1290" vendor="Khronos">
             <unused start="0x1290" end="0x1291" comment="Reserved for MR179"/>
         <enum value="0x1292"        name="Reserved for PR750"/>
+    </enums>
+
+    <enums start="0x1293" end="0x1293" name="cl_command_buffer_properties_khr" vendor="Khronos">
         <enum value="0x1293"             name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
+    </enums>
+
+    <enums start="0x1294" end="0x12A7" name="cl_command_buffer_info_khr" vendor="Khronos">
         <enum value="0x1294"             name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
         <enum value="0x1295"             name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
         <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
         <enum value="0x1297"             name="CL_COMMAND_BUFFER_STATE_KHR"/>
         <enum value="0x1298"             name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
             <unused start="0x1299" end="0x12A7" comment="Used by future command-buffer extensions"/>
+    </enums>
+
+    <enums start="0x12A8" end="0x12A8" name="cl_command_type" vendor="Khronos">
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
+    </enums>
+
+    <enums start="0x12A9" end="0x12B1" name="cl_device_info" vendor="Khronos">
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
             <unused start="0x12AB" end="0x12B1" comment="Used by future command-buffer extensions"/>
+    </enums>
+
+    <enums start="0x12B2" end="0x1FFF" name="enums.12B2" vendor="Khronos">
             <unused start="0x12B2" end="0x12B6" comment="Reserved for PR750"/>
             <unused start="0x12B7" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
-    <enums start="0x2000" end="0x201F" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">
+    <enums start="0x2000" end="0x2032" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">
         <enum value="0x2000"        name="CL_GL_OBJECT_BUFFER"/>
         <enum value="0x2001"        name="CL_GL_OBJECT_TEXTURE2D"/>
         <enum value="0x2002"        name="CL_GL_OBJECT_TEXTURE3D"/>
@@ -1714,10 +1813,16 @@ server's OpenCL/api-docs repository.
         <enum value="0x2030"        name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
         <enum value="0x2031"        name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
         <enum value="0x2032"        name="CL_CONTEXT_TERMINATE_KHR"/>
+    </enums>
+
+    <enums start="0x2033" end="0x2034" name="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE"/>
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
+    </enums>
+
+    <enums start="0x2035" end="0x201F" name="enums.2035" vendor="Khronos" comment="Reserved for interop with other APIs">
         <enum value="0x2035"        name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
         <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
         <enum value="0x2037"        name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>


### PR DESCRIPTION
Tokens from the main block are marked rather inconsistently - some are separated in their own "enums" elements, but many are not.
This adds some of the missing enums.