### PR TITLE
fix cl_khr_extended_async_copies descriptions

### DIFF
--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -104,16 +104,10 @@ This function does not perform any implicit synchronization of source
 data such as using a *barrier* before performing the copy.
 
 The behavior of *async_work_group_copy_2D2D* is undefined if the
-_num_elements_per_line_ or _src_stride_ or _dst_stride_ values cause
-the _src_ or _dst_ addresses to exceed the upper bounds of the address
-space during the copy.
+source or destination addresses exceed the upper bounds of the address space
+during the copy.
 
-The behavior of *async_work_group_copy_2D2D* is undefined if the
-_src_total_line_length_ or _dst_total_line_length_ or _src_offset_
-or _dst_offset_ values cause the _src_ or _dst_ addresses to exceed
-the upper bounds of the address space during the copy.
-
-The behavior of *async_work_group_copy_2D2D* is undefined if the
+The behavior of *async_work_group_copy_2D2D* is also undefined if the
 _src_total_line_length_ or _dst_total_line_length_ values are smaller
 than _num_elements_per_line_, i.e. overlapping of lines is undefined.
 
@@ -195,15 +189,14 @@ This function does not perform any implicit synchronization of source
 data such as using a *barrier* before performing the copy.
 
 The behavior of *async_work_group_copy_3D3D* is undefined if the
-_src_total_size_ or _dst_total_size_ or _src_offset_
-or _dst_offset_ values cause the _src_ or _dst_ addresses to exceed
-the upper bounds of the address space during the copy.
+source or destination addresses exceed the upper bounds of the address space
+during the copy.
 
-The behavior of *async_work_group_copy_3D3D* is undefined if the
+The behavior of *async_work_group_copy_3D3D* is also undefined if the
 _src_total_line_length_ or _dst_total_line_length_ values are smaller
 than _num_elements_per_line_, i.e. overlapping of lines is undefined.
 
-The behavior of *async_work_group_copy_3D3D* is undefined if
+The behavior of *async_work_group_copy_3D3D* is also undefined if
 _src_total_plane_area_ is smaller than (_num_lines_ * _src_total_line_length_),
 or _dst_total_plane_area_ is smaller than (_num_lines_ * _dst_total_line_length_),
 i.e. overlapping of planes is undefined.


### PR DESCRIPTION
Fixes #774 

Changes the descriptions of the cl_khr_extended_async_copies functions to remove the references to removed function arguments.