### PR TITLE
Ensure cl.xml passes validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.3.3
 
 before_install:
-  - sudo apt-get install -y libpango1.0-dev ghostscript fonts-lyx
+  - sudo apt-get install -y libpango1.0-dev ghostscript fonts-lyx jing
   - gem install asciidoctor -v 2.0.16
   - gem install coderay -v 1.1.1
   - gem install rouge -v 3.19.0
@@ -20,6 +20,7 @@ before_install:
 script:
   - git describe --tags --dirty
   - make -O -j 5 api c env ext cxx4opencl manhtmlpages
+  - make -C xml validate
 
 deploy:
   provider: releases

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -494,7 +494,7 @@ server's OpenCL/api-docs repository.
         <enum value="SIZE_MAX"      name="CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM"/>
     </enums>
 
-    <enums name="Constants.cl_intel_command_queue_families" vendor="Intel" commant="cl_intel_command_queue_families constants, in cl_ext.h">
+    <enums name="Constants.cl_intel_command_queue_families" vendor="Intel" comment="cl_intel_command_queue_families constants, in cl_ext.h">
         <enum value="64"            name="CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL"/>
         <enum value="0"             name="CL_QUEUE_DEFAULT_CAPABILITIES_INTEL"/>
     </enums>
@@ -7144,12 +7144,9 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_JOB_SLOT_ARM"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer_mutable_dispatch" comment="version 0.9.0" supported="opencl">
+        <extension name="cl_khr_command_buffer_mutable_dispatch" requires="cl_khr_command_buffer" comment="version 0.9.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
-            </require>
-            <require>
-                <extension name="cl_khr_command_buffer"/>
             </require>
             <require>
                 <type name="cl_command_buffer_structure_type_khr"/>

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -436,6 +436,7 @@ Extension = element extension {
     attribute type { text } ? ,
     attribute requires { text } ? ,
     attribute requiresCore { text } ? ,
+    attribute condition { text } ? ,
     attribute supported { StringGroup } ? ,
     attribute promotedto { text } ? ,
     attribute deprecatedby { text } ? ,
@@ -445,6 +446,7 @@ Extension = element extension {
     (
         element require {
             attribute api { text } ? ,
+            attribute condition { text } ? ,
             ProfileName ? ,
             ExtensionName ? ,
             FeatureName ? ,
@@ -478,6 +480,7 @@ InterfaceElement =
     Enum |
     element command {
         Name ,
+        attribute requires { text } ? ,
         Comment ?
     }
 


### PR DESCRIPTION
Ensure cl.xml passes validation, and add validation to CI to avoid regressions.

Some issues were fixed by changing cl.xml, some by changing registry.rnc.  I tested that XML changes didn't break anything by ensuring the generated spec doesn't change, and that the re-generated extension headers didn't change.

I tested the CI change by leaving a validation in the XML at first and ensuring that the build failed.

Fixes #830