### PR TITLE
update the spec change log with changes from v3.0.12

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -557,6 +557,7 @@ Changes from *v3.0.12*:
   * Fixed the accuracy requirements description for half-precision math functions (those prefixed by `half_`).
   * Clarified that the semaphore type must always be provided when creating a semaphore.
   * Removed an unnecessary and contradictory error condition when creating a semaphore.
+  * Added an issue regarding non-linear image import to the `cl_khr_external_memory` extension.
   * Added missing calls to {clBuildProgram} to the `cl_khr_command_buffer` and `cl_khr_command_buffer_mutable_dispatch` sample code.
   * Fixed a copy-paste error in the extensions quick reference appendix.
   * Fixed typos and improved formatting consistency in the extensions spec.

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -551,3 +551,12 @@ Changes from *v3.0.11*:
   * Specified error behavior when a command buffer is finalized multiple times.
   * Added new extension:
       ** `cl_khr_command_buffer_mutable_dispatch` (provisional)
+
+Changes from *v3.0.12*:
+
+  * Fixed the accuracy requirements description for half-precision math functions (those prefixed by `half_`).
+  * Clarified that the semaphore type must always be provided when creating a semaphore.
+  * Removed an unnecessary and contradictory error condition when creating a semaphore.
+  * Added missing calls to {clBuildProgram} to the `cl_khr_command_buffer` and `cl_khr_command_buffer_mutable_dispatch` sample code.
+  * Fixed a copy-paste error in the extensions quick reference appendix.
+  * Fixed typos and improved formatting consistency in the extensions spec.


### PR DESCRIPTION
This includes all of the spec changes so far.

If we merge any other changes before release they will need to be added to the change log.

Diff: https://github.com/KhronosGroup/OpenCL-Docs/compare/v3.0.12...main