### PR TITLE
update the Travis config to focal (20.04) and newer rvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 
 language: ruby
 
@@ -6,7 +6,7 @@ git:
   depth: 200
 
 rvm:
-  - 2.3.3
+  - 2.7.1
 
 before_install:
   - sudo apt-get install -y libpango1.0-dev ghostscript fonts-lyx jing


### PR DESCRIPTION
Updates the travis-ci config to unblock CI:

- Switches to Ubuntu 20.04 (Focal Fossa) rather than 16.04 (Xenial Xerus).
- Switches to rvm 2.7.1 rather than 2.3.3.

Builds seem to be working again...