### PR TITLE
cl_khr_command_buffer_mutable_dispatch

### DIFF
--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -106,6 +106,8 @@ include::ext/cl_khr_expect_assume.asciidoc[]
 include::ext/cl_khr_subgroup_rotate.asciidoc[]
 include::ext/cl_khr_work_group_uniform_arithmetic.asciidoc[]
 
+include::ext/cl_khr_command_buffer_mutable_dispatch.asciidoc[]
+
 // NOTE: To keep meaningful section numbers, new
 // extension documents should be added above here!
 

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -517,6 +517,7 @@ supported property and its value is not specified in properties, its
 default value will be used. _properties_ can be `NULL` in which case the
 default values for supported command-buffer properties will be used.
 
+[[commandbuffer-properties]]
 .*clCreateCommandBufferKHR* properties
 [cols=",,",options="header",]
 |====
@@ -531,7 +532,7 @@ default values for supported command-buffer properties will be used.
   `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` - Allow multiple instances of the
   command-buffer to be submitted to the device for execution. If set, devices
   must support `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR`.
-  
+
   The default value of this property is `0`.
 |====
 

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -1,0 +1,980 @@
+// Copyright 2018-2022 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_khr_command_buffer_mutable_dispatch]]
+== Command Buffers - Mutable Dispatch (Provisional)
+
+This extension enables users to modify the configuration of kernel execution
+commands between command-buffer enqueues.
+
+=== General Information
+
+==== Name Strings
+
+`cl_khr_command_buffer_mutable_dispatch`
+
+==== Version History
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2022-08-31 | 0.9.0     | First assigned version (provisional).
+|====
+
+==== Dependencies
+
+This extension requires the `cl_khr_command_buffer` extension version 0.9.0.
+
+==== Contributors
+
+Ewan Crawford, Codeplay Software Ltd. +
+Gordon Brown, Codeplay Software Ltd. +
+Kenneth Benzie, Codeplay Software Ltd. +
+Alastair Murray, Codeplay Software Ltd. +
+Jack Frankland, Codeplay Software Ltd. +
+Balaji Calidas, Qualcomm Technologies Inc. +
+Joshua Kelly, Qualcomm Technologies, Inc. +
+Kevin Petit, Arm Ltd. +
+Aharon Abramson, Intel. +
+Ben Ashbaugh, Intel. +
+Boaz Ouriel, Intel. +
+Pekka Jääskeläinen, Tampere University +
+Nikhil Joshi, NVIDIA +
+James Price, Google +
+
+=== Overview
+
+The `cl_khr_command_buffer` extension separates command construction from
+enqueue by providing a mechanism to record a set of commands which can then be
+repeatedly enqueued. However, the commands recorded to the command-buffer are
+immutable between enqueues.
+
+`cl_khr_command_buffer_mutable_dispatch` removes this restriction, in particular,
+this extension allows the configuration of a kernel execution command in a
+command-buffer, called a _mutable-dispatch_, to be modified. This allows inputs
+and outputs to the kernel, as well as work-item sizes and offsets, to change
+without having to re-record the entire command sequence in a new command-buffer.
+
+=== Interactions with Other Extensions
+
+The `cl_command_buffer_structure_type_khr` type has been added to this
+extension for the purpose of allowing expansion of mutable functionality in
+future extensions layered on top of `cl_khr_command_buffer_mutable_dispatch`.
+Any parameter that is a structure containing a `void* next` member *must* have
+a value of `next` that is either `NULL`, or is a pointer to a valid structure
+defined by `cl_khr_command_buffer_mutable_dispatch` or an extension layered on
+top. To be a valid structure in the pointer chain the first member of the
+structure *must* be a `cl_command_buffer_structure_type_khr` identifier for the
+structure being iterated through, and the second member a `void* next` pointer
+to the next structure in the chain.
+
+[NOTE]
+====
+This approach is based on structure pointer chains in Vulkan, for more details
+see the "Valid Usage for Structure Pointer Chains" section of the Vulkan
+specification.
+====
+
+This is designed so that another extension layered on
+`cl_khr_command_buffer_mutable_dispatch` could allow modification of commands
+recorded to a command-buffer other than kernel execution commands. As all
+command recording entry-points return a `cl_mutable_command_khr` handle, and
+aspects like which `cl_mem` object a command uses could also be updated between
+enqueues of the command-buffer.
+
+=== New Types
+
+====  Mutable Command Types
+
+Types for using mutable-commands objects from
+<<mutable-commands, Section 5.X.5>>:
+
+[source,c]
+----
+// Bitfield covering each aspect of a mutable-dispatch which can be updated
+typedef cl_bitfield cl_mutable_dispatch_fields_khr;
+
+// For querying mutable-command objects with clGetMutableCommandInfoKHR
+typedef cl_uint cl_mutable_command_info_khr;
+
+// Identifies the type of a structure to allow structure pointer chains
+typedef cl_uint cl_command_buffer_structure_type_khr;
+----
+
+[[cl_mutable_dispatch_arg_khr]]
+Struct type for setting kernel arguments normally passed using *clSetKernelArg*
+and *clSetKernelArgSVMPointer*:
+
+[source, c]
+----
+typedef struct _cl_mutable_dispatch_arg_khr {
+    cl_uint arg_index;
+    size_t arg_size;
+    const void* arg_value;
+} cl_mutable_dispatch_arg_khr;
+----
+
+[[cl_mutable_dispatch_exec_info_khr]]
+Struct type for setting kernel execution info normally passed using
+*clSetKernelExecInfo*:
+[source, c]
+----
+typedef struct _cl_mutable_dispatch_exec_info_khr {
+    cl_uint param_name;
+    size_t param_value_size;
+    const void* param_value;
+} cl_mutable_dispatch_exec_info_khr;
+----
+
+[NOTE]
+====
+_param_name_ is of type `cl_uint` rather than `cl_kernel_exec_info` so that the
+extension can be implemented on OpenCL 1.2 where the `cl_kernel_exec_info`
+typedef is unavailable.
+====
+
+[[cl_mutable_dispatch_config_khr]]
+Struct type passed to *clUpdateMutableCommandsKHR* for setting the kernel
+configuration of a mutable *clCommandNDRangeKernelKHR* command:
+[source, c]
+----
+typedef struct _cl_mutable_dispatch_config_khr {
+    cl_command_buffer_structure_type_khr type;
+    const void* next;
+    cl_mutable_command_khr command;
+    cl_uint num_args;
+    cl_uint num_svm_args;
+    cl_uint num_exec_infos;
+    cl_uint work_dim;
+    const cl_mutable_dispatch_arg_khr* arg_list;
+    const cl_mutable_dispatch_arg_khr* arg_svm_list;
+    const cl_mutable_dispatch_exec_info_khr* exec_info_list;
+    const size_t* global_work_offset;
+    const size_t* global_work_size;
+    const size_t* local_work_size;
+} cl_mutable_dispatch_config_khr;
+----
+
+_type_ Type of this structure, must be
+`CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR`.
+
+_next_ Is `NULL` or a pointer to an extending structure.
+
+_command_ A mutable-command object returned by *clCommandNDRangeKernelKHR*
+representing a kernel execution as part of a command-buffer.
+
+_num_args_ Is the number of kernel arguments being changed.
+
+_num_svm_args_ Is the number of SVM kernel arguments being changed.
+
+_num_exec_infos_ Is the number of kernel execution info objects to set for
+this dispatch.
+
+_work_dim_ Is the number of dimensions used to specify the global work-items
+and work-items in the work-group. See *clEnqueueNDRangeKernel* for valid usage.
+
+_arg_list_ Is an array describing the new kernel arguments for this enqueue. It
+must contain _num_args_ array elements, each of which encapsulates parameters
+passed to *clSetKernelArg*. See *clSetKernelArg* for usage of
+<<cl_mutable_dispatch_arg_khr, cl_mutable_dispatch_arg_khr>> members.
+
+_arg_svm_list_ is an array describing the new SVM kernel arguments for this
+enqueue. It must contain _num_svm_args_ array elements, each of which
+encapsulates parameters passed to *clSetKernelArgSVMPointer*. See
+*clSetKernelArgSVMPointer* for usage of
+<<cl_mutable_dispatch_arg_khr, cl_mutable_dispatch_arg_khr>> members,
+`arg_size` is ignored.
+
+_exec_info_list_ Is an array containing _num_exec_infos_ elements
+specifying the list of execution info objects use for this command-buffer
+enqueue. See *clSetKernelExecInfo* for usage of
+<<cl_mutable_dispatch_exec_info_khr, cl_mutable_dispatch_exec_info_khr>>
+members.
+
+_global_work_offset_ Can be used to specify an array of _work_dim_ unsigned
+values that describe the offset used to calculate the global ID of a work-item.
+If _global_work_offset_ is `NULL` then the global offset of the dispatch is not
+changed. See *clEnqueueNDRangeKernel* for valid usage.
+
+_global_work_size_ Points to an array of _work_dim_ unsigned values that
+describe the number of global work-items in _work_dim_ dimensions that will
+execute the kernel function. If _global_work_size_ is `NULL` then the number of
+global work-items in the dispatch is not changed. See *clEnqueueNDRangeKernel*
+for valid usage.
+
+_local_work_size_ Points to an array of _work_dim_ unsigned values that
+describe the number of work-items that make up a work-group that will execute
+the kernel. If _local_work_size_ is `NULL` then the number of local work-items
+in the dispatch is not changed. See *clEnqueueNDRangeKernel* for valid usage.
+
+[[cl_mutable_base_config_khr]]
+[source,c]
+----
+typedef struct _cl_mutable_base_config_khr {
+    cl_command_buffer_structure_type_khr type,
+    const void* next,
+    cl_uint num_mutable_dispatch,
+    const cl_mutable_dispatch_config_khr* mutable_dispatch_list
+} cl_mutable_base_config_khr;
+----
+
+_type_ Type of this structure, must be
+`CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR`
+
+_next_ Is `NULL` or a pointer to an extending structure.
+
+_num_mutable_dispatch_ Is the number of mutable-dispatch objects to configure
+in this enqueue of the command-buffer.
+
+_mutable_dispatch_list_ Is an array containing _num_mutable_dispatch_ elements
+describing the configurations of mutable kernel execution commands in the
+command-buffer. For a description of struct members making up each array
+element see <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>>.
+
+=== New API Functions
+
+Mutable-handle entry points from <<mutable-commands, Section 5.X.5>>:
+[source,c]
+----
+cl_int clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer,
+    const cl_mutable_base_config_khr* mutable_config);
+
+cl_int clGetMutableCommandInfoKHR(
+    cl_mutable_command_khr command,
+    cl_mutable_command_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+----
+
+=== New API Enums
+
+Enums for working with mutable-command objects from
+<<mutable-commands, Section 5.X.5>>:
+
+[source,c]
+----
+// Error code
+CL_INVALID_MUTABLE_COMMAND_KHR                     -1141
+
+// Accepted values for the param_name parameter to clGetDeviceInfo
+CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR        0x12B0
+
+// Property to cl_ndrange_kernel_command_properties_khr
+CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR           0x12B1
+
+// Bits for cl_mutable_dispatch_fields_khr bitfield
+CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR              (0x1 << 0)
+CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR                (0x1 << 1)
+CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR                 (0x1 << 2)
+CL_MUTABLE_DISPATCH_ARGUMENTS_KHR                  (0x1 << 3)
+CL_MUTABLE_DISPATCH_EXEC_INFO_KHR                  (0x1 << 4)
+
+// cl_mutable_command_info_khr
+CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR               0x12A0
+CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR              0x12A1
+CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR           0x12A2
+CL_MUTABLE_DISPATCH_KERNEL_KHR                     0x12A3
+CL_MUTABLE_DISPATCH_DIMENSIONS_KHR                 0x12A4
+CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR         0x12A5
+CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR           0x12A6
+CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR            0x12A7
+CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR                0x12AD
+
+// Bits for cl_command_buffer_flags_khr
+CL_COMMAND_BUFFER_MUTABLE_KHR                    (0x1 << 1)
+----
+
+Enum values for `cl_command_buffer_structure_type_khr` allowing the structure
+types used for mutating commands between enqueues to be extended by future
+extensions built on top of `cl_khr_command_buffer_mutable_dispatch`. Based on
+structure pointer chains in Vulkan.
+[source,c]
+----
+CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR          0
+CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR      1
+----
+
+=== Modifications to section 4.2 of the OpenCL API Specification
+
+Add to *Table 5*, _Device Queries_, of section 4.2:
+[[command-dispatch-queries]]
+[cols="1,1,4",options="header"]
+|====
+| cl_device_info
+| Return Type
+| Description
+
+| `CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR`
+| `cl_mutable_dispatch_fields_khr`
+| Describes device mutable-dispatch capabilities, encoded as bits in a bitfield.
+  Supported capabilities are:
+
+  `CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR` Device supports the ability to modify
+  the _global_work_offset_ of kernel execution after command recording.
+
+  `CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR` Device supports the ability to modify
+  the _global_work_size_ of kernel execution after command recording.
+
+  `CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR` Device supports the ability to modify
+  the _local_work_size_ of kernel execution after command recording.
+
+  `CL_MUTABLE_DISPATCH_ARGUMENTS_KHR` Device supports the ability to modify
+  arguments set on a kernel after command recording.
+
+  `CL_MUTABLE_DISPATCH_EXEC_INFO_KHR` Device supports the ability to modify
+  execution information set on a kernel after command recording.
+
+|====
+
+=== Modifications to Section 5.X - Command Buffers of the OpenCL API Specification
+
+==== Modifications to clCreateCommandBufferKHR
+
+Modify the `CL_COMMAND_BUFFER_FLAGS_KHR` property in the
+<<commandbuffer-properties, clCreateCommandBufferKHR properties>> table to
+introduce a new flag to the bitfield. The following text is now included in the
+description of property values.
+
+[cols=",,",options="header",]
+|====
+| *Recording Properties*
+| *Property Value*
+| *Description*
+
+| *CL_COMMAND_BUFFER_FLAGS_KHR*
+| `cl_command_buffer_flags_khr`
+| `CL_COMMAND_BUFFER_MUTABLE_KHR` - Enables modification of the
+  command-buffer, by default command-buffers are immutable. If set,
+  commands in the command-buffer may be updated via *clUpdateMutableCommandsKHR*.
+|====
+
+==== Modifications to clCommandNDRangeKernelKHR
+
+===== Properties Parameter
+
+Description of the _properties_ parameter is changed to:
+
+_properties_ Specifies a list of properties for the kernel command and their
+corresponding values. Each property name is immediately followed by the
+corresponding desired value. The list is terminated with 0. If a supported
+property and its value is not specified in _properties_, its default value will
+be used. _properties_ may be `NULL` in which case the default values for
+supported properties will be used. The list of supported properties is described
+in the table below.
+
+.*clCommandNDRangeKernelKHR* properties
+[cols=",,",options="header",]
+|====
+| *Recording Properties*
+| *Property Value*
+| *Description*
+
+| *CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR*
+| `cl_mutable_dispatch_fields_khr`
+| This is a bitfield and can be set to a combination of the following values:
+
+  `CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR`
+  Determines whether the _global_work_offset_ of kernel execution can be
+  modified after recording. If set, the _global_work_offset_ of the kernel
+  execution can be changed with *clUpdateMutableCommandsKHR* using the
+  <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> field
+  of the _mutable_config_ parameter. Otherwise, the _global_work_offset_ cannot
+  be modified.
+
+  `CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR`
+  Determines whether the _global_work_size_ of kernel execution can be
+  modified after recording. If set, the _global_work_size_ of the kernel
+  execution can be changed with *clUpdateMutableCommandsKHR* using the
+  <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> field
+  of the _mutable_config_ parameter. Otherwise, the _global_work_size_ cannot be
+  modified.
+
+  `CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR`
+  Determines whether the _local_work_size_ of kernel execution can be
+  modified after recording. If set, the _local_work_size_ of the kernel
+  execution can be changed with *clUpdateMutableCommandsKHR* using the
+  <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> field
+  of the _mutable_config_ parameter. Otherwise, the _local_work_size_ cannot be
+  modified.
+
+  `CL_MUTABLE_DISPATCH_ARGUMENTS_KHR`
+  Determines whether the kernel arguments set on _kernel_ can be updated
+  between executions. If set, the kernel arguments normally set with
+  *clSetKernelArg* and *clSetKernelArgSVMPointer* can be changed with
+  *clUpdateMutableCommandsKHR* using the
+  <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> field
+  of the _mutable_config_ parameter. Otherwise, the kernel arguments cannot be
+  modified between executions.
+
+  `CL_MUTABLE_DISPATCH_EXEC_INFO_KHR`
+  Determines whether the information passed to _kernel_ can be updated between
+  executions. If set, the execution information of the kernel can be changed
+  with *clUpdateMutableCommandsKHR* using the
+  <<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> field of
+  the _mutable_config_ parameter. Otherwise, the kernel execution information
+  cannot be modified.
+
+  If `CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR` is not specified then it
+  defaults to the value returned by the
+  `CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR` device query.
+|====
+
+===== Mutable Handle Parameter
+
+Description of the _mutable_handle_ parameter is changed to:
+
+_mutable_handle_ Returns a handle to the command that can be used in the
+<<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> struct
+to update the command configuration between recordings, may be `NULL`. The
+lifetime of this handle is tied to the parent command-buffer, such that freeing
+the command-buffer will also free this handle.
+
+===== Additional Errors
+
+The error condition:
+
+* `CL_INVALID_OPERATION` if _mutable_handle_ is not `NULL`.
+
+Is replaced with
+
+* `CL_INVALID_OPERATION` if the requested
+  `CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR` properties are not reported by
+  `CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR` for the device associated with
+  _command_queue_. If _command_queue_ is `NULL`, the device associated with
+  _command_buffer_ must report support for these properties.
+
+[[mutable-commands]]
+==== New Section in the OpenCL API specification 5.X.5 - Mutable Commands:
+
+A generic `cl_mutable_command_khr` handle is called a _mutable-command_ object
+as it can be returned from any command recording entry-point in the
+`cl_khr_command_buffer` family of extensions. The mutable-command handles
+returned by *clCommandNDRangeKernelKHR* in particular are referred to as
+_mutable-dispatch_ objects, and can be modified through the fields of
+<<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>>.
+
+Mutable-command handles are updated between enqueues using entry-point
+*clUpdateMutableCommandsKHR*. To enable performant usage, all aspects of
+mutation are encapsulated inside a single
+<<cl_mutable_base_config_khr,cl_mutable_base_config_khr>> parameter. This means
+that the runtime has access to all the information about how the command-buffer
+will change, allowing the command-buffer to be rebuilt as efficiently as
+possible. Any modifications to the arguments or execution info of a mutable-dispatch
+handle using <<cl_mutable_dispatch_arg_khr, cl_mutable_dispatch_arg_khr>> or
+<<cl_mutable_dispatch_exec_info_khr, cl_mutable_dispatch_exec_info_khr>> have no
+affect on the original kernel object used when the command was recorded, and
+only influence the *clCommandNDRangeKernelKHR* command associated with the
+mutable-dispatch.
+
+To facilitate performant usage for pipelined work flows, where applications
+repeatedly call command-buffer update then enqueue, implementations may defer
+some of the work to allow *clUpdateMutableCommandsKHR* to return immediately.
+Deferring any recompilation until *clEnqueueCommandBufferKHR* avoids blocking
+in host code and keeps device occupancy high. This is only possible with a
+command-buffer created with the `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` flag,
+as without this the enqueued command-buffer must complete before any modification
+occurs.
+
+The function
+indexterm:[clUpdateMutableCommandsKHR]
+[source, c]
+----
+cl_int clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer,
+    const cl_mutable_base_config_khr* mutable_config);
+----
+Modifies the configuration of mutable-command handles returned during
+_command_buffer_ recording, updating the behaviour of those commands in future
+enqueues of _command_buffer_. Using this function when _command_buffer_ is in
+the <<pending, pending>> state and not created with the
+`CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` flag causes undefined behaviour.
+
+[NOTE]
+====
+Performant usage is to call *clUpdateMutableCommandsKHR* only when the desired
+state of all commands is known, rather than iteratively updating each command
+individually.
+====
+
+_command_buffer_ Refers to a valid command-buffer object.
+
+_mutable_config_ Is a pointer to a
+<<cl_mutable_base_config_khr,cl_mutable_base_config_khr>> structure defining
+updates to make to mutable-commands.
+
+*clUpdateMutableCommandsKHR* returns `CL_SUCCESS` if all the mutable-command
+objects were updated successfully. Otherwise, none of the updates to
+mutable-command objects are preserved and one of the errors below is returned:
+
+* `CL_INVALID_COMMAND_BUFFER_KHR` if _command_buffer_ is not a valid
+  command-buffer.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ has not been finalized.
+
+* `CL_INVALID_OPERATION` if _command_buffer_ was not created with the
+  `CL_COMMAND_BUFFER_MUTABLE_KHR` flag.
+
+* `CL_INVALID_VALUE` if the _type_ member of _mutable_config_ is not
+  `CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR`.
+
+* `CL_INVALID_VALUE` if the _mutable_dispatch_list_ member of _mutable_config_
+  is `NULL` and _num_mutable_dispatch_ > 0, or _mutable_dispatch_list_ is not
+  `NULL` and _num_mutable_dispatch_ is 0.
+
+* `CL_INVALID_VALUE` if the _next_ member of _mutable_config_ is not `NULL` and
+  any iteration of the structure pointer chain does not contain valid _type_
+  and _next_ members.
+
+* `CL_INVALID_VALUE` if _mutable_config_ is `NULL`, or if both _next_ and
+  _mutable_dispatch_list_ members of _mutable_config_ are `NULL`.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by
+  the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by
+  the OpenCL implementation on the host.
+
+If the _mutable_dispatch_list_ member of _mutable_config_ is non-`NULL`, then
+errors defined by *clEnqueueNDRangeKernel*, *clSetKernelExecInfo*,
+*clSetKernelArg*, and *clSetKernelArgSVMPointer* are returned by
+*clUpdateMutableCommandsKHR* if any of the array elements are set to an invalid
+value. Additionally, the following errors are returned if any
+<<cl_mutable_dispatch_config_khr, cl_mutable_dispatch_config_khr>> element of
+the array violates the defined conditions:
+
+* `CL_INVALID_MUTABLE_COMMAND_KHR` if _command_ is not a valid mutable
+  command object, or created from _command_buffer_.
+
+* `CL_INVALID_VALUE` if _type_ is not
+  `CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR`.
+
+* `CL_INVALID_OPERATION` if values of _local_work_size_ and/or
+  _global_work_size_ result in an increase to the number of work-groups in the
+  ND-range.
+
+* `CL_INVALID_OPERATION` if the values of _local_work_size_ and/or
+  _global_work_size_ result in a change to work-group uniformity.
+
+* `CL_INVALID_OPERATION` if the _work_dim_ is different from the _work_dim_ set
+  on _command_ recording.
+
+* `CL_INVALID_OPERATION` if the `CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR` property
+  was not set on _command_ recording and _global_work_offset_ is not `NULL`.
+
+* `CL_INVALID_OPERATION` if the `CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR` property
+  was not set on _command_ recording and _global_work_size_ is not `NULL`.
+
+* `CL_INVALID_OPERATION` if the `CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR` property
+  was not set on _command_ recording and _local_work_size_ is not `NULL`.
+
+* `CL_INVALID_OPERATION` if the `CL_MUTABLE_DISPATCH_ARGUMENTS_KHR` property was
+  not set on _command_ recording and _num_args_ or _num_svm_args_ is non-zero.
+
+* `CL_INVALID_OPERATION` if the `CL_MUTABLE_DISPATCH_EXEC_INFO_KHR` property was
+  not set on _command_ recording and _num_exec_infos_ is non-zero.
+
+* `CL_INVALID_VALUE` if _arg_list_ is `NULL` and _num_args_ > 0, or _arg_list_
+  is not `NULL` and _num_args_ is 0.
+
+* `CL_INVALID_VALUE` if _arg_svm_list_ is `NULL` and _num_svm_args_ > 0, or
+  _arg_svm_list_ is not `NULL` and _num_svm_args_ is 0.
+
+* `CL_INVALID_VALUE` if _exec_info_list_ is `NULL` and _num_exec_infos_ > 0, or
+  _exec_info_list_ is not `NULL` and _num_exec_infos_ is 0.
+
+The function
+indexterm:[clGetMutableCommandInfoKHR]
+[source, c]
+----
+cl_int clGetMutableCommandInfoKHR(
+    cl_mutable_command_khr command,
+    cl_mutable_command_info_khr param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret);
+----
+Queries information about the _command_ object.
+
+_command_ Specifies the mutable-command object being queried.
+
+_param_name_ Specifies the information to query. The list of supported
+_param_name_ types and the information returned in _param_value_ by
+*clGetMutableCommandInfoKHR* is described in the
+<<mutable-command-object-queries, Mutable Command Object Queries>> table.
+
+_param_value_size_ Is used to specify the size in bytes of memory pointed to by
+_param_value_. This size must be ≥ size of return type as described in the
+<<mutable-command-object-queries, Mutable Command Object Queries>> table.
+
+_param_value_ Is a pointer to memory where the appropriate result being queried
+is returned. If _param_value_ is `NULL`, it is ignored.
+
+_param_value_size_ret_ Returns the actual size in bytes of data being queried
+by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
+
+[[mutable-command-object-queries]]
+._Mutable Command Object Queries_
+[width="100%",cols="<33%,<17%,<50%",options="header"]
+|====
+| Mutable Command Info
+| Return Type
+| Description
+
+| `CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR`
+| `cl_command_queue`
+| Return the command-queue associated with _command_. If `NULL` was passed as
+  the queue when _command_ was recorded, then the queue associated with the
+  command-buffer that _command_ belongs to is returned.
+
+| `CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR`
+| `cl_command_buffer_khr`
+| Return the command-buffer associated with _command_.
+
+| `CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR`
+| `cl_command_type`
+| Return the command-type associated with _command_.
+
+  The list of supported event command types defined by *clGetEventInfo* is used
+  with the matching command.
+
+| `CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR`
+| `cl_ndrange_kernel_command_properties_khr[]`
+| Return the properties argument specified on _command_ recording with
+  *clCommandNDRangeKernel*.
+
+  If the properties argument specified on creation of _dispatch_ was not
+  `NULL`, the implementation must return the values specified in the
+  properties argument in the same order and without including additional
+  properties.
+
+  If the properties argument specified on creation of _dispatch_ was `NULL`,
+  or _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  there are no properties to be returned.
+
+| `CL_MUTABLE_DISPATCH_KERNEL_KHR`
+| `cl_kernel`
+| Return the kernel associated with _command_ when recorded with
+  *clCommandNDRangeKernel*.
+
+  If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  the value returned in _param_value_ is not valid.
+
+| `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`
+| `cl_uint`
+| Return the number of work-item dimensions specified when _dispatch_ was
+  created.
+
+  If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  the value returned in _param_value_ is not valid.
+
+| `CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR`
+| `size_t[]`
+| Return the global work-item offset set on _dispatch_ creation, or from
+  the most recent update via *clUpdateMutableCommandsKHR* where this value
+  was modified. The output array contains _work_dim_ values, where _work_dim_ is
+  returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`. If a global work-item
+  offset was not set, zero is returned for each element in the array.
+
+  If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  the value returned in _param_value_ is not valid.
+
+| `CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR`
+| `size_t[]`
+| Return the global work-item size set on _dispatch_ creation, or from
+  the most recent update via *clUpdateMutableCommandsKHR* where this value
+  was modified. The output array contains _work_dim_ values, where _work_dim_ is
+  returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`.
+
+  If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  the value returned in _param_value_ is not valid.
+
+| `CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR`
+| `size_t[]`
+| Return the local work-item size set on _dispatch_ creation, or from
+  the most recent update via *clUpdateMutableCommandsKHR* where this value
+  was modified. The output array contains _work_dim_ values, where _work_dim_ is
+  returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`. If a local work-item
+  size was not set, zero is returned for each element in the array.
+
+  If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
+  implementation must return _param_value_size_ret_ equal to 0, indicating that
+  the value returned in _param_value_ is not valid.
+|====
+
+*clGetMutableCommandInfoKHR* returns `CL_SUCCESS` if the function is executed
+successfully. Otherwise, it returns one of the following errors:
+
+* `CL_INVALID_VALUE` if _param_name_ is not valid, or if size in bytes
+  specified by _param_value_size_ is < size of return type as described in the
+  <<mutable-command-object-queries, Mutable Command Object Queries>> table
+  and _param_value_ is not `NULL`.
+
+* `CL_INVALID_MUTABLE_COMMAND_KHR` if _command_ is not a valid mutable
+  command object.
+
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources
+  required by the OpenCL implementation on the device.
+
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources
+  required by the OpenCL implementation on the host.
+
+=== Sample Code
+
+Sample application updating the arguments to a mutable-dispatch between
+command-buffer submissions.
+
+[source]
+----
+  #define CL_CHECK(ERROR)                             \
+    if (ERROR) {                                      \
+      std::cerr << "OpenCL error: " << ERROR << "\n"; \
+      return ERROR;                                   \
+    }
+
+  int main() {
+    cl_platform_id platform;
+    CL_CHECK(clGetPlatformIDs(1, &platform, nullptr));
+    cl_device_id device;
+    CL_CHECK(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, nullptr));
+
+    cl_mutable_dispatch_fields_khr mutable_capabilities;
+    CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR,
+                             sizeof(mutable_capabilities), &mutable_capabilities,
+                             nullptr));
+    if (!(mutable_capabilities & CL_MUTABLE_DISPATCH_ARGUMENTS_KHR)) {
+      std::cerr
+          << "Device does not support update arguments to a mutable-dispatch, "
+             "skipping example.\n";
+      return 0;
+    }
+
+    cl_int error;
+    cl_context context =
+        clCreateContext(nullptr, 1, &device, nullptr, nullptr, &error);
+    CL_CHECK(error);
+
+    const char* code = R"OpenCLC(
+  kernel void vector_addition(global int* tile1, global int* tile2,
+                              global int* res) {
+    size_t index = get_global_id(0);
+    res[index] = tile1[index] + tile2[index];
+  }
+  )OpenCLC";
+    const size_t length = std::strlen(code);
+
+    cl_program program =
+        clCreateProgramWithSource(context, 1, &code, &length, &error);
+    CL_CHECK(error);
+
+    cl_kernel kernel = clCreateKernel(program, "vector_addition", &error);
+    CL_CHECK(error);
+
+    // Set the parameters of the frames
+    constexpr size_t iterations = 60;
+    constexpr size_t elem_size = sizeof(cl_int);
+    constexpr size_t frame_width = 32;
+    constexpr size_t frame_count = frame_width * frame_width;
+    constexpr size_t frame_size = frame_count * elem_size;
+
+    cl_mem input_A_buffers[2] = {nullptr, nullptr};
+    cl_mem input_B_buffers[2] = {nullptr, nullptr};
+    cl_mem output_buffers[2] = {nullptr, nullptr};
+
+    // Create the buffer to swap between even and odd kernel iterations
+    for (size_t i = 0; i < 2; i++) {
+      input_A_buffers[i] =
+          clCreateBuffer(context, CL_MEM_READ_ONLY, frame_size, nullptr, &error);
+      CL_CHECK(error);
+
+      input_B_buffers[i] =
+          clCreateBuffer(context, CL_MEM_READ_ONLY, frame_size, nullptr, &error);
+      CL_CHECK(error);
+
+      output_buffers[i] =
+          clCreateBuffer(context, CL_MEM_WRITE_ONLY, frame_size, nullptr, &error);
+      CL_CHECK(error);
+    }
+
+    cl_command_queue command_queue =
+        clCreateCommandQueue(context, device, 0, &error);
+    CL_CHECK(error);
+
+    // Create command-buffer with mutable flag so we can update it
+    cl_command_buffer_properties_khr properties[3] = {
+        CL_COMMAND_BUFFER_FLAGS_KHR, CL_COMMAND_BUFFER_MUTABLE_KHR, 0};
+    cl_command_buffer_khr command_buffer =
+        clCreateCommandBufferKHR(1, &command_queue, properties, &error);
+    CL_CHECK(error);
+
+    CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &input_A_buffers[0]));
+    CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &input_B_buffers[0]));
+    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &output_buffers[0]));
+
+    // Instruct the nd-range command to allow for mutable kernel arguments
+    cl_ndrange_kernel_command_properties_khr mutable_properties[] = {
+        CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
+        CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0};
+
+    // Create command handle for mutating nd-range command
+    cl_mutable_command_khr command_handle = nullptr;
+
+    // Add the nd-range kernel command
+    error = clCommandNDRangeKernelKHR(
+        command_buffer, command_queue, mutable_properties, kernel, 1, nullptr,
+        &frame_count, nullptr, 0, nullptr, nullptr, &command_handle);
+    CL_CHECK(error);
+
+    CL_CHECK(clFinalizeCommandBufferKHR(command_buffer));
+
+    // Prepare for random input generation
+    std::random_device random_device;
+    std::mt19937 random_engine{random_device()};
+    std::uniform_int_distribution<cl_int> random_distribution{
+        std::numeric_limits<cl_int>::min() / 2,
+        std::numeric_limits<cl_int>::max() / 2};
+
+    // Iterate over each frame
+    for (size_t i = 0; i < iterations; i++) {
+      // Set the buffers for the current frame
+      cl_mem input_A_buffer = input_A_buffers[i % 2];
+      cl_mem input_B_buffer = input_B_buffers[i % 2];
+      cl_mem output_buffer = output_buffers[i % 2];
+
+      // Generate input A data
+      std::vector<cl_int> input_a(frame_count);
+      std::generate(std::begin(input_a), std::end(input_a),
+                    [&]() { return random_distribution(random_engine); });
+
+      // Write the generated data to the input A buffer
+      error =
+          clEnqueueWriteBuffer(command_queue, input_A_buffer, CL_FALSE, 0,
+                               frame_size, input_a.data(), 0, nullptr, nullptr);
+      CL_CHECK(error);
+
+      // Generate input B data
+      std::vector<cl_int> input_b(frame_count);
+      std::generate(std::begin(input_b), std::end(input_b),
+                    [&]() { return random_distribution(random_engine); });
+
+      // Write the generated data to the input B buffer
+      error =
+          clEnqueueWriteBuffer(command_queue, input_B_buffer, CL_FALSE, 0,
+                               frame_size, input_b.data(), 0, nullptr, nullptr);
+      CL_CHECK(error);
+
+      // If not executing the first frame
+      if (i != 0) {
+        // Configure the mutable configuration to update the kernel arguments
+        cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem), &input_A_buffer};
+        cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem), &input_B_buffer};
+        cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem), &output_buffer};
+        cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
+        cl_mutable_dispatch_config_khr dispatch_config{
+            CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
+            nullptr,
+            command_handle,
+            3 /* num_args */,
+            0 /* num_svm_arg */,
+            0 /* num_exec_infos */,
+            0 /* work_dim - 0 means no change to dimensions */,
+            args /* arg_list */,
+            nullptr /* arg_svm_list - nullptr means no change*/,
+            nullptr /* exec_info_list */,
+            nullptr /* global_work_offset */,
+            nullptr /* global_work_size */,
+            nullptr /* local_work_size */};
+        cl_mutable_base_config_khr mutable_config{
+            CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
+            &dispatch_config};
+
+        // Update the command buffer with the mutable configuration
+        error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
+        CL_CHECK(error);
+      }
+
+      // Enqueue the command buffer
+      error = clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0, nullptr,
+                                        nullptr);
+      CL_CHECK(error);
+
+      // Allocate memory for the output data
+      std::vector<cl_int> output(frame_count);
+
+      // Read the output data from the output buffer
+      error = clEnqueueReadBuffer(command_queue, output_buffer, CL_TRUE, 0,
+                                  frame_size, output.data(), 0, nullptr, nullptr);
+      CL_CHECK(error);
+
+      // Flush and execute the read buffer
+      error = clFinish(command_queue);
+      CL_CHECK(error);
+
+      // Verify the results of the frame
+      for (size_t i = 0; i < frame_count; ++i) {
+        const cl_int result = input_a[i] + input_b[i];
+        if (output[i] != result) {
+          std::cerr << "Error: Incorrect result at index " << i << " - Expected "
+                    << output[i] << " was " << result << std::endl;
+          std::exit(1);
+        }
+      }
+    }
+
+    std::cout << "Result verified\n";
+
+    CL_CHECK(clReleaseCommandBufferKHR(command_buffer));
+    for (size_t i = 0; i < 2; i++) {
+      CL_CHECK(clReleaseMemObject(input_A_buffers[i]));
+      CL_CHECK(clReleaseMemObject(input_B_buffers[i]));
+      CL_CHECK(clReleaseMemObject(output_buffers[i]));
+    }
+    CL_CHECK(clReleaseCommandQueue(command_queue));
+    CL_CHECK(clReleaseKernel(kernel));
+    CL_CHECK(clReleaseProgram(program));
+    CL_CHECK(clReleaseContext(context));
+    CL_CHECK(clReleaseDevice(device));
+    return 0;
+  }
+----
+
+=== Issues
+
+. Include simpler, more user friendly, entry-points for updating kernel
+  arguments?
++
+--
+*RESOLVED*: Can be implemented in the ecosystem as a layer on top, if
+that layer proves popular then can be introduced, possibly as another
+extension on top.
+--
+
+. Add a command-buffer clone entry-point for deep copying a command-buffer?
+  Arguments could then be updated and both command-buffers used. Useful for
+  techniques like double buffering.
++
+--
+*Resolved*: In the use-case we're targeting a user would only have a handle to
+the original command-buffer, but not the clone, which may limit the usefulness
+of this capability. Additionally, an implementation could be complicated by
+non-trivial deep copying of the underlying objects contained in the
+command-buffer. As a result of this new entry-point being an additive change to
+the specification it is omitted, and if its functionality has demand later, it
+may be a introduced as a stand alone extension.
+--
+
+. Introduce a `CL_MUTABLE_DISPATCH_ADDITIONAL_WORK_GROUPS_KHR` capability to
+  allow the number of work-groups in kernel execution to be increased during
+  update.
++
+--
+*Resolved*: Can be included in the final release of the extension if there is
+implementation coverage.
+--

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -645,12 +645,12 @@ by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
 | Return the properties argument specified on _command_ recording with
   *clCommandNDRangeKernel*.
 
-  If the properties argument specified on creation of _dispatch_ was not
+  If the properties argument specified on creation of _command_ was not
   `NULL`, the implementation must return the values specified in the
   properties argument in the same order and without including additional
   properties.
 
-  If the properties argument specified on creation of _dispatch_ was `NULL`,
+  If the properties argument specified on creation of _command_ was `NULL`,
   or _command_ was not recorded from a *clCommandNDRangeKernel* command, the
   implementation must return _param_value_size_ret_ equal to 0, indicating that
   there are no properties to be returned.
@@ -666,7 +666,7 @@ by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
 
 | `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`
 | `cl_uint`
-| Return the number of work-item dimensions specified when _dispatch_ was
+| Return the number of work-item dimensions specified when _command_ was
   created.
 
   If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
@@ -675,7 +675,7 @@ by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
 
 | `CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR`
 | `size_t[]`
-| Return the global work-item offset set on _dispatch_ creation, or from
+| Return the global work-item offset set on _command_ creation, or from
   the most recent update via *clUpdateMutableCommandsKHR* where this value
   was modified. The output array contains _work_dim_ values, where _work_dim_ is
   returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`. If a global work-item
