### PR TITLE
add missing OpenCL 2.1 APIs to reference pages

### DIFF
--- a/man/toctail
+++ b/man/toctail
@@ -50,6 +50,7 @@
                             <li>Buffer Objects
                                 <ul class="Level4">
                                     <li><a href="clCreateBuffer.html" target="pagedisplay">clCreateBuffer</a></li>
+                                    <li><a href="clCreateBuffer.html" target="pagedisplay">clCreateBufferWithProperties</a></li>
                                     <li><a href="clCreateSubBuffer.html" target="pagedisplay">clCreateSubBuffer</a></li>
                                     <li><a href="clEnqueueReadBuffer.html" target="pagedisplay">clEnqueueReadBuffer</a></li>
                                     <li><a href="clEnqueueWriteBuffer.html" target="pagedisplay">clEnqueueWriteBuffer</a></li>
@@ -65,6 +66,7 @@
                             <li>Image Objects
                                 <ul class="Level4">
                                     <li><a href="clCreateImage.html" target="pagedisplay">clCreateImage</a></li>
+                                    <li><a href="clCreateImage.html" target="pagedisplay">clCreateImageWithProperties</a></li>
                                     <li><a href="clEnqueueReadImage.html" target="pagedisplay">clEnqueueReadImage</a></li>
                                     <li><a href="clEnqueueWriteImage.html" target="pagedisplay">clEnqueueWriteImage</a></li>
                                     <li><a href="clEnqueueCopyImage.html" target="pagedisplay">clEnqueueCopyImage</a></li>
@@ -112,6 +114,8 @@
                                     <li><a href="clLinkProgram.html" target="pagedisplay">clLinkProgram</a></li>
                                     <li><a href="clReleaseProgram.html" target="pagedisplay">clReleaseProgram</a></li>
                                     <li><a href="clRetainProgram.html" target="pagedisplay">clRetainProgram</a></li>
+                                    <li><a href="clSetProgramReleaseCallback.html" target="pagedisplay">clSetProgramReleaseCallback</a></li>
+                                    <li><a href="clSetProgramSpecializationConstant.html" target="pagedisplay">clSetProgramSpecializationConstant</a></li>
                                     <li><a href="clUnloadPlatformCompiler.html" target="pagedisplay">clUnloadPlatformCompiler</a></li>
                                 </ul>
                             </li>
@@ -171,7 +175,7 @@
                                 <ul class="Level4">
                                     <li><a href="clFlush.html" target="pagedisplay">clFlush</a></li>
                                     <li><a href="clFinish.html" target="pagedisplay">clFinish</a></li>
-                                                        </ul>
+                                </ul>
                             </li>
 
                             <li>Pipes


### PR DESCRIPTION
fixes #350 

Adds missing OpenCL 2.1 and 3.0 APIs to the reference pages:

* clCreateBufferWithProperties
* clCreateImageWithProperties
* clSetProgramReleaseCallback
* clSetProgramSpecializationConstant

Note that there isn't a specific page for clCreateBufferWithProperties or clCreateImageWithProperties because these APIs are currently described on the pages for clCreateBuffer and clCreateImage.  Is there a better way to do this?