### PR TITLE
Add command-buffer context query

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -20,6 +20,7 @@ This extension adds the ability to record and replay buffers of OpenCL commands.
 | *Date*     | *Version* | *Description*
 | 2021-11-10 | 0.9.0     | First assigned version (provisional).
 | 2022-08-24 | 0.9.1     | Specify an error if a command-buffer is finalized multiple times (provisional).
+| 2023-03-31 | 0.9.2     | Introduce context query {CL_COMMAND_BUFFER_CONTEXT_KHR} (provisional).
 |====
 
 ==== Dependencies
@@ -422,6 +423,7 @@ CL_COMMAND_BUFFER_NUM_QUEUES_KHR                   0x1295
 CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR              0x1296
 CL_COMMAND_BUFFER_STATE_KHR                        0x1297
 CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR             0x1298
+CL_COMMAND_BUFFER_CONTEXT_KHR                      0x1299
 
 // cl_event command-buffer enqueue command type
 CL_COMMAND_COMMAND_BUFFER_KHR                      0x12A8
@@ -1589,6 +1591,10 @@ _param_value_ by {clGetCommandBufferInfoKHR} is described in the table below.
   _param_value_size_ret_ of 0 (i.e. there is are no properties to be returned),
   or the implementation may return a property value of 0 (where 0 is used to
   terminate the properties list).
+
+| {CL_COMMAND_BUFFER_CONTEXT_KHR}
+| {cl_context_TYPE}
+| Return the context associated with _command_buffer_.
 
 |====
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1728,7 +1728,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
         <enum value="0x1297"             name="CL_COMMAND_BUFFER_STATE_KHR"/>
         <enum value="0x1298"             name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
-            <unused start="0x1299" comment="Reserved for MR199"/>
+        <enum value="0x1299"             name="CL_COMMAND_BUFFER_CONTEXT_KHR"/>
             <unused start="0x129A" end="0x129F" comment="Available to use"/>
         <enum value="0x12A0"             name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
         <enum value="0x12A1"             name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
@@ -7038,7 +7038,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetContentSizeBufferPoCL"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer" comment="in sync with version 0.9.0" supported="opencl">
+        <extension name="cl_khr_command_buffer" comment="in sync with version 0.9.2" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7080,6 +7080,7 @@ server's OpenCL/api-docs repository.
                <enum name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
                <enum name="CL_COMMAND_BUFFER_STATE_KHR"/>
                <enum name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_CONTEXT_KHR"/>
             </require>
             <require comment="cl_command_buffer_state_khr">
                <enum name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>


### PR DESCRIPTION
Introduce query `CL_COMMAND_BUFFER_CONTEXT_KHR` for the `cl_context` associated with a command-buffer.

This PR uses enum value `0x1299` which is also attempting to be used by another command-buffer PR https://github.com/KhronosGroup/OpenCL-Docs/pull/850 However, that PR still needs reviewed, so would prefer to use that enum here as `0x1299` is contiguous with the other command-buffer query enums, and I can find a new value for PR #850

Closes https://github.com/KhronosGroup/OpenCL-Docs/issues/898