### PR TITLE
Fix clInitLayer parameter name

### DIFF
--- a/ext/cl_loader_layers.asciidoc
+++ b/ext/cl_loader_layers.asciidoc
@@ -44,7 +44,7 @@ cl_int clGetLayerInfo(cl_layer_info  param_name,
 cl_int clInitLayer(cl_uint                 num_entries,
                    const cl_icd_dispatch  *target_dispatch,
                    cl_uint                *num_entries_ret,
-                   const cl_icd_dispatch **layer_dispatch);
+                   const cl_icd_dispatch **layer_dispatch_ret);
 ----
 
 [[cl_loader_layers-new-api-types]]

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4113,7 +4113,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_entries</name></param>
             <param>const <type>cl_icd_dispatch</type>*                  <name>target_dispatch</name></param>
             <param><type>cl_uint</type>*                                <name>num_entries_ret</name></param>
-            <param>const <type>cl_icd_dispatch</type>**                 <name>layer_dispatch</name></param>
+            <param>const <type>cl_icd_dispatch</type>**                 <name>layer_dispatch_ret</name></param>
         </command>
         <command>
             <proto><type>cl_int</type>              <name>clGetSupportedGLTextureFormatsINTEL</name></proto>


### PR DESCRIPTION
This fixes an issue where the `layer_dispatch_ret` parameter of `clInitLayer` was incorrectly named `layer_dispatch` in some part of the specification and in the xml, but not in the Headers. This is a return parameter.