### PR TITLE
Fix minor command-buffer extension typo

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -481,7 +481,7 @@ The function
 indexterm:[clCreateCommandBufferKHR]
 [source]
 ----
-cl_command_buffer clCreateCommandBufferKHR(
+cl_command_buffer_khr clCreateCommandBufferKHR(
     cl_uint num_queues,
     const cl_command_queue* queues,
     const cl_command_buffer_properties_khr* properties,


### PR DESCRIPTION
The `cl_command_buffer_khr` return type of `clCreateCommandBufferKHR` is missing the `_khr` suffix in its definition.