### PR TITLE
fix the name of the cl_khr_image2d_from_buffer extension in the xml file

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5515,7 +5515,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateProgramWithILKHR" comment="No EXT_SUFFIX?"/>
             </require>
         </extension>
-        <extension name="cl_khr_image2D_from_buffer" supported="opencl">
+        <extension name="cl_khr_image2d_from_buffer" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR"/>
                 <enum name="CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR"/>


### PR DESCRIPTION
Found while working on generation for extension headers https://github.com/KhronosGroup/OpenCL-Headers/pull/161: The name of the `cl_khr_image2d_from_buffer` extension is currently incorrect in the XML file, note the capital `D`.