@@ -687,10 +687,12 @@ by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
 
 | `CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR`
 | `size_t[]`
-| Return the global work-item size set on _dispatch_ creation, or from
+| Return the global work-item size set on _command_ creation, or from
   the most recent update via *clUpdateMutableCommandsKHR* where this value
   was modified. The output array contains _work_dim_ values, where _work_dim_ is
   returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`.
+  If a global work-item size was not set, zero is returned for each element in
+  the array.
 
   If _command_ was not recorded from a *clCommandNDRangeKernel* command, the
   implementation must return _param_value_size_ret_ equal to 0, indicating that
@@ -698,7 +700,7 @@ by _param_name_. If _param_value_size_ret_ is `NULL`, it is ignored.
 
 | `CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR`
 | `size_t[]`
-| Return the local work-item size set on _dispatch_ creation, or from
+| Return the local work-item size set on _command_ creation, or from
   the most recent update via *clUpdateMutableCommandsKHR* where this value
   was modified. The output array contains _work_dim_ values, where _work_dim_ is
   returned by the query `CL_MUTABLE_DISPATCH_DIMENSIONS_KHR`. If a local work-item

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -29,6 +29,10 @@
 | Record and Replay Commands
 | Provisional Extension
 
+| <<cl_khr_command_buffer_mutable_dispatch,cl_khr_command_buffer_mutable_dispatch>>
+| Modify kernel execution commands between enqueues of a command-buffer
+| Provisional Extension
+
 | <<cl_khr_create_command_queue,cl_khr_create_command_queue>>
 | API to Create Command Queues with Properties
 | Core Feature in OpenCL 2.0

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -243,6 +243,9 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_flags_khr</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
         <type category="define">typedef struct _cl_mutable_command_khr* <name>cl_mutable_command_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>       <name>cl_mutable_dispatch_fields_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_mutable_command_info_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_structure_type_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_fp_atomic_capabilities_ext</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_image_requirements_info_ext</name>;</type>
 
@@ -333,6 +336,38 @@ server's OpenCL/api-docs repository.
             <member><type>cl_bool</type><name>accumulating_saturating_signed_accelerated</name></member>
             <member><type>cl_bool</type><name>accumulating_saturating_unsigned_accelerated</name></member>
             <member><type>cl_bool</type><name>accumulating_saturating_mixed_signedness_accelerated</name></member>
+        </type>
+        <type category="struct" name="cl_mutable_dispatch_arg_khr">
+            <member><type>cl_uint</type>          <name>arg_index</name></member>
+            <member><type>size_t</type>           <name>arg_size</name></member>
+            <member>const <type>void</type>*      <name>arg_value</name></member>
+        </type>
+        <type category="struct" name="cl_mutable_dispatch_exec_info_khr">
+            <member><type>cl_uint</type>                <name>param_name</name></member>
+            <member><type>size_t</type>                 <name>param_value_size</name></member>
+            <member>const <type>void</type>*            <name>param_value</name></member>
+        </type>
+        <type category="struct" name="cl_mutable_dispatch_config_khr">
+            <member><type>cl_command_buffer_structure_type_khr</type>      <name>type</name></member>
+            <member>const <type>void</type>*                               <name>next</name></member>
+            <member><type>cl_mutable_command_khr</type>                    <name>command</name></member>
+            <member><type>cl_uint</type>                                   <name>num_args</name></member>
+            <member><type>cl_uint</type>                                   <name>num_svm_args</name></member>
+            <member><type>cl_uint</type>                                   <name>num_exec_infos</name></member>
+            <member><type>cl_uint</type>                                   <name>work_dim</name></member>
+            <member>const <type>cl_mutable_dispatch_arg_khr</type>*        <name>arg_list</name></member>
+            <member>const <type>cl_mutable_dispatch_arg_khr</type>*        <name>arg_svm_list</name></member>
+            <member>const <type>cl_mutable_dispatch_exec_info_khr</type>*  <name>exec_info_list</name></member>
+            <member>const <type>size_t</type>*                             <name>global_work_offset</name></member>
+            <member>const <type>size_t</type>*                             <name>global_work_size</name></member>
+            <member>const <type>size_t</type>*                             <name>local_work_size</name></member>
+        </type>
+
+        <type category="struct" name="cl_mutable_base_config_khr">
+            <member><type>cl_command_buffer_structure_type_khr</type>    <name>type</name></member>
+            <member>const <type>void</type>*                             <name>next</name></member>
+            <member><type>cl_uint</type>                                 <name>num_mutable_dispatch</name></member>
+            <member>const <type>cl_mutable_dispatch_config_khr</type>*   <name>mutable_dispatch_list</name></member>
         </type>
     </types>
 
@@ -640,7 +675,7 @@ server's OpenCL/api-docs repository.
         <enum value="-1138"         name="CL_INVALID_COMMAND_BUFFER_KHR"/>
         <enum value="-1139"         name="CL_INVALID_SYNC_POINT_WAIT_LIST_KHR"/>
         <enum value="-1140"         name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
-            <unused start="-1141" end="-1141" comment="Used by future command-buffer extensions"/>
+        <enum value="-1141"         name="CL_INVALID_MUTABLE_COMMAND_KHR"/>
     </enums>
 
     <enums start="-1142" end="-1142" name="ErrorCodes.1142" vendor="Khronos" comment="For cl_khr_semaphore">
@@ -1253,14 +1288,15 @@ server's OpenCL/api-docs repository.
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
         <enum bitpos="3"            name="CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR"/>
-            <unused start="4" end="6" comment="Used by future command-buffer extensions"/>
+            <unused start="4" end="5" comment="Used by future command-buffer extensions"/>
             <unused start="6" end="31"/>
     </enums>
 
     <enums name="cl_command_buffer_flags_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
-            <unused start="1" end="2" comment="Used by future command-buffer extensions"/>
-            <unused start="2" end="31"/>
+        <enum bitpos="1"            name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
+        <unused start="2" end="2" comment="Used by future command-buffer extensions"/>
+            <unused start="3" end="31"/>
     </enums>
 
     <enums name="cl_command_buffer_state_khr" vendor="Khronos">
@@ -1268,6 +1304,20 @@ server's OpenCL/api-docs repository.
         <enum value="1"            name="CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR"/>
         <enum value="2"            name="CL_COMMAND_BUFFER_STATE_PENDING_KHR"/>
         <enum value="3"            name="CL_COMMAND_BUFFER_STATE_INVALID_KHR"/>
+    </enums>
+    <enums name="cl_mutable_dispatch_fields_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR"/>
+        <enum bitpos="1"            name="CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR"/>
+        <enum bitpos="2"            name="CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR"/>
+        <enum bitpos="3"            name="CL_MUTABLE_DISPATCH_ARGUMENTS_KHR"/>
+        <enum bitpos="4"            name="CL_MUTABLE_DISPATCH_EXEC_INFO_KHR"/>
+            <unused start="5" end="31"/>
+    </enums>
+
+    <enums name="cl_command_buffer_structure_type_khr" vendor="Khronos">
+        <enum value="0"             name="CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR"/>
+        <enum value="1"             name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
+            <unused start="2" end="2" comment="Used by future command-buffer extensions"/>
     </enums>
 
     <enums name="cl_device_fp_atomic_capabilities_ext" vendor="EXT" type="bitmask">
@@ -1668,11 +1718,24 @@ server's OpenCL/api-docs repository.
         <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
         <enum value="0x1297"             name="CL_COMMAND_BUFFER_STATE_KHR"/>
         <enum value="0x1298"             name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
-            <unused start="0x1299" end="0x12A7" comment="Used by future command-buffer extensions"/>
+            <unused start="0x1299" comment="Reserved for MR199"/>
+            <unused start="0x129A" end="0x129F" comment="Available to use"/>
+        <enum value="0x12A0"             name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
+        <enum value="0x12A1"             name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
+        <enum value="0x12A2"             name="CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR"/>
+        <enum value="0x12A3"             name="CL_MUTABLE_DISPATCH_KERNEL_KHR"/>
+        <enum value="0x12A4"             name="CL_MUTABLE_DISPATCH_DIMENSIONS_KHR"/>
+        <enum value="0x12A5"             name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR"/>
+        <enum value="0x12A6"             name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR"/>
+        <enum value="0x12A7"             name="CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR"/>
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
-            <unused start="0x12AB" end="0x12B1" comment="Used by future command-buffer extensions"/>
+            <unused start="0x12AB" end="0x12AC" comment="Used by future command-buffer extensions"/>
+        <enum value="0x12AD"             name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
+            <unused start="0x12AE" end="0x12AF" comment="Used by future command-buffer extensions"/>
+        <enum value="0x12B0"             name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
+        <enum value="0x12B1"             name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
         <enum value="0x12B2"        name="CL_IMAGE_REQUIREMENTS_SIZE_EXT"/>
         <enum value="0x12B3"        name="CL_IMAGE_REQUIREMENTS_MAX_WIDTH_EXT"/>
         <enum value="0x12B4"        name="CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT"/>
@@ -3092,7 +3155,19 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                      <name>param_value</name></param>
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
-
+        <command>
+            <proto><type>cl_int</type>                             <name>clUpdateMutableCommandsKHR</name></proto>
+            <param><type>cl_command_buffer_khr</type>              <name>command_buffer</name></param>
+            <param>const <type>cl_mutable_base_config_khr</type>*  <name>mutable_config</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                       <name>clGetMutableCommandInfoKHR</name></proto>
+            <param><type>cl_mutable_command_khr</type>       <name>command</name></param>
+            <param><type>cl_mutable_command_info_khr</type>  <name>param_name</name></param>
+            <param><type>size_t</type>                       <name>param_value_size</name></param>
+            <param><type>void</type>*                        <name>param_value</name></param>
+            <param><type>size_t</type>*                      <name>param_value_size_ret</name></param>
+        </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                     <name>clSetContentSizeBufferPoCL</name></proto>
             <param><type>cl_mem</type>                     <name>buffer</name></param>
@@ -7034,6 +7109,62 @@ server's OpenCL/api-docs repository.
         <extension name="cl_intel_queue_no_sync_operations" supported="opencl">
             <require comment="cl_command_queue_properties">
                 <enum name="CL_QUEUE_NO_SYNC_OPERATIONS_INTEL"/>
+            </require>
+        </extension>
+        <extension name="cl_khr_command_buffer_mutable_dispatch" comment="version 0.9.0" supported="opencl">
+            <require>
+                <type name="CL/cl.h"/>
+            </require>
+            <require>
+                <extension name="cl_khr_command_buffer"/>
+            </require>
+            <require>
+                <type name="cl_command_buffer_structure_type_khr"/>
+                <type name="cl_mutable_dispatch_fields_khr"/>
+                <type name="cl_mutable_command_info_khr"/>
+                <type name="cl_mutable_dispatch_arg_khr"/>
+                <type name="cl_mutable_dispatch_exec_info_khr"/>
+                <type name="cl_mutable_dispatch_config_khr"/>
+                <type name="cl_mutable_base_config_khr"/>
+            </require>
+            <require comment="cl_command_buffer_flags_khr - bitfield">
+               <enum name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
+            </require>
+            <require comment="Error codes">
+                <enum name="CL_INVALID_MUTABLE_COMMAND_KHR"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
+            </require>
+            <require comment="cl_ndrange_kernel_command_properties_khr">
+               <enum name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
+            </require>
+
+            <require comment="cl_mutable_dispatch_fields_khr - bitfield">
+                <enum name="CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR"/>
+                <enum name="CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR"/>
+                <enum name="CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR"/>
+                <enum name="CL_MUTABLE_DISPATCH_ARGUMENTS_KHR"/>
+                <enum name="CL_MUTABLE_DISPATCH_EXEC_INFO_KHR"/>
+            </require>
+            <require comment="cl_mutable_command_info_khr">
+               <enum name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
+               <enum name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
+               <enum name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_KERNEL_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_DIMENSIONS_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR"/>
+               <enum name="CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR"/>
+            </require>
+            <require comment="cl_command_buffer_structure_type_khr">
+                <enum name="CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR"/>
+                <enum name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
+            </require>
+            <require>
+                <command name="clUpdateMutableCommandsKHR"/>
+                <command name="clGetMutableCommandInfoKHR"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Add extension spec for provisional extension `cl_khr_command_buffer_mutable_dispatch`, which is layered on top of `cl_khr_command_buffer`.

This extension allows a user to update kernel execution commands recorded to a command-buffer between kernel enqueues.

Added at bottom of `OpenCL_Ext` extension list, rather than next to entry for `cl_khr_command_buffer` to avoid reordering the section numbers of the following extensions.