### PR TITLE
Add definition of cl_icdl extension.

### DIFF
--- a/ext/cl_icdl.asciidoc
+++ b/ext/cl_icdl.asciidoc
@@ -1,0 +1,133 @@
+// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+[[cl_icdl-opencl]]
+== OpenCL ICD Loader Info Queries
+
+[[cl_icdl-overview]]
+=== Overview
+
+This section describes *cl_icdl* loader extension which defines
+a simple mechanism through which an OpenCL installable client
+driver loader (ICD Loader) may report loader specific meta-data
+such as version or vendor.
+
+=== General information
+
+==== Version history
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2023-02-24 | 1.0.0     | First assigned version.
+|====
+
+==== Contributors
+
+Vincent Danjean, Université Grenoble Alpes
+Brice Videau, Argonne National Laboratory
+
+[[cl_icdl-new-procedures-and-functions]]
+=== New Procedures and Functions
+
+An ICD loader needs to implement and expose through
+*clGetExtensionFunctionAddress* and
+*clGetExtensionFunctionAddressForPlatform* this new
+entry point.
+
+[source,opencl]
+----
+cl_int clGetICDLoaderInfoOCLICD(cl_icdl_info  param_name,
+                                size_t        param_value_size,
+                                void         *param_value,
+                                size_t       *param_value_size_ret);
+----
+
+[[cl_icdl-new-api-types]]
+=== New API Types
+
+[source,opencl]
+----
+typedef cl_uint cl_icdl_info;
+----
+
+[[cl_icdl-new-enums]]
+=== New API Enums
+
+Accepted as _param_name_ to the function *clGetICDLoaderInfoOCLICD*:
+
+[source,opencl]
+----
+#define CL_ICDL_OCL_VERSION 1
+#define CL_ICDL_VERSION     2
+#define CL_ICDL_NAME        3
+#define CL_ICDL_VENDOR      4
+----
+
+Note that for backward compatibility reasons, the enum values do not
+follow OpenCL enum values attribution.
+
+[[cl_icdl-documentation]]
+=== OpenCL ICD Loader Info Queries Documentation
+
+==== Querying ICD Loader Info
+
+[open,refpage='clGetICDLoaderInfoOCLICD',desc='Query information about an OpenCL ICD Loader',type='protos']
+Information concerning an OpenCL ICD Loader can be obtained with the function:
+[source,opencl]
+----
+cl_int clGetICDLoaderInfoOCLICD(cl_icdl_info  param_name,
+                                size_t        param_value_size,
+                                void         *param_value,
+                                size_t       *param_value_size_ret);
+----
+
+  * _param_name_ is an enumeration constant that identifies the ICD loader
+    information being queried. It can be one of the following values as
+    specified in the <<loader-queries-table, ICD Loader Queries>> table.
+  * _param_value_size_ specifies the size in bytes of memory pointed to by
+    _param_value_.
+    This size in bytes must be ≥ to the size of return type specified in the
+    <<loader-queries-table, ICD Loader Queries>> table.
+  * _param_value_ is a pointer to memory location where appropriate values for a
+    given _param_name_, as specified in the <<loader-queries-table, ICD Loader Queries
+    Queries>> table, will be returned.
+    If _param_value_ is `NULL`, it is ignored.
+  * _param_value_size_ret_ returns the actual size in bytes of data being
+    queried by _param_name_.
+    If _param_value_size_ret_ is `NULL`, it is ignored.
+
+The information that can be queried using *clGetICDLoaderInfoOCLICD* is specified
+in the <<loader-queries-table, ICD Loader Queries>> table.
+
+[[loader-queries-table]]
+.List of supported param_names by <<clGetICDLoaderInfoOCLICD>>
+[width="100%",cols="<34%,<33%,<33%",options="header"]
+|====
+| ICD Loader Info | Return Type | Description
+| *CL_ICDL_OCL_VERSION* | char[] | OpenCL version supported by the ICD Loader
+| *CL_ICDL_VERSION* | char[] | ICD Loader version string
+| *CL_ICDL_NAME* | char[] | ICD Loader name string
+| *CL_ICDL_VENDOR* | char[] | ICD Loader vendor string
+|====
+
+*clGetICDLoaderInfoOCLICD* returns *CL_SUCCESS* if the function is
+executed successfully.
+Otherwise, it returns one of the following errors.
+
+  * *CL_INVALID_VALUE* if _param_name_ is not one of the supported values or
+    if size in bytes specified by _param_value_size_ is < size of return
+    type as specified in the <<loader-queries-table, ICD Loader Queries>> table,
+    and _param_value_ is not a `NULL` value.
+
+[[cl_icdl-info-queries-souce-code]]
+=== Source Code
+
+The official source for the ICD loader is available on github, at:
+
+https://github.com/KhronosGroup/OpenCL-ICD-Loader
+The official API headers are available on github, at:
+
+https://github.com/KhronosGroup/OpenCL-Headers
+The header file *CL/cl_icdl.h* defines the ICD Loader info queries.

