### PR TITLE
clarify a clCreateBuffer with SVM pointer error condition

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -518,8 +518,10 @@ returned in _errcode_ret_:
     once.
   * {CL_INVALID_VALUE} if values specified in _flags_ are not valid as defined
     in the <<memory-flags-table,Memory Flags>> table.
-  * {CL_INVALID_BUFFER_SIZE} if _size_ is 0 or if _size_ is greater than
-    {CL_DEVICE_MAX_MEM_ALLOC_SIZE} for all devices in _context_.
+  * {CL_INVALID_BUFFER_SIZE} if _size_ is 0, or if _size_ is greater than
+    {CL_DEVICE_MAX_MEM_ALLOC_SIZE} for all devices in _context_, or if
+    {CL_MEM_USE_HOST_PTR} is set in _flags_ and _host_ptr_ is a pointer returned by
+    {clSVMAlloc} and _size_ is greater than the size passed to {clSVMAlloc}.
   * {CL_INVALID_HOST_PTR} if _host_ptr_ is `NULL` and {CL_MEM_USE_HOST_PTR} or
     {CL_MEM_COPY_HOST_PTR} are set in _flags_ or if _host_ptr_ is not `NULL`
     but {CL_MEM_COPY_HOST_PTR} or {CL_MEM_USE_HOST_PTR} are not set in _flags_.


### PR DESCRIPTION
Fixes #875.

Clarifies that `CL_INVALID_BUFFER_SIZE` should be returned if `clCreateBuffer` is passed a pointer returned by `clSVMAlloc` as its _host_ptr_ and the size of the buffer exceeds the size of the SVM allocation.