### PR TITLE
Reserve enum for MR 192

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1365,7 +1365,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x0906"        name="CL_PLATFORM_NUMERIC_VERSION"/>
         <enum value="0x0907"        name="CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR"/>
         <enum value="0x0907"        name="CL_PLATFORM_EXTENSIONS_WITH_VERSION"/>
-            <unused start="0x0908" end="0x091F" comment="Reserved to Khronos"/>
+            <unused start="0x0908" end="0x0908" comment="Reserved for MR 192"/>
+            <unused start="0x0909" end="0x091F" comment="Reserved to Khronos"/>
         <enum value="0x0920"        name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
             <unused start="0x0921" end="0x09FF" comment="Vendor extensions"/>
     </enums>


### PR DESCRIPTION
Reserve platform querying enum `0x0908` for internal MR 192.