### PR TITLE
clarify clGetEventProfilingInfo error condition

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -9359,6 +9359,9 @@ Otherwise, it returns one of the following errors:
     not set for the command-queue, if the execution status of the command
     identified by _event_ is not {CL_COMPLETE} or if _event_ is a user event
     object.
+    Prior to OpenCL 3.0, implementations may return
+    {CL_PROFILING_INFO_NOT_AVAILABLE} for an event created by
+    {clEnqueueSvmFree}.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
     the <<event-profiling-info-table,Event Profiling Queries>> table and


### PR DESCRIPTION
Fixes #493

Adds a sentence as described in the issue discussion:
> Prior to OpenCL 3.0, implementations may return CL_PROFILING_INFO_NOT_AVAILABLE for an event created by clEnqueueSVMFree.