### PR TITLE
fix a typo in the extension quick reference guide

### DIFF
--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -121,7 +121,7 @@
 | Sync FD External Semaphore Handles
 | Provisional Extension
 
-| <<cl_khr_external_semaphore,cl_khr_external_memory_win32>>
+| <<cl_khr_external_semaphore,cl_khr_external_semaphore_win32>>
 | NT Handle External Semaphore Handles
 | Provisional Extension
 


### PR DESCRIPTION
Fixes a copy-paste typo in the extension quick reference guide.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>