### PR TITLE
more XML fixes for code generation

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5936,7 +5936,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetKernelExecInfoARM"/>
             </require>
         </extension>
-        <extension name="cl_arm_get_core_id" requires="CL_VERSION_1_2" supported="opencl">
+        <extension name="cl_arm_get_core_id" condition="defined(CL_VERSION_1_2)" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2490,7 +2490,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_platform_id</type>*            <name>platforms</name></param>
             <param><type>cl_uint</type>*                   <name>num_platforms</name></param>
         </command>
-        <command>
+        <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_program</type>                 <name>clCreateProgramWithILKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param>const <type>void</type>*                <name>il</name></param>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4163,7 +4163,7 @@ server's OpenCL/api-docs repository.
             <param><type>VAImageFormat</type>*      <name>va_api_formats</name></param>
             <param><type>cl_uint</type>*            <name>num_surface_formats</name></param>
         </command>
-        <command>
+        <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>              <name>clEnqueueReadHostPipeINTEL</name></proto>
             <param><type>cl_command_queue</type>    <name>command_queue</name></param>
             <param><type>cl_program</type>          <name>program</name></param>
@@ -4175,7 +4175,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_event</type>*     <name>event_wait_list</name></param>
             <param><type>cl_event</type>*           <name>event</name></param>
         </command>
-        <command>
+        <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>              <name>clEnqueueWriteHostPipeINTEL</name></proto>
             <param><type>cl_command_queue</type>    <name>command_queue</name></param>
             <param><type>cl_program</type>          <name>program</name></param>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -3000,7 +3000,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_event</type>*                 <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                       <name>event</name></param>
         </command>
-        <command>
+        <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_mem</type>                          <name>clCreateBufferWithPropertiesINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2793,7 +2793,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>cl_GLuint</type>                  <name>bufobj</name></param>
-            <param><type>int</type>*                       <name>errcode_ret</name></param>
+            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_mem</type>                     <name>clCreateFromGLTexture</name></proto>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7202,7 +7202,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetMutableCommandInfoKHR"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_from_buffer" supported="opencl">
+        <extension name="cl_ext_image_from_buffer" condition="defined(CL_VERSION_3_0)" supported="opencl">
             <require comment="cl_image_requirements_info_ext">
                 <enum name="CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT"/>
             </require>


### PR DESCRIPTION
This PR includes a few more XML fixes to support generation of extension headers, see https://github.com/KhronosGroup/OpenCL-Headers/pull/161.