### PR TITLE
update the spec copyright dates to 2023

### DIFF
--- a/copyrights-ccby.txt
+++ b/copyrights-ccby.txt
@@ -1,4 +1,4 @@
-Copyright 2019-2022 The Khronos Group.
+Copyright 2019-2023 The Khronos Group.
 
 Khronos licenses this file to you under the Creative Commons Attribution 4.0 
 International (CC BY 4.0) License (the "License"); you may not use this file 

--- a/copyrights.txt
+++ b/copyrights.txt
@@ -1,4 +1,4 @@
-Copyright 2008-2022 The Khronos Group Inc.
+Copyright 2008-2023 The Khronos Group Inc.
 
 This Specification is protected by copyright laws and contains material proprietary to Khronos.
 Except as described by these terms, it or any components may not be reproduced, republished,


### PR DESCRIPTION
Copyright dates that get included in the specs to 2023.

Note, this doesn't update all of the spec source copyright dates to 2023.  I'll do that in a separate PR.