### PR TITLE
add definition of Valid Object to glossary

### DIFF
--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -799,6 +799,21 @@ Unit of execution ::
     host-thread), kernel-instance, host program, work-item or any other
     executable agent that advances the work associated with a program.
 
+Valid Object ::
+    An OpenCL object is considered valid if it meets all of the following
+    criteria:
++
+--
+  * The object was created by a successful call to an OpenCL API function.
+  * The object has a strictly positive application-owned reference count.
+  * The object has not had its backing memory changed outside of normal
+    usage by the OpenCL implementation (e.g. corrupted by the application, a
+    library it uses, the implementation itself, or any other agent that can
+    access the object's backing memory).
+
+An object is only valid in the platform where it was created.
+--
+
 Work-group ::
     A collection of related _work-items_ that execute on a single _compute
     unit_.


### PR DESCRIPTION
Adds the definition of a "valid object" to the glossary, with the text described in this comment:

https://github.com/KhronosGroup/OpenCL-Docs/issues/482#issuecomment-795685410