### PR TITLE
update OpenCL change log from v3.0.11

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -543,8 +543,10 @@ Changes from *v3.0.10*:
 
 Changes from *v3.0.11*:
 
-  * Added the definition of a valid object.
-  * Clarified comparability and uniqueness of OpenCL object handles.
+  * Added a definition for a valid object and requirements for testing for valid objects.
+  * Added a maximum limit for the number of arguments supported by a kernel.
+  * Clarified requirements for comparability and uniqueness of object handles.
+  * Clarified behavior for invalid device-side enqueue `clk_event_t` handles.
   * Clarified `cl_khr_command_buffer` interactions with other extensions.
   * Specified error behavior when a command buffer is finalized multiple times.
   * Added new extension:

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -543,8 +543,9 @@ Changes from *v3.0.10*:
 
 Changes from *v3.0.11*:
 
-  * Specified error behavior when a command buffer is finalized multiple times.
+  * Added the definition of a valid object.
   * Clarified comparability and uniqueness of OpenCL object handles.
   * Clarified `cl_khr_command_buffer` interactions with other extensions.
+  * Specified error behavior when a command buffer is finalized multiple times.
   * Added new extension:
       ** `cl_khr_command_buffer_mutable_dispatch` (provisional)

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -540,3 +540,11 @@ Changes from *v3.0.10*:
   * Added new extensions:
       ** `cl_khr_subgroup_rotate`
       ** `cl_khr_work_group_uniform_arithmetic`
+
+Changes from *v3.0.11*:
+
+  * Specified error behavior when a command buffer is finalized multiple times.
+  * Clarified comparability and uniqueness of OpenCL object handles.
+  * Clarified `cl_khr_command_buffer` interactions with other extensions.
+  * Added new extension:
+      ** `cl_khr_command_buffer_mutable_dispatch` (provisional)


### PR DESCRIPTION
Update the spec change log with changes from v3.0.11.

I'll leave this as a draft for now in case any additional changes are merged in the next week or so.