### PR TITLE
update change log with changes from v3.0.10

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -533,6 +533,7 @@ Changes from *v3.0.10*:
   * Added missing device scope atomic feature guards to several atomic function overloads.
   * Added a possible error condition for {clGetEventProfilingInfo} for pre-OpenCL 3.0 devices.
   * Added several missing error conditions for {clGetKernelSubGroupInfo}.
+  * Clarified the expected return value for the of {CL_IMAGE_ROW_PITCH} and {CL_IMAGE_SLICE_PITCH} queries.
   * Updated descriptions of the extended async copies functions to remove references to nonexistent function arguments.
   * Clarified that the extended versioning extension is a core OpenCL 3.0 feature.
   * Clarified subgroup clustered reduction behavior when the cluster size is not an integer constant or a power of two.

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -526,3 +526,16 @@ Changes from *v3.0.9*:
       ** `cl_khr_extended_async_copies` (final)
       ** `cl_khr_expect_assume`
       ** `cl_khr_command_buffer` (provisional)
+
+Changes from *v3.0.10*:
+
+  * Added a requirement for implementations supporting device-side enqueue to also support program scope global variables.
+  * Added missing device scope atomic feature guards to several atomic function overloads.
+  * Added a possible error condition for {clGetEventProfilingInfo} for pre-OpenCL 3.0 devices.
+  * Added several missing error conditions for {clGetKernelSubGroupInfo}.
+  * Updated descriptions of the extended async copies functions to remove references to nonexistent function arguments.
+  * Clarified that the extended versioning extension is a core OpenCL 3.0 feature.
+  * Clarified subgroup clustered reduction behavior when the cluster size is not an integer constant or a power of two.
+  * Added new extensions:
+      ** `cl_khr_subgroup_rotate`
+      ** `cl_khr_work_group_uniform_arithmetic`


### PR DESCRIPTION
Updates the specification change log with the changes from v3.0.10.

Please note that this change log includes the following PRs, so it should not be merged before they are merged:

* https://github.com/KhronosGroup/OpenCL-Docs/pull/783
* https://github.com/KhronosGroup/OpenCL-Docs/pull/784
* https://github.com/KhronosGroup/OpenCL-Docs/pull/785
* https://github.com/KhronosGroup/OpenCL-Docs/pull/786