### PR TITLE
Fix incorrect command-buffer error case

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -733,7 +733,8 @@ execution was successfully queued, or one of the errors below:
 * `CL_INVALID_VALUE` if _num_queues_ is > 0 and not the same value as
   _num_queues_ set on _command_buffer_ creation.
 
-* `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not a valid command-queue.
+* `CL_INVALID_COMMAND_QUEUE` if any element of _queues_ is not a valid
+  command-queue.
 
 * `CL_INCOMPATIBLE_COMMAND_QUEUE_KHR` if any element of _queues_ is not
   <<compatible, compatible>>  with the command-queue set on _command_buffer_


### PR DESCRIPTION
`clEnqueueCommandBufferKHR()` in the cl_khr_command_buffer extension currently has an error case defined as

* `CL_INVALID_COMMAND_QUEUE` if *command_queue* is not a valid command-queue.

However there is no parameter named `command_queue` in `clEnqueueCommandBufferKHR()`, only `queues` and `num_queues`. This patch updates the error condition to reflect this and return the error code if any queue in the `queues` list is not a valid command-queue.