### PR TITLE
document implementation requirements for invalid object checking

### DIFF
--- a/api/appendix_f.asciidoc
+++ b/api/appendix_f.asciidoc
@@ -98,7 +98,7 @@ include::{generated}/api/version-notes/CL_INVALID_BUILD_OPTIONS.asciidoc[]
 | {CL_INVALID_COMMAND_QUEUE_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_COMMAND_QUEUE.asciidoc[]
-| Returned when the specified command queue is not a valid command queue.
+| Returned when the specified command queue is not a <<valid-object-definition,valid command queue>>.
 
 | {CL_INVALID_COMPILER_OPTIONS_anchor}
 
@@ -108,12 +108,12 @@ include::{generated}/api/version-notes/CL_INVALID_COMPILER_OPTIONS.asciidoc[]
 | {CL_INVALID_CONTEXT_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_CONTEXT.asciidoc[]
-| Returned when a specified context is not a valid context, or when mixing objects from multiple contexts.
+| Returned when a specified context is not a <<valid-object-definition,valid context>>, or when mixing objects from multiple contexts.
 
 | {CL_INVALID_DEVICE_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_DEVICE.asciidoc[]
-| Returned when a specified device is not valid.
+| Returned when a specified device is not a <<valid-object-definition,valid device>>.
 
 | {CL_INVALID_DEVICE_PARTITION_COUNT_anchor}
 
@@ -133,7 +133,7 @@ include::{generated}/api/version-notes/CL_INVALID_DEVICE_TYPE.asciidoc[]
 | {CL_INVALID_EVENT_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_EVENT.asciidoc[]
-| Returned when a specified event object is not a valid event object.
+| Returned when a specified event object is not a <<valid-object-definition,valid event object>>.
 
 | {CL_INVALID_EVENT_WAIT_LIST_anchor}
 
@@ -179,7 +179,7 @@ include::{generated}/api/version-notes/CL_INVALID_IMAGE_SIZE.asciidoc[]
 | {CL_INVALID_KERNEL_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_KERNEL.asciidoc[]
-| Returned when the specified kernel is not a valid kernel.
+| Returned when the specified kernel is not a <<valid-object-definition,valid kernel object>>.
 
 | {CL_INVALID_KERNEL_ARGS_anchor}
 
@@ -204,7 +204,7 @@ include::{generated}/api/version-notes/CL_INVALID_LINKER_OPTIONS.asciidoc[]
 | {CL_INVALID_MEM_OBJECT_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_MEM_OBJECT.asciidoc[]
-| Returned when a specified memory object is not a valid memory object.
+| Returned when a specified memory object is not a <<valid-object-definition,valid memory object>>.
 
 // This currently defined in cl.h, but it's not a core API error code.
 //| {CL_INVALID_MIP_LEVEL_anchor}
@@ -225,12 +225,12 @@ include::{generated}/api/version-notes/CL_INVALID_PIPE_SIZE.asciidoc[]
 | {CL_INVALID_PLATFORM_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_PLATFORM.asciidoc[]
-| Returned when the specified platform is not a valid platform.
+| Returned when the specified platform is not a <<valid-object-definition,valid platform>>.
 
 | {CL_INVALID_PROGRAM_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_PROGRAM.asciidoc[]
-| Returned when a specified program is not a valid program object.
+| Returned when a specified program is not a <<valid-object-definition,valid program object>>.
 
 | {CL_INVALID_PROGRAM_EXECUTABLE_anchor}
 
@@ -250,7 +250,7 @@ include::{generated}/api/version-notes/CL_INVALID_QUEUE_PROPERTIES.asciidoc[]
 | {CL_INVALID_SAMPLER_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_SAMPLER.asciidoc[]
-| Returned when a specified sampler is not a valid sampler object.
+| Returned when a specified sampler is not a <<valid-object-definition,valid sampler object>>.
 
 | {CL_INVALID_SPEC_ID_anchor}
 

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -799,6 +799,7 @@ Unit of execution ::
     host-thread), kernel-instance, host program, work-item or any other
     executable agent that advances the work associated with a program.
 
+[[valid-object-definition]]
 Valid Object ::
     An OpenCL object is considered valid if it meets all of the following
     criteria:
@@ -812,6 +813,10 @@ Valid Object ::
     access the object's backing memory).
 
 An object is only valid in the platform where it was created.
+
+An OpenCL implementation must check for a `NULL` object to determine if an
+object is valid.  The behavior for all other invalid objects is
+implementation-defined.
 --
 
 Work-group ::


### PR DESCRIPTION
This is a follow-on to PR #834, and a possible fix for #482.

This specifies the implementation requirements to test for invalid objects:

> An OpenCL implementation must check for a `NULL` object to determine if an object is valid.  The behavior for all other invalid objects is implementation-defined.

It also links the error code descriptions to the "valid object" glossary entry, to (hopefully) make it easier to navigate from an invalid object error code in an API description to the error code description then to the valid object definition.