--- a/extensions/cl_loader_info.asciidoc
+++ b/extensions/cl_loader_info.asciidoc
@@ -1,42 +1,69 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2023 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-[[cl_icdl-opencl]]
-== OpenCL ICD Loader Info Queries
+:data-uri:
+:icons: font
+include::../config/attribs.txt[]
+:source-highlighter: coderay
 
-[[cl_icdl-overview]]
-=== Overview
+= cl_loader_info
+:R: pass:q,r[^(R)^]
+Khronos{R} OpenCL Working Group
 
-This section describes *cl_icdl* loader extension which defines
-a simple mechanism through which an OpenCL installable client
-driver loader (ICD Loader) may report loader specific meta-data
-such as version or vendor.
+== Name Strings
 
-=== General information
+`cl_loader_info`
 
-==== Version history
+== Contact
 
-[cols="1,1,3",options="header",]
-|====
-| *Date*     | *Version* | *Description*
-| 2023-02-24 | 1.0.0     | First assigned version.
-|====
+Please see the *Issues* list in the Khronos *OpenCL-Docs* repository: +
+https://github.com/KhronosGroup/OpenCL-Docs
 
-==== Contributors
+****
+The 'Contact' section describes a way for users of the extension to
+report bugs or to suggest clarifications to the specification text.
+It may be a pointer to a 'git' repo, or to a vendors support forum,
+or an email address for the principal extension author.
+****
 
-Vincent Danjean, Université Grenoble Alpes
+== Contributors
+
+// spell-checker: disable
+Vincent Danjean, Université Grenoble Alpes +
 Brice Videau, Argonne National Laboratory
+// spell-checker: enable
 
-[[cl_icdl-new-procedures-and-functions]]
-=== New Procedures and Functions
+== Notice
 
-An ICD loader needs to implement and expose through
-*clGetExtensionFunctionAddress* and
-*clGetExtensionFunctionAddressForPlatform* this new
-entry point.
+Copyright (c) 2023 The Khronos Group Inc.
 
