### PR TITLE
add missing type and enum for cl_khr_terminate_context

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -207,6 +207,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_profiling_info</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_sampler_properties</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_kernel_exec_info</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_terminate_capability_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_unified_shared_memory_capabilities_intel</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_mem_properties_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_alloc_flags_intel</name>;</type>
@@ -794,6 +795,11 @@ server's OpenCL/api-docs repository.
         <enum bitpos="29"           name="CL_QUEUE_NO_SYNC_OPERATIONS_INTEL"/>
         <enum bitpos="30"           name="CL_QUEUE_RESERVED_QCOM"/>
         <enum bitpos="31"           name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
+    </enums>
+
+    <enums name="cl_device_terminate_capability_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR"/>
+            <unused start="1" end="31"/>
     </enums>
 
     <enums name="cl_queue_priority_khr" vendor="Khronos" type="bitmask">
@@ -5442,11 +5448,17 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
+            <require>
+                <type name="cl_device_terminate_capability_khr"/>
+            </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
             </require>
             <require comment="cl_context_properties">
                 <enum name="CL_CONTEXT_TERMINATE_KHR"/>
+            </require>
+            <require comment="cl_device_terminate_capability_khr">
+                <enum name="CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR"/>
             </require>
             <require comment="Error codes">
                 <enum name="CL_CONTEXT_TERMINATED_KHR"/>


### PR DESCRIPTION
Fixes #813 (maybe).

This PR adds the missing type and enum value for `cl_device_terminate_capability_khr` and `CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR`:

```c
/***************************************************************
* cl_khr_terminate_context
***************************************************************/
#define cl_khr_terminate_context 1
#define CL_KHR_TERMINATE_CONTEXT_EXTENSION_NAME \
    "cl_khr_terminate_context"

typedef cl_bitfield         cl_device_terminate_capability_khr;

...

/* cl_device_terminate_capability_khr */
#define CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR          (1 << 0)
```

I think this type and enum value makes sense, and this is consistent with the inferred type and enum value in e.g. clinfo, but if any vendor has implemented this extension and used a different type or enum value this would be good to know.