### PR TITLE
clarify that extended versioning is a core OpenCL 3.0 feature

### DIFF
--- a/ext/cl_khr_extended_versioning.asciidoc
+++ b/ext/cl_khr_extended_versioning.asciidoc
@@ -13,6 +13,10 @@ number for each of the extensions they support and remove the requirement
 for applications to process strings to test for the presence of an extension or
 intermediate language or built-in kernel.
 
+Extended versioning was promoted to a core feature in OpenCL 3.0, however note
+that the query for {CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR} was replaced by the
+query for {CL_DEVICE_OPENCL_C_ALL_VERSIONS}.
+
 === General information
 
 ==== Name Strings

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -75,7 +75,7 @@
 
 | <<cl_khr_extended_versioning,cl_khr_extended_versioning>>
 | Extend versioning of platform, devices, extensions, etc.
-| Extension
+| Core Feature in OpenCL 3.0 (with minor changes)
 
 | <<cl_khr_external_memory,cl_khr_external_memory>>
 | Common Functionality for External Memory Sharing

--- a/ext/to_core_features.asciidoc
+++ b/ext/to_core_features.asciidoc
@@ -59,4 +59,5 @@
 
 === For OpenCL 3.0:
 
+* The API functionality described by *cl_khr_extended_versioning* is now part of the core API feature set, with minor modifications.
 * The built-in functions described by *cl_khr_subgroups* are now supported in OpenCL C 3.0 when the `+__opencl_c_subgroups+` feature is supported.


### PR DESCRIPTION
Fixes #771 

Clarifies that the extended versioning extension is a core OpenCL 3.0 feature, albeit with one minor change.