-[source,opencl]
+== Status
+
+Final Draft
+
+== Version
+
+Built On: {docdate} +
+Version: 1.0.0
+
+== Dependencies
+
+This extension is written against the OpenCL Specification
+Version 1.0, Revision 1.
+
+This extension requires OpenCL 1.0.
+
+== Overview
+
+This extension describes the `cl_loader_info` loader extension which
+defines a simple mechanism through which an OpenCL installable client
+driver loader (ICD Loader) may report loader specific meta-data such
+as version or vendor.
+
+== New API Functions
+
+[source,c]
 ----
 cl_int clGetICDLoaderInfoOCLICD(cl_icdl_info  param_name,
                                 size_t        param_value_size,
@@ -44,20 +71,18 @@ cl_int clGetICDLoaderInfoOCLICD(cl_icdl_info  param_name,
                                 size_t       *param_value_size_ret);
 ----
 
-[[cl_icdl-new-api-types]]
-=== New API Types
+== New API Types
 
-[source,opencl]
+[source,c]
 ----
 typedef cl_uint cl_icdl_info;
 ----
 
-[[cl_icdl-new-enums]]
-=== New API Enums
+== New API Enums
 
 Accepted as _param_name_ to the function *clGetICDLoaderInfoOCLICD*:
 
-[source,opencl]
+[source,c]
 ----
 #define CL_ICDL_OCL_VERSION 1
 #define CL_ICDL_VERSION     2
@@ -68,14 +93,11 @@ Accepted as _param_name_ to the function *clGetICDLoaderInfoOCLICD*:
 Note that for backward compatibility reasons, the enum values do not
 follow OpenCL enum values attribution.
 
-[[cl_icdl-documentation]]
-=== OpenCL ICD Loader Info Queries Documentation
-
-==== Querying ICD Loader Info
+== Modifications to the OpenCL API Specification
 
 [open,refpage='clGetICDLoaderInfoOCLICD',desc='Query information about an OpenCL ICD Loader',type='protos']
 Information concerning an OpenCL ICD Loader can be obtained with the function:
-[source,opencl]
+[source,c]
 ----
 cl_int clGetICDLoaderInfoOCLICD(cl_icdl_info  param_name,
                                 size_t        param_value_size,
@@ -121,13 +143,27 @@ Otherwise, it returns one of the following errors.
     type as specified in the <<loader-queries-table, ICD Loader Queries>> table,
     and _param_value_ is not a `NULL` value.
 
-[[cl_icdl-info-queries-souce-code]]
-=== Source Code
 
-The official source for the ICD loader is available on github, at:
+== Conformance tests
 
-https://github.com/KhronosGroup/OpenCL-ICD-Loader
-The official API headers are available on github, at:
+. The new *clGetICDLoaderInfoOCLICD* entrypoint must be called and succeed.
+. The value returned for `CL_ICDL_OCL_VERSION` must repect the OpenCL version
+  string format. 
 
-https://github.com/KhronosGroup/OpenCL-Headers
-The header file *CL/cl_icdl.h* defines the ICD Loader info queries.
+== Issues
+
+. Should this extension be a regular extension?
++
+--
+*RESOLVED*: Yes.  This is a userfacing extension.
+--
+
+== Version History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|====
+| Version | Date       | Author       | Changes
+| 1.0.0   | 2023-03-01 | Brice Videau | *Initial revision*
+|====

--- a/extensions/cl_loader_info.asciidoc
+++ b/extensions/cl_loader_info.asciidoc
@@ -118,7 +118,9 @@ in the <<loader-queries-table, ICD Loader Queries>> table.
 
 [[loader-queries-table]]
 .List of supported param_names by <<clGetICDLoaderInfoOCLICD>>
-[width="100%",cols="<34%,<33%,<33%",options="header"]
+[width="100%"]
+[cols="30,20,80"]
+[options="header"]
 |====
 | ICD Loader Info | Return Type | Description
 | *CL_ICDL_OCL_VERSION* | char[] | OpenCL version supported by the ICD Loader

--- a/extensions/cl_loader_info.asciidoc
+++ b/extensions/cl_loader_info.asciidoc
@@ -20,13 +20,6 @@ Khronos{R} OpenCL Working Group
 Please see the *Issues* list in the Khronos *OpenCL-Docs* repository: +
 https://github.com/KhronosGroup/OpenCL-Docs
 
-****
-The 'Contact' section describes a way for users of the extension to
-report bugs or to suggest clarifications to the specification text.
-It may be a pointer to a 'git' repo, or to a vendors support forum,
-or an email address for the principal extension author.
-****
-
 == Contributors
 
 // spell-checker: disable

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5516,9 +5516,9 @@ server's OpenCL/api-docs repository.
                 <command name="clInitLayer"/>
             </require>
         </extension>
-        <extension name="cl_icdl" supported="opencl">
+        <extension name="cl_loader_info" supported="opencl">
             <require>
-                <type name="CL/cl_icdl.h"/>
+                <type name="CL/cl.h"/>
             </require>
             <require>
                 <type name="cl_icdl_info"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -223,6 +223,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mem_alloc_flags_img</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_layer_info</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_layer_api_version</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_icdl_info</name>;</type>
         <type category="define">typedef struct _cl_icd_dispatch       <name>cl_icd_dispatch</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_scheduling_controls_capabilities_arm</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_controlled_termination_capabilities_arm</name>;</type>
@@ -2212,6 +2213,13 @@ server's OpenCL/api-docs repository.
             <unused start="0x4242" end="0x424F"/>
     </enums>
 
+    <enums name="cl_icdl_info" comment="OpenCL ICD Loader info queries.">
+        <enum value="1"             name="CL_ICDL_OCL_VERSION"/>
+        <enum value="2"             name="CL_ICDL_VERSION"/>
+        <enum value="3"             name="CL_ICDL_NAME"/>
+        <enum value="4"             name="CL_ICDL_VENDOR"/>
+    </enums>
+
     <enums start="0x4250" end="0x425F" name="enums.4250" vendor="Intel">
         <enum value="0x4250"        name="CL_DEVICE_IP_VERSION_INTEL"/>
         <enum value="0x4251"        name="CL_DEVICE_ID_INTEL"/>
@@ -4116,6 +4124,13 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_icd_dispatch</type>**                 <name>layer_dispatch</name></param>
         </command>
         <command>
+            <proto><type>cl_int</type>                                  <name>clGetICDLoaderInfoOCLICD</name></proto>
+            <param><type>cl_icdl_info</type>                            <name>param_name</name></param>
+            <param><type>size_t</type>                                  <name>param_value_size</name></param>
+            <param><type>void</type>*                                   <name>param_value</name></param>
+            <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
+        </command>
+        <command>
             <proto><type>cl_int</type>              <name>clGetSupportedGLTextureFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
@@ -5499,6 +5514,23 @@ server's OpenCL/api-docs repository.
             <require>
                 <command name="clGetLayerInfo"/>
                 <command name="clInitLayer"/>
+            </require>
+        </extension>
+        <extension name="cl_icdl" supported="opencl">
+            <require>
+                <type name="CL/cl_icdl.h"/>
+            </require>
+            <require>
+                <type name="cl_icdl_info"/>
+            </require>
+            <require comment="cl_icdl_info"/>
+                <enum name="CL_ICDL_OCL_VERSION"/>
+                <enum name="CL_ICDL_VERSION"/>
+                <enum name="CL_ICDL_NAME"/>
+                <enum name="CL_ICDL_VENDOR"/>
+            </require>
+            <require>
+                <command name="clGetICDLoaderInfoOCLICD"/>
             </require>
         </extension>
         <extension name="cl_khr_il_program" supported="opencl">


### PR DESCRIPTION
This is the formal definition of the cl_icdl extension that adds info queries to an OpenCL ICD loader.
The PR for the headers is here:
https://github.com/KhronosGroup/OpenCL-Headers/pull/214

Once those two are merged, we can update the loader and remove the temporary definition there.