### PR TITLE
Move semaphore sharing error condition to cl_khr_external_semaphore

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -235,6 +235,10 @@ Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
         semaphore does not support any handle types for exporting.
 |====
 
+Add to the list of error conditions for {clEnqueueWaitSemaphoresKHR} and {clEnqueueSignalSemaphoresKHR}:
+
+* {CL_INVALID_COMMAND_QUEUE} if one or more of _sema_objects_ can not be shared with the device associated with _command_queue_.
+
 === Exporting semaphore external handles
 
 To export an external handle from a semaphore, call the function

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -316,8 +316,7 @@ Otherwise, it returns one of the following errors:
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
 ** if the device associated with _command_queue_ is not same as one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_, or
-** if one or more of _sema_objects_ belong to a context that does not contain a device associated with_command_queue_, or
-** if one or more of _sema_objects_ can not be shared with the device associated with _command_queue_.
+** if one or more of _sema_objects_ belong to a context that does not contain a device associated with_command_queue_.
 * {CL_INVALID_VALUE} if _num_sema_objects_ is 0.
 * {CL_INVALID_SEMAPHORE_KHR} if any of the semaphore objects specified by _sema_objects_ is not valid.
 * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and any of the semaphore objects in _sema_objects_ are not the same or if the context associated with _command_queue_ and that associated with events in _event_wait_list_ are not the same.
@@ -368,8 +367,7 @@ Otherwise, it returns one of the following errors:
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
 ** if device associated with _command_queue_ is not same as one of devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_, or
-** if one or more of _sema_objects_ belong to a context that does not contain a device associated _command_queue_, or
-** if one or more of _sema_objects_ can not be shared with device associated with _command_queue_.
+** if one or more of _sema_objects_ belong to a context that does not contain a device associated _command_queue_.
 * {CL_INVALID_VALUE} if _num_sema_objects_ is 0
 * {CL_INVALID_SEMAPHORE_KHR} if any of the semaphore objects specified by _sema_objects_ is not valid.
 * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and any of the semaphore objects in _sema_objects_ are not the same or if the context associated with _command_queue_ and that associated with events in _event_wait_list_ are not the same.


### PR DESCRIPTION
Semaphore sharing is not defined by the cl_khr_semaphore specification.