### PR TITLE
Error on command-buffer multiple finalization

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -19,6 +19,7 @@ This extension adds the ability to record and replay buffers of OpenCL commands.
 |====
 | *Date*     | *Version* | *Description*
 | 2021-11-10 | 0.9.0     | First assigned version (provisional).
+| 2022-08-24 | 0.9.1     | Specify an error if a command-buffer is finalized multiple times (provisional).
 |====
 
 ==== Dependencies
@@ -40,9 +41,12 @@ Kevin Petit, Arm Ltd. +
 Aharon Abramson, Intel. +
 Ben Ashbaugh, Intel. +
 Boaz Ouriel, Intel. +
+Chris Gearing, Intel. +
 Pekka Jääskeläinen, Tampere University +
+Jan Solanti, Tampere University +
 Nikhil Joshi, NVIDIA +
 James Price, Google +
+Brice Videau, Argonne National Laboratory +
 
 === Overview
 
@@ -660,6 +664,9 @@ successfully. Otherwise, it returns one of the following errors:
 
 * `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
   command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ is not in the
+  <<recording, Recording>> state.
 
 * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
   the OpenCL implementation on the device.


### PR DESCRIPTION
Action issue [816](https://github.com/KhronosGroup/OpenCL-Docs/issues/816) to make it an error for a command-buffer to be finalized multiple times.

Bumped the patch version of the cl_khr_command_buffer extension as this is a behaviour change, and included contributors who I could recall participating in the teleconference discussion but weren't already listed.