### PR TITLE
fix a few minor cosmetic subgroup rotate issues

### DIFF
--- a/ext/cl_khr_subgroup_rotate.asciidoc
+++ b/ext/cl_khr_subgroup_rotate.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2021 The Khronos Group. This work is licensed under a
+// Copyright 2022 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -43,7 +43,7 @@ Stuart Brady, Arm Ltd. +
 
 This extension adds the following built-in function:
 
-[source,c]
+[source,opencl_c]
 ----
 gentype sub_group_rotate(gentype value, int delta)
 gentype sub_group_clustered_rotate(gentype value, int delta, uint clustersize)
@@ -57,7 +57,7 @@ gentype sub_group_clustered_rotate(gentype value, int delta, uint clustersize)
 
 The following preprocessor definitions are added:
 
-[source,c]
+[source,opencl_c]
 ----
 #define cl_khr_subgroup_rotate 1
 ----
@@ -75,7 +75,7 @@ or `half` (if half precision is supported).
 |*Function*
 |*Description*
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_rotate(
     gentype value, int delta)
@@ -89,7 +89,7 @@ the subgroup, otherwise the behavior is undefined.
 The return value is undefined if the work item with subgroup local ID equal to the
 calculated index is inactive.
 
-|[source,c]
+|[source,opencl_c]
 ----
 gentype sub_group_clustered_rotate(
     gentype value, int delta, uint clustersize)

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -249,16 +249,16 @@
 | Hold Votes Among Sub-Groupings of Work Items
 | Extension
 
+| <<cl_khr_subgroup_rotate,cl_khr_subgroup_rotate>>
+| Rotation Among Sub-Groupings of Work Items
+| Extension
+
 | <<cl_khr_subgroup_shuffle,cl_khr_subgroup_shuffle>>
 | General-Purpose Shuffles Among Sub-Groupings of Work Items
 | Extension
 
 | <<cl_khr_subgroup_shuffle_relative,cl_khr_subgroup_shuffle_relative>>
 | Relative Shuffles Among Sub-Groupings of Work Items
-| Extension
-
-| <<cl_khr_subgroup_rotate,cl_khr_subgroup_rotate>>
-| Rotation Among Sub-Groupings of Work Items
 | Extension
 
 | <<cl_khr_suggested_local_work_size,cl_khr_suggested_local_work_size>>


### PR DESCRIPTION
- changes the spec copyright date to 2022
- uses opencl_c source highlighting
- keeps the extension quick reference in alphabetical order