### PR TITLE
Fix __remove_address_space documentation code example

### DIFF
--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -600,7 +600,7 @@ void foo(T *par) {
           // address space.
   __private T var2; // error: conflicting address space qualifiers are provided
                     // between types '__private T' and '__global int'.
-  __private __remove_address_space<T>::type var3; // type of var3 is __private int.
+  __private typename __remove_address_space<T>::type var3; // type of var3 is __private int.
 }
 
 void bar() {


### PR DESCRIPTION
Previously code example didn't compile because of missing keyword
'typename'. Keyword is now inserted.