### PR TITLE
limit the number of kernel arguments to 255

### DIFF
--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -220,6 +220,8 @@ Device Queries>> table.
       | Max size in bytes of all arguments that can be passed to a kernel.
         The minimum value is 256 bytes for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
+
+        A maximum of 255 arguments can be passed to a kernel.
 | {CL_DEVICE_SINGLE_FP_CONFIG}
   | {cl_device_fp_config_TYPE}
       | Describes single precision floating-point capability of the device.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -659,7 +659,9 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
         The minimum value is 1024 for devices that are not of type
         {CL_DEVICE_TYPE_CUSTOM}.
         For this minimum value, only a maximum of 128 arguments can be
-        passed to a kernel
+        passed to a kernel.
+        For all other values, a maximum of 255 arguments can be passed
+        to a kernel.
 | {CL_DEVICE_MEM_BASE_ADDR_ALIGN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]


### PR DESCRIPTION
This is a partial fix for #805.

Updates the API spec to say that the maximum number of kernel arguments is 255, both for the full and embedded profiles.