### PR TITLE
A couple of fixes to clCreateSemaphoreWithPropertiesKHR

### DIFF
--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -256,7 +256,7 @@ Following new properties are added to the list of possible supported properties 
 | Semaphore Property | Property Value | Description
 | {CL_SEMAPHORE_TYPE_KHR}
   | {cl_semaphore_type_khr_TYPE}
-      | Specifies the type of semaphore to create.
+      | Specifies the type of semaphore to create. This property is always required.
 | {CL_DEVICE_HANDLE_LIST_KHR}
   | {cl_device_id_TYPE}[]
       | Specifies the list of OpenCL devices (terminated with {CL_DEVICE_HANDLE_LIST_END_KHR}) to associate with the semaphore.
@@ -275,7 +275,6 @@ Otherwise, it returns a `NULL` value with one of the following error values retu
 * {CL_INVALID_VALUE}
 ** if _sema_props_ is `NULL`, or
 ** if _sema_props_ do not specify <property, value> pairs for minimum set of properties (i.e. {CL_SEMAPHORE_TYPE_KHR}) required for successful creation of a {cl_semaphore_khr_TYPE}, or
-** if one or more properties and/or their values specified by _sema_props_ are not valid.
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
 


### PR DESCRIPTION
- Remove an error case for CL_INVALID_VALUE. Invalid properties or property values are already covered by CL_INVALID_PROPERTY.
- State clearly that CL_SEMAPHORE_TYPE_KHR must be pass when creating a semaphore in the table describing the property. This was previously just documented in the description for CL_INVALID_VALUE.

Signed-off-by: Kévin Petit <kpet@free.fr>