### PR TITLE
Define cl_khr_fp16 cross/dot error in terms of HALF_EPSILON

### DIFF
--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -285,7 +285,7 @@ devices given as ULP values.
 
 // 3 operations from the 2 multiplications and 1 subtraction per component
 | *OpExtInst* *cross*
-| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
+| absolute error tolerance of 'max * max * (3 * HALF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 
@@ -305,7 +305,7 @@ devices given as ULP values.
 // n + n-1  Number of operations from n multiples and (n-1) additions
 // 2n - 1
 | *OpExtInst* *dot*
-| absolute error tolerance of 'max * max * (2n - 1) * HLF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
+| absolute error tolerance of 'max * max * (2n - 1) * HALF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -1513,7 +1513,7 @@ is the infinitely precise result.
 
 // 3 operations from the 2 multiplications and 1 subtraction per component
 | *cross*
-| absolute error tolerance of 'max * max * (3 * HLF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
+| absolute error tolerance of 'max * max * (3 * HALF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | Implementation-defined
 
 | *degrees*
@@ -1534,7 +1534,7 @@ is the infinitely precise result.
 // n + n-1  Number of operations from n multiples and (n-1) additions
 // 2n - 1
 | *dot*
-| absolute error tolerance of 'max * max * (2n - 1) * HLF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
+| absolute error tolerance of 'max * max * (2n - 1) * HALF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | Implementation-defined
 
 | *erfc*


### PR DESCRIPTION
The error for geometric cl_khr_fp16 builtins `cross` & `dot` is currently defined in terms of `HLF_EPSILON`. However `HLF_EPSILON` isn't defined anywhere, the OpenCL language macro defined by cl_khr_fp16 is `HALF_EPSILON`.