### PR TITLE
add a condition for the cl_ext_image_requirements_info extension

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7114,7 +7114,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueWriteHostPipeINTEL"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_requirements_info" supported="opencl">
+        <extension name="cl_ext_image_requirements_info" condition="defined(CL_VERSION_3_0)" supported="opencl">
             <require comment="Types">
                 <type name="cl_image_requirements_info_ext"/>
             </require>


### PR DESCRIPTION
This PR adds a "condition" to the XML file for the cl_ext_image_requirements_info extension.  This condition is needed because this entire extension requires OpenCL 3.0 and therefore all parts of the extension need to be guarded, including the extension define itself, rather than specific blocks in the extension.

See related discussion here: https://github.com/KhronosGroup/OpenCL-Headers/pull/197#discussion_r853974250

I updated the header generation scripts to use the condition here: https://github.com/KhronosGroup/OpenCL-Headers/pull/161/commits/b1b1518bc2e568294d5e1c0b771877fb41f07a68