### PR TITLE
Add missing clBuildProgram call to command-buffer extension samples

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -1797,6 +1797,8 @@ Add to Table 37, _Event Command Types_:
         clCreateProgramWithSource(context, 1, &code, &length, &error);
     CL_CHECK(error);
 
+    CL_CHECK(clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr));
+
     cl_kernel kernel = clCreateKernel(program, "vector_addition", &error);
     CL_CHECK(error);
 

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -40,6 +40,7 @@ Aharon Abramson, Intel. +
 Ben Ashbaugh, Intel. +
 Boaz Ouriel, Intel. +
 Pekka Jääskeläinen, Tampere University +
+Jan Solanti, Tampere University +
 Nikhil Joshi, NVIDIA +
 James Price, Google +
 
@@ -775,6 +776,8 @@ command-buffer submissions.
     cl_program program =
         clCreateProgramWithSource(context, 1, &code, &length, &error);
     CL_CHECK(error);
+
+    CL_CHECK(clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr));
 
     cl_kernel kernel = clCreateKernel(program, "vector_addition", &error);
     CL_CHECK(error);


### PR DESCRIPTION
The sample code in the `cl_khr_command_buffer` and `cl_khr_command_buffer_mutable_dispatch` extensions was missing a call to `clBuildProgram` which would be required for the sample to work.

Discovered when looking at some application code @jansol had written.