### PR TITLE
hyphenation changes for consistency

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11072,9 +11072,9 @@ footnote:[{fn-int64-supported}], `ulong`, `half` footnote:[{fn-half-supported}],
 
 The *<op>* in *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* defines the operator and can be *add*, *min* or *max*.
 
-The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
+The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
 
-The inclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
+The inclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
 
 If *op* = *add*, the identity I is 0.
 If *op* = *min*, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`, `ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
@@ -11084,7 +11084,7 @@ Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and `-INF
 [NOTE]
 ====
 The order of floating-point operations is not guaranteed for the *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* built-in functions that operate on `half`, `float` and `double` data types.
-The order of these floating-point operations is also non-deterministic for a given sub-group.
+The order of these floating-point operations is also non-deterministic for a given subgroup.
 ====
 
 NOTE: The functionality described in the following table <<unified-spec,

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1287,7 +1287,7 @@ Example 2:
 ----------
 float4 f;
 
-// values implementation defined for
+// values implementation-defined for
 // f > INT_MAX, f < INT_MIN or NaN
 int4 i = convert_int4( f );
 
@@ -2244,7 +2244,7 @@ kernel void k2(global int *buf)
 ----------
 
 Implementations are not required to aggregate these declarations into the
-fewest number of constant arguments. This behavior is implementation defined.
+fewest number of constant arguments. This behavior is implementation-defined.
 
 Thus portable code must conservatively assume that each variable declared
 inside a function or in program scope allocated in the `{constant}`
@@ -10254,12 +10254,12 @@ they are ordered in the program.
 Reservations made by different work-items that belong to the same work-group
 can be ordered using the work-group barrier function.
 The order of work-item based reservations that belong to different
-work-groups is implementation defined.
+work-groups is implementation-defined.
 
 Work-group based reservations made by a work-group are ordered in the pipe
 as they are ordered in the program.
 The order of work-group based reservations by different work-groups is
-implementation defined.
+implementation-defined.
 --
 
 
@@ -11138,7 +11138,7 @@ ordered in the program.
 Reservations made by different subgroups that belong to the same work-group
 can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
-groups is implementation defined.
+groups is implementation-defined.
 
 NOTE: The functionality described in the following table <<unified-spec,
 requires>> support for OpenCL C 3.0 or newer and the {opencl_c_subgroups}

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -545,7 +545,7 @@ OpenCL.
 | `sampler_t` footnote:image-functions[]
     | A sampler type.
 | `queue_t`
-    | A device command queue.
+    | A device command-queue.
       This queue can only be used to enqueue commands from kernels executing
       on the device.
 
@@ -558,7 +558,7 @@ OpenCL.
       newer and the {opencl_c_device_enqueue} feature.
 | `clk_event_t`
     | A device side event that identifies a command enqueue to
-      a device command queue.
+      a device command-queue.
 
       <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
       newer and the {opencl_c_device_enqueue} feature.
@@ -8030,7 +8030,7 @@ The OpenCL C programming language implements the *printf* function.
 When the event that is associated with a particular kernel invocation is
 completed, the output of all printf() calls executed by this kernel
 invocation is flushed to the implementation-defined output stream.
-Calling *clFinish* on a command queue flushes all pending output by printf
+Calling *clFinish* on a command-queue flushes all pending output by printf
 in previously enqueued and completed commands to the implementation-defined
 output stream.
 In the case that printf is executed from multiple work-items concurrently,
@@ -10808,7 +10808,7 @@ events.
     | Decrements the event reference count.
       The event object is deleted once the event reference count is zero,
       the specific command identified by this event has completed (or
-      terminated), and there are no commands in any device command queue that
+      terminated), and there are no commands in any device command-queue that
       require a wait for this event to complete.
       Behavior is undefined if _event_ is not a valid event.
 | |

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -172,7 +172,7 @@ feature macros.
 
 | {opencl_c_fp64}
 | The OpenCL C compiler supports types and built-in functions with 64-bit
-floating point types.
+floating-point types.
 
 | {opencl_c_images}
 | The OpenCL C compiler supports types and built-in functions for images.
@@ -288,11 +288,11 @@ The following table describes the list of built-in scalar data types.
 | `unsigned long`, `ulong` footnote:long[]
     | An unsigned 64-bit integer.
 | `float`
-    | A 32-bit floating-point.
+    | A 32-bit floating-point number.
       The `float` data type must conform to the IEEE 754 single precision
       storage format.
 | `double` footnote:[{fn-double}]
-    | A 64-bit floating-point.
+    | A 64-bit floating-point number.
       The `double` data type must conform to the IEEE 754 double precision
       storage format.
 
@@ -300,7 +300,7 @@ The following table describes the list of built-in scalar data types.
       OpenCL C 3.0 it requires support of the {opencl_c_fp64} feature.
       Also see extension *cl_khr_fp64*.
 | `half`
-    | A 16-bit floating-point.
+    | A 16-bit floating-point number.
       The `half` data type must conform to the IEEE 754-2008 half precision
       storage format.
 | `size_t` footnote:size_t[{fn-size_t}]
@@ -12861,7 +12861,7 @@ else
     result = powr((c + 0.055) / 1.055, 2.4);
 ----------
 
-The resulting floating point value, if converted back to an sRGB value
+The resulting floating-point value, if converted back to an sRGB value
 without rounding to a 8-bit unsigned integer value, must be within 0.5 ulp
 of the original sRGB value.
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -557,7 +557,7 @@ OpenCL.
       <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
       newer and the {opencl_c_device_enqueue} feature.
 | `clk_event_t`
-    | A device-side event that identifies a command enqueue to
+    | A device-side event that identifies a command enqueued to
       a device command-queue.
 
       <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
@@ -4501,30 +4501,30 @@ requires>> support for OpenCL C 3.0 or newer and the {opencl_c_subgroups}
 feature.
 
 The following table describes the list of built-in work-item functions that
-can be used to query the size of a subgroup, number of subgroups per work-group,
-and identifier of the subgroup within a work-group and work-item within a
-subgroup when this kernel is being executed on a device.
+can be used to query the size of a sub-group, number of sub-groups per work-group,
+and identifier of the sub-group within a work-group and work-item within a
+sub-group when this kernel is being executed on a device.
 
-.Built-in Work-Item Functions for Subgroups
+.Built-in Work-Item Functions for Sub-groups
 [cols="a,",options="header",]
 |====
 | *Function*
 | *Description*
 
 | uint *get_sub_group_size*()
-| Returns the number of work-items in the subgroup.
-  This value is no more than the maximum subgroup size and is
+| Returns the number of work-items in the sub-group.
+  This value is no more than the maximum sub-group size and is
   implementation-defined based on a combination of the compiled kernel and
   the dispatch dimensions.
-  This will be a constant value for the lifetime of the subgroup.
+  This will be a constant value for the lifetime of the sub-group.
 
 | uint *get_max_sub_group_size*()
-| Returns the maximum size of a subgroup within the dispatch.
+| Returns the maximum size of a sub-group within the dispatch.
   This value will be invariant for a given set of dispatch dimensions and a
   kernel object compiled for a given device.
 
 | uint *get_num_sub_groups*()
-| Returns the number of subgroups that the current work-group is divided
+| Returns the number of sub-groups that the current work-group is divided
   into.
 
   This number will be constant for the duration of a work-group's execution.
@@ -4539,17 +4539,17 @@ subgroup when this kernel is being executed on a device.
   kernel is executed with a uniform work-group size.
 
   If the kernel is executed with a non-uniform work-group size, returns the
-  number of subgroups in each of the work-groups that make up the uniform
+  number of sub-groups in each of the work-groups that make up the uniform
   region of the global range.
 
 | uint *get_sub_group_id*()
-| *get_sub_group_id* returns the subgroup ID which is a number from 0 ..
+| *get_sub_group_id* returns the sub-group ID which is a number from 0 ..
   *get_num_sub_groups*() - 1.
 
   For *clEnqueueTask*, this returns 0.
 
 | uint *get_sub_group_local_id*()
-| Returns the unique work-item ID within the current subgroup.
+| Returns the unique work-item ID within the current sub-group.
   The mapping from *get_local_id*(__dimindx__) to *get_sub_group_local_id*
   will be invariant for the lifetime of the work-group.
 
@@ -6205,9 +6205,9 @@ requires>> support for OpenCL 3.0 or newer and the {opencl_c_subgroups}
 feature.
 
 The following table describes built-in functions to synchronize the work-items
-in a subgroup.
+in a sub-group.
 
-.Built-in Subgroup Synchronization Functions
+.Built-in Sub-group Synchronization Functions
 [cols="3,7",options="header",]
 |====
 | *Function*
@@ -6220,16 +6220,16 @@ in a subgroup.
   cl_mem_fence_flags _flags_, +
   memory_scope _scope_)
 
-| For these functions, if any work-item in a subgroup encounters a
+| For these functions, if any work-item in a sub-group encounters a
   *sub_group_barrier*, the barrier must be encountered by all work-items in the
-  subgroup before any are allowed to continue execution beyond the barrier.
+  sub-group before any are allowed to continue execution beyond the barrier.
 
   If *sub_group_barrier* is inside a conditional statement, then all
-  work-items within the subgroup must enter the conditional if any work-item in
-  the subgroup enters the conditional statement and executes the
+  work-items within the sub-group must enter the conditional if any work-item in
+  the sub-group enters the conditional statement and executes the
   *sub_group_barrier*.
 
-  If the *sub_group_barrier* is inside a loop, then all work-items in the subgroup
+  If the *sub_group_barrier* is inside a loop, then all work-items in the sub-group
   must execute the barrier on each iteration of the loop if any work-item executes the barrier on that iteration.
 
   The *sub_group_barrier* function can specify which
@@ -6710,7 +6710,7 @@ or `local` memory.
 --
 
 The enumerated type `memory_scope` specifies whether the memory ordering
-constraints given by `memory_order` apply to work-items in a subgroup,
+constraints given by `memory_order` apply to work-items in a sub-group,
 work-items in a work-group, or work-items from one or more kernels executing
 on the device or across devices (in the case of shared virtual memory).
 The following table lists the enumeration constants:
@@ -11001,80 +11001,80 @@ foo(queue_t q, ...)
 |====
 --
 
-[[subgroup-functions]]
-=== Subgroup Functions
+[[sub-group-functions]]
+=== Sub-group Functions
 
-[open,refpage='subgroupFunctions',desc='Subgroup Functions',type='freeform',spec='clang',anchor='subgroup-functions',xrefs='',alias='sub_group_all sub_group_any sub_group_broadcast sub_group_reduce sub_group_scan_exclusive sub_group_scan_inclusive sub_group_reserve_read_pipe sub_gorup_reserve_write_pipe sub_group_commit_read_pipe sub_group_commit_write_pipe get_kernel_sub_group_count_for_ndrange get_kernel_max_sub_group_size_for_ndrange']
+[open,refpage='subGroupFunctions',desc='Sub-group Functions',type='freeform',spec='clang',anchor='sub-group-functions',xrefs='',alias='sub_group_all sub_group_any sub_group_broadcast sub_group_reduce sub_group_scan_exclusive sub_group_scan_inclusive sub_group_reserve_read_pipe sub_gorup_reserve_write_pipe sub_group_commit_read_pipe sub_group_commit_write_pipe get_kernel_sub_group_count_for_ndrange get_kernel_max_sub_group_size_for_ndrange']
 --
 
 NOTE: The functionality described in this section <<unified-spec, requires>>
 support for OpenCL C 3.0 or newer and the {opencl_c_subgroups} feature.
 
-The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
-These built-in functions must be encountered by all work-items in the subgroup executing the kernel.
+The table below describes OpenCL C programming language built-in functions that operate on a sub-group level.
+These built-in functions must be encountered by all work-items in the sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be the one of the
 supported built-in scalar data types `int`, `uint`, `long`
 footnote:[{fn-int64-supported}], `ulong`, `half` footnote:[{fn-half-supported}],
 `float`, and `double` footnote:[{fn-double-supported}].
 
-.Built-in Subgroup Collective Functions
+.Built-in Sub-group Collective Functions
 [cols=",",options="header",]
 |====
 | *Function*
 | *Description*
 
 | int *sub_group_all* (int _predicate_)
-| Evaluates _predicate_ for all work-items in the subgroup and returns a
+| Evaluates _predicate_ for all work-items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for all work-items in
-  the subgroup.
+  the sub-group.
 
 | int *sub_group_any* (int _predicate_)
-| Evaluates _predicate_ for all work-items in the subgroup and returns a
+| Evaluates _predicate_ for all work-items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for any work-items in
-  the subgroup.
+  the sub-group.
 
 | gentype *sub_group_broadcast* ( +
   gentype _x_, uint _sub_group_local_id_)
 | Broadcast the value of _x_ for work-item identified by
   _sub_group_local_id_ (value returned by *get_sub_group_local_id*) to all
-  work-items in the subgroup.
+  work-items in the sub-group.
 
   Behavior is undefined when the value of _sub_group_local_id_ is not
-  equivalent for all work-items in the subgroup.
+  equivalent for all work-items in the sub-group.
 
   Behavior is undefined when _sub_group_local_id_ is greater or equal to the
-  subgroup size.
+  sub-group size.
 
 | gentype *sub_group_reduce_<op>* ( +
   gentype _x_)
 | Return result of reduction operation specified by *<op>* for all values of
-  _x_ specified by work-items in a subgroup.
+  _x_ specified by work-items in a sub-group.
 
 | gentype *sub_group_scan_exclusive_<op>* ( +
   gentype _x_)
 | Do an exclusive scan operation specified by *<op>* of all values specified
-  by work-items in a subgroup.
+  by work-items in a sub-group.
   The scan results are returned for each work-item.
 
-  The scan order is defined by increasing subgroup local ID within the
-  subgroup.
+  The scan order is defined by increasing sub-group local ID within the
+  sub-group.
 
 | gentype *sub_group_scan_inclusive_<op>* ( +
   gentype _x_)
 | Do an inclusive scan operation specified by *<op>* of all values specified
-  by work-items in a subgroup.
+  by work-items in a sub-group.
   The scan results are returned for each work-item.
 
-  The scan order is defined by increasing subgroup local ID within the
-  subgroup.
+  The scan order is defined by increasing sub-group local ID within the
+  sub-group.
 
 |====
 
 The *<op>* in *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* defines the operator and can be *add*, *min* or *max*.
 
-The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
+The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
 
-The inclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
+The inclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
 
 If *op* = *add*, the identity I is 0.
 If *op* = *min*, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`, `ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
@@ -11084,7 +11084,7 @@ Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and `-INF
 [NOTE]
 ====
 The order of floating-point operations is not guaranteed for the *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* built-in functions that operate on `half`, `float` and `double` data types.
-The order of these floating-point operations is also non-deterministic for a given subgroup.
+The order of these floating-point operations is also non-deterministic for a given sub-group.
 ====
 
 NOTE: The functionality described in the following table <<unified-spec,
@@ -11092,8 +11092,8 @@ requires>> support for OpenCL C 3.0 or newer and the {opencl_c_subgroups}
 and {opencl_c_pipes} features.
 
 The following table describes built-in pipe functions that operate at a
-subgroup level.
-These built-in functions must be encountered by all work-items in a subgroup
+sub-group level.
+These built-in functions must be encountered by all work-items in a sub-group
 executing the kernel with the same argument values, otherwise the behavior
 is undefined.
 We use the generic type name `gentype` to indicate the built-in OpenCL C
@@ -11101,7 +11101,7 @@ scalar or vector integer or floating-point data types or any user defined
 type built from these scalar and vector data types can be used as the type
 for the arguments to the pipe functions listed in _table 6.29_.
 
-.Built-in Subgroup Pipe Functions
+.Built-in Sub-group Pipe Functions
 [cols=",",options="header",]
 |====
 | *Function*
@@ -11133,21 +11133,21 @@ for the arguments to the pipe functions listed in _table 6.29_.
 
 |====
 
-Note: Reservations made by a subgroup are ordered in the pipe as they are
+Note: Reservations made by a sub-group are ordered in the pipe as they are
 ordered in the program.
-Reservations made by different subgroups that belong to the same work-group
-can be ordered using subgroup synchronization.
-The order of subgroup based reservations that belong to different work
+Reservations made by different sub-groups that belong to the same work-group
+can be ordered using sub-group synchronization.
+The order of sub-group based reservations that belong to different work
 groups is implementation-defined.
 
 NOTE: The functionality described in the following table <<unified-spec,
 requires>> support for OpenCL C 3.0 or newer and the {opencl_c_subgroups}
 and {opencl_c_device_enqueue} features.
 
-The following table describes built-in functions to query subgroup
+The following table describes built-in functions to query sub-group
 information for a block to be enqueued.
 
-.Built-in Subgroup Kernel Query Functions
+.Built-in Sub-group Kernel Query Functions
 [cols="5,4",options="header",]
 |====
 | *Built-in Function*
@@ -11160,7 +11160,7 @@ information for a block to be enqueued.
   uint *get_kernel_sub_group_count_for_ndrange* ( +
   const ndrange_t _ndrange_, +
   void (^block)(local void *, ...));
-| Returns the number of subgroups in each work-group of the dispatch (except
+| Returns the number of sub-groups in each work-group of the dispatch (except
   for the last in cases where the global size does not divide cleanly into
   work-groups) given the combination of the passed ndrange and block.
 
@@ -11173,7 +11173,7 @@ information for a block to be enqueued.
   uint *get_kernel_max_sub_group_size_for_ndrange* ( +
   const ndrange_t _ndrange_, +
   void (^block)(local void *, ...));
-| Returns the maximum subgroup size for a block.
+| Returns the maximum sub-group size for a block.
 
 |====
 --

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -10944,7 +10944,7 @@ foo(queue_t q, ...)
                    ^{barB_kernel(...);} );
 
     // barA_kernel and barB_kernel can be executed
-    // out of order. we need to wait for both these
+    // out-of-order. We need to wait for both these
     // kernels to finish execution before barC_kernel
     // starts execution so we enqueue a marker command and
     // then enqueue barC_kernel that waits on the event

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -557,7 +557,7 @@ OpenCL.
       <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or
       newer and the {opencl_c_device_enqueue} feature.
 | `clk_event_t`
-    | A device side event that identifies a command enqueue to
+    | A device-side event that identifies a command enqueue to
       a device command-queue.
 
       <<unified-spec, Requires>> support for OpenCL C 2.0, or OpenCL C 3.0 or

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6140,7 +6140,7 @@ in a work-group.
 // table widths can be re-adjusted.
 
 [[table-builtin-synchronization]]
-.Built-in Work-Group Synchronization Functions
+.Built-in Work-group Synchronization Functions
 [cols="3,7",]
 |====
 | *Function* | *Description*
@@ -9088,8 +9088,8 @@ The sampler-less image read functions behave exactly as the corresponding
 integer coordinates and a sampler with filter mode set to
 `CLK_FILTER_NEAREST`, normalized coordinates set to
 `CLK_NORMALIZED_COORDS_FALSE` and addressing mode to `CLK_ADDRESS_NONE`.
-There is one exception when the _image_channel_data_type_ is a floating
-point type (such as `CL_FLOAT`).
+There is one exception when the _image_channel_data_type_ is a floating-point
+type (such as `CL_FLOAT`).
 In this exceptional case, when channel data values are denormalized, the
 sampler-less image read function may return the denormalized data, while
 the image read function with a sampler argument may flush the denormalized

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -90,10 +90,10 @@ The following features in OpenCL 1.0 are deprecated (see glossary) in OpenCL
 // Bugzilla 6140
   * The {clSetCommandQueueProperty} API is deprecated, which simplifies
     implementations and possibly improves performance by enforcing that
-    command queue properties are invariant.
-    Applications are encouraged to create multiple command queues with
+    command-queue properties are invariant.
+    Applications are encouraged to create multiple command-queues with
     different properties versus modifying the properties of a single
-    command queue.
+    command-queue.
 // Bugzilla 6628
   * The `-cl-strict-aliasing` build option has been deprecated.
     It is no longer required after defining type-based aliasing rules.
@@ -210,7 +210,7 @@ runtime (_sections 4 and 5_):
      regions.
   * Device queues used to enqueue kernels on the device.
   ** {clCreateCommandQueueWithProperties} is added to allow creation of a
-     command queue with properties that affect both host command queues and
+     command-queue with properties that affect both host command-queues and
      device queues.
   * Pipes.
   ** {clCreatePipe} and {clGetPipeInfo} have been added to the API for host
@@ -246,7 +246,7 @@ The following APIs are deprecated (see glossary) in OpenCL 2.0:
   * The {clCreateCommandQueue} API has been deprecated to simplify
     the API.
     The {clCreateCommandQueueWithProperties} API provides equivalent
-    functionality and supports specifying additional command queue
+    functionality and supports specifying additional command-queue
     properties.
 // Bugzilla 8093 - cl_khr_mipmap_image specification
   * The {clCreateSampler} API has been deprecated to simplify the
@@ -412,7 +412,7 @@ new buffer and image extensions to be added easily and consistently:
   * {clCreateImageWithProperties}
 
 OpenCL 3.0 adds new queries for the properties arrays specified
-when creating buffers, images, pipes, samplers, and command queues:
+when creating buffers, images, pipes, samplers, and command-queues:
 
   * {CL_MEM_PROPERTIES}
   * {CL_PIPE_PROPERTIES}

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -491,7 +491,7 @@ Changes from *v3.0.6*:
 Changes from *v3.0.7*:
 
   * Clarified optionality support for double-precision literals.
-  * Removed unnecessary phrase from subgroup mask function descriptions.
+  * Removed unnecessary phrase from sub-group mask function descriptions.
   * Added _input_slice_pitch_ error condition for read and write image APIs.
   * Added new extension:
       ** `cl_khr_integer_dot_product`
@@ -500,7 +500,7 @@ Changes from *v3.0.8*:
 
   * Added a missing error condition for {clGetKernelSuggestedLocalWorkSizeKHR}.
   * Clarified requirements for {CL_DEVICE_DOUBLE_FP_CONFIG} prior to OpenCL 2.0.
-  * Clarified the behavior of ballot operations for remainder subgroups.
+  * Clarified the behavior of ballot operations for remainder sub-groups.
   * Added new extensions:
       ** `cl_khr_integer_dot_product` (version 2)
       ** `cl_khr_semaphore` (provisional)
@@ -536,7 +536,7 @@ Changes from *v3.0.10*:
   * Clarified the expected return value for the of {CL_IMAGE_ROW_PITCH} and {CL_IMAGE_SLICE_PITCH} queries.
   * Updated descriptions of the extended async copies functions to remove references to nonexistent function arguments.
   * Clarified that the extended versioning extension is a core OpenCL 3.0 feature.
-  * Clarified subgroup clustered reduction behavior when the cluster size is not an integer constant or a power of two.
+  * Clarified sub-group clustered reduction behavior when the cluster size is not an integer constant or a power of two.
   * Added new extensions:
       ** `cl_khr_subgroup_rotate`
       ** `cl_khr_work_group_uniform_arithmetic`

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -464,7 +464,7 @@ The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
 
 Changes from *v3.0.5*:
 
-  * Fixed the calculation in "mapping work-items onto an NDRange".
+  * Fixed the calculation in "mapping work-items onto an ND-range".
   * Added new extensions:
       ** `cl_khr_extended_versioning`
       ** `cl_khr_subgroup_extended_types`

--- a/api/appendix_f.asciidoc
+++ b/api/appendix_f.asciidoc
@@ -98,7 +98,7 @@ include::{generated}/api/version-notes/CL_INVALID_BUILD_OPTIONS.asciidoc[]
 | {CL_INVALID_COMMAND_QUEUE_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_COMMAND_QUEUE.asciidoc[]
-| Returned when the specified command queue is not a <<valid-object-definition,valid command queue>>.
+| Returned when the specified command-queue is not a <<valid-object-definition,valid command-queue>>.
 
 | {CL_INVALID_COMPILER_OPTIONS_anchor}
 
@@ -123,7 +123,7 @@ include::{generated}/api/version-notes/CL_INVALID_DEVICE_PARTITION_COUNT.asciido
 | {CL_INVALID_DEVICE_QUEUE_anchor}
 
 include::{generated}/api/version-notes/CL_INVALID_DEVICE_QUEUE.asciidoc[]
-| Returned when setting a device queue kernel argument to a value that is not a valid device command queue.
+| Returned when setting a device queue kernel argument to a value that is not a valid device command-queue.
 
 | {CL_INVALID_DEVICE_TYPE_anchor}
 
@@ -331,6 +331,6 @@ include::{generated}/api/version-notes/CL_MAX_SIZE_RESTRICTION_EXCEEDED.asciidoc
 | {CL_PROFILING_INFO_NOT_AVAILABLE_anchor}
 
 include::{generated}/api/version-notes/CL_PROFILING_INFO_NOT_AVAILABLE.asciidoc[]
-| Returned by {clGetEventProfilingInfo} when the command associated with the specified event was not enqueued into a command queue with {CL_QUEUE_PROFILING_ENABLE}.
+| Returned by {clGetEventProfilingInfo} when the command associated with the specified event was not enqueued into a command-queue with {CL_QUEUE_PROFILING_ENABLE}.
 
 |====

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -251,7 +251,7 @@ OpenCL C compilers supporting program scope global variables will define the fea
 // May need to update the validation rules to disallow program scope global variables
 // for OpenCL 1.2 consumers regardless.
 
-== Non-Uniform Work Groups
+== Non-Uniform Work-groups
 
 Support for non-uniform work-groups is optional for devices supporting OpenCL 3.0.
 When non-uniform work-groups are not supported:
@@ -266,7 +266,7 @@ When non-uniform work-groups are not supported:
 | May return {CL_FALSE}, indicating that _device_ does not support non-uniform work-groups.
 
 | {clEnqueueNDRangeKernel}
-| Behaves as though non-uniform Work Groups were not enabled for _kernel_, if the device associated with _command_queue_ does not support non-uniform work-groups.
+| Behaves as though non-uniform work-groups were not enabled for _kernel_, if the device associated with _command_queue_ does not support non-uniform work-groups.
 
 |====
 
@@ -274,7 +274,7 @@ When non-uniform work-groups are not supported:
 // The `get_enqueued_local_size` and `get_enqueued_num_sub_groups` built-in
 // functions, and the *EnqueuedWorkgroupSize* and *NumEnqueuedSubGroups*
 // *BuiltIn* decorations will be supported even if the device does not support
-// non-uniform Work Groups.
+// non-uniform work-groups.
 
 == Read-Write Images
 
@@ -483,7 +483,7 @@ When writing to 3D image objects is not supported:
 
 OpenCL C compilers supporting writing to 3D image objects will define the feature macro `+__opencl_c_3d_image_writes+`.
 
-== Work Group Collective Functions
+== Work-group Collective Functions
 
 Work-group collective functions for broadcasts, scans, and reductions are optional for devices supporting OpenCL 3.0.
 When work-group collective functions are not supported:

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -402,14 +402,14 @@ When intermediate language programs are not supported:
 
 | {clGetKernelSubGroupInfo}, passing +
 {CL_KERNEL_COMPILE_NUM_SUB_GROUPS}
-| Returns `0` if _device_ does not support intermediate language programs, since there is currently no way to require a number of subgroups per work-group for programs created from source.
+| Returns `0` if _device_ does not support intermediate language programs, since there is currently no way to require a number of sub-groups per work-group for programs created from source.
 
 |====
 
-== Subgroups
+== Sub-groups
 
-Subgroups are optional for devices supporting OpenCL 3.0.
-When subgroups are not supported:
+Sub-groups are optional for devices supporting OpenCL 3.0.
+When sub-groups are not supported:
 
 [cols="2,3",options="header",]
 |====
@@ -418,25 +418,25 @@ When subgroups are not supported:
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_MAX_NUM_SUB_GROUPS}
-| May return `0`, indicating that _device_ does not support subgroups.
+| May return `0`, indicating that _device_ does not support sub-groups.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS}
-| Returns {CL_FALSE} if _device_ does not support subgroups.
+| Returns {CL_FALSE} if _device_ does not support sub-groups.
 
 | {clGetDeviceInfo}, passing +
 {CL_DEVICE_EXTENSIONS}
-| Will not describe support for the `cl_khr_subgroups` extension if _device_ does not support subgroups.
+| Will not describe support for the `cl_khr_subgroups` extension if _device_ does not support sub-groups.
 
 | {clGetKernelSubGroupInfo}
-| Returns {CL_INVALID_OPERATION} if _device_ does not support subgroups.
+| Returns {CL_INVALID_OPERATION} if _device_ does not support sub-groups.
 // Note: for {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE}, {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE},
 //       {CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT}, {CL_KERNEL_MAX_NUM_SUB_GROUPS},
 //       {CL_KERNEL_COMPILE_NUM_SUB_GROUPS}.
 
 |====
 
-OpenCL C compilers supporting subgroups will define the feature macro `+__opencl_c_subgroups+`.
+OpenCL C compilers supporting sub-groups will define the feature macro `+__opencl_c_subgroups+`.
 
 == Program Initialization and Clean-Up Kernels
 

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -43,7 +43,7 @@ Blocking and Non-Blocking Enqueue API calls ::
 
 Barrier ::
     There are three types of _barriers_ a command-queue barrier, a
-    work-group barrier, and a subgroup barrier.
+    work-group barrier, and a sub-group barrier.
 +
 --
   * The OpenCL API provides a function to enqueue a _command-queue_
@@ -59,12 +59,12 @@ Barrier ::
     All the _work-items_ of a _work-group_ must execute the _barrier_
     construct before any are allowed to continue execution beyond the
     _barrier_.
-  * The OpenCL kernel execution model provides built-in _subgroup barrier_
+  * The OpenCL kernel execution model provides built-in _sub-group barrier_
     functionality.
     This _barrier_ built-in function can be used by a _kernel_ executing on
     a _device_ to perform synchronization between _work-items_ in a
-    _subgroup_ executing the _kernel_.
-    All the _work-items_ of a _subgroup_ must execute the _barrier_
+    _sub-group_ executing the _kernel_.
+    All the _work-items_ of a _sub-group_ must execute the _barrier_
     construct before any are allowed to continue execution beyond the
     _barrier_.
 --
@@ -350,10 +350,10 @@ Independent Forward Progress ::
     must be released by, any other entity), then its execution cannot be
     blocked by the execution of any other entity in the system (it will not
     be starved).
-    Work-items in a subgroup, for example, typically do not support
-    independent forward progress, so one work-item in a subgroup may be
+    Work-items in a sub-group, for example, typically do not support
+    independent forward progress, so one work-item in a sub-group may be
     completely blocked (starved) if a different work-item in the same
-    subgroup enters a spin loop.
+    sub-group enters a spin loop.
 
 In-order Execution ::
     A model of execution in OpenCL where the _commands_ in a _command-queue_
@@ -444,7 +444,7 @@ Memory Scopes ::
     Current values are *memory_scope_work_item* (memory constraints only
     apply to a single work-item and in practice apply only to image
     operations), *memory_scope_sub_group* (memory-ordering constraints only
-    apply to work-items executing in a subgroup), *memory_scope_work_group*
+    apply to work-items executing in a sub-group), *memory_scope_work_group*
     (memory-ordering constraints only apply to work-items executing in a
     work-group), *memory_scope_device* (memory-ordering constraints only
     apply to work-items executing on a single device) and
@@ -638,7 +638,7 @@ Scope inclusion ::
     Two actions *A* and *B* are defined to have an inclusive scope if they
     have the same scope *P* such that: (1) if *P* is
     *memory_scope_sub_group*, and *A* and *B* are executed by work-items
-    within the same subgroup, or (2) if *P* is *memory_scope_work_group*,
+    within the same sub-group, or (2) if *P* is *memory_scope_work_group*,
     and *A* and *B* are executed by work-items within the same work-group,
     or (3) if *P* is *memory_scope_device*, and *A* and *B* are executed by
     work-items on the same device, or (4) if *P* is
@@ -727,12 +727,12 @@ Sub-device ::
     _sub-devices_.
     Also see _Device_, _Parent device_ and _Root device_.
 
-Subgroup ::
-    Subgroups are an implementation-dependent grouping of work-items within
+Sub-group ::
+    Sub-groups are an implementation-dependent grouping of work-items within
     a work-group.
-    The size and number of subgroups is implementation-defined.
+    The size and number of sub-groups is implementation-defined.
 
-Subgroup Barrier ::
+Sub-group Barrier ::
     See _Barrier_.
 
 Submitted ::

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -377,7 +377,7 @@ Kernel-instance ::
     of kernel-instances on devices.
     The kernel instance is the _kernel object_, the values associated with
     the arguments to the kernel, and the parameters that define the
-    _NDRange_ index space.
+    _ND-range_ index space.
 
 Kernel Object ::
     A _kernel object_ encapsulates a specific _kernel_ function declared
@@ -592,9 +592,9 @@ Release Semantics ::
 Remainder work-groups ::
     When the work-groups associated with a kernel-instance are defined, the
     sizes of a work-group in each dimension may not evenly divide the size
-    of the NDRange in the corresponding dimensions.
+    of the ND-range in the corresponding dimensions.
     The result is a collection of work-groups on the boundaries of the
-    NDRange that are smaller than the base work-group size.
+    ND-range that are smaller than the base work-group size.
     These are known as _remainder work-groups_.
 
 Running ::

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -200,7 +200,7 @@ Data race ::
     same memory location, and (2) at least one of these actions is not
     atomic, or the corresponding memory scopes are not inclusive, and (3)
     the actions are global actions unordered by the global-happens-before
-    relation or are local actions unordered by the local-happens before
+    relation or are local actions unordered by the local-happens-before
     relation.
 
 Deprecation ::
@@ -265,8 +265,8 @@ Generic address space ::
     write a single function that at compile time can take arguments from any
     of the three named address spaces.
 
-Global Happens before ::
-    See _Happens before_.
+Global-happens-before ::
+    See _Happens-before_.
 
 Global ID ::
     A _global ID_ is used to uniquely identify a _work-item_ and is derived
@@ -296,12 +296,12 @@ Handle ::
     lifetime. Handle values may be, but are not required to be, re-used by
     an implementation.
 
-Happens before ::
+Happens-before ::
     An ordering relationship between operations that execute on multiple
     units of execution.
     If an operation A happens-before operation B then A must occur before B;
     in particular, any value written by A will be visible to B.
-    We define two separate happens before relations: _global-happens-before_
+    We define two separate happens-before relations: _global-happens-before_
     and _local-happens-before_.
     These are defined in <<memory-ordering-rules, Memory Ordering Rules>>.
 

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -107,7 +107,7 @@ Command-queue ::
     The _command-queue_ is created on a specific _device_ in a _context_.
     _Commands_ to a _command-queue_ are queued in-order but may be executed
     in-order or out-of-order.
-    _Refer to In-order Execution_and_Out-of-order Execution_.
+    Refer to _In-order Execution_ and _Out-of-order Execution_.
 
 Command-queue Barrier ::
     See _Barrier_.
@@ -359,7 +359,7 @@ In-order Execution ::
     A model of execution in OpenCL where the _commands_ in a _command-queue_
     are executed in order of submission with each _command_ running to
     completion before the next one begins.
-    See Out-of-order Execution.
+    See _Out-of-order Execution_.
 
 Intermediate Language ::
     A lower-level language that may be used to create programs.
@@ -469,7 +469,7 @@ Object ::
     Examples include _program objects_, _kernel objects_, and _memory
     objects_.
 
-Out-of-Order Execution ::
+Out-of-order Execution ::
     A model of execution in which _commands_ placed in the _work queue_ may
     begin and complete execution in any order consistent with constraints
     imposed by _event wait lists_and_command-queue barrier_.

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -337,7 +337,7 @@ The elements of an image are selected from a list of predefined image
 formats.
 --
 
-Implementation Defined ::
+Implementation-Defined ::
     Behavior that is explicitly allowed to vary between conforming
     implementations of OpenCL.
     An OpenCL implementor is required to document the implementation-defined

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -223,7 +223,7 @@ Device-side enqueue ::
     This produces _nested parallelism_; i.e. additional levels of
     concurrency are nested inside a running kernel-instance.
     The kernel-instance executing on a device (the _parent kernel_) enqueues
-    a kernel-instance (the _child kernel_) to a device-side command queue.
+    a kernel-instance (the _child kernel_) to a device-side command-queue.
     Child and parent kernels execute asynchronously though a parent kernel
     does not complete until all of its child-kernels have completed.
 

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -43,7 +43,7 @@ Blocking and Non-Blocking Enqueue API calls ::
 
 Barrier ::
     There are three types of _barriers_ a command-queue barrier, a
-    work-group barrier and a sub-group barrier.
+    work-group barrier, and a subgroup barrier.
 +
 --
   * The OpenCL API provides a function to enqueue a _command-queue_
@@ -59,12 +59,12 @@ Barrier ::
     All the _work-items_ of a _work-group_ must execute the _barrier_
     construct before any are allowed to continue execution beyond the
     _barrier_.
-  * The OpenCL kernel execution model provides built-in _sub-group barrier_
+  * The OpenCL kernel execution model provides built-in _subgroup barrier_
     functionality.
     This _barrier_ built-in function can be used by a _kernel_ executing on
     a _device_ to perform synchronization between _work-items_ in a
-    _sub-group_ executing the _kernel_.
-    All the _work-items_ of a _sub-group_ must execute the _barrier_
+    _subgroup_ executing the _kernel_.
+    All the _work-items_ of a _subgroup_ must execute the _barrier_
     construct before any are allowed to continue execution beyond the
     _barrier_.
 --
@@ -444,7 +444,7 @@ Memory Scopes ::
     Current values are *memory_scope_work_item* (memory constraints only
     apply to a single work-item and in practice apply only to image
     operations), *memory_scope_sub_group* (memory-ordering constraints only
-    apply to work-items executing in a sub-group), *memory_scope_work_group*
+    apply to work-items executing in a subgroup), *memory_scope_work_group*
     (memory-ordering constraints only apply to work-items executing in a
     work-group), *memory_scope_device* (memory-ordering constraints only
     apply to work-items executing on a single device) and
@@ -638,7 +638,7 @@ Scope inclusion ::
     Two actions *A* and *B* are defined to have an inclusive scope if they
     have the same scope *P* such that: (1) if *P* is
     *memory_scope_sub_group*, and *A* and *B* are executed by work-items
-    within the same sub-group, or (2) if *P* is *memory_scope_work_group*,
+    within the same subgroup, or (2) if *P* is *memory_scope_work_group*,
     and *A* and *B* are executed by work-items within the same work-group,
     or (3) if *P* is *memory_scope_device*, and *A* and *B* are executed by
     work-items on the same device, or (4) if *P* is
@@ -727,12 +727,12 @@ Sub-device ::
     _sub-devices_.
     Also see _Device_, _Parent device_ and _Root device_.
 
-Sub-group ::
-    Sub-groups are an implementation-dependent grouping of work-items within
+Subgroup ::
+    Subgroups are an implementation-dependent grouping of work-items within
     a work-group.
-    The size and number of sub-groups is implementation-defined.
+    The size and number of subgroups is implementation-defined.
 
-Sub-group Barrier ::
+Subgroup Barrier ::
     See _Barrier_.
 
 Submitted ::

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -193,7 +193,7 @@ Unsuccessful completion results in abnormal termination of the command which
 is indicated by setting the event status to a negative value.
 In this case, the command-queue associated with the abnormally terminated
 command and all other command-queues in the same context may no longer be
-available and their behavior is implementation defined.
+available and their behavior is implementation-defined.
 
 A command submitted to a device will not launch until prerequisites that
 constrain the order of commands have been resolved.
@@ -695,7 +695,7 @@ The OpenCL execution model supports three types of kernels:
     The common use of built in kernels is to expose fixed-function hardware
     or firmware associated with a particular OpenCL device or custom device.
     The semantics of a built-in kernel may be defined outside of OpenCL and
-    hence are implementation defined.
+    hence are implementation-defined.
     Note: Built-in kernels are <<unified-spec, missing before>> version 1.2.
 
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1488,7 +1488,7 @@ The value of *M*, as determined by evaluation *B*, shall be the value stored
 by some operation in the visible sequence of *M* with respect to *B*.
 <<iso-c11,[C11 standard, Section 5.1.2.4, paragraph 22, modified.]>>
 
-If an operation *A* that modifies an atomic object *M* global-happens before
+If an operation *A* that modifies an atomic object *M* global-happens-before
 an operation *B* that modifies *M*, then *A* shall be earlier than *B* in
 the modification order of *M*.
 This requirement is known as write-write coherence.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -288,10 +288,10 @@ Each of these executing kernel functions is called a _work-item_.
 The work-items associated with a given kernel-instance are managed by the
 device in groups called _work-groups_.
 These work-groups define a coarse grained decomposition of the Index space.
-Work-groups are further divided into _subgroups_, which provide an
+Work-groups are further divided into _sub-groups_, which provide an
 additional level of control over execution.
 
-NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
+NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
 
 Work-items have a global ID based on their coordinates within the Index
 space.
@@ -384,30 +384,30 @@ is computed as:
 [[index-space-image]]
 image::images/index_space.jpg[align="center", title="An example of an ND-range index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global ND-range size (i.e. all work-groups have the same size) and that the offset is equal to zero."]
 
-Within a work-group work-items may be divided into subgroups.
-The mapping of work-items to subgroups is implementation-defined and may be
+Within a work-group work-items may be divided into sub-groups.
+The mapping of work-items to sub-groups is implementation-defined and may be
 queried at runtime.
-While subgroups may be used in multi-dimensional work-groups, each
-subgroup is 1-dimensional and any given work-item may query which subgroup
+While sub-groups may be used in multi-dimensional work-groups, each
+sub-group is 1-dimensional and any given work-item may query which sub-group
 it is a member of.
 
-NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
+NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
 
-Work-items are mapped into subgroups through a combination of compile-time
+Work-items are mapped into sub-groups through a combination of compile-time
 decisions and the parameters of the dispatch.
-The mapping to subgroups is invariant for the duration of a kernels
+The mapping to sub-groups is invariant for the duration of a kernels
 execution, across dispatches of a given kernel with the same work-group
 dimensions, between dispatches and query operations consistent with the
 dispatch parameterization, and from one work-group to another within the
 dispatch (excluding the trailing edge work-groups in the presence of
 non-uniform work-group sizes).
-In addition, all subgroups within a work-group will be the same size, apart
-from the subgroup with the maximum index which may be smaller if the size
-of the work-group is not evenly divisible by the size of the subgroups.
+In addition, all sub-groups within a work-group will be the same size, apart
+from the sub-group with the maximum index which may be smaller if the size
+of the work-group is not evenly divisible by the size of the sub-groups.
 
-In the degenerate case, a single subgroup must be supported for each
+In the degenerate case, a single sub-group must be supported for each
 work-group.
-In this situation all subgroup scope functions are equivalent to their
+In this situation all sub-group scope functions are equivalent to their
 work-group level equivalents.
 
 
@@ -474,28 +474,28 @@ There is no safe and portable way to synchronize across the independent
 execution of work-groups since once in the work-pool, they can execute in
 any order.
 
-The work-items within a single subgroup execute concurrently but not
+The work-items within a single sub-group execute concurrently but not
 necessarily in parallel (i.e. they are not guaranteed to make independent
 forward progress).
-Therefore, only high-level synchronization constructs (e.g. subgroup
-functions such as barriers) that apply to all the work-items in a subgroup
+Therefore, only high-level synchronization constructs (e.g. sub-group
+functions such as barriers) that apply to all the work-items in a sub-group
 are well defined and included in OpenCL.
 
-NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
+NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
 
-Subgroups execute concurrently within a given work-group and with
+Sub-groups execute concurrently within a given work-group and with
 appropriate device support (see <<platform-querying-devices, Querying
 Devices>>), may make independent forward progress with respect to each
 other, with respect to host threads and with respect to any entities
 external to the OpenCL system but running on an OpenCL device, even in the
 absence of work-group barrier operations.
-In this situation, subgroups are able to internally synchronize using
+In this situation, sub-groups are able to internally synchronize using
 barrier operations without synchronizing with each other and may perform
-operations that rely on runtime dependencies on operations other subgroups
+operations that rely on runtime dependencies on operations other sub-groups
 perform.
 
 The work-items within a single work-group execute concurrently but are only
-guaranteed to make independent progress in the presence of subgroups and
+guaranteed to make independent progress in the presence of sub-groups and
 device support.
 In the absence of this capability, only high-level synchronization
 constructs (e.g. work-group functions such as barriers) that apply to all
@@ -503,13 +503,13 @@ the work-items in a work-group are well defined and included in OpenCL for
 synchronization within the work-group.
 
 In the absence of synchronization functions (e.g. a barrier), work-items
-within a subgroup may be serialized.
-In the presence of subgroup functions, work-items within a subgroup may
-be serialized before any given subgroup function, between dynamically
-encountered pairs of subgroup functions and between a work-group function
+within a sub-group may be serialized.
+In the presence of sub-group functions, work-items within a sub-group may
+be serialized before any given sub-group function, between dynamically
+encountered pairs of sub-group functions and between a work-group function
 and the end of the kernel.
 
-In the absence of independent forward progress of constituent subgroups,
+In the absence of independent forward progress of constituent sub-groups,
 work-items within a work-group may be serialized before, after or between
 work-group synchronization functions.
 
@@ -570,9 +570,9 @@ Consider the following three domains of synchronization in OpenCL:
 
   * Work-group synchronization: Constraints on the order of execution for
     work-items in a single work-group
-  * Subgroup synchronization: Constraints on the order of execution for
-    work-items in a single subgroup.
-    Note: Subgroups are <<unified-spec, missing before>> version 2.1
+  * Sub-group synchronization: Constraints on the order of execution for
+    work-items in a single sub-group.
+    Note: Sub-groups are <<unified-spec, missing before>> version 2.1
   * Command synchronization: Constraints on the order of commands launched
     for execution
 
@@ -596,24 +596,24 @@ OpenCL since OpenCL does not define forward-progress or ordering relations
 between work-groups, hence collective synchronization operations are not
 well defined.
 
-Synchronization across all work-items within a single subgroup is carried
-out using a _subgroup function_.
+Synchronization across all work-items within a single sub-group is carried
+out using a _sub-group function_.
 These functions carry out collective operations across all the work-items in
-a subgroup.
+a sub-group.
 Available collective operations are: barrier, reduction, broadcast, prefix
 sum, and evaluation of a predicate.
-A subgroup function must occur within a converged control flow; i.e. all
-work-items in the subgroup must encounter precisely the same subgroup
+A sub-group function must occur within a converged control flow; i.e. all
+work-items in the sub-group must encounter precisely the same sub-group
 function.
 For example, if a work-group function occurs within a loop, the work-items
-must encounter the same subgroup function in the same loop iterations.
-All the work-items of a subgroup must execute the subgroup function and
+must encounter the same sub-group function in the same loop iterations.
+All the work-items of a sub-group must execute the sub-group function and
 complete reads and writes to memory before any are allowed to continue
-execution beyond the subgroup function.
-Synchronization between subgroups must either be performed using work-group
+execution beyond the sub-group function.
+Synchronization between sub-groups must either be performed using work-group
 functions, or through memory operations.
-Using memory operations for subgroup synchronization should be used
-carefully as forward progress of subgroups relative to each other is only
+Using memory operations for sub-group synchronization should be used
+carefully as forward progress of sub-groups relative to each other is only
 supported optionally by OpenCL implementations.
 
 Command synchronization is defined in terms of distinct *synchronization
@@ -1176,7 +1176,7 @@ enumeration constant:
   * *memory_scope_work_item*: memory-ordering constraints only apply within
     the work-item footnote:[{fn-image-mem-fence}].
   * *memory_scope_sub_group*: memory-ordering constraints only apply within
-    the subgroup.
+    the sub-group.
   * *memory_scope_work_group*: memory-ordering constraints only apply to
     work-items executing within a single work-group.
   * *memory_scope_device:* memory-ordering constraints only apply to
@@ -1322,7 +1322,7 @@ Two actions *A* and *B* are defined to have an inclusive scope if they have
 the same scope *P* such that:
 
   * *P* is *memory_scope_sub_group* and *A* and *B* are executed by
-    work-items within the same subgroup.
+    work-items within the same sub-group.
   * *P* is *memory_scope_work_group* and *A* and *B* are executed by
     work-items within the same work-group.
   * *P* is *memory_scope_device* and *A* and *B* are executed by work-items
@@ -1793,20 +1793,20 @@ must execute the same work-group function call site, or dynamic work-group
 function instance.
 
 
-==== Subgroup Functions
+==== Sub-group Functions
 
-NOTE: Subgroup functions are <<unified-spec, missing before>> version 2.1.
+NOTE: Sub-group functions are <<unified-spec, missing before>> version 2.1.
 Also see extension *cl_khr_subgroups*.
 
 The OpenCL kernel execution model includes collective operations across the
-work-items within a single subgroup.
-These are called subgroup functions.
-We will first discuss the subgroup barrier.
-Other subgroup functions are discussed afterwards.
+work-items within a single sub-group.
+These are called sub-group functions.
+We will first discuss the sub-group barrier.
+Other sub-group functions are discussed afterwards.
 
 The barrier function provides a mechanism for a kernel to synchronize the
-work-items within a single subgroup: informally, each work-item of the
-subgroup must execute the barrier before any are allowed to proceed.
+work-items within a single sub-group: informally, each work-item of the
+sub-group must execute the barrier before any are allowed to proceed.
 It also orders memory operations to a specified combination of one or more
 address spaces such as local memory or global memory, in a similar manner to
 a fence.
@@ -1816,7 +1816,7 @@ distinguish between a dynamic and a static instance of the call to a
 barrier.
 A call to a barrier can appear in a loop, for example, and each execution of
 the same static barrier call results in a new dynamic instance of the
-barrier that will independently synchronize the work-items in a subgroup.
+barrier that will independently synchronize the work-items in a sub-group.
 
 A work-item executing a dynamic instance of a barrier results in two
 operations, both fences, that are called the entry and exit fences.
@@ -1830,21 +1830,21 @@ chapter as well as the following:
   * For each work-item the entry fence is sequenced before the exit fence.
   * If the flags have `CLK_GLOBAL_MEM_FENCE` set then for each work-item the
     entry fence global-synchronizes-with the exit fence of all other
-    work-items in the same subgroup.
+    work-items in the same sub-group.
   * If the flags have `CLK_LOCAL_MEM_FENCE` set then for each work-item the
     entry fence local-synchronizes-with the exit fence of all other
-    work-items in the same subgroup.
+    work-items in the same sub-group.
 
-Other subgroup functions include such functions as scans, reductions,
+Other sub-group functions include such functions as scans, reductions,
 and broadcasts, and are described in the kernel languages and IL specifications.
-The use of these subgroup functions implies sequenced-before relationships
+The use of these sub-group functions implies sequenced-before relationships
 between statements within the execution of a single work-item in order to
 satisfy data dependencies.
-For example, a work-item that provides a value to a subgroup function must
+For example, a work-item that provides a value to a sub-group function must
 behave as if it generates that value before beginning execution of that
-subgroup function.
-Furthermore, the programmer must ensure that all work-items in a subgroup
-must execute the same subgroup function call site, or dynamic subgroup
+sub-group function.
+Furthermore, the programmer must ensure that all work-items in a sub-group
+must execute the same sub-group function call site, or dynamic sub-group
 function instance.
 
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -437,7 +437,7 @@ then execute in that same order; where we use the term appear to emphasize
 that when there are no dependencies between commands and hence differences
 in the order that commands execute cannot be observed in a program, an
 implementation can reorder commands even in an in-order command-queue.
-For an out of order command-queue, kernel-instances wait to be launched
+For an out-of-order command-queue, kernel-instances wait to be launched
 until:
 
   * Synchronization commands enqueued prior to the kernel-instance are

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -300,13 +300,13 @@ within a work-group.
 The details of this mapping are described in the following section.
 
 
-=== Mapping work-items onto an NDRange
+=== Mapping work-items onto an ND-range
 
-The index space supported by OpenCL is called an NDRange.
-An NDRange is an N-dimensional index space, where N is one, two or three.
-The NDRange is decomposed into work-groups forming blocks that cover the
+The index space supported by OpenCL is called an ND-range.
+An ND-range is an N-dimensional index space, where N is one, two or three.
+The ND-range is decomposed into work-groups forming blocks that cover the
 Index space.
-An NDRange is defined by three integer arrays of length N:
+An ND-range is defined by three integer arrays of length N:
 
   * The extent of the index space (or global size) in each dimension.
   * An offset index F indicating the initial value of the indices in each
@@ -319,7 +319,7 @@ number of elements in that dimension minus one.
 
 Unless a kernel comes from a source that disallows it, e.g. OpenCL C 1.x or
 using `-cl-uniform-work-group-size`, the size of work-groups in
-an NDRange (the local size) need not be the same for all work-groups.
+an ND-range (the local size) need not be the same for all work-groups.
 In this case, any single dimension for which the global size is not
 divisible by the local size will be partitioned into two regions.
 One region will have work-groups that have the same number of work-items as
@@ -341,7 +341,7 @@ range from zero to the size of the work-group in that dimension minus one.
 
 Work-groups are assigned IDs similarly.
 The number of work-groups in each dimension is not directly defined but is
-inferred from the local and global NDRanges provided when a kernel-instance
+inferred from the local and global ND-ranges provided when a kernel-instance
 is enqueued.
 A work-group's ID is an N-dimensional tuple with components in the range 0
 to the ceiling of the global size in that dimension divided by the local
@@ -382,7 +382,7 @@ is computed as:
 * (w~x~, w~y~) = ( (g~x~ - s~x~ - F~x~) / S~x~, (g~y~ - s~y~ - F~y~) / S~y~ )
 
 [[index-space-image]]
-image::images/index_space.jpg[align="center", title="An example of an NDRange index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global NDRange size (i.e. all work-groups have the same size) and that the offset is equal to zero."]
+image::images/index_space.jpg[align="center", title="An example of an ND-range index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global ND-range size (i.e. all work-groups have the same size) and that the offset is equal to zero."]
 
 Within a work-group work-items may be divided into subgroups.
 The mapping of work-items to subgroups is implementation-defined and may be
@@ -422,7 +422,7 @@ command-queue, executes on a device, and completes.
 A kernel object is defined as a function within the program object and a
 collection of arguments connecting the kernel to a set of argument values.
 The host program enqueues a kernel object to the command-queue along with
-the NDRange and the work-group decomposition.
+the ND-range and the work-group decomposition.
 These define a _kernel-instance_.
 In addition, an optional set of events may be defined when the kernel is
 enqueued.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -156,8 +156,8 @@ each command passes through six states.
     prerequisites for execution are met.
   . *Ready*: All prerequisites constraining execution of a command have been
     met.
-    The command, or for a kernel-enqueue command the collection of work
-    groups associated with a command, is placed in a device work-pool from
+    The command, or for a kernel-enqueue command the collection of work-groups
+    associated with a command, is placed in a device work-pool from
     which it is scheduled for execution.
   . *Running*: Execution of the command starts.
     For the case of a kernel-enqueue command, one or more work-groups

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -141,7 +141,7 @@ The commands placed into the command-queue fall into one of three types:
     order constraints between commands.
 
 In addition to commands submitted from the host command-queue, a kernel
-running on a device can enqueue commands to a device-side command queue.
+running on a device can enqueue commands to a device-side command-queue.
 This results in _child kernels_ enqueued by a kernel executing on a device
 (the _parent kernel_).
 Regardless of whether the command-queue resides on the host or a device,
@@ -201,7 +201,7 @@ These prerequisites have three sources:
 
   * They may arise from commands submitted to a command-queue that constrain
     the order in which commands are launched.
-    For example, commands that follow a command queue barrier will not
+    For example, commands that follow a command-queue barrier will not
     launch until all commands prior to the barrier are complete.
   * The second source of prerequisites is dependencies between commands
     expressed through events.
@@ -262,13 +262,13 @@ of two modes:
     commands appear to the OpenCL application as if they execute in the same
     order they are enqueued to a command-queue.
   * *Out-of-order Execution*: Commands execute in any order constrained only
-    by explicit synchronization points (e.g. through command queue barriers)
+    by explicit synchronization points (e.g. through command-queue barriers)
     or explicit dependencies on events.
 
 Multiple command-queues can be present within a single context.
 Multiple command-queues execute commands independently.
 Event objects visible to the host program can be used to define
-synchronization points between commands in multiple command queues.
+synchronization points between commands in multiple command-queues.
 If such synchronization points are established between commands in multiple
 command-queues, an implementation must assure that the command-queues
 progress concurrently and correctly account for the dependencies established
@@ -421,7 +421,7 @@ command-queue, executes on a device, and completes.
 
 A kernel object is defined as a function within the program object and a
 collection of arguments connecting the kernel to a set of argument values.
-The host program enqueues a kernel object to the command queue along with
+The host program enqueues a kernel object to the command-queue along with
 the NDRange and the work-group decomposition.
 These define a _kernel-instance_.
 In addition, an optional set of events may be defined when the kernel is
@@ -432,11 +432,11 @@ commands in the queue or to commands in other queues within the same
 context.
 
 A kernel-instance is submitted to a device.
-For an in-order command queue, the kernel instances appear to launch and
+For an in-order command-queue, the kernel instances appear to launch and
 then execute in that same order; where we use the term appear to emphasize
 that when there are no dependencies between commands and hence differences
 in the order that commands execute cannot be observed in a program, an
-implementation can reorder commands even in an in-order command queue.
+implementation can reorder commands even in an in-order command-queue.
 For an out of order command-queue, kernel-instances wait to be launched
 until:
 
@@ -462,7 +462,7 @@ to {CL_COMPLETE}.
 While a command-queue is associated with only one device, a single device
 may be associated with multiple command-queues all feeding into the single
 work-pool.
-A device may also be associated with command queues associated with
+A device may also be associated with command-queues associated with
 different contexts within the same platform, again all feeding into the
 single work-pool.
 The device will pull work-groups from the work-pool and execute them on one
@@ -535,7 +535,7 @@ so-called *device-side enqueue*.
 Device-side kernel-enqueue commands are similar to host-side kernel-enqueue
 commands.
 The kernel executing on a device (the *parent kernel*) enqueues a
-kernel-instance (the *child kernel*) to a device-side command queue.
+kernel-instance (the *child kernel*) to a device-side command-queue.
 This is an out-of-order command-queue and follows the same behavior as the
 out-of-order command-queues exposed to the host program.
 Commands enqueued to a device side command-queue generate and use events to
@@ -633,7 +633,7 @@ The synchronization points defined in OpenCL include:
     the work-groups in the kernel and all of its child kernels have
     completed.
     This is signaled to the host, a parent kernel or other kernels within
-    command queues by setting the value of the event associated with a
+    command-queues by setting the value of the event associated with a
     kernel to {CL_COMPLETE}.
   * *Blocking Commands:* A blocking command defines a synchronization point
     between the unit of execution that calls the blocking API function and
@@ -642,7 +642,7 @@ The synchronization points defined in OpenCL include:
     previously enqueued commands have completed before subsequently enqueued
     commands can be launched.
   * {clFinish}: This function blocks until all previously enqueued commands
-    in the command queue have completed after which {clFinish} defines a
+    in the command-queue have completed after which {clFinish} defines a
     synchronization point and the {clFinish} function returns.
 
 
@@ -699,7 +699,7 @@ The OpenCL execution model supports three types of kernels:
     Note: Built-in kernels are <<unified-spec, missing before>> version 1.2.
 
 
-All three types of kernels are manipulated through the OpenCL command queues
+All three types of kernels are manipulated through the OpenCL command-queues
 and must conform to the synchronization points defined in the OpenCL
 execution model.
 
@@ -940,7 +940,7 @@ devices.
 
   * *Read/Write/Fill commands*: The data associated with a memory object is
     explicitly read and written between the host and global memory regions
-    using commands enqueued to an OpenCL command queue.
+    using commands enqueued to an OpenCL command-queue.
     Note: Fill commands are <<unified-spec, missing before>> version 1.2.
   * *Map/Unmap commands*: Data from the memory object is mapped into a
     contiguous block of memory accessed through a host accessible pointer.
@@ -979,7 +979,7 @@ multiple devices, the OpenCL runtime system must manage the association of
 memory objects with a given device.
 In most cases the OpenCL runtime will implicitly associate a memory object
 with a device.
-A kernel instance is naturally associated with the command queue to which
+A kernel instance is naturally associated with the command-queue to which
 the kernel was submitted.
 Since a command-queue can only access a single device, the queue uniquely
 defines which device is involved with any given kernel-instance; hence
@@ -1214,7 +1214,7 @@ model.
 This is accomplished by following these guidelines.
 
   * Write programs that manage safe sharing of global memory objects through
-    the synchronization points defined by the command queues.
+    the synchronization points defined by the command-queues.
   * Restrict low level synchronization inside work-groups to the work-group
     functions such as barrier.
   * If you want sequential consistency behavior with system allocations or
@@ -1852,9 +1852,9 @@ function instance.
 
 This section describes how the OpenCL API functions associated with
 command-queues contribute to happens-before relations.
-There are two types of command queues and associated API functions in OpenCL
+There are two types of command-queues and associated API functions in OpenCL
 2.x; _host command-queues_ and _device command-queues_.
-The interaction of these command queues with the memory model are for the
+The interaction of these command-queues with the memory model are for the
 most part equivalent.
 In a few cases, the rules only applies to the host command-queue.
 We will indicate these special cases by specifically denoting the host
@@ -1904,7 +1904,7 @@ following:
     memory operations made by the host thread.
   . If a command *C* has an event *E* that signals its completion, then *C*
     global- synchronizes-with *E*.
-  . For a command *C* enqueued to a host-side command queue, if *C* has an
+  . For a command *C* enqueued to a host-side command-queue, if *C* has an
     event *E* that signals its completion, then *E* global-synchronizes-with
     an API call *X* that waits on *E*.
     For example, if a host thread or kernel-instance calls the
@@ -1953,7 +1953,7 @@ following:
     `CLK_ENQUEUE_FLAGS_WAIT_WORK_GROUP` flag, then the end state of the
     work-group global-synchronizes with *C*.
 
-When using an out-of-order command queue, a wait on an event or a marker or
+When using an out-of-order command-queue, a wait on an event or a marker or
 command-queue barrier command can be used to ensure the correct ordering of
 dependent commands.
 In those cases, the wait for the event or the marker or barrier command will
@@ -1991,7 +1991,7 @@ No writes to fine-grained SVM buffers can be introduced that were not in the
 original program.
 
 In the remainder of this section, we discuss a few points regarding the
-ordering rules for commands with a host command queue.
+ordering rules for commands with a host command-queue.
 
 NOTE: In an OpenCL 1.x implementation a synchronization point is a
 kernel-instance or host program location where the contents of memory
@@ -2012,7 +2012,7 @@ may be overwritten by the map operation.
 
 Access to non-SVM {cl_mem_TYPE} buffers and coarse-grained SVM allocations is
 ordered at synchronization points between host commands.
-In the presence of an out-of-order command queue or a set of command queues
+In the presence of an out-of-order command-queue or a set of command-queues
 mapped to the same device, multiple kernel instances may execute
 concurrently on the same device.
 
@@ -2052,7 +2052,7 @@ The platform version indicates the version of the OpenCL runtime that is
 supported.
 This includes all of the APIs that the host can use to interact with
 resources exposed by the OpenCL runtime; including contexts, memory objects,
-devices, and command queues.
+devices, and command-queues.
 
 The device version is an indication of the device's capabilities separate
 from the runtime and compiler as represented by the device info returned by

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -504,8 +504,8 @@ synchronization within the work-group.
 
 In the absence of synchronization functions (e.g. a barrier), work-items
 within a sub-group may be serialized.
-In the presence of sub -group functions, work-items within a sub -group may
-be serialized before any given sub -group function, between dynamically
+In the presence of sub-group functions, work-items within a sub-group may
+be serialized before any given sub-group function, between dynamically
 encountered pairs of sub-group functions and between a work-group function
 and the end of the kernel.
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -288,10 +288,10 @@ Each of these executing kernel functions is called a _work-item_.
 The work-items associated with a given kernel-instance are managed by the
 device in groups called _work-groups_.
 These work-groups define a coarse grained decomposition of the Index space.
-Work-groups are further divided into _sub-groups_, which provide an
+Work-groups are further divided into _subgroups_, which provide an
 additional level of control over execution.
 
-NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
+NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
 
 Work-items have a global ID based on their coordinates within the Index
 space.
@@ -384,30 +384,30 @@ is computed as:
 [[index-space-image]]
 image::images/index_space.jpg[align="center", title="An example of an NDRange index space showing work-items, their global IDs and their mapping onto the pair of work-group and local IDs. In this case, we assume that in each dimension, the size of the work-group evenly divides the global NDRange size (i.e. all work-groups have the same size) and that the offset is equal to zero."]
 
-Within a work-group work-items may be divided into sub-groups.
-The mapping of work-items to sub-groups is implementation-defined and may be
+Within a work-group work-items may be divided into subgroups.
+The mapping of work-items to subgroups is implementation-defined and may be
 queried at runtime.
-While sub-groups may be used in multi-dimensional work-groups, each
-sub-group is 1-dimensional and any given work-item may query which sub-group
+While subgroups may be used in multi-dimensional work-groups, each
+subgroup is 1-dimensional and any given work-item may query which subgroup
 it is a member of.
 
-NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
+NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
 
-Work-items are mapped into sub-groups through a combination of compile-time
+Work-items are mapped into subgroups through a combination of compile-time
 decisions and the parameters of the dispatch.
-The mapping to sub-groups is invariant for the duration of a kernels
+The mapping to subgroups is invariant for the duration of a kernels
 execution, across dispatches of a given kernel with the same work-group
 dimensions, between dispatches and query operations consistent with the
 dispatch parameterization, and from one work-group to another within the
 dispatch (excluding the trailing edge work-groups in the presence of
 non-uniform work-group sizes).
-In addition, all sub-groups within a work-group will be the same size, apart
-from the sub-group with the maximum index which may be smaller if the size
-of the work-group is not evenly divisible by the size of the sub-groups.
+In addition, all subgroups within a work-group will be the same size, apart
+from the subgroup with the maximum index which may be smaller if the size
+of the work-group is not evenly divisible by the size of the subgroups.
 
-In the degenerate case, a single sub-group must be supported for each
+In the degenerate case, a single subgroup must be supported for each
 work-group.
-In this situation all sub-group scope functions are equivalent to their
+In this situation all subgroup scope functions are equivalent to their
 work-group level equivalents.
 
 
@@ -474,28 +474,28 @@ There is no safe and portable way to synchronize across the independent
 execution of work-groups since once in the work-pool, they can execute in
 any order.
 
-The work-items within a single sub-group execute concurrently but not
+The work-items within a single subgroup execute concurrently but not
 necessarily in parallel (i.e. they are not guaranteed to make independent
 forward progress).
-Therefore, only high-level synchronization constructs (e.g. sub-group
-functions such as barriers) that apply to all the work-items in a sub-group
+Therefore, only high-level synchronization constructs (e.g. subgroup
+functions such as barriers) that apply to all the work-items in a subgroup
 are well defined and included in OpenCL.
 
-NOTE: Sub-groups are <<unified-spec, missing before>> version 2.1.
+NOTE: Subgroups are <<unified-spec, missing before>> version 2.1.
 
-Sub-groups execute concurrently within a given work-group and with
+Subgroups execute concurrently within a given work-group and with
 appropriate device support (see <<platform-querying-devices, Querying
 Devices>>), may make independent forward progress with respect to each
 other, with respect to host threads and with respect to any entities
 external to the OpenCL system but running on an OpenCL device, even in the
 absence of work-group barrier operations.
-In this situation, sub-groups are able to internally synchronize using
+In this situation, subgroups are able to internally synchronize using
 barrier operations without synchronizing with each other and may perform
-operations that rely on runtime dependencies on operations other sub-groups
+operations that rely on runtime dependencies on operations other subgroups
 perform.
 
 The work-items within a single work-group execute concurrently but are only
-guaranteed to make independent progress in the presence of sub-groups and
+guaranteed to make independent progress in the presence of subgroups and
 device support.
 In the absence of this capability, only high-level synchronization
 constructs (e.g. work-group functions such as barriers) that apply to all
@@ -503,13 +503,13 @@ the work-items in a work-group are well defined and included in OpenCL for
 synchronization within the work-group.
 
 In the absence of synchronization functions (e.g. a barrier), work-items
-within a sub-group may be serialized.
-In the presence of sub-group functions, work-items within a sub-group may
-be serialized before any given sub-group function, between dynamically
-encountered pairs of sub-group functions and between a work-group function
+within a subgroup may be serialized.
+In the presence of subgroup functions, work-items within a subgroup may
+be serialized before any given subgroup function, between dynamically
+encountered pairs of subgroup functions and between a work-group function
 and the end of the kernel.
 
-In the absence of independent forward progress of constituent sub-groups,
+In the absence of independent forward progress of constituent subgroups,
 work-items within a work-group may be serialized before, after or between
 work-group synchronization functions.
 
@@ -570,9 +570,9 @@ Consider the following three domains of synchronization in OpenCL:
 
   * Work-group synchronization: Constraints on the order of execution for
     work-items in a single work-group
-  * Sub-group synchronization: Constraints on the order of execution for
-    work-items in a single sub-group.
-    Note: Sub-groups are <<unified-spec, missing before>> version 2.1
+  * Subgroup synchronization: Constraints on the order of execution for
+    work-items in a single subgroup.
+    Note: Subgroups are <<unified-spec, missing before>> version 2.1
   * Command synchronization: Constraints on the order of commands launched
     for execution
 
@@ -596,24 +596,24 @@ OpenCL since OpenCL does not define forward-progress or ordering relations
 between work-groups, hence collective synchronization operations are not
 well defined.
 
-Synchronization across all work-items within a single sub-group is carried
-out using a _sub-group function_.
+Synchronization across all work-items within a single subgroup is carried
+out using a _subgroup function_.
 These functions carry out collective operations across all the work-items in
-a sub-group.
+a subgroup.
 Available collective operations are: barrier, reduction, broadcast, prefix
 sum, and evaluation of a predicate.
-A sub-group function must occur within a converged control flow; i.e. all
-work-items in the sub-group must encounter precisely the same sub-group
+A subgroup function must occur within a converged control flow; i.e. all
+work-items in the subgroup must encounter precisely the same subgroup
 function.
 For example, if a work-group function occurs within a loop, the work-items
-must encounter the same sub-group function in the same loop iterations.
-All the work-items of a sub-group must execute the sub-group function and
+must encounter the same subgroup function in the same loop iterations.
+All the work-items of a subgroup must execute the subgroup function and
 complete reads and writes to memory before any are allowed to continue
-execution beyond the sub-group function.
-Synchronization between sub-groups must either be performed using work-group
+execution beyond the subgroup function.
+Synchronization between subgroups must either be performed using work-group
 functions, or through memory operations.
-Using memory operations for sub-group synchronization should be used
-carefully as forward progress of sub-groups relative to each other is only
+Using memory operations for subgroup synchronization should be used
+carefully as forward progress of subgroups relative to each other is only
 supported optionally by OpenCL implementations.
 
 Command synchronization is defined in terms of distinct *synchronization
@@ -1176,7 +1176,7 @@ enumeration constant:
   * *memory_scope_work_item*: memory-ordering constraints only apply within
     the work-item footnote:[{fn-image-mem-fence}].
   * *memory_scope_sub_group*: memory-ordering constraints only apply within
-    the sub-group.
+    the subgroup.
   * *memory_scope_work_group*: memory-ordering constraints only apply to
     work-items executing within a single work-group.
   * *memory_scope_device:* memory-ordering constraints only apply to
@@ -1322,7 +1322,7 @@ Two actions *A* and *B* are defined to have an inclusive scope if they have
 the same scope *P* such that:
 
   * *P* is *memory_scope_sub_group* and *A* and *B* are executed by
-    work-items within the same sub-group.
+    work-items within the same subgroup.
   * *P* is *memory_scope_work_group* and *A* and *B* are executed by
     work-items within the same work-group.
   * *P* is *memory_scope_device* and *A* and *B* are executed by work-items
@@ -1793,20 +1793,20 @@ must execute the same work-group function call site, or dynamic work-group
 function instance.
 
 
-==== Sub-group Functions
+==== Subgroup Functions
 
-NOTE: Sub-group functions are <<unified-spec, missing before>> version 2.1.
+NOTE: Subgroup functions are <<unified-spec, missing before>> version 2.1.
 Also see extension *cl_khr_subgroups*.
 
 The OpenCL kernel execution model includes collective operations across the
-work-items within a single sub-group.
-These are called sub-group functions.
-We will first discuss the sub-group barrier.
-Other sub-group functions are discussed afterwards.
+work-items within a single subgroup.
+These are called subgroup functions.
+We will first discuss the subgroup barrier.
+Other subgroup functions are discussed afterwards.
 
 The barrier function provides a mechanism for a kernel to synchronize the
-work-items within a single sub-group: informally, each work-item of the
-sub-group must execute the barrier before any are allowed to proceed.
+work-items within a single subgroup: informally, each work-item of the
+subgroup must execute the barrier before any are allowed to proceed.
 It also orders memory operations to a specified combination of one or more
 address spaces such as local memory or global memory, in a similar manner to
 a fence.
@@ -1816,7 +1816,7 @@ distinguish between a dynamic and a static instance of the call to a
 barrier.
 A call to a barrier can appear in a loop, for example, and each execution of
 the same static barrier call results in a new dynamic instance of the
-barrier that will independently synchronize a sub-groups work-items.
+barrier that will independently synchronize the work-items in a subgroup.
 
 A work-item executing a dynamic instance of a barrier results in two
 operations, both fences, that are called the entry and exit fences.
@@ -1830,21 +1830,21 @@ chapter as well as the following:
   * For each work-item the entry fence is sequenced before the exit fence.
   * If the flags have `CLK_GLOBAL_MEM_FENCE` set then for each work-item the
     entry fence global-synchronizes-with the exit fence of all other
-    work-items in the same sub-group.
+    work-items in the same subgroup.
   * If the flags have `CLK_LOCAL_MEM_FENCE` set then for each work-item the
     entry fence local-synchronizes-with the exit fence of all other
-    work-items in the same sub-group.
+    work-items in the same subgroup.
 
-Other sub-group functions include such functions as scans, reductions,
+Other subgroup functions include such functions as scans, reductions,
 and broadcasts, and are described in the kernel languages and IL specifications.
-The use of these sub-group functions implies sequenced-before relationships
+The use of these subgroup functions implies sequenced-before relationships
 between statements within the execution of a single work-item in order to
 satisfy data dependencies.
-For example, a work-item that provides a value to a sub-group function must
+For example, a work-item that provides a value to a subgroup function must
 behave as if it generates that value before beginning execution of that
-sub-group function.
-Furthermore, the programmer must ensure that all work-items in a sub-group
-must execute the same sub-group function call site, or dynamic sub-group
+subgroup function.
+Furthermore, the programmer must ensure that all work-items in a subgroup
+must execute the same subgroup function call site, or dynamic subgroup
 function instance.
 
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -538,7 +538,7 @@ The kernel executing on a device (the *parent kernel*) enqueues a
 kernel-instance (the *child kernel*) to a device-side command-queue.
 This is an out-of-order command-queue and follows the same behavior as the
 out-of-order command-queues exposed to the host program.
-Commands enqueued to a device side command-queue generate and use events to
+Commands enqueued to a device-side command-queue generate and use events to
 enforce order constraints just as for the command-queue on the host.
 These events, however, are only visible to the parent kernel running on the
 device.

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1229,7 +1229,7 @@ include::{generated}/api/version-notes/CL_DEVICE_PARTITION_PROPERTIES.asciidoc[]
 
         If the device cannot be partitioned (i.e. there is no partitioning
         scheme supported by the device that will return at least two
-        subdevices), a value of 0 will be returned.
+        sub-devices), a value of 0 will be returned.
 | {CL_DEVICE_PARTITION_AFFINITY_DOMAIN_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_PARTITION_AFFINITY_DOMAIN.asciidoc[]
@@ -1593,7 +1593,7 @@ include::{generated}/api/version-notes/clCreateSubDevices.asciidoc[]
     value.
     The list is terminated with 0.
     The list of supported partitioning schemes is described in the
-    <<subdevice-partition-table, Subdevice Partition>> table.
+    <<sub-device-partition-table, Sub-device Partition>> table.
     Only one of the listed partitioning schemes can be specified in
     _properties_.
   * _num_devices_ is the size of memory pointed to by _out_devices_ specified as
@@ -1617,7 +1617,7 @@ calls to {clCreateSubDevices} and creating command-queues.
 When a command-queue is created against a sub-device, the commands enqueued
 on the queue are executed only on the sub-device.
 
-[[subdevice-partition-table]]
+[[sub-device-partition-table]]
 .List of supported partition schemes by <<clCreateSubDevices>>
 [width="100%",cols="<33%,<17%,<50%",options="header"]
 |====

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1333,10 +1333,10 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMEN
         is aligned to the natural size of the type.
 | {CL_DEVICE_MAX_NUM_SUB_GROUPS_anchor}
 
-// Note: This sub-group property is not in cl_khr_subgroups.
+// Note: This subgroup property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
   | {cl_uint_TYPE}
-      | Maximum number of sub-groups in a work-group that a device is
+      | Maximum number of subgroups in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device.
 
@@ -1347,11 +1347,11 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
         (Refer also to {clGetKernelSubGroupInfo}.)
 | {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS_anchor}
 
-// Note: This sub-group property is not in cl_khr_subgroups.
+// Note: This subgroup property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS.asciidoc[]
   | {cl_bool_TYPE}
       | Is {CL_TRUE} if this device supports independent forward progress of
-        sub-groups, {CL_FALSE} otherwise.
+        subgroups, {CL_FALSE} otherwise.
 
         This query must return {CL_TRUE} for devices that support the
         *cl_khr_subgroups* extension, and must return {CL_FALSE} for

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1510,7 +1510,7 @@ timestamps from the device timer and the host timer as seen by _device_.
 Implementations may need to execute this query with a high latency in order
 to provide reasonable synchronization of the timestamps.
 The host timestamp and device timestamp returned by this function and
-{clGetHostTimer} each have an implementation defined timebase.
+{clGetHostTimer} each have an implementation-defined timebase.
 The timestamps will always be in their respective timebases regardless of
 which query function is used.
 The timestamp returned from {clGetEventProfilingInfo} for an event on a
@@ -1553,7 +1553,7 @@ This value is in the same timebase as the _host_timestamp_ returned from
 The implementation will return with as low a latency as possible to allow a
 correlation with a subsequent application sampled time.
 The host timestamp and device timestamp returned by this function and
-{clGetDeviceAndHostTimer} each have an implementation defined timebase.
+{clGetDeviceAndHostTimer} each have an implementation-defined timebase.
 The timestamps will always be in their respective timebases regardless of
 which query function is used.
 The timestamp returned from {clGetEventProfilingInfo} for an event on a

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1333,29 +1333,29 @@ include::{generated}/api/version-notes/CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMEN
         is aligned to the natural size of the type.
 | {CL_DEVICE_MAX_NUM_SUB_GROUPS_anchor}
 
-// Note: This subgroup property is not in cl_khr_subgroups.
+// Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_MAX_NUM_SUB_GROUPS.asciidoc[]
   | {cl_uint_TYPE}
-      | Maximum number of subgroups in a work-group that a device is
+      | Maximum number of sub-groups in a work-group that a device is
         capable of executing on a single compute unit, for any given
         kernel-instance running on the device.
 
-        The minimum value is 1 if the device supports subgroups, and must be
-        0 for devices that do not support subgroups.
-        Support for subgroups is required for an OpenCL 2.1 or 2.2 device.
+        The minimum value is 1 if the device supports sub-groups, and must be
+        0 for devices that do not support sub-groups.
+        Support for sub-groups is required for an OpenCL 2.1 or 2.2 device.
 
         (Refer also to {clGetKernelSubGroupInfo}.)
 | {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS_anchor}
 
-// Note: This subgroup property is not in cl_khr_subgroups.
+// Note: This sub-group property is not in cl_khr_subgroups.
 include::{generated}/api/version-notes/CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS.asciidoc[]
   | {cl_bool_TYPE}
       | Is {CL_TRUE} if this device supports independent forward progress of
-        subgroups, {CL_FALSE} otherwise.
+        sub-groups, {CL_FALSE} otherwise.
 
         This query must return {CL_TRUE} for devices that support the
         *cl_khr_subgroups* extension, and must return {CL_FALSE} for
-        devices that do not support subgroups.
+        devices that do not support sub-groups.
 
 | {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES_anchor}
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2884,7 +2884,7 @@ include::{generated}/api/version-notes/clEnqueueFillImage.asciidoc[]
     same.
   * _image_ is a valid image object.
   * _fill_color_ is the color used to fill the image.
-    The fill color is a single floating point value if the channel order is
+    The fill color is a single floating-point value if the channel order is
     {CL_DEPTH}.
     Otherwise, the fill color is a four component RGBA floating-point color
     value if the _image_ channel data type is not an unnormalized signed or

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -9221,7 +9221,7 @@ The _properties_ argument in {clCreateCommandQueueWithProperties} or
 {clCreateCommandQueue} can be used to specify the execution order.
 
 If the {CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE} property of a command-queue is
-not set, the commands enqueued to a command-queue execute in order.
+not set, the commands enqueued to a command-queue execute in-order.
 For example, if an application calls {clEnqueueNDRangeKernel} to execute
 kernel A followed by a {clEnqueueNDRangeKernel} to execute kernel B, the
 application can assume that kernel A finishes first and then kernel B is
@@ -9239,7 +9239,7 @@ property of the command-queue.
 This can be specified when the command-queue is created.
 In out-of-order execution mode there is no guarantee that the enqueued
 commands will finish execution in the order they were queued.
-As there is no guarantee that kernels will be executed in order, i.e. based
+As there is no guarantee that kernels will be executed in-order, i.e. based
 on when the {clEnqueueNDRangeKernel} or {clEnqueueTask} calls are made within a
 command-queue, it is therefore possible that an earlier
 {clEnqueueNDRangeKernel} call to execute kernel A identified by event A may

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5639,7 +5639,7 @@ include::{generated}/api/version-notes/clSetProgramReleaseCallback.asciidoc[]
     This callback function may be called asynchronously by the OpenCL
     implementation.
     It is the application's responsibility to ensure that the callback function
-    is thread safe.
+    is thread-safe.
     The parameters to this callback function are:
   ** _program_ is the program being deleted.
      When the callback function is called by the implementation, this program

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5780,7 +5780,7 @@ include::{generated}/api/version-notes/clBuildProgram.asciidoc[]
     If the program was created using {clCreateProgramWithBinary} and _options_
     string contains anything other than the same options in the same order
     (whitespace ignored) as when the program binary was originally built, then
-    the behavior is implementation defined.
+    the behavior is implementation-defined.
     Otherwise, if _options_ is a `NULL` pointer then it will have the same
     result as the empty string.
   * _pfn_notify_ is a function pointer to a notification routine.
@@ -6060,7 +6060,7 @@ include::{generated}/api/version-notes/clLinkProgram.asciidoc[]
     If the program was created using {clCreateProgramWithBinary} and _options_
     string contains anything other than the same options in the same order
     (whitespace ignored) as when the program binary was originally built, then
-    the behavior is implementation defined.
+    the behavior is implementation-defined.
     Otherwise, if _options_ is a `NULL` pointer then it will have the same
     result as the empty string.
   * _num_input_programs_ specifies the number of programs in array referenced by
@@ -6199,7 +6199,7 @@ These options are ignored for programs created with IL.
 `-D` options are processed in the order they are given in the _options_
 argument to {clBuildProgram} or {clCompileProgram}.
 Note that a space is required between the `-D` option and the symbol it
-defines, otherwise behavior is implementation defined.
+defines, otherwise behavior is implementation-defined.
 --
 
 `-I dir` ::

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11,7 +11,7 @@ functions in a program and calls that allow you to enqueue commands to a
 command-queue such as executing a kernel, reading, or writing a memory
 object.
 
-== Command Queues
+== Command-Queues
 
 OpenCL objects such as memory, program and kernel objects are created using
 a context.
@@ -192,20 +192,20 @@ returned in _errcode_ret_:
     required by the OpenCL implementation on the host.
 --
 
-[open,refpage='clSetDefaultDeviceCommandQueue',desc='Replaces the default command queue on the device.',type='protos']
+[open,refpage='clSetDefaultDeviceCommandQueue',desc='Replaces the default command-queue on the device.',type='protos']
 --
-To replace the default command queue on a device, call the function
+To replace the default command-queue on a device, call the function
 
 include::{generated}/api/protos/clSetDefaultDeviceCommandQueue.txt[]
 include::{generated}/api/version-notes/clSetDefaultDeviceCommandQueue.asciidoc[]
 
   * _context_ is the OpenCL context used to create _command_queue_.
   * _device_ is a valid OpenCL device associated with _context_.
-  * _command_queue_ specifies a command queue object which replaces the
-    default device command queue
+  * _command_queue_ specifies a command-queue object which replaces the
+    default device command-queue
 
 {clSetDefaultDeviceCommandQueue} may be used to replace a default device
-command queue created with {clCreateCommandQueueWithProperties} and the
+command-queue created with {clCreateCommandQueueWithProperties} and the
 {CL_QUEUE_ON_DEVICE_DEFAULT} flag.
 
 // refError
@@ -228,7 +228,7 @@ Otherwise, it returns one of the following errors:
 
 [open,refpage='clRetainCommandQueue',desc='Increments the command_queue reference count.',type='protos']
 --
-To retain a command queue, call the function
+To retain a command-queue, call the function
 
 include::{generated}/api/protos/clRetainCommandQueue.txt[]
 include::{generated}/api/version-notes/clRetainCommandQueue.asciidoc[]
@@ -263,7 +263,7 @@ Otherwise, it returns one of the following errors:
 
 [open,refpage='clReleaseCommandQueue',desc='Decrements the command_queue reference count.',type='protos']
 --
-To release a command queue, call the function
+To release a command-queue, call the function
 
 include::{generated}/api/protos/clReleaseCommandQueue.txt[]
 include::{generated}/api/version-notes/clReleaseCommandQueue.asciidoc[]
@@ -310,7 +310,7 @@ include::{generated}/api/version-notes/clGetCommandQueueInfo.asciidoc[]
   * _param_value_size_ is used to specify the size in bytes of memory pointed to
     by _param_value_.
     This size must be {geq} size of return type as described in the
-    <<command-queue-param-table,Command Queue Parameter>> table.
+    <<command-queue-param-table,Command-Queue Parameter>> table.
     If _param_value_ is `NULL`, it is ignored.
   * _param_value_size_ret_ returns the actual size in bytes of data being
     queried by _param_name_.
@@ -318,7 +318,7 @@ include::{generated}/api/version-notes/clGetCommandQueueInfo.asciidoc[]
 
 The list of supported _param_name_ values and the information returned in
 _param_value_ by {clGetCommandQueueInfo} is described in the
-<<command-queue-param-table,Command Queue Parameter>> table.
+<<command-queue-param-table,Command-Queue Parameter>> table.
 
 [[command-queue-param-table]]
 .List of supported param_names by <<clGetCommandQueueInfo>>
@@ -380,7 +380,7 @@ include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
 
 include::{generated}/api/version-notes/CL_QUEUE_DEVICE_DEFAULT.asciidoc[]
   | {cl_command_queue_TYPE}
-      | Return the current default command queue for the underlying device.
+      | Return the current default command-queue for the underlying device.
 |====
 
 // refError
@@ -394,7 +394,7 @@ Otherwise, it returns one of the following errors:
     for _param_name_.
   * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values or
     if size in bytes specified by _param_value_size_ is < size of return
-    type as specified in the <<command-queue-param-table,Command Queue
+    type as specified in the <<command-queue-param-table,Command-Queue
     Parameter>> table, and _param_value_ is not a `NULL` value.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
@@ -3814,7 +3814,7 @@ queue is flushed.
 In standard usage, blocking enqueue calls serve this role by implicitly
 flushing the queue.
 Since blocking calls are not permitted in callbacks, those callbacks that
-enqueue commands on a command queue should either call {clFlush} on the
+enqueue commands on a command-queue should either call {clFlush} on the
 queue before returning or arrange for {clFlush} to be called later on
 another thread.
 
@@ -4034,7 +4034,7 @@ enqueued commands, using the memory object, are targeted.
 {clEnqueueMigrateMemObjects} allows this migration to be explicitly
 performed ahead of the dependent commands.
 This allows a user to preemptively change the association of a memory
-object, through regular command queue scheduling, in order to prepare for
+object, through regular command-queue scheduling, in order to prepare for
 another upcoming command.
 This also permits an application to overlap the placement of memory objects
 with other unrelated operations before these memory objects are needed
@@ -4306,7 +4306,7 @@ We call this fine-grained sharing.
     This memory consistency applies to the regions of buffers being shared
     in a coarse-grained fashion.
     It is enforced at the synchronization points between commands enqueued
-    to command queues in a single context with the additional consideration
+    to command-queues in a single context with the additional consideration
     that multiple kernels concurrently running on the same device may safely
     share the data.
   * Fine-grained sharing: Shared virtual memory where memory consistency is
@@ -4525,7 +4525,7 @@ include::{generated}/api/version-notes/clEnqueueSVMFree.asciidoc[]
     function returns.
   * _pfn_free_func_ specifies the callback function to be called to free the SVM
     pointers.
-    _pfn_free_func_ takes four arguments: _queue_ which is the command queue in
+    _pfn_free_func_ takes four arguments: _queue_ which is the command-queue in
     which {clEnqueueSVMFree} was enqueued, the count and list of SVM pointers to
     free and _user_data_ which is a pointer to user specified data.
     If _pfn_free_func_ is `NULL`, all pointers specified in _svm_pointers_ must
@@ -4569,7 +4569,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_VALUE} if _num_svm_pointers_ is 0 and _svm_pointers_ is
     non-`NULL`, _or_ if _svm_pointers_ is `NULL` and _num_svm_pointers_ is
     not 0.
@@ -4646,7 +4646,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
     events in _event_wait_list_ are not the same.
   * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
@@ -4728,7 +4728,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
     events in _event_wait_list_ are not the same.
   * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
@@ -4808,7 +4808,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
     in _event_wait_list_ are not the same.
   * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
@@ -4874,7 +4874,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
     in _event_wait_list_ are not the same.
   * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
@@ -4918,7 +4918,7 @@ allocations should be associated with, call the function
 include::{generated}/api/protos/clEnqueueSVMMigrateMem.txt[]
 include::{generated}/api/version-notes/clEnqueueSVMMigrateMem.asciidoc[]
 
-  * _command_queue_ is a valid host command queue.
+  * _command_queue_ is a valid host command-queue.
     The specified set of allocation ranges will be migrated to the OpenCL device
     associated with _command_queue_.
   * _num_svm_pointers_ is the number of pointers in the specified _svm_pointers_
@@ -4960,7 +4960,7 @@ include::{generated}/api/version-notes/clEnqueueSVMMigrateMem.asciidoc[]
 
 Once the event returned by {clEnqueueSVMMigrateMem} has become {CL_COMPLETE},
 the ranges specified by svm pointers and sizes have been successfully
-migrated to the device associated with command queue.
+migrated to the device associated with command-queue.
 
 The user is responsible for managing the event dependencies associated with
 this command in order to avoid overlapping access to SVM allocations.
@@ -4975,7 +4975,7 @@ Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
     command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command queue_ does not support SVM.
+  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
     in _event_wait_list_ are not the same.
   * {CL_INVALID_VALUE} if _num_svm_pointers_ is zero or _svm_pointers_ is
@@ -8961,8 +8961,8 @@ to the user event, it would be in principle no longer valid for the
 application to change the status of the event to unblock all the other
 machinery.
 As a result the waiting tasks will wait forever, and associated events,
-{cl_mem_TYPE} objects, command queues and contexts are likely to leak.
-In-order command queues caught up in this deadlock may cease to do any work.
+{cl_mem_TYPE} objects, command-queues and contexts are likely to leak.
+In-order command-queues caught up in this deadlock may cease to do any work.
 ====
 
 // refError
@@ -9393,7 +9393,7 @@ To flush commands to a device, call the function
 include::{generated}/api/protos/clFlush.txt[]
 include::{generated}/api/version-notes/clFlush.asciidoc[]
 
-  * _command_queue_ is the command queue to flush.
+  * _command_queue_ is the command-queue to flush.
 
 All previously queued OpenCL commands in _command_queue_ are issued to the
 device associated with _command_queue_.
@@ -9437,7 +9437,7 @@ To wait for completion of commands on a device, call the function
 include::{generated}/api/protos/clFinish.txt[]
 include::{generated}/api/version-notes/clFinish.asciidoc[]
 
-  * _command_queue_ is the command queue to wait for.
+  * _command_queue_ is the command-queue to wait for.
 
 All previously queued OpenCL commands in _command_queue_ are issued to the
 associated device, and the function blocks until all previously queued

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6305,11 +6305,11 @@ Note: This option is <<unified-spec, missing before>> version 2.0.
 --
 
 `-cl-no-subgroup-ifp` ::
-    This indicates that kernels in this program do not require subgroups to
+    This indicates that kernels in this program do not require sub-groups to
     make independent forward progress.
     Allows optimizations that are made possible by this restriction.
     This option has no effect for devices that do not support independent
-    forward progress for subgroups.
+    forward progress for sub-groups.
 +
 --
 Note: This option is <<unified-spec, missing before>> version 2.1.
@@ -7713,7 +7713,7 @@ Also see extension *cl_khr_subgroups*.
   * _param_name_ specifies the information to query.
     The list of supported _param_name_ types and the information returned in
     _param_value_ by {clGetKernelSubGroupInfo} is described in the
-    <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table.
+    <<kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table.
   * _input_value_size_ is used to specify the size in bytes of memory pointed to
     by _input_value_.
     This size must be == size of input type as described in the table below.
@@ -7726,25 +7726,25 @@ Also see extension *cl_khr_subgroups*.
   * _param_value_size_ is used to specify the size in bytes of memory pointed to
     by _param_value_.
     This size must be {geq} size of return type as described in the
-    <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table.
+    <<kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table.
   * _param_value_size_ret_ returns the actual size in bytes of data being
     queried by _param_name_.
     If _param_value_size_ret_ is `NULL`, it is ignored.
 
-[[kernel-subgroup-info-table]]
+[[kernel-sub-group-info-table]]
 .List of supported param_names by <<clGetKernelSubGroupInfo>>
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
-| Kernel Subgroup Info | Input Type | Return Type | Description
+| Kernel Sub-group Info | Input Type | Return Type | Description
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE.asciidoc[]
 Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the maximum subgroup size for this kernel.
-            All subgroups must be the same size, while the last subgroup in
-            any work-group (i.e. the subgroup with the maximum index) could
+          | Returns the maximum sub-group size for this kernel.
+            All sub-groups must be the same size, while the last sub-group in
+            any work-group (i.e. the sub-group with the maximum index) could
             be the same or smaller size.
 
             The _input_value_ must be an array of {size_t_TYPE} values
@@ -7758,11 +7758,11 @@ include::{generated}/api/version-notes/CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE.asc
 Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the number of subgroups that will be present in each
+          | Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of subgroups.
+            same number of sub-groups.
 
             The _input_value_ must be an array of {size_t_TYPE} values
             corresponding to the local work size parameter of the intended
@@ -7776,18 +7776,18 @@ Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}
       | {size_t_TYPE}[]
           | Returns the local size that will generate the requested number
-            of subgroups for the kernel.
+            of sub-groups for the kernel.
             The output array must be an array of {size_t_TYPE} values corresponding
             to the local size parameter.
             Any returned work-group will have one dimension.
             Other dimensions inferred from the value specified for
             param_value_size will be filled with the value 1.
-            The returned value will produce an exact number of subgroups
+            The returned value will produce an exact number of sub-groups
             and result in no partial groups for an executing kernel except
             in the case where the last work-group in a dimension has a size
             different from that of the other groups.
             If no work-group size can accommodate the requested number of
-            subgroups, 0 will be returned in each element of the return
+            sub-groups, 0 will be returned in each element of the return
             array.
 | {CL_KERNEL_MAX_NUM_SUB_GROUPS_anchor}
 
@@ -7796,13 +7796,13 @@ Also see extension *cl_khr_subgroups*.
   | ignored
       | {size_t_TYPE}
           | This provides a mechanism for the application to query the
-            maximum number of subgroups that may make up each work-group to
+            maximum number of sub-groups that may make up each work-group to
             execute a kernel on a specific device given by device.
             The OpenCL implementation uses the resource requirements of the
             kernel (register usage etc.) to determine what this work-group
             size should be.
             The returned value may be used to compute a work-group size to
-            enqueue the kernel with to give a round number of subgroups for
+            enqueue the kernel with to give a round number of sub-groups for
             an enqueue.
 | {CL_KERNEL_COMPILE_NUM_SUB_GROUPS_anchor}
 
@@ -7810,8 +7810,8 @@ include::{generated}/api/version-notes/CL_KERNEL_COMPILE_NUM_SUB_GROUPS.asciidoc
 Also see extension *cl_khr_subgroups*.
   | ignored
       | {size_t_TYPE}
-          | Returns the number of subgroups per work-group specified in the kernel
-            source or IL. If the subgroup count is not specified then 0 is returned.
+          | Returns the number of sub-groups per work-group specified in the kernel
+            source or IL. If the sub-group count is not specified then 0 is returned.
 |====
 
 // refError
@@ -7823,10 +7823,10 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_DEVICE} if _device_ is not in the list of devices associated
     with _kernel_ or if _device_ is `NULL` but there is more than one device
     associated with _kernel_.
-  * {CL_INVALID_OPERATION} if _device_ does not support subgroups.
+  * {CL_INVALID_OPERATION} if _device_ does not support sub-groups.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
-    the <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table
+    the <<kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table
     and _param_value_ is not `NULL`.
   * {CL_INVALID_VALUE} if _param_name_ is
     {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE},
@@ -8117,7 +8117,7 @@ Otherwise, it returns one of the following errors:
     not match the required work-group size for _kernel_ in the program
     source.
   * {CL_INVALID_WORK_GROUP_SIZE} if _local_work_size_ is specified and is not
-    consistent with the required number of subgroups for _kernel_ in the
+    consistent with the required number of sub-groups for _kernel_ in the
     program source.
   * {CL_INVALID_WORK_GROUP_SIZE} if _local_work_size_ is specified and the
     total number of work-items in the work-group computed as
@@ -8233,7 +8233,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_WORK_GROUP_SIZE} if a work-group size is specified for _kernel_
     in the program source and it is not (1, 1, 1).
 // TODO I'm not sure if the next error makes sense for a 'task'.
-  * {CL_INVALID_WORK_GROUP_SIZE} if the required number of subgroups is
+  * {CL_INVALID_WORK_GROUP_SIZE} if the required number of sub-groups is
     specified for _kernel_ in the program source and is not consistent with a
     work-group size of (1, 1, 1).
   * {CL_MISALIGNED_SUB_BUFFER_OFFSET} if a sub-buffer object is specified as

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -92,8 +92,8 @@ include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE.asciidoc[]
         This can only be used with {CL_QUEUE_ON_DEVICE}.
 include::{generated}/api/version-notes/CL_QUEUE_ON_DEVICE_DEFAULT.asciidoc[]
 
-        If {CL_QUEUE_PROPERTIES} is not specified an in-order host command
-        queue is created for the specified device
+        If {CL_QUEUE_PROPERTIES} is not specified an in-order host command-queue
+        is created for the specified device
 | {CL_QUEUE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_QUEUE_SIZE.asciidoc[]
@@ -7598,7 +7598,7 @@ include::{generated}/api/version-notes/clGetKernelWorkGroupInfo.asciidoc[]
 .List of supported param_names by <<clGetKernelWorkGroupInfo>>
 [width="100%",cols="<33%,<17%,<50%",options="header"]
 |====
-| Kernel Work Group Info | Return Type | Description
+| Kernel Work-group Info | Return Type | Description
 | {CL_KERNEL_GLOBAL_WORK_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_GLOBAL_WORK_SIZE.asciidoc[]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5093,10 +5093,10 @@ include::{generated}/api/version-notes/CL_SAMPLER_ADDRESSING_MODE.asciidoc[]
         assigned a border color value.
 
         {CL_ADDRESS_REPEAT_anchor} - Out-of-range image coordinates read
-        from the image as-if the image data were replicated in all dimensions.
+        from the image as if the image data were replicated in all dimensions.
 
         {CL_ADDRESS_MIRRORED_REPEAT_anchor} - Out-of-range image coordinates
-        read from the image as-if the image data were replicated in all
+        read from the image as if the image data were replicated in all
         dimensions, mirroring the image contents at the edge of each
         replication.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7742,8 +7742,8 @@ include::{generated}/api/version-notes/CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE.
 Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the maximum sub-group size for this kernel.
-            All sub-groups must be the same size, while the last subgroup in
+          | Returns the maximum subgroup size for this kernel.
+            All subgroups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.
 
@@ -7758,11 +7758,11 @@ include::{generated}/api/version-notes/CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE.asc
 Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the number of sub-groups that will be present in each
+          | Returns the number of subgroups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of sub-groups.
+            same number of subgroups.
 
             The _input_value_ must be an array of {size_t_TYPE} values
             corresponding to the local work size parameter of the intended
@@ -7776,18 +7776,18 @@ Also see extension *cl_khr_subgroups*.
   | {size_t_TYPE}
       | {size_t_TYPE}[]
           | Returns the local size that will generate the requested number
-            of sub-groups for the kernel.
+            of subgroups for the kernel.
             The output array must be an array of {size_t_TYPE} values corresponding
             to the local size parameter.
             Any returned work-group will have one dimension.
             Other dimensions inferred from the value specified for
             param_value_size will be filled with the value 1.
-            The returned value will produce an exact number of sub-groups
+            The returned value will produce an exact number of subgroups
             and result in no partial groups for an executing kernel except
             in the case where the last work-group in a dimension has a size
             different from that of the other groups.
             If no work-group size can accommodate the requested number of
-            sub-groups, 0 will be returned in each element of the return
+            subgroups, 0 will be returned in each element of the return
             array.
 | {CL_KERNEL_MAX_NUM_SUB_GROUPS_anchor}
 
@@ -7796,13 +7796,13 @@ Also see extension *cl_khr_subgroups*.
   | ignored
       | {size_t_TYPE}
           | This provides a mechanism for the application to query the
-            maximum number of sub-groups that may make up each work-group to
+            maximum number of subgroups that may make up each work-group to
             execute a kernel on a specific device given by device.
             The OpenCL implementation uses the resource requirements of the
             kernel (register usage etc.) to determine what this work-group
             size should be.
             The returned value may be used to compute a work-group size to
-            enqueue the kernel with to give a round number of sub-groups for
+            enqueue the kernel with to give a round number of subgroups for
             an enqueue.
 | {CL_KERNEL_COMPILE_NUM_SUB_GROUPS_anchor}
 
@@ -7810,8 +7810,8 @@ include::{generated}/api/version-notes/CL_KERNEL_COMPILE_NUM_SUB_GROUPS.asciidoc
 Also see extension *cl_khr_subgroups*.
   | ignored
       | {size_t_TYPE}
-          | Returns the number of sub-groups per work-group specified in the kernel
-            source or IL. If the sub-group count is not specified then 0 is returned.
+          | Returns the number of subgroups per work-group specified in the kernel
+            source or IL. If the subgroup count is not specified then 0 is returned.
 |====
 
 // refError
@@ -8117,7 +8117,7 @@ Otherwise, it returns one of the following errors:
     not match the required work-group size for _kernel_ in the program
     source.
   * {CL_INVALID_WORK_GROUP_SIZE} if _local_work_size_ is specified and is not
-    consistent with the required number of sub-groups for _kernel_ in the
+    consistent with the required number of subgroups for _kernel_ in the
     program source.
   * {CL_INVALID_WORK_GROUP_SIZE} if _local_work_size_ is specified and the
     total number of work-items in the work-group computed as
@@ -8233,7 +8233,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_WORK_GROUP_SIZE} if a work-group size is specified for _kernel_
     in the program source and it is not (1, 1, 1).
 // TODO I'm not sure if the next error makes sense for a 'task'.
-  * {CL_INVALID_WORK_GROUP_SIZE} if the required number of sub-groups is
+  * {CL_INVALID_WORK_GROUP_SIZE} if the required number of subgroups is
     specified for _kernel_ in the program source and is not consistent with a
     work-group size of (1, 1, 1).
   * {CL_MISALIGNED_SUB_BUFFER_OFFSET} if a sub-buffer object is specified as

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -276,7 +276,7 @@ Except for 3-component vectors whose size is defined as 4 times the size of each
 *vload3* and *vload_half3* read (_x_,_y_,_z_) components from address `(_p_ + (_offset_ * 3))` into a 3-component vector. \
 *vstore3* and *vstore_half3* write (_x_,_y_,_z_) components from a 3-component vector to address `(_p_ + (_offset_ * 3))`. \
 In addition, *vloada_half3* reads (_x_,_y_,_z_) components from address `(_p_ + (_offset_ * 4))` into a 3-component vector and *vstorea_half3* writes (_x_,_y_,_z_) components from a 3-component vector to address `(_p_ {plus} (_offset_ * 4))`. \
-Whether *vloada_half3* and *vstorea_half3* read/write padding data between the third vector element and the next alignment boundary is implementation defined. \
+Whether *vloada_half3* and *vstorea_half3* read/write padding data between the third vector element and the next alignment boundary is implementation-defined. \
 The *vloada_* and *vstorea_* variants are provided to access data that is aligned to the size of the vector, and are intended to enable performance on hardware that can take advantage of the increased alignment. \
 ]
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -82,7 +82,7 @@ In {cpp}17 there is an explicit builtin pointer literal `nullptr` that should
 be used instead ({cpp}17 `[lex.nullptr]`).
 
 `NULL` macro definition in {cpp} for OpenCL follows {cpp}17
-`[support.types.nullptr]` where it is an implementation defined macro and it
+`[support.types.nullptr]` where it is an implementation-defined macro and it
 is not guaranteed to be the same as in OpenCL C. Reusing the definition of
 `NULL` from OpenCL C does not guarantee that any code with NULL is legal in
 {cpp} for OpenCL even if it is legal in OpenCL C.

--- a/env/appendix_a.asciidoc
+++ b/env/appendix_a.asciidoc
@@ -15,7 +15,7 @@ The first non-provisional version of the OpenCL 3.0 specifications was *v3.0.5*.
 
 Changes from *v3.0.5*:
 
-  * Clarified subgroup barrier behavior in non-uniform control flow.
+  * Clarified sub-group barrier behavior in non-uniform control flow.
   * Added required alignment of types.
   * Added new extensions:
       ** `cl_khr_subgroup_extended_types`

--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -184,7 +184,7 @@ OpenCL environment:
 
 // clk_event_t
 | *OpTypeDeviceEvent*
-| OpenCL device-side event representing commands enqueued to device command queues.
+| OpenCL device-side event representing commands enqueued to device command-queues.
 
 // pipe_t
 | *OpTypePipe*
@@ -196,7 +196,7 @@ OpenCL environment:
 
 // queue_t
 | *OpTypeQueue*
-| OpenCL device-side command queue.
+| OpenCL device-side command-queue.
 
 |====
 

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -873,7 +873,7 @@ b. Convert a floating-point sRGB value r to a floating-point linear RGB color va
 ++++
 
 2. The following process is used by image write instructions to convert a linear RGB floating-point color value y to a normalized 8-bit unsigned integer sRGB value x:
-a. Convert a floating-point linear RGB value y to a normalized floating point sRGB value r:
+a. Convert a floating-point linear RGB value y to a normalized floating-point sRGB value r:
 +
 [latexmath]
 ++++

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -81,7 +81,7 @@ Converting an out-of-range integer to an integer type without a
 *SaturatedConversion* decoration follows <<C99-spec, C99>>/<<cpp14-spec,
 C++14>> conversion rules.
 
-Converting an out-of-range floating point number to an integer type without
+Converting an out-of-range floating-point number to an integer type without
 a *SaturatedConversion* decoration is implementation-defined.
 
 === INF, NaN, and Denormalized Numbers

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -25,7 +25,7 @@ modules that declare the following capabilities:
   * *GenericPointer*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting the Generic Address Space (where {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} is {CL_TRUE}).
   * *Groups*
-    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`) or Work Group Collective Functions (where {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
+    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`) or Work-group Collective Functions (where {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
   * *Pipes*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Pipes (where {CL_DEVICE_PIPE_SUPPORT} is {CL_TRUE}).
   * *ImageBasic*

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -25,7 +25,7 @@ modules that declare the following capabilities:
   * *GenericPointer*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting the Generic Address Space (where {CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT} is {CL_TRUE}).
   * *Groups*
-    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`) or Work Group Collective Functions (where {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
+    ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`) or Work Group Collective Functions (where {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
   * *Pipes*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting Pipes (where {CL_DEVICE_PIPE_SUPPORT} is {CL_TRUE}).
   * *ImageBasic*
@@ -55,7 +55,7 @@ In addition, an OpenCL environment consuming SPIR-V 1.1 must support
 SPIR-V 1.1 modules that declare the following capabilities:
 
   * *SubgroupDispatch*
-    ** For OpenCL 2.2 devices, or OpenCL 3.0 devices supporting Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
+    ** For OpenCL 2.2 devices, or OpenCL 3.0 devices supporting Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
 // TODO: Do we need a device query for pipe storage?
 //       We do not currently expose pipe storage in OpenCL C.
   * *PipeStorage*

--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -67,7 +67,7 @@ be one of:
 
   * *Workgroup*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices
-       supporting Work Group Collective Functions (where
+       supporting Work-group Collective Functions (where
        {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
   * *Subgroup*
     ** For OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting

--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -55,7 +55,7 @@ For all *Atomic Instructions*:
 Recursion is not supported.
 The static function call graph for an entry point must not contain cycles.
 
-Whether irreducible control flow is legal is implementation defined.
+Whether irreducible control flow is legal is implementation-defined.
 
 For the instructions *OpGroupAsyncCopy* and *OpGroupWaitEvents*,
 _Scope_ for _Execution_ must be:

--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -71,14 +71,14 @@ be one of:
        {CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT} is {CL_TRUE}).
   * *Subgroup*
     ** For OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting
-       Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
+       Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
 
 For all other instructions, _Scope_ for _Execution_ must be one of:
 
   * *Workgroup*
   * *Subgroup*
     ** For OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting
-       Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
+       Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`)
 
 In an OpenCL 1.2 environment,
 for the *Barrier Instructions* *OpControlBarrier* and *OpMemoryBarrier*, the
@@ -100,7 +100,7 @@ Otherwise, _Scope_ for _Memory_ must be one of:
        {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES}.
   * *Subgroup*
     ** For OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting
-       Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`).
+       Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`).
   * *Invocation*
     ** For OpenCL 2.0, OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices
        supporting {CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM} in
@@ -123,7 +123,7 @@ And, the memory-order constraint in _Memory Semantics_ must be one of:
 
 In all OpenCL environments, for the *Barrier Instruction* *OpControlBarrier*,
 when the _Scope_ for _Execution_ is *Subgroup*, behavior is undefined unless
-all invocations in the subgroup execute the same dynamic instance of the
+all invocations in the sub-group execute the same dynamic instance of the
 instruction.
 
 In an OpenCL 1.2 environment,
@@ -145,7 +145,7 @@ Otherwise, _Scope_ for _Memory_ must be one of:
        {CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES}.
   * *Subgroup*
     ** For OpenCL 2.1, OpenCL 2.2, or OpenCL 3.0 devices supporting
-       Subgroups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`).
+       Sub-groups (where {CL_DEVICE_MAX_NUM_SUB_GROUPS} is not `0`).
 // From the OpenCL C spec:
 // memory_scope_work_item can only be used with atomic_work_item_fence
 // with flags set to CLK_IMAGE_MEM_FENCE.

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -3,7 +3,7 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_async_work_group_copy_fence]]
-== Async Work Group Copy Fence
+== Async Work-group Copy Fence
 
 This section describes the *cl_khr_async_work_group_copy_fence* extension.
 The extension adds a new built-in function to OpenCL C to establish a memory synchronization ordering of asynchronous copies.

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -829,7 +829,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -900,7 +900,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -986,7 +986,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1056,7 +1056,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1134,7 +1134,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1204,7 +1204,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1283,7 +1283,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1359,7 +1359,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.
@@ -1460,7 +1460,7 @@ must be 0. If _sync_point_wait_list_ is not `NULL`, the list of
 synchronization-points pointed to by _sync_point_wait_list_ must be
 valid and _num_sync_points_in_wait_list_ must be greater than 0.
 The synchronization-points specified in _sync_point_wait_list_ are
-*device side* synchronization-points. The command-buffer associated
+*device-side* synchronization-points. The command-buffer associated
 with synchronization-points in _sync_point_wait_list_ must be the same
 as _command_buffer_. The memory associated with _sync_point_wait_list_
 can be reused or freed after the function returns.

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -146,7 +146,7 @@ retain its provisional extension status until other layered extensions are
 released, as these may reveal modifications needed to the base specification to
 support their intended use cases.
 
-==== NDRange Kernel Command Properties
+==== ND-range Kernel Command Properties
 
 The {clCommandNDRangeKernelKHR} entry-point defines a `properties` parameter of
 new type {cl_ndrange_kernel_command_properties_khr_TYPE}. No properties are defined

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -1416,7 +1416,7 @@ Records a command to execute a kernel on a device.
 The work-group size to be used for _kernel_ can also be specified in the
 program source using the
 `+__attribute__((reqd_work_group_size(X, Y, Z)))+` qualifier. In this case the
-size of work group specified by _local_work_size_ must match the value
+size of work-group specified by _local_work_size_ must match the value
 specified by the `reqd_work_group_size` `+__attribute__+` qualifier.
 
 These work-group instances are executed in parallel across multiple compute

--- a/ext/cl_khr_create_command_queue.asciidoc
+++ b/ext/cl_khr_create_command_queue.asciidoc
@@ -3,7 +3,7 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_create_command_queue]]
-== Creating Command Queues with Properties
+== Creating Command-Queues with Properties
 
 === Overview
 
@@ -13,12 +13,12 @@ This extension allows OpenCL 1.x devices to support an equivalent of the
 {clCreateCommandQueueWithProperties} API that was added in OpenCL 2.0.
 This allows OpenCL 1.x devices to support other optional extensions or
 features that use the {clCreateCommandQueueWithProperties} API to specify
-additional command queue properties that cannot be specified using the 
+additional command-queue properties that cannot be specified using the 
 OpenCL 1.x {clCreateCommandQueue} API.
 
-No new command queue properties are required by this extension.
+No new command-queue properties are required by this extension.
 Applications may use the existing {CL_DEVICE_QUEUE_PROPERTIES} query to 
-determine command queue properties that are supported by the device.
+determine command-queue properties that are supported by the device.
 
 OpenCL 2.x devices may support this extension for compatibility.  In
 this scenario, the function added by this extension will have the same
@@ -77,7 +77,7 @@ These properties are specified by the _properties_ argument in
 |=======================================================================
 --
 
-(Add a new Section 5.1.1, *Creating Command Queues With Properties*) ::
+(Add a new Section 5.1.1, *Creating Command-Queues With Properties*) ::
 +
 --
 
@@ -123,7 +123,7 @@ commands are executed in-order. +
 the command-queue. If set, the profiling of commands is enabled. Otherwise,
 profiling of commands is disabled. +
 {blank}
-If {CL_QUEUE_PROPERTIES} is not specified an in-order command queue that
+If {CL_QUEUE_PROPERTIES} is not specified an in-order command-queue that
 does not support profiling of commands is created for the specified device.
 
 |=======================================================================

--- a/ext/cl_khr_egl_event.asciidoc
+++ b/ext/cl_khr_egl_event.asciidoc
@@ -122,7 +122,7 @@ The parameters of an event object linked to an EGL sync object will return
 the following values when queried with *clGetEventInfo*:
 
   * The CL_EVENT_COMMAND_QUEUE of a linked event is `NULL`, because the
-    event is not associated with any OpenCL command queue.
+    event is not associated with any OpenCL command-queue.
   * The CL_EVENT_COMMAND_TYPE of a linked event is
     CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR, indicating that the event is
     associated with a EGL sync object, rather than an OpenCL command.

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -186,7 +186,7 @@ Attempting to access the data store of an EGLImage object after it has been
 acquired by OpenCL and before it has been released will result in undefined
 behavior.
 Similarly, attempting to access a shared EGLImage object from OpenCL before
-it has been acquired by the OpenCL command queue or after it has been
+it has been acquired by the OpenCL command-queue or after it has been
 released, will result in undefined behavior.
 
 [[cl_khr_egl_image-sharing-memory-objects-created-from-egl-resources-between-egldisplays-and-opencl-contexts]]

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -56,7 +56,7 @@ The relational, equality, logical and logical unary operators described in
 _section 6.3_ can be used with `half` scalar and `halfn` vector types and
 shall produce a scalar `int` and vector `shortn` result respectively.
 
-The OpenCL compiler accepts an h and H suffix on floating point literals,
+The OpenCL compiler accepts an h and H suffix on floating-point literals,
 indicating the literal is typed as a half.
 
 [[cl_khr_fp16-conversions]]
@@ -1384,7 +1384,7 @@ If {CL_FP_ROUND_TO_NEAREST} is supported, the default rounding mode for
 half-precision floating-point operations will be round to nearest even;
 otherwise the default rounding mode will be round to zero.
 
-Conversions to half floating point format must be correctly rounded using
+Conversions to half floating-point format must be correctly rounded using
 the indicated `convert` operator rounding mode or the default rounding mode
 for half-precision floating-point operations if no rounding mode is
 specified by the operator, or a C-style cast is used.
@@ -1392,7 +1392,7 @@ specified by the operator, or a C-style cast is used.
 Conversions from half to integer format shall correctly round using the
 indicated `convert` operator rounding mode, or towards zero if no rounding
 mode is specified by the operator or a C-style cast is used.
-All conversions from half to floating point formats are exact.
+All conversions from half to floating-point formats are exact.
 
 [[cl_khr_fp16-relative-error-as-ulps]]
 ==== Relative Error as ULPs

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -707,7 +707,7 @@ writes (_x_,_y_,_z_) components from a 3-component vector to address
 `(_p_ + (_offset_ * 4))`.
 Whether *vloada_half3* and *vstorea_half3* read/write padding data
 between the third vector element and the next alignment boundary is
-implementation defined.
+implementation-defined.
 *vloada_* and *vstoreaa_* variants are provided to access data that is
 aligned to the size of the vector, and are intended to enable performance
 on hardware that can take advantage of the increased alignment.

--- a/ext/cl_khr_gl_event.asciidoc
+++ b/ext/cl_khr_gl_event.asciidoc
@@ -106,7 +106,7 @@ The parameters of an event object linked to a GL sync object will return the
 following values when queried with *clGetEventInfo*:
 
   * The CL_EVENT_COMMAND_QUEUE of a linked event is `NULL`, because the
-    event is not associated with any OpenCL command queue.
+    event is not associated with any OpenCL command-queue.
   * The CL_EVENT_COMMAND_TYPE of a linked event is
     CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR, indicating that the event is
     associated with a GL sync object, rather than an OpenCL command.

--- a/ext/cl_khr_gl_sharing__context.asciidoc
+++ b/ext/cl_khr_gl_sharing__context.asciidoc
@@ -216,11 +216,11 @@ support sharing with OpenGL:
 
 "`OpenCL device(s) corresponding to an OpenGL context may be queried.
 Such a device may not always exist (for example, if an OpenGL context is
-specified on a GPU not supporting OpenCL command queues, but which does
+specified on a GPU not supporting OpenCL command-queues, but which does
 support shared CL/GL objects), and if it does exist, may change over time.
 When such a device does exist, acquiring and releasing shared CL/GL objects
-may be faster on a command queue corresponding to this device than on
-command queues corresponding to other devices available to an OpenCL
+may be faster on a command-queue corresponding to this device than on
+command-queues corresponding to other devices available to an OpenCL
 context.
 
 To query the currently corresponding device, use the function
@@ -417,17 +417,17 @@ Sharing between OpenCL and OpenGL requires integration at the driver
 internals level.
 --
 
-  . What command queues can *clEnqueueAcquire/ReleaseGLObjects* be placed
+  . What command-queues can *clEnqueueAcquire/ReleaseGLObjects* be placed
     on?
 +
 --
-RESOLVED: All command queues.
+RESOLVED: All command-queues.
 This restriction is enforced at context creation time.
 If any device passed to context creation cannot support shared CL/GL
 objects, context creation will fail with a CL_INVALID_OPERATION error.
 --
 
-  . How can applications determine which command queue to place an
+  . How can applications determine which command-queue to place an
     Acquire/Release on?
 +
 --

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -720,7 +720,7 @@ Implementations may offer more efficient synchronization methods; for
 example on some platforms calling *glFlush* may be sufficient, or
 synchronization may be implicit within a thread, or there may be
 vendor-specific extensions that enable placing a fence in the GL command
-stream and waiting for completion of that fence in the CL command queue.
+stream and waiting for completion of that fence in the CL command-queue.
 Note that no synchronization methods other than *glFinish* are portable
 between OpenGL implementations at this time.
 
@@ -749,7 +749,7 @@ Attempting to access the data store of an OpenGL object after it has been
 acquired by OpenCL and before it has been released will result in undefined
 behavior.
 Similarly, attempting to access a shared CL/GL object from OpenCL before it
-has been acquired by the OpenCL command queue, or after it has been
+has been acquired by the OpenCL command-queue, or after it has been
 released, will result in undefined behavior.
 
 [[cl_khr_gl_sharing__memobjs-event-command-types]]

--- a/ext/cl_khr_priority_hints.asciidoc
+++ b/ext/cl_khr_priority_hints.asciidoc
@@ -28,7 +28,7 @@ guarantees.
 The function {clCreateCommandQueueWithProperties} (Section 5.1) is
 extended to support a priority value as part of the _properties_ argument.
 
-The priority property applies to OpenCL command queues that belong to the
+The priority property applies to OpenCL command-queues that belong to the
 same OpenCL context.
 
 The properties field accepts the {CL_QUEUE_PRIORITY_KHR} property, with a

--- a/ext/cl_khr_spir.asciidoc
+++ b/ext/cl_khr_spir.asciidoc
@@ -89,8 +89,8 @@ specify the version of the SPIR specification that describes the format and
 meaning of the binary.
 For example, if the binary is as described in SPIR version 1.2, then
 `-spir-std=1.2` must be specified.
-Failing to specify these compile options may result in implementation
-defined behavior."
+Failing to specify these compile options may result in implementation-defined
+behavior."
 
 *Additions to _section 5.8.5_ -- Separate Compilation and Linking of Programs:*
 

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -436,15 +436,15 @@ gentype sub_group_non_uniform_scan_exclusive_mul(
 
 If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
 For *add*, the identity value is `0`.
-For *min*, the identity value is the largest representable value for integer types, or `+INF` for floating point types.
-For *max*, the identity value is the minimum representable value for integer types, or `-INF` for floating point types.
+For *min*, the identity value is the largest representable value for integer types, or `+INF` for floating-point types.
+For *max*, the identity value is the minimum representable value for integer types, or `-INF` for floating-point types.
 For *mul*, the identity value is `1`.
 
 Note: This behavior is the same as the *add*, *min*, and *max* exclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
 
 |=======================================================================
 
-Note: The order of floating-point operations is not guaranteed for the subgroup scan and reduction built-in functions that operate on floating point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+Note: The order of floating-point operations is not guaranteed for the subgroup scan and reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given subgroup.
 
 ===== Bitwise Operations
 
@@ -669,7 +669,7 @@ gentype sub_group_clustered_reduce_max(
 
 |=======================================================================
 
-Note: The order of floating-point operations is not guaranteed for the subgroup clustered reduction built-in functions that operate on floating point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+Note: The order of floating-point operations is not guaranteed for the subgroup clustered reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given subgroup.
 
 ===== Bitwise Operations
 

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -1,9 +1,9 @@
-== Extended Subgroup Functions
+== Extended Sub-group Functions
 
-[[extended-subgroups]]
+[[extended-sub-groups]]
 === Overview
 
-This section describes a family of extensions that provide extended subgroup functionality.
+This section describes a family of extensions that provide extended sub-group functionality.
 The extensions in this family are:
 
 * `cl_khr_subgroup_extended_types`
@@ -16,14 +16,14 @@ The extensions in this family are:
 
 The functionality added by these extensions includes:
 
-* Additional data type support for subgroup broadcast, scan, and reduction functions;
-* The ability to elect a single work item from a subgroup to perform a task;
-* The ability to hold votes among work items in a subgroup;
-* The ability to collect and operate on ballots from work items in the subgroup;
-* The ability to use some subgroup functions, such as any, all, broadcasts, scans, and reductions within non-uniform flow control;
+* Additional data type support for sub-group broadcast, scan, and reduction functions;
+* The ability to elect a single work item from a sub-group to perform a task;
+* The ability to hold votes among work items in a sub-group;
+* The ability to collect and operate on ballots from work items in the sub-group;
+* The ability to use some sub-group functions, such as any, all, broadcasts, scans, and reductions within non-uniform flow control;
 * Additional scan and reduction operators;
-* Additional ways to exchange data among work items in a subgroup;
-* Clustered reductions, that operate on a subset of work items in the subgroup.
+* Additional ways to exchange data among work items in a sub-group;
+* Clustered reductions, that operate on a subset of work items in the sub-group.
 
 This section describes changes to the OpenCL C Language for these extensions.
 There are no new API functions or enums added by these extensions.
@@ -40,7 +40,7 @@ For all of the extensions described in this section:
 | 2020-12-15 | 1.0.0     | First assigned version.
 |====
 
-[[extended-subgroups-summary]]
+[[extended-sub-groups-summary]]
 === Summary of New OpenCL C Functions
 
 [source,opencl_c]
@@ -161,15 +161,15 @@ int     sub_group_clustered_reduce_logical_xor( int predicate, uint clustersize 
 === Extended Types
 
 This section describes functionality added by `cl_khr_subgroup_extended_types`.
-This extension adds additional supported data types to the existing subgroup broadcast, scan, and reduction functions.
+This extension adds additional supported data types to the existing sub-group broadcast, scan, and reduction functions.
 
-==== Modify the Existing Section Describing Subgroup Functions
+==== Modify the Existing Section Describing Sub-group Functions
 
-Modify the first paragraph in this section that describes `gentype` type support for the subgroup `broadcast`, `scan`, and `reduction` functions to add scalar `char`, `uchar`, `short`, and `ushort` support, and to additionally add built-in vector type support for `broadcast` specifically.
+Modify the first paragraph in this section that describes `gentype` type support for the sub-group `broadcast`, `scan`, and `reduction` functions to add scalar `char`, `uchar`, `short`, and `ushort` support, and to additionally add built-in vector type support for `broadcast` specifically.
 The functions in the table and their descriptions remain unchanged by this extension:
 
-The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
-These built-in functions must be encountered by all work items in the subgroup executing the kernel.
+The table below describes OpenCL C programming language built-in functions that operate on a sub-group level.
+These built-in functions must be encountered by all work items in the sub-group executing the kernel.
 We use the generic type name `gentype` to indicate the built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 For the `sub_group_broadcast` function, the generic type name `gentype` may additionally be one of the supported built-in vector data types `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `float__n__`, `double__n__` (if double precision is supported), or `half__n__` (if half precision is supported).
@@ -178,12 +178,12 @@ For the `sub_group_broadcast` function, the generic type name `gentype` may addi
 === Votes and Elections
 
 This section describes functionality added by `cl_khr_subgroup_non_uniform_vote`.
-This extension adds the ability to elect a single work item from a subgroup to perform a task and to hold votes among work items in a subgroup.
+This extension adds the ability to elect a single work item from a sub-group to perform a task and to hold votes among work items in a sub-group.
 
-==== Add a new Section 6.15.X - Subgroup Vote and Elect Built-in Functions
+==== Add a new Section 6.15.X - Sub-group Vote and Elect Built-in Functions
 
-The table below describes the OpenCL C programming language built-in functions to elect a single work item in a subgroup to perform a task and to collectively vote to determine a boolean condition for the subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions to elect a single work item in a sub-group to perform a task and to collectively vote to determine a boolean condition for the sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols="1a,1",options="header",]
@@ -195,33 +195,33 @@ For the functions below, the generic type name `gentype` may be the one of the s
 ----
 int sub_group_elect()
 ----
-| Elects a single work item in the subgroup to perform a task.
-This function will return true (nonzero) for the active work item in the subgroup with the smallest subgroup local ID, and false (zero) for all other active work items in the subgroup.
+| Elects a single work item in the sub-group to perform a task.
+This function will return true (nonzero) for the active work item in the sub-group with the smallest sub-group local ID, and false (zero) for all other active work items in the sub-group.
 
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_all(
     int predicate )
 ----
-| Examines _predicate_ for all active work items in the subgroup and returns a non-zero value if _predicate_ is non-zero for all active work items in the subgroup and zero otherwise.
+| Examines _predicate_ for all active work items in the sub-group and returns a non-zero value if _predicate_ is non-zero for all active work items in the sub-group and zero otherwise.
 
-Note: This behavior is the same as `sub_group_all` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
+Note: This behavior is the same as `sub_group_all` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the sub-group executing the kernel.
 
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_any(
     int predicate )
 ----
-| Examines _predicate_ for all active work items in the subgroup and returns a non-zero value if _predicate_ is non-zero for any active work item in the subgroup and zero otherwise.
+| Examines _predicate_ for all active work items in the sub-group and returns a non-zero value if _predicate_ is non-zero for any active work item in the sub-group and zero otherwise.
 
-Note: This behavior is the same as `sub_group_any` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the subgroup executing the kernel.
+Note: This behavior is the same as `sub_group_any` from `cl_khr_subgroups` and OpenCL 2.1, except this function need not be encountered by all work items in the sub-group executing the kernel.
 
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_all_equal(
     gentype value )
 ----
-| Examines _value_ for all active work items in the subgroup and returns a non-zero value if _value_ is equivalent for all active invocations in the subgroup and zero otherwise.
+| Examines _value_ for all active work items in the sub-group and returns a non-zero value if _value_ is equivalent for all active invocations in the sub-group and zero otherwise.
 
 Integer types use a bitwise test for equality.  Floating-point types use an ordered floating-point test for equality.
 
@@ -231,12 +231,12 @@ Integer types use a bitwise test for equality.  Floating-point types use an orde
 === Ballots
 
 This section describes functionality added by `cl_khr_subgroup_ballot`.
-This extension adds the ability to collect and operate on ballots from work items in the subgroup.
+This extension adds the ability to collect and operate on ballots from work items in the sub-group.
 
-==== Add a new Section 6.15.X - Subgroup Ballot Built-in Functions
+==== Add a new Section 6.15.X - Sub-group Ballot Built-in Functions
 
-The table below describes the OpenCL C programming language built-in functions to allow work items in a subgroup to collect and operate on ballots from work items in the subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions to allow work items in a sub-group to collect and operate on ballots from work items in the sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 
 For the `sub_group_non_uniform_broadcast` and `sub_group_broadcast_first` functions, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
@@ -253,26 +253,26 @@ gentype sub_group_non_uniform_broadcast(
     gentype value,
     uint index )
 ----
-| Returns _value_ for the work item with subgroup local ID equal to _index_.
+| Returns _value_ for the work item with sub-group local ID equal to _index_.
 
-Behavior is undefined when the value of _index_ is not equivalent for all active work items in the subgroup.
+Behavior is undefined when the value of _index_ is not equivalent for all active work items in the sub-group.
 
-The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
+The return value is undefined if the work item with sub-group local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the sub-group.
 
 |[source,opencl_c]
 ----
 gentype sub_group_broadcast_first(
     gentype value )
 ----
-| Returns _value_ for the work item with the smallest subgroup local ID among active work items in the subgroup.
+| Returns _value_ for the work item with the smallest sub-group local ID among active work items in the sub-group.
 
 |[source,opencl_c]
 ----
 uint4 sub_group_ballot(
     int predicate )
 ----
-| Returns a bitfield combining the _predicate_ values from all work items in the subgroup.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Returns a bitfield combining the _predicate_ values from all work items in the sub-group.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 The representative bit in the bitfield is set if the work item is active and the _predicate_ is non-zero, and is unset otherwise.
 
 |[source,opencl_c]
@@ -280,10 +280,10 @@ The representative bit in the bitfield is set if the work item is active and the
 int sub_group_inverse_ballot(
     uint4 value )
 ----
-| Returns the predicate value for this work item in the subgroup from the bitfield _value_ representing predicate values from all work items in the subgroup.
+| Returns the predicate value for this work item in the sub-group from the bitfield _value_ representing predicate values from all work items in the sub-group.
 The predicate return value will be non-zero if the bit in the bitfield _value_ for this work item is set, and zero otherwise.
 
-Behavior is undefined when _value_ is not equivalent for all active work items in the subgroup.
+Behavior is undefined when _value_ is not equivalent for all active work items in the sub-group.
 
 This is a specialized function that may perform better than the equivalent `sub_group_ballot_bit_extract` on some implementations.
 
@@ -293,82 +293,82 @@ int sub_group_ballot_bit_extract(
     uint4 value,
     uint index )
 ----
-| Returns the predicate value for the work item with subgroup local ID equal to _index_ from the bitfield _value_ representing predicate values from all work items in the subgroup.
-The predicate return value will be non-zero if the bit in the bitfield _value_ for the work item with subgroup local ID equal to _index_ is set, and zero otherwise.
+| Returns the predicate value for the work item with sub-group local ID equal to _index_ from the bitfield _value_ representing predicate values from all work items in the sub-group.
+The predicate return value will be non-zero if the bit in the bitfield _value_ for the work item with sub-group local ID equal to _index_ is set, and zero otherwise.
 
-The predicate return value is undefined if the work item with subgroup local ID equal to _index_ is greater than or equal to the size of the subgroup.
+The predicate return value is undefined if the work item with sub-group local ID equal to _index_ is greater than or equal to the size of the sub-group.
 
 |[source,opencl_c]
 ----
 uint sub_group_ballot_bit_count(
     uint4 value )
 ----
-| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to subgroup local IDs less than the maximum subgroup size within the dispatch (as returned by `get_max_sub_group_size`).
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to sub-group local IDs less than the maximum sub-group size within the dispatch (as returned by `get_max_sub_group_size`).
 
 |[source,opencl_c]
 ----
 uint sub_group_ballot_inclusive_scan(
     uint4 value )
 ----
-| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than or equal to this work item's subgroup local ID.
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a sub-group local ID less than or equal to this work item's sub-group local ID.
 
 |[source,opencl_c]
 ----
 uint sub_group_ballot_exclusive_scan(
     uint4 value )
 ----
-| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a subgroup local ID less than this work item's subgroup local ID.
+| Returns the number of bits that are set in the bitfield _value_, only considering the bits in _value_ representing work items with a sub-group local ID less than this work item's sub-group local ID.
 
 |[source,opencl_c]
 ----
 uint sub_group_ballot_find_lsb(
     uint4 value )
 ----
-| Returns the smallest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to subgroup local IDs less than the maximum subgroup size within the dispatch (as returned by `get_max_sub_group_size`).
-If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
+| Returns the smallest sub-group local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to sub-group local IDs less than the maximum sub-group size within the dispatch (as returned by `get_max_sub_group_size`).
+If no bits representing predicate values from all work items in the sub-group are set in the bitfield _value_ then the return value is undefined.
 
 |[source,opencl_c]
 ----
 uint sub_group_ballot_find_msb(
     uint4 value )
 ----
-| Returns the largest subgroup local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to subgroup local IDs less than the maximum subgroup size within the dispatch (as returned by `get_max_sub_group_size`).
-If no bits representing predicate values from all work items in the subgroup are set in the bitfield _value_ then the return value is undefined.
+| Returns the largest sub-group local ID with a bit set in the bitfield _value_, only considering the bits in _value_ that represent predicate values corresponding to sub-group local IDs less than the maximum sub-group size within the dispatch (as returned by `get_max_sub_group_size`).
+If no bits representing predicate values from all work items in the sub-group are set in the bitfield _value_ then the return value is undefined.
 
 |[source,opencl_c]
 ----
 uint4 get_sub_group_eq_mask()
 ----
-| Generates a bitmask where the bit is set in the bitmask if the bit index equals the subgroup local ID and unset otherwise.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Generates a bitmask where the bit is set in the bitmask if the bit index equals the sub-group local ID and unset otherwise.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 
 |[source,opencl_c]
 ----
 uint4 get_sub_group_ge_mask()
 ----
-| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than or equal to the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than or equal to the sub-group local ID and less than the maximum sub-group size, and unset otherwise.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 
 |[source,opencl_c]
 ----
 uint4 get_sub_group_gt_mask()
 ----
-| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than the subgroup local ID and less than the maximum subgroup size, and unset otherwise.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is greater than the sub-group local ID and less than the maximum sub-group size, and unset otherwise.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 
 |[source,opencl_c]
 ----
 uint4 get_sub_group_le_mask()
 ----
-| Generates a bitmask where the bit is set in the bitmask if the bit index is less than or equal to the subgroup local ID and unset otherwise.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is less than or equal to the sub-group local ID and unset otherwise.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 
 |[source,opencl_c]
 ----
 uint4 get_sub_group_lt_mask()
 ----
-| Generates a bitmask where the bit is set in the bitmask if the bit index is less than the subgroup local ID and unset otherwise.
-Bit zero of the first vector component represents the subgroup local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing subgroup local IDs.
+| Generates a bitmask where the bit is set in the bitmask if the bit index is less than the sub-group local ID and unset otherwise.
+Bit zero of the first vector component represents the sub-group local ID zero, with higher-order bits and subsequent vector components representing, in order, increasing sub-group local IDs.
 
 |=======================================================================
 
@@ -376,14 +376,14 @@ Bit zero of the first vector component represents the subgroup local ID zero, wi
 === Non-Uniform Arithmetic
  
 This section describes functionality added by `cl_khr_subgroup_non_uniform_arithmetic`.
-This extension adds the ability to use some subgroup functions within non-uniform flow control, including additional scan and reduction operators.
+This extension adds the ability to use some sub-group functions within non-uniform flow control, including additional scan and reduction operators.
 
-==== Add a new Section 6.15.X - Non Uniform Subgroup Scan and Reduction Built-in Functions
+==== Add a new Section 6.15.X - Non Uniform Sub-group Scan and Reduction Built-in Functions
 
 ===== Arithmetic Operations
 
-The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations across work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations across work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols="3a,2",options="header",]
@@ -402,9 +402,9 @@ gentype sub_group_non_uniform_reduce_max(
 gentype sub_group_non_uniform_reduce_mul(
     gentype value )
 ----
-| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup.
+| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the sub-group.
 
-Note: This behavior is the same as the *add*, *min*, and *max* reduction built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+Note: This behavior is the same as the *add*, *min*, and *max* reduction built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the sub-group executing the kernel.
 
 |[source,opencl_c]
 ----
@@ -417,9 +417,9 @@ gentype sub_group_non_uniform_scan_inclusive_max(
 gentype sub_group_non_uniform_scan_inclusive_mul(
     gentype value )
 ----
-| Returns the result of an inclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+| Returns the result of an inclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the sub-group with a sub-group local ID less than or equal to this work item's sub-group local ID.
 
-Note: This behavior is the same as the *add*, *min*, and *max* inclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+Note: This behavior is the same as the *add*, *min*, and *max* inclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the sub-group executing the kernel.
 
 |[source,opencl_c]
 ----
@@ -432,24 +432,24 @@ gentype sub_group_non_uniform_scan_exclusive_max(
 gentype sub_group_non_uniform_scan_exclusive_mul(
     gentype value )
 ----
-| Returns the result of an exclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+| Returns the result of an exclusive scan operation, which is the summation, multiplication, minimum, or maximum of _value_ for all active work items in the sub-group with a sub-group local ID less than this work item's sub-group local ID.
 
-If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+If there is no active work item in the sub-group with a sub-group local ID less than this work item's sub-group local ID then an identity value `I` is returned.
 For *add*, the identity value is `0`.
 For *min*, the identity value is the largest representable value for integer types, or `+INF` for floating-point types.
 For *max*, the identity value is the minimum representable value for integer types, or `-INF` for floating-point types.
 For *mul*, the identity value is `1`.
 
-Note: This behavior is the same as the *add*, *min*, and *max* exclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the subgroup executing the kernel.
+Note: This behavior is the same as the *add*, *min*, and *max* exclusive scan built-in functions from `cl_khr_subgroups` and OpenCL 2.1, except these functions support additional types and need not be encountered by all work items in the sub-group executing the kernel.
 
 |=======================================================================
 
-Note: The order of floating-point operations is not guaranteed for the subgroup scan and reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+Note: The order of floating-point operations is not guaranteed for the sub-group scan and reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given sub-group.
 
 ===== Bitwise Operations
 
-The table below describes the OpenCL C programming language built-in functions that perform simple bitwise integer operations across work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions that perform simple bitwise integer operations across work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, and `ulong`.
 
 [cols="3a,2",options="header",]
@@ -466,7 +466,7 @@ gentype sub_group_non_uniform_reduce_or(
 gentype sub_group_non_uniform_reduce_xor(
     gentype value )
 ----
-| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup.
+| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the sub-group.
 
 |[source,opencl_c]
 ----
@@ -477,7 +477,7 @@ gentype sub_group_non_uniform_scan_inclusive_or(
 gentype sub_group_non_uniform_scan_inclusive_xor(
     gentype value )
 ----
-| Returns the result of an inclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+| Returns the result of an inclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the sub-group with a sub-group local ID less than or equal to this work item's sub-group local ID.
 
 |[source,opencl_c]
 ----
@@ -488,9 +488,9 @@ gentype sub_group_non_uniform_scan_exclusive_or(
 gentype sub_group_non_uniform_scan_exclusive_xor(
     gentype value )
 ----
-| Returns the result of an exclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+| Returns the result of an exclusive scan operation, which is the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the sub-group with a sub-group local ID less than this work item's sub-group local ID.
 
-If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+If there is no active work item in the sub-group with a sub-group local ID less than this work item's sub-group local ID then an identity value `I` is returned.
 For *and*, the identity value is `~0` (all bits set).
 For *or* and *xor*, the identity value is `0`.
 
@@ -498,8 +498,8 @@ For *or* and *xor*, the identity value is `0`.
 
 ===== Logical Operations
 
-The table below describes the OpenCL C programming language built-in functions that perform simple logical operations across work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions that perform simple logical operations across work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For these functions, a non-zero _predicate_ argument or return value is logically `true` and a zero _predicate_ argument or return value is logically `false`.
 
 [cols="2a,1",options="header",]
@@ -516,7 +516,7 @@ int sub_group_non_uniform_reduce_logical_or(
 int sub_group_non_uniform_reduce_logical_xor(
     int predicate )
 ----
-| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup.
+| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the sub-group.
 
 |[source,opencl_c]
 ----
@@ -527,7 +527,7 @@ int sub_group_non_uniform_scan_inclusive_logical_or(
 int sub_group_non_uniform_scan_inclusive_logical_xor(
     int predicate )
 ----
-| Returns the result of an inclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup with a subgroup local ID less than or equal to this work item's subgroup local ID.
+| Returns the result of an inclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the sub-group with a sub-group local ID less than or equal to this work item's sub-group local ID.
 
 |[source,opencl_c]
 ----
@@ -538,9 +538,9 @@ int sub_group_non_uniform_scan_exclusive_logical_or(
 int sub_group_non_uniform_scan_exclusive_logical_xor(
     int predicate )
 ----
-| Returns the result of an exclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup with a subgroup local ID less than this work item's subgroup local ID.
+| Returns the result of an exclusive scan operation, which is the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the sub-group with a sub-group local ID less than this work item's sub-group local ID.
 
-If there is no active work item in the subgroup with a subgroup local ID less than this work item's subgroup local ID then an identity value `I` is returned.
+If there is no active work item in the sub-group with a sub-group local ID less than this work item's sub-group local ID then an identity value `I` is returned.
 For *and*, the identity value is `true` (non-zero).
 For *or* and *xor*, the identity value is `false` (zero).
 
@@ -550,12 +550,12 @@ For *or* and *xor*, the identity value is `false` (zero).
 === General Purpose Shuffles
 
 This section describes functionality added by `cl_khr_subgroup_shuffle`.
-This extension adds additional ways to exchange data among work items in a subgroup.
+This extension adds additional ways to exchange data among work items in a sub-group.
 
-==== Add a new Section 6.15.X - Subgroup Shuffle Built-in Functions
+==== Add a new Section 6.15.X - Sub-group Shuffle Built-in Functions
 
-The table below describes the OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions that allow work items in a sub-group to exchange data.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols="1a,1",options="header",]
@@ -568,20 +568,20 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 gentype sub_group_shuffle(
     gentype value, uint index )
 ----
-| Returns _value_ for the work item with subgroup local ID equal to _index_.
-The shuffle _index_ need not be the same for all work items in the subgroup.
+| Returns _value_ for the work item with sub-group local ID equal to _index_.
+The shuffle _index_ need not be the same for all work items in the sub-group.
 
-The return value is undefined if the work item with subgroup local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the subgroup.
+The return value is undefined if the work item with sub-group local ID equal to _index_ is inactive or if _index_ is greater than or equal to the size of the sub-group.
 
 |[source,opencl_c]
 ----
 gentype sub_group_shuffle_xor(
     gentype value, uint mask )
 ----
-| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID xor'd with _mask_.
-The shuffle _mask_ need not be the same for all work items in the subgroup.
+| Returns _value_ for the work item with sub-group local ID equal to this work item's sub-group local ID xor'd with _mask_.
+The shuffle _mask_ need not be the same for all work items in the sub-group.
 
-The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive or if the calculated index is greater than or equal to the size of the subgroup.
+The return value is undefined if the work item with sub-group local ID equal to the calculated index is inactive or if the calculated index is greater than or equal to the size of the sub-group.
 
 This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
 
@@ -591,12 +591,12 @@ This is a specialized function that may perform better than the equivalent `sub_
 === Relative Shuffles
 
 This section describes functionality added by `cl_khr_subgroup_shuffle_relative`.
-This extension adds specialized ways to exchange data among work items in a subgroup that may perform better on some implementations.
+This extension adds specialized ways to exchange data among work items in a sub-group that may perform better on some implementations.
 
-==== Add a new Section 6.15.X - Subgroup Relative Shuffle Built-in Functions
+==== Add a new Section 6.15.X - Sub-group Relative Shuffle Built-in Functions
 
-The table below describes specialized OpenCL C programming language built-in functions that allow work items in a subgroup to exchange data.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes specialized OpenCL C programming language built-in functions that allow work items in a sub-group to exchange data.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols="1a,1",options="header",]
@@ -609,10 +609,10 @@ For the functions below, the generic type name `gentype` may be one of the suppo
 gentype sub_group_shuffle_up(
     gentype value, uint delta )
 ----
-| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID minus _delta_.
-The shuffle _delta_ need not be the same for all work items in the subgroup.
+| Returns _value_ for the work item with sub-group local ID equal to this work item's sub-group local ID minus _delta_.
+The shuffle _delta_ need not be the same for all work items in the sub-group.
 
-The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive, or _delta_ is greater than this work item's subgroup local ID.
+The return value is undefined if the work item with sub-group local ID equal to the calculated index is inactive, or _delta_ is greater than this work item's sub-group local ID.
 
 This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
 
@@ -621,10 +621,10 @@ This is a specialized function that may perform better than the equivalent `sub_
 gentype sub_group_shuffle_down(
     gentype value, uint delta )
 ----
-| Returns _value_ for the work item with subgroup local ID equal to this work item's subgroup local ID plus _delta_.
-The shuffle _delta_ need not be the same for all work items in the subgroup.
+| Returns _value_ for the work item with sub-group local ID equal to this work item's sub-group local ID plus _delta_.
+The shuffle _delta_ need not be the same for all work items in the sub-group.
 
-The return value is undefined if the work item with subgroup local ID equal to the calculated index is inactive, or this work item's subgroup local ID plus _delta_ is greater than or equal to the size of the subgroup.
+The return value is undefined if the work item with sub-group local ID equal to the calculated index is inactive, or this work item's sub-group local ID plus _delta_ is greater than or equal to the size of the sub-group.
 
 This is a specialized function that may perform better than the equivalent `sub_group_shuffle` on some implementations.
 
@@ -634,19 +634,19 @@ This is a specialized function that may perform better than the equivalent `sub_
 === Clustered Reductions
 
 This section describes functionality added by `cl_khr_subgroup_clustered_reduce`.
-This extension adds support for clustered reductions that operate on a subset of work items in the subgroup.
+This extension adds support for clustered reductions that operate on a subset of work items in the sub-group.
 
-==== Add a new Section 6.15.X - Subgroup Clustered Reduction Built-in Functions
+==== Add a new Section 6.15.X - Sub-group Clustered Reduction Built-in Functions
 
-This section describes arithmetic operations that are performed on a subset of work items in a subgroup, referred to as a cluster.
+This section describes arithmetic operations that are performed on a subset of work items in a sub-group, referred to as a cluster.
 A cluster is described by a specified cluster size.
-Work items in a subgroup are assigned to clusters such that for cluster size _n_, the _n_ work items in the subgroup with the smallest subgroup local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest subgroup local IDs are assigned to the next cluster, and so on.
-Behavior is undefined if the specified cluster size is not an integer constant expression, is not a power-of-two, or is greater than the maximum size of a subgroup within the dispatch.
+Work items in a sub-group are assigned to clusters such that for cluster size _n_, the _n_ work items in the sub-group with the smallest sub-group local IDs are assigned to the first cluster, then the _n_ remaining work items with the smallest sub-group local IDs are assigned to the next cluster, and so on.
+Behavior is undefined if the specified cluster size is not an integer constant expression, is not a power-of-two, or is greater than the maximum size of a sub-group within the dispatch.
 
 ===== Arithmetic Operations
 
-The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations on a cluster of work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions that perform simple arithmetic operations on a cluster of work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols="1a,1",options="header",]
@@ -665,16 +665,16 @@ gentype sub_group_clustered_reduce_min(
 gentype sub_group_clustered_reduce_max(
     gentype value, uint clustersize )
 ----
-| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+| Returns the summation, multiplication, minimum, or maximum of _value_ for all active work items in the sub-group within a cluster of the specified _clustersize_.
 
 |=======================================================================
 
-Note: The order of floating-point operations is not guaranteed for the subgroup clustered reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given subgroup.
+Note: The order of floating-point operations is not guaranteed for the sub-group clustered reduction built-in functions that operate on floating-point types, and the order of operations may additionally be non-deterministic for a given sub-group.
 
 ===== Bitwise Operations
 
-The table below describes the OpenCL C programming language built-in functions to perform simple bitwise integer operations across a cluster of work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions to perform simple bitwise integer operations across a cluster of work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, or `ulong`.
 
 [cols="1a,1",options="header",]
@@ -691,14 +691,14 @@ gentype sub_group_clustered_reduce_or(
 gentype sub_group_clustered_reduce_xor(
     gentype value, uint clustersize )
 ----
-| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+| Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work items in the sub-group within a cluster of the specified _clustersize_.
 
 |=======================================================================
 
 ===== Logical Operations
 
-The table below describes the OpenCL C programming language built-in functions to perform simple logical operations across a cluster of work items in a subgroup.
-These functions need not be encountered by all work items in a subgroup executing the kernel.
+The table below describes the OpenCL C programming language built-in functions to perform simple logical operations across a cluster of work items in a sub-group.
+These functions need not be encountered by all work items in a sub-group executing the kernel.
 For these functions, a non-zero _predicate_ argument or return value is logically `true` and a zero _predicate_ argument or return value is logically `false`.
 
 [cols="3a,2",options="header",]
@@ -715,11 +715,11 @@ int sub_group_clustered_reduce_logical_or(
 int sub_group_clustered_reduce_logical_xor(
     int predicate, uint clustersize )
 ----
-| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the subgroup within a cluster of the specified _clustersize_.
+| Returns the logical *and*, *or*, or *xor* of _predicate_ for all active work items in the sub-group within a cluster of the specified _clustersize_.
 
 |=======================================================================
 
-[[extended-subgroups-mapping]]
+[[extended-sub-groups-mapping]]
 === Function Mapping and Capabilities
 
 This section describes a possible mapping between OpenCL built-in functions and SPIR-V instructions and required SPIR-V capabilities.
@@ -821,7 +821,7 @@ This section is informational and non-normative.
             | *DeviceEnqueue*
 
 3+| For `cl_khr_subgroup_extended_types`: +
-Note: This extension adds new types to uniform subgroup operations.
+Note: This extension adds new types to uniform sub-group operations.
 
 | `sub_&#8203;group_&#8203;broadcast`
         | *OpGroupBroadcast*

--- a/ext/cl_khr_subgroup_named_barrier.asciidoc
+++ b/ext/cl_khr_subgroup_named_barrier.asciidoc
@@ -3,15 +3,15 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_subgroup_named_barrier]]
-== Named Barriers for Subgroups
+== Named Barriers for Sub-groups
 
 This section describes the *cl_khr_subgroup_named_barrier* extension.
 This extension adds barrier operations that cover subsets of an OpenCL
 work-group.
 Only the OpenCL API changes are described in this section.
 Please refer to the SPIR-V specification for information about using
-subgroups named barriers in the SPIR-V intermediate representation, and to
-the OpenCL {cpp} specification for descriptions of the subgroup named
+sub-groups named barriers in the SPIR-V intermediate representation, and to
+the OpenCL {cpp} specification for descriptions of the sub-group named
 barrier built-in functions in the OpenCL {cpp} kernel language.
 
 === General information

--- a/ext/cl_khr_subgroup_rotate.asciidoc
+++ b/ext/cl_khr_subgroup_rotate.asciidoc
@@ -3,10 +3,10 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_subgroup_rotate]]
-== Subgroup Rotation
+== Sub-group Rotation
 
-This extension adds support for a new subgroup data exchange operation that
-makes it possible to rotate values through the work items in a subgroup.
+This extension adds support for a new sub-group data exchange operation that
+makes it possible to rotate values through the work items in a sub-group.
 
 === General Information
 
@@ -51,7 +51,7 @@ gentype sub_group_clustered_rotate(gentype value, int delta, uint clustersize)
 
 === Modifications to the OpenCL C Specification
 
-(Add a new section 6.15.x, *Subgroup Rotation*) ::
+(Add a new section 6.15.x, *Sub-group Rotation*) ::
 +
 --
 
@@ -63,8 +63,8 @@ The following preprocessor definitions are added:
 ----
 
 The table below describes a specialized OpenCL C programming language built-in
-function that allow work items in a subgroup to exchange data. This function
-need not be encountered by all work items in a subgroup executing the kernel.
+function that allow work items in a sub-group to exchange data. This function
+need not be encountered by all work items in a sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be one of the
 supported built-in scalar data types `char`, `uchar`, `short`, `ushort`, `int`,
 `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported),
@@ -80,13 +80,13 @@ or `half` (if half precision is supported).
 gentype sub_group_rotate(
     gentype value, int delta)
 ----
-| Returns _value_ for the work item with subgroup local ID equal to the remainder
-of the division of the sum of this work item's subgroup local ID and _delta_ by
-the maximum subgroup size. +
+| Returns _value_ for the work item with sub-group local ID equal to the remainder
+of the division of the sum of this work item's sub-group local ID and _delta_ by
+the maximum sub-group size. +
 The value of _delta_ is required to be dynamically-uniform for all work items in
-the subgroup, otherwise the behavior is undefined.
+the sub-group, otherwise the behavior is undefined.
 
-The return value is undefined if the work item with subgroup local ID equal to the
+The return value is undefined if the work item with sub-group local ID equal to the
 calculated index is inactive.
 
 |[source,opencl_c]
@@ -95,17 +95,17 @@ gentype sub_group_clustered_rotate(
     gentype value, int delta,
     uint clustersize)
 ----
-| Returns _value_ for the work item with subgroup local ID equal to the sum of, the
+| Returns _value_ for the work item with sub-group local ID equal to the sum of, the
 remainder of the division of the sum of this work item's ID within the cluster and
-_delta_ by _clustersize_, and the subgroup local ID of the first work-item of the
+_delta_ by _clustersize_, and the sub-group local ID of the first work-item of the
 cluster to which the work-item executing the function belongs. +
 The value of _delta_ is required to be dynamically-uniform for all work items in
-the subgroup, otherwise the behavior is undefined.
+the sub-group, otherwise the behavior is undefined.
 
 _clustersize_ must be an integer constant expression and a power of two, smaller
-than or equal to the maximum subgroup size, otherwise the behavior is undefined.
+than or equal to the maximum sub-group size, otherwise the behavior is undefined.
 
-The return value is undefined if the work item with subgroup local ID equal to the
+The return value is undefined if the work item with sub-group local ID equal to the
 calculated index is inactive.
 |=======================================================================
 --

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -3,18 +3,18 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_subgroups]]
-== Subgroups
+== Sub-groups
 
 This section describes the *cl_khr_subgroups* extension.
 
-This extension adds support for implementation-controlled groups of work items, known as subgroups.
-Subgroups behave similarly to work groups and have their own sets of built-ins and synchronization primitives.
-Subgroups within a work group are independent, may make forward progress with respect to each other, and may map to optimized hardware structures where that makes sense.
+This extension adds support for implementation-controlled groups of work items, known as sub-groups.
+Sub-groups behave similarly to work groups and have their own sets of built-ins and synchronization primitives.
+Sub-groups within a work group are independent, may make forward progress with respect to each other, and may map to optimized hardware structures where that makes sense.
 
-Subgroups were promoted to a core feature in OpenCL 2.1, however note that:
+Sub-groups were promoted to a core feature in OpenCL 2.1, however note that:
 
-* The subgroup OpenCL C built-in functions described by this extension must still be accessed as an OpenCL C extension in OpenCL 2.1.
-* Subgroup independent forward progress is an optional device property in OpenCL 2.1, see {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS}.
+* The sub-group OpenCL C built-in functions described by this extension must still be accessed as an OpenCL C extension in OpenCL 2.1.
+* Sub-group independent forward progress is an optional device property in OpenCL 2.1, see {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS}.
 
 === General information
 
@@ -32,19 +32,19 @@ Subgroups were promoted to a core feature in OpenCL 2.1, however note that:
 [[cl_khr_subgroups-additions-to-section-3.2-execution-model]]
 === Additions to section 3.2 -- Execution Model
 
-Within a work-group work-items may be divided into subgroups.
-The mapping of work-items to subgroups is implementation-defined and may be queried at runtime.
-While subgroups may be used in multi-dimensional work-groups, each subgroup is 1-dimensional and any given work-item may query which subgroup it is a member of.
+Within a work-group work-items may be divided into sub-groups.
+The mapping of work-items to sub-groups is implementation-defined and may be queried at runtime.
+While sub-groups may be used in multi-dimensional work-groups, each sub-group is 1-dimensional and any given work-item may query which sub-group it is a member of.
 
-Work items are mapped into subgroups through a combination of compile-time decisions and the parameters of the dispatch.
-The mapping to subgroups is invariant for the duration of a kernel’s execution, across dispatches of a given kernel with the same launch parameters, and from one work-group to another within the dispatch (excluding the trailing edge work-groups in the presence of non-uniform work-group sizes).
-In addition, all subgroups within a work-group will be the same size, apart from the subgroup with the maximum index which may be smaller if the size of the work-group is not evenly divisible by the size of the subgroup.
+Work items are mapped into sub-groups through a combination of compile-time decisions and the parameters of the dispatch.
+The mapping to sub-groups is invariant for the duration of a kernel’s execution, across dispatches of a given kernel with the same launch parameters, and from one work-group to another within the dispatch (excluding the trailing edge work-groups in the presence of non-uniform work-group sizes).
+In addition, all sub-groups within a work-group will be the same size, apart from the sub-group with the maximum index which may be smaller if the size of the work-group is not evenly divisible by the size of the sub-group.
 
-Subgroups execute concurrently within a given work-group and make independent forward progress with respect to each other even in the absence of work-group barrier operations.
-Subgroups are able to internally synchronize using barrier operations without synchronizing with each other.
+Sub-groups execute concurrently within a given work-group and make independent forward progress with respect to each other even in the absence of work-group barrier operations.
+Sub-groups are able to internally synchronize using barrier operations without synchronizing with each other.
 
-In the degenerate case, with the extension enabled, a single subgroup must be supported for each work-group.
-In this situation all subgroup scope functions alias their work-group level equivalents.
+In the degenerate case, with the extension enabled, a single sub-group must be supported for each work-group.
+In this situation all sub-group scope functions alias their work-group level equivalents.
 
 [[cl_khr_subgroups-additions-to-chapter-5-of-the-opencl-2.0-specification]]
 === Additions to Chapter 5 of the OpenCL 2.0 Specification
@@ -67,7 +67,7 @@ can be a `NULL` value.
 _param_name_ specifies the information to query.
 The list of supported _param_name_ types and the information returned in
 _param_value_ by {clGetKernelSubGroupInfoKHR} is described in the
-<<cl_khr_subgroups-kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table.
+<<cl_khr_subgroups-kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table.
 
 _input_value_size_ is used to specify the size in bytes of memory pointed to
 by _input_value_.
@@ -84,23 +84,23 @@ If _param_value_ is `NULL`, it is ignored.
 _param_value_size_ is used to specify the size in bytes of memory pointed to
 by _param_value_.
 This size must be {geq} size of return type as described in the
-<<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table.
+<<cl_khr_subgroups-kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table.
 
 _param_value_size_ret_ returns the actual size in bytes of data being
 queried by _param_name_.
 If _param_value_size_ret_ is `NULL`, it is ignored.
 
-[[cl_khr_subgroups-kernel-subgroup-info-table]]
+[[cl_khr_subgroups-kernel-sub-group-info-table]]
 .List of supported param_names by <<clGetKernelSubGroupInfoKHR>>
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
-| Kernel Subgroup Info | Input Type | Return Type | Description
+| Kernel Sub-group Info | Input Type | Return Type | Description
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR}
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the maximum subgroup size for this kernel.
-            All subgroups must be the same size, while the last subgroup in
-            any work-group (i.e. the subgroup with the maximum index) could
+          | Returns the maximum sub-group size for this kernel.
+            All sub-groups must be the same size, while the last sub-group in
+            any work-group (i.e. the sub-group with the maximum index) could
             be the same or smaller size.
 
             The _input_value_ must be an array of size_t values
@@ -111,11 +111,11 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR}
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the number of subgroups that will be present in each
+          | Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of subgroups.
+            same number of sub-groups.
 
             The _input_value_ must be an array of size_t values
             corresponding to the local work size parameter of the intended
@@ -133,7 +133,7 @@ Otherwise, it returns one of the following errors:
     associated with _kernel_.
   * {CL_INVALID_VALUE} if _param_name_ is not valid, or if size in bytes
     specified by _param_value_size_ is < size of return type as described in
-    the <<kernel-subgroup-info-table,Kernel Object Subgroup Queries>> table
+    the <<cl_khr_subgroups-kernel-sub-group-info-table,Kernel Object Sub-group Queries>> table
     and _param_value_ is not `NULL`.
   * {CL_INVALID_VALUE} if _param_name_ is
     {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR} and the size in bytes specified by
@@ -156,19 +156,19 @@ Otherwise, it returns one of the following errors:
 | *Description*
 
 | uint *get_sub_group_size* ()
-| Returns the number of work items in the subgroup.
-  This value is no more than the maximum subgroup size and is
+| Returns the number of work items in the sub-group.
+  This value is no more than the maximum sub-group size and is
   implementation-defined based on a combination of the compiled kernel and
   the dispatch dimensions.
-  This will be a constant value for the lifetime of the subgroup.
+  This will be a constant value for the lifetime of the sub-group.
 
 | uint *get_max_sub_group_size* ()
-| Returns the maximum size of a subgroup within the dispatch.
+| Returns the maximum size of a sub-group within the dispatch.
   This value will be invariant for a given set of dispatch dimensions and a
   kernel object compiled for a given device.
 
 | uint *get_num_sub_groups* ()
-| Returns the number of subgroups that the current work group is divided
+| Returns the number of sub-groups that the current work group is divided
   into.
 
   This number will be constant for the duration of a work group's execution.
@@ -183,17 +183,17 @@ Otherwise, it returns one of the following errors:
   kernel is executed with a uniform work group size.
 
   If the kernel is executed with a non-uniform work group size, returns the
-  number of subgroups in each of the work groups that make up the uniform
+  number of sub-groups in each of the work groups that make up the uniform
   region of the global range.
 
 | uint *get_sub_group_id* ()
-| *get_sub_group_id* returns the subgroup ID which is a number from 0 ..
+| *get_sub_group_id* returns the sub-group ID which is a number from 0 ..
   *get_num_sub_groups*() - 1.
 
   For {clEnqueueTask}, this returns 0.
 
 | uint *get_sub_group_local_id* ()
-| Returns the unique work item ID within the current subgroup.
+| Returns the unique work item ID within the current sub-group.
   The mapping from *get_local_id*(__dimindx__) to *get_sub_group_local_id*
   will be invariant for the lifetime of the work group.
 
@@ -213,20 +213,20 @@ Otherwise, it returns one of the following errors:
   void **sub_group_barrier** ( +
   cl_mem_fence_flags _flags_, memory_scope _scope_)
 
-| All work items in a subgroup executing the kernel on a processor must
+| All work items in a sub-group executing the kernel on a processor must
   execute this function before any are allowed to continue execution beyond
-  the subgroup barrier.
-  This function must be encountered by all work items in a subgroup
+  the sub-group barrier.
+  This function must be encountered by all work items in a sub-group
   executing the kernel.
   These rules apply to ND-ranges implemented with uniform and non-uniform
   work groups.
 
   If *sub_group_barrier* is inside a conditional statement, then all work
-  items within the subgroup must enter the conditional if any work item in
-  the subgroup enters the conditional statement and executes the
+  items within the sub-group must enter the conditional if any work item in
+  the sub-group enters the conditional statement and executes the
   sub_group_barrier.
 
-  If *sub_group_barrier* is inside a loop, all work items within the subgroup
+  If *sub_group_barrier* is inside a loop, all work items within the sub-group
   must execute the sub_group_barrier for each iteration of the loop before
   any are allowed to continue execution beyond the sub_group_barrier.
 
@@ -265,15 +265,15 @@ memory_scope_sub_group
 ----
 
 The `memory_scope_sub_group` specifies that the memory ordering constraints
-given by `memory_order` apply to work items in a subgroup.
+given by `memory_order` apply to work items in a sub-group.
 This memory scope can be used when performing atomic operations to global or
 local memory.
 
-[[cl_khr_subgroups-add-a-new-section-6.13.X-subgroup-functions]]
-==== Add a new section 6.13.X -- Subgroup Functions
+[[cl_khr_subgroups-add-a-new-section-6.13.X-sub-group-functions]]
+==== Add a new section 6.13.X -- Sub-group Functions
 
-The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
-These built-in functions must be encountered by all work items in the subgroup executing the kernel.
+The table below describes OpenCL C programming language built-in functions that operate on a sub-group level.
+These built-in functions must be encountered by all work items in the sub-group executing the kernel.
 For the functions below, the generic type name `gentype` may be the one of the supported built-in scalar data types `int`, `uint`, `long`, `ulong`, `float`, `double` (if double precision is supported), or `half` (if half precision is supported).
 
 [cols=",",options="header",]
@@ -282,54 +282,54 @@ For the functions below, the generic type name `gentype` may be the one of the s
 | *Description*
 
 | int *sub_group_all* (int _predicate_)
-| Evaluates _predicate_ for all work items in the subgroup and returns a
+| Evaluates _predicate_ for all work items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for all work items in
-  the subgroup.
+  the sub-group.
 
 | int *sub_group_any* (int _predicate_)
-| Evaluates _predicate_ for all work items in the subgroup and returns a
+| Evaluates _predicate_ for all work items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for any work items in
-  the subgroup.
+  the sub-group.
 
 | gentype *sub_group_broadcast* ( +
   gentype _x_, uint _sub_group_local_id_)
 | Broadcast the value of _x_ for work item identified by
   _sub_group_local_id_ (value returned by *get_sub_group_local_id*) to all
-  work items in the subgroup.
+  work items in the sub-group.
 
   _sub_group_local_id_ must be the same value for all work items in the
-  subgroup.
+  sub-group.
 
 | gentype *sub_group_reduce_<op>* ( +
   gentype _x_)
 | Return result of reduction operation specified by *<op>* for all values of
-  _x_ specified by work items in a subgroup.
+  _x_ specified by work items in a sub-group.
 
 | gentype *sub_group_scan_exclusive_<op>* ( +
   gentype _x_)
 | Do an exclusive scan operation specified by *<op>* of all values specified
-  by work items in a subgroup.
+  by work items in a sub-group.
   The scan results are returned for each work item.
 
-  The scan order is defined by increasing subgroup local ID within the
-  subgroup.
+  The scan order is defined by increasing sub-group local ID within the
+  sub-group.
 
 | gentype *sub_group_scan_inclusive_<op>* ( +
   gentype _x_)
 | Do an inclusive scan operation specified by *<op>* of all values specified
-  by work items in a subgroup.
+  by work items in a sub-group.
   The scan results are returned for each work item.
 
-  The scan order is defined by increasing subgroup local ID within the
-  subgroup.
+  The scan order is defined by increasing sub-group local ID within the
+  sub-group.
 
 |====
 
 The *<op>* in *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* defines the operator and can be *add*, *min* or *max*.
 
-The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
+The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
 
-The inclusive scan operation takes a binary operator *op* with _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
+The inclusive scan operation takes a binary operator *op* with _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
 
 If *op* = *add*, the identity I is 0.
 If *op* = *min*, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`, `ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
@@ -339,15 +339,15 @@ Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and `-INF
 [NOTE]
 ====
 The order of floating-point operations is not guaranteed for the *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* built-in functions that operate on `half`, `float` and `double` data types.
-The order of these floating-point operations is also non-deterministic for a given subgroup.
+The order of these floating-point operations is also non-deterministic for a given sub-group.
 ====
 
 [[cl_khr_subgroups-additions-to-section-6.13.16-pipe-functions]]
 ==== Additions to section 6.13.16 -- Pipe Functions
 
 The OpenCL C programming language implements the following built-in pipe
-functions that operate at a subgroup level.
-These built-in functions must be encountered by all work items in a subgroup
+functions that operate at a sub-group level.
+These built-in functions must be encountered by all work items in a sub-group
 executing the kernel with the same argument values; otherwise the behavior
 is undefined.
 We use the generic type name `gentype` to indicate the built-in OpenCL C
@@ -386,11 +386,11 @@ for the arguments to the pipe functions listed in _table 6.29_.
 
 |====
 
-Note: Reservations made by a subgroup are ordered in the pipe as they are
+Note: Reservations made by a sub-group are ordered in the pipe as they are
 ordered in the program.
-Reservations made by different subgroups that belong to the same work group
-can be ordered using subgroup synchronization.
-The order of subgroup based reservations that belong to different work
+Reservations made by different sub-groups that belong to the same work group
+can be ordered using sub-group synchronization.
+The order of sub-group based reservations that belong to different work
 groups is implementation-defined.
 
 [[cl_khr_subgroups-additions-to-section-6.13.17.6-enqueuing-kernels-kernel-query-functions]]
@@ -408,7 +408,7 @@ groups is implementation-defined.
   uint *get_kernel_sub_group_count_for_ndrange* ( +
   const ndrange_t _ndrange_, +
   void (^block)(local void *, ...));
-| Returns the number of subgroups in each work group of the dispatch (except
+| Returns the number of sub-groups in each work group of the dispatch (except
   for the last in cases where the global size does not divide cleanly into
   work groups) given the combination of the passed ndrange and block.
 
@@ -421,6 +421,6 @@ groups is implementation-defined.
   uint *get_kernel_max_sub_group_size_for_ndrange* ( +
   const ndrange_t _ndrange_, +
   void (^block)(local void *, ...));
-| Returns the maximum subgroup size for a block.
+| Returns the maximum sub-group size for a block.
 
 |====

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -32,19 +32,19 @@ Subgroups were promoted to a core feature in OpenCL 2.1, however note that:
 [[cl_khr_subgroups-additions-to-section-3.2-execution-model]]
 === Additions to section 3.2 -- Execution Model
 
-Within a work-group work-items may be divided into sub-groups.
-The mapping of work-items to sub-groups is implementation-defined and may be queried at runtime.
-While sub-groups may be used in multi-dimensional work-groups, each subgroup is 1-dimensional and any given work-item may query which sub-group it is a member of.
+Within a work-group work-items may be divided into subgroups.
+The mapping of work-items to subgroups is implementation-defined and may be queried at runtime.
+While subgroups may be used in multi-dimensional work-groups, each subgroup is 1-dimensional and any given work-item may query which subgroup it is a member of.
 
 Work items are mapped into subgroups through a combination of compile-time decisions and the parameters of the dispatch.
 The mapping to subgroups is invariant for the duration of a kernel’s execution, across dispatches of a given kernel with the same launch parameters, and from one work-group to another within the dispatch (excluding the trailing edge work-groups in the presence of non-uniform work-group sizes).
-In addition, all sub-groups within a work-group will be the same size, apart from the sub-group with the maximum index which may be smaller if the size of the work-group is not evenly divisible by the size of the sub-group.
+In addition, all subgroups within a work-group will be the same size, apart from the subgroup with the maximum index which may be smaller if the size of the work-group is not evenly divisible by the size of the subgroup.
 
-Sub-groups execute concurrently within a given work-group and make independent forward progress with respect to each other even in the absence of work-group barrier operations.
+Subgroups execute concurrently within a given work-group and make independent forward progress with respect to each other even in the absence of work-group barrier operations.
 Subgroups are able to internally synchronize using barrier operations without synchronizing with each other.
 
-In the degenerate case, with the extension enabled, a single sub-group must be supported for each work-group.
-In this situation all sub-group scope functions alias their work-group level equivalents.
+In the degenerate case, with the extension enabled, a single subgroup must be supported for each work-group.
+In this situation all subgroup scope functions alias their work-group level equivalents.
 
 [[cl_khr_subgroups-additions-to-chapter-5-of-the-opencl-2.0-specification]]
 === Additions to Chapter 5 of the OpenCL 2.0 Specification
@@ -98,8 +98,8 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR}
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the maximum sub-group size for this kernel.
-            All sub-groups must be the same size, while the last subgroup in
+          | Returns the maximum subgroup size for this kernel.
+            All subgroups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.
 
@@ -111,11 +111,11 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR}
   | {size_t_TYPE}*
       | {size_t_TYPE}
-          | Returns the number of sub-groups that will be present in each
+          | Returns the number of subgroups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of sub-groups.
+            same number of subgroups.
 
             The _input_value_ must be an array of size_t values
             corresponding to the local work size parameter of the intended
@@ -269,8 +269,8 @@ given by `memory_order` apply to work items in a subgroup.
 This memory scope can be used when performing atomic operations to global or
 local memory.
 
-[[cl_khr_subgroups-add-a-new-section-6.13.X-sub-group-functions]]
-==== Add a new section 6.13.X -- Sub-Group Functions
+[[cl_khr_subgroups-add-a-new-section-6.13.X-subgroup-functions]]
+==== Add a new section 6.13.X -- Subgroup Functions
 
 The table below describes OpenCL C programming language built-in functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in the subgroup executing the kernel.
@@ -327,9 +327,9 @@ For the functions below, the generic type name `gentype` may be the one of the s
 
 The *<op>* in *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* defines the operator and can be *add*, *min* or *max*.
 
-The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
+The exclusive scan operation takes a binary operator *op* with an identity I and _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [I, a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-2~)].
 
-The inclusive scan operation takes a binary operator *op* with _n_ (where _n_ is the size of the sub-group) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
+The inclusive scan operation takes a binary operator *op* with _n_ (where _n_ is the size of the subgroup) elements [a~0~, a~1~, ... a~n-1~] and returns [a~0~, (a~0~ *op* a~1~), ... (a~0~ *op* a~1~ *op* ... *op* a~n-1~)].
 
 If *op* = *add*, the identity I is 0.
 If *op* = *min*, the identity I is `INT_MAX`, `UINT_MAX`, `LONG_MAX`, `ULONG_MAX`, for `int`, `uint`, `long`, `ulong` types and is `+INF` for
@@ -339,7 +339,7 @@ Similarly if *op* = max, the identity I is `INT_MIN`, 0, `LONG_MIN`, 0 and `-INF
 [NOTE]
 ====
 The order of floating-point operations is not guaranteed for the *sub_group_reduce_<op>*, *sub_group_scan_inclusive_<op>* and *sub_group_scan_exclusive_<op>* built-in functions that operate on `half`, `float` and `double` data types.
-The order of these floating-point operations is also non-deterministic for a given sub-group.
+The order of these floating-point operations is also non-deterministic for a given subgroup.
 ====
 
 [[cl_khr_subgroups-additions-to-section-6.13.16-pipe-functions]]

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -8,8 +8,8 @@
 This section describes the *cl_khr_subgroups* extension.
 
 This extension adds support for implementation-controlled groups of work items, known as sub-groups.
-Sub-groups behave similarly to work groups and have their own sets of built-ins and synchronization primitives.
-Sub-groups within a work group are independent, may make forward progress with respect to each other, and may map to optimized hardware structures where that makes sense.
+Sub-groups behave similarly to work-groups and have their own sets of built-ins and synchronization primitives.
+Sub-groups within a work-group are independent, may make forward progress with respect to each other, and may map to optimized hardware structures where that makes sense.
 
 Sub-groups were promoted to a core feature in OpenCL 2.1, however note that:
 
@@ -168,22 +168,22 @@ Otherwise, it returns one of the following errors:
   kernel object compiled for a given device.
 
 | uint *get_num_sub_groups* ()
-| Returns the number of sub-groups that the current work group is divided
+| Returns the number of sub-groups that the current work-group is divided
   into.
 
-  This number will be constant for the duration of a work group's execution.
-  If the kernel is executed with a non-uniform work group size
+  This number will be constant for the duration of a work-group's execution.
+  If the kernel is executed with a non-uniform work-group size
   (i.e. the global_work_size values specified to {clEnqueueNDRangeKernel} 
   are not evenly divisible by the local_work_size values for any dimension,
-  calls to this built-in from some work groups may return different values
-  than calls to this built-in from other work groups.
+  calls to this built-in from some work-groups may return different values
+  than calls to this built-in from other work-groups.
 
 | uint *get_enqueued_num_sub_groups* ()
 | Returns the same value as that returned by *get_num_sub_groups* if the
-  kernel is executed with a uniform work group size.
+  kernel is executed with a uniform work-group size.
 
-  If the kernel is executed with a non-uniform work group size, returns the
-  number of sub-groups in each of the work groups that make up the uniform
+  If the kernel is executed with a non-uniform work-group size, returns the
+  number of sub-groups in each of the work-groups that make up the uniform
   region of the global range.
 
 | uint *get_sub_group_id* ()
@@ -195,7 +195,7 @@ Otherwise, it returns one of the following errors:
 | uint *get_sub_group_local_id* ()
 | Returns the unique work item ID within the current sub-group.
   The mapping from *get_local_id*(__dimindx__) to *get_sub_group_local_id*
-  will be invariant for the lifetime of the work group.
+  will be invariant for the lifetime of the work-group.
 
 |====
 
@@ -219,7 +219,7 @@ Otherwise, it returns one of the following errors:
   This function must be encountered by all work items in a sub-group
   executing the kernel.
   These rules apply to ND-ranges implemented with uniform and non-uniform
-  work groups.
+  work-groups.
 
   If *sub_group_barrier* is inside a conditional statement, then all work
   items within the sub-group must enter the conditional if any work item in
@@ -388,7 +388,7 @@ for the arguments to the pipe functions listed in _table 6.29_.
 
 Note: Reservations made by a sub-group are ordered in the pipe as they are
 ordered in the program.
-Reservations made by different sub-groups that belong to the same work group
+Reservations made by different sub-groups that belong to the same work-group
 can be ordered using sub-group synchronization.
 The order of sub-group based reservations that belong to different work
 groups is implementation-defined.
@@ -408,9 +408,9 @@ groups is implementation-defined.
   uint *get_kernel_sub_group_count_for_ndrange* ( +
   const ndrange_t _ndrange_, +
   void (^block)(local void *, ...));
-| Returns the number of sub-groups in each work group of the dispatch (except
+| Returns the number of sub-groups in each work-group of the dispatch (except
   for the last in cases where the global size does not divide cleanly into
-  work groups) given the combination of the passed ndrange and block.
+  work-groups) given the combination of the passed ndrange and block.
 
   _block_ specifies the block to be enqueued.
 

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -391,7 +391,7 @@ ordered in the program.
 Reservations made by different subgroups that belong to the same work group
 can be ordered using subgroup synchronization.
 The order of subgroup based reservations that belong to different work
-groups is implementation defined.
+groups is implementation-defined.
 
 [[cl_khr_subgroups-additions-to-section-6.13.17.6-enqueuing-kernels-kernel-query-functions]]
 ==== Additions to section 6.13.17.6 -- Enqueuing Kernels (Kernel Query Functions)

--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -53,9 +53,9 @@ To query a suggested local work size for a kernel object, call the function
 
 include::{generated}/api/protos/clGetKernelSuggestedLocalWorkSizeKHR.txt[]
 
-The returned suggested local work size is expected to match the local work size that would be chosen if the specified kernel object, with the same kernel arguments, were enqueued into the specified command queue with the specified global work size, specified global work offset, and with a `NULL` local work size.
+The returned suggested local work size is expected to match the local work size that would be chosen if the specified kernel object, with the same kernel arguments, were enqueued into the specified command-queue with the specified global work size, specified global work offset, and with a `NULL` local work size.
 
-* _command_queue_ specifies the command queue and device for the query.
+* _command_queue_ specifies the command-queue and device for the query.
 * _kernel_ specifies the kernel object and kernel arguments for the query.
 The OpenCL context associated with _kernel_ and _command_queue_ must the same.
 * _work_dim_ specifies the number of work dimensions in the input global work offset and global work size, and the output suggested local work size.
@@ -67,7 +67,7 @@ This is optional and may be `NULL` to indicate there is no global ID offset.
 {clGetKernelSuggestedLocalWorkSizeKHR} returns {CL_SUCCESS} if the query executed successfully.
 Otherwise, it returns one of the following errors:
 
-* {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host command queue.
+* {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host command-queue.
 * {CL_INVALID_KERNEL} if _kernel_ is not a valid kernel object.
 * {CL_INVALID_CONTEXT} if the context associated with _kernel_ is not the same as the context associated with _command_queue_.
 * {CL_INVALID_PROGRAM_EXECUTABLE} if there is no successfully built program executable available for _kernel_ for the device associated with _command_queue_.

--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -5,10 +5,10 @@
 [[cl_khr_suggested_local_work_size]]
 == Suggested Local Work Size Query
 
-This extension adds the ability to query a suggested local work group size for a kernel running on a device for a specified global work size and global work offset.
-The suggested local work group size will match the work group size that would be chosen if the kernel were enqueued with the specified global work size and global work offset and a `NULL` local work size.
+This extension adds the ability to query a suggested local work-group size for a kernel running on a device for a specified global work size and global work offset.
+The suggested local work-group size will match the work-group size that would be chosen if the kernel were enqueued with the specified global work size and global work offset and a `NULL` local work size.
 
-By using the suggested local work group size query an application has greater insight into the local work group size chosen by the OpenCL implementation, and the OpenCL implementation need not re-compute the local work group size if the same kernel is enqueued multiple times with the same parameters.
+By using the suggested local work-group size query an application has greater insight into the local work-group size chosen by the OpenCL implementation, and the OpenCL implementation need not re-compute the local work-group size if the same kernel is enqueued multiple times with the same parameters.
 
 === General Information
 

--- a/ext/cl_khr_terminate_context.asciidoc
+++ b/ext/cl_khr_terminate_context.asciidoc
@@ -117,7 +117,7 @@ When a context is terminated:
     {clTerminateContextKHR} was not called.
   * The behavior of callbacks will remain unchanged, and will report
     appropriate error, if executing after termination of context.
-    This behavior is similar to enqueued commands, after the command queue
+    This behavior is similar to enqueued commands, after the command-queue
     has become invalid.
 
 {clTerminateContextKHR} returns {CL_SUCCESS} if the function is executed

--- a/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
+++ b/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
@@ -229,7 +229,7 @@ gentype work_group_scan_exclusive_mul(gentype value);
 
 === Issues
 
-. For these built-in functions, do we only want to support the types supported by the existing work-group collective functions, or do we want to support the types supported by the sub-group collective functions?
+. For these built-in functions, do we only want to support the types supported by the existing work-group collective functions, or do we want to support the types supported by the subgroup collective functions?
 +
 --
 `RESOLVED`: The extension will require the same types as the existing work-group collective functions.

--- a/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
+++ b/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
@@ -3,7 +3,7 @@
 // http://creativecommons.org/licenses/by/4.0/
 
 [[cl_khr_work_group_uniform_arithmetic]]
-== Work Group Uniform Arithmetic
+== Work-group Uniform Arithmetic
 
 This extension adds additional work-group collective functions to OpenCL C. 
 Specifically, this extension adds support for work-group scans and reductions for the following operators:
@@ -229,7 +229,7 @@ gentype work_group_scan_exclusive_mul(gentype value);
 
 === Issues
 
-. For these built-in functions, do we only want to support the types supported by the existing work-group collective functions, or do we want to support the types supported by the subgroup collective functions?
+. For these built-in functions, do we only want to support the types supported by the existing work-group collective functions, or do we want to support the types supported by the sub-group collective functions?
 +
 --
 `RESOLVED`: The extension will require the same types as the existing work-group collective functions.

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -34,7 +34,7 @@
 | Provisional Extension
 
 | <<cl_khr_create_command_queue,cl_khr_create_command_queue>>
-| API to Create Command Queues with Properties
+| API to Create Command-Queues with Properties
 | Core Feature in OpenCL 2.0
 
 | <<cl_khr_d3d10_sharing,cl_khr_d3d10_sharing>>
@@ -206,7 +206,7 @@
 | Extension
 
 | <<cl_khr_priority_hints,cl_khr_priority_hints>>
-| Create Command Queues with Different Priorities
+| Create Command-Queues with Different Priorities
 | Extension
 
 | <<cl_khr_select_fprounding_mode,cl_khr_select_fprounding_mode>>
@@ -274,7 +274,7 @@
 | Extension
 
 | <<cl_khr_throttle_hints,cl_khr_throttle_hints>>
-| Create Command Queues with Different Throttle Policies
+| Create Command-Queues with Different Throttle Policies
 | Extension
 
 | <<cl_khr_work_group_uniform_arithmetic,cl_khr_work_group_uniform_arithmetic>>

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -238,7 +238,7 @@
 | Extension
 
 | <<cl_khr_subgroup_extended_types,cl_khr_subgroup_extended_types>>
-| Additional Type Support for Sub-Group Functions
+| Additional Type Support for Subgroup Functions
 | Extension
 
 | <<cl_khr_subgroup_named_barrier,cl_khr_subgroup_named_barrier>>
@@ -246,7 +246,7 @@
 | Extension
 
 | <<cl_khr_subgroup_non_uniform_arithmetic,cl_khr_subgroup_non_uniform_arithmetic>>
-| Sub-Group Arithmetic Functions in Non-Uniform Control Flow
+| Subgroup Arithmetic Functions in Non-Uniform Control Flow
 | Extension
 
 | <<cl_khr_subgroup_non_uniform_vote,cl_khr_subgroup_non_uniform_vote>>

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -242,7 +242,7 @@
 | Extension
 
 | <<cl_khr_subgroup_named_barrier,cl_khr_subgroup_named_barrier>>
-| Barriers for Subsets of a Work Group
+| Barriers for Subsets of a Work-group
 | Extension
 
 | <<cl_khr_subgroup_non_uniform_arithmetic,cl_khr_subgroup_non_uniform_arithmetic>>
@@ -278,7 +278,7 @@
 | Extension
 
 | <<cl_khr_work_group_uniform_arithmetic,cl_khr_work_group_uniform_arithmetic>>
-| Work Group Uniform Arithmetic
+| Work-group Uniform Arithmetic
 | Extension
 
 |====

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -238,7 +238,7 @@
 | Extension
 
 | <<cl_khr_subgroup_extended_types,cl_khr_subgroup_extended_types>>
-| Additional Type Support for Subgroup Functions
+| Additional Type Support for Sub-group Functions
 | Extension
 
 | <<cl_khr_subgroup_named_barrier,cl_khr_subgroup_named_barrier>>
@@ -246,7 +246,7 @@
 | Extension
 
 | <<cl_khr_subgroup_non_uniform_arithmetic,cl_khr_subgroup_non_uniform_arithmetic>>
-| Subgroup Arithmetic Functions in Non-Uniform Control Flow
+| Sub-group Arithmetic Functions in Non-Uniform Control Flow
 | Extension
 
 | <<cl_khr_subgroup_non_uniform_vote,cl_khr_subgroup_non_uniform_vote>>

--- a/extensions/cl_arm_printf.asciidoc
+++ b/extensions/cl_arm_printf.asciidoc
@@ -106,7 +106,7 @@ a kernel will be discarded.
 A printf buffer is allocated per device per context, within a context the buffer
 will be shared between kernels executing on a device. The implementation is free
 to round up or ignore this value. +
-If this property is not specified an implementation defined default size will be
+If this property is not specified an implementation-defined default size will be
 chosen. For OpenCL driver versions prior to OpenCL 1.2 this value will be 1 MiB.
 For driver versions of OpenCL 1.2 or greater this value is defined by the
 `CL_DEVICE_PRINTF_BUFFER_SIZE` value returned by *clGetDeviceInfo*.

--- a/extensions/cl_arm_printf.asciidoc
+++ b/extensions/cl_arm_printf.asciidoc
@@ -43,7 +43,7 @@ This extension requires OpenCL 1.0 (version 1.0.0) or OpenCL 1.2 (version 2.0.0)
 
 == Overview
 
-This extension enables the device side `printf` built in function for OpenCL C
+This extension enables the device-side `printf` built in function for OpenCL C
 versions prior to 1.2 (version 1.0.0 only).
 
 It also extends the `cl_context_properties` enumeration to allow a user defined

--- a/extensions/cl_arm_scheduling_controls.asciidoc
+++ b/extensions/cl_arm_scheduling_controls.asciidoc
@@ -235,9 +235,9 @@ being returned by *clBuildProgram*.
 | Set the size of batches of work groups distributed to compute units.
   The value is a number of work groups. If set to 0, then the runtime
   will pick a suitable value automatically. Defaults to 0. If the value is
-  greater than the number of work groups necessary to execute a given NDRange,
+  greater than the number of work groups necessary to execute a given ND-range,
   the actual batch size will be capped at the number of work groups in the
-  NDRange. When a value is not directly usable due to device-specific
+  ND-range. When a value is not directly usable due to device-specific
   constraints, it will be rounded up to the next usable value.
 
 | `CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM`

--- a/extensions/cl_arm_scheduling_controls.asciidoc
+++ b/extensions/cl_arm_scheduling_controls.asciidoc
@@ -163,7 +163,7 @@ NOTE: Missing before version 0.3.0
 --
 --
 
-(Modify Section 5.1, *Command Queues*) ::
+(Modify Section 5.1, *Command-Queues*) ::
 +
 --
 

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -91,7 +91,7 @@ This extension is written against the OpenCL API Specification, OpenCL C Specifi
 
 The functionality added by this extension uses the OpenCL C 2.0 atomic syntax and hence requires OpenCL 2.0 or newer.
 
-This extension interacts with `cl_khr_fp16` by optionally adding the ability to atomically operate on 16-bit floating point values in memory.
+This extension interacts with `cl_khr_fp16` by optionally adding the ability to atomically operate on 16-bit floating-point values in memory.
 
 This extension depends on `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
 

--- a/extensions/cl_img_use_gralloc_ptr.asciidoc
+++ b/extensions/cl_img_use_gralloc_ptr.asciidoc
@@ -162,7 +162,7 @@ Prior to calling *clEnqueueAcquireGrallocObjectsIMG*, the application must ensur
 +
 Similarly, after calling *clEnqueueReleaseGrallocObjectsIMG*, the application is responsible for ensuring that any pending OpenCL operations which access the objects specified in _mem_objects_ have completed prior to executing subsequent commands in other APIs which reference these objects. This may be accomplished in a portable way by calling *clWaitForEvents* with the event object returned by *clEnqueueReleaseGrallocObjects*, or by calling *clFinish*. As above, some implementations may offer more efficient methods.
 +
-Attempting to access the data store of a gralloc allocation after it has been acquired by OpenCL and before it has been released will result in undefined behaviour. Similarly, attempting to access a shared gralloc object from OpenCL before it has been acquired by the OpenCL command queue or after it has been released, will result in undefined behaviour.
+Attempting to access the data store of a gralloc allocation after it has been acquired by OpenCL and before it has been released will result in undefined behaviour. Similarly, attempting to access a shared gralloc object from OpenCL before it has been acquired by the OpenCL command-queue or after it has been released, will result in undefined behaviour.
 
 (Add a new Section 5.16.2, _Sharing Memory Objects Created From Gralloc Resources With OpenCL Contexts_) :::
 +

--- a/extensions/cl_intel_command_queue_families.asciidoc
+++ b/extensions/cl_intel_command_queue_families.asciidoc
@@ -49,30 +49,30 @@ Revision: 1.0.0
 
 This extension is written against the OpenCL API Specification Version 3.0.5.
 
-Because this extension adds to the command queue properties accepted by the *clCreateCommandQueueWithProperties* API, this extension requires support for either OpenCL 2.0 or the `cl_khr_create_command_queue` extension.
+Because this extension adds to the command-queue properties accepted by the *clCreateCommandQueueWithProperties* API, this extension requires support for either OpenCL 2.0 or the `cl_khr_create_command_queue` extension.
 
 == Overview
 
-Some OpenCL devices may support different sets of command queues with different capabilities or execution properties.
-These sets are described in this extension as _command queue families_.
-Applications may be able to improve performance or predictability by creating command queues from a specific _command queue family_.
+Some OpenCL devices may support different sets of command-queues with different capabilities or execution properties.
+These sets are described in this extension as _command-queue families_.
+Applications may be able to improve performance or predictability by creating command-queues from a specific _command-queue family_.
 
 This extension adds the ability to:
 
-* Query the _command queue families_ supported by an OpenCL device and their capabilities.
-* Create an OpenCL command queue from a specific _command queue family_.
-* Query the _command queue family_ and _command queue index_ associated with an OpenCL command queue.
+* Query the _command-queue families_ supported by an OpenCL device and their capabilities.
+* Create an OpenCL command-queue from a specific _command-queue family_.
+* Query the _command-queue family_ and _command-queue index_ associated with an OpenCL command-queue.
 
 == New API Enums
 
-Accepted value for the _param_name_ parameter to *clGetDeviceInfo* to query the number of command queue families and command queue family properties supported by an OpenCL device:
+Accepted value for the _param_name_ parameter to *clGetDeviceInfo* to query the number of command-queue families and command-queue family properties supported by an OpenCL device:
 
 [source]
 ----
 #define CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL 0x418B
 ----
 
-Accepted as a property name for the _properties_ parameter to *clCreateCommandQueueWithProperties* to specify the command queue family and command queue index that this command queue should submit work to; and for the _param_name_ parameter to *clGetCommandQueueInfo* to query the command queue family or command queue index associated with a command queue:
+Accepted as a property name for the _properties_ parameter to *clCreateCommandQueueWithProperties* to specify the command-queue family and command-queue index that this command-queue should submit work to; and for the _param_name_ parameter to *clGetCommandQueueInfo* to query the command-queue family or command-queue index associated with a command-queue:
 
 [source]
 ----
@@ -96,7 +96,7 @@ typedef struct _cl_queue_family_properties_intel {
 } cl_queue_family_properties_intel;
 ----
 
-Bitfield type describing the capabilities of the queues in a command queue family.
+Bitfield type describing the capabilities of the queues in a command-queue family.
 Subsequent versions of this extension may add additional queue capabilities:
 
 [source]
@@ -155,25 +155,25 @@ The device queries described in the Device Queries table should return the same 
 | Device Info | Return Type | Description
 | `CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL`
   | `cl_queue_family_properties_intel[]`
-      | Returns an array of `cl_queue_family_properties_intel` structures describing command queue families supported by the device.
+      | Returns an array of `cl_queue_family_properties_intel` structures describing command-queue families supported by the device.
       Each structure consists of:
 
-      `properties`: Describes the host command queue properties supported by this command queue family.
+      `properties`: Describes the host command-queue properties supported by this command-queue family.
       The supported property values are the same as those returned by the query for `CL_DEVICE_QUEUE_ON_HOST_PROPERTIES`.
 
-      `capabilities`: Describes the command queue capabilities supported by this command queue family.
+      `capabilities`: Describes the command-queue capabilities supported by this command-queue family.
       This is a bitfield value that may either be `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` or a set of queue capabilities from the <<queue-capabilities-table,Queue Capabilities Table>>.
 
-      `count`: Describes the number of command queues in this command queue family.
-      Command queues created with unique command queue indices may execute more efficiently than command queues created with equal indices.
+      `count`: Describes the number of command-queues in this command-queue family.
+      Command-queues created with unique command-queue indices may execute more efficiently than command-queues created with equal indices.
 
       `name`: An array of `CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL` bytes used as storage for a null-terminated string.
-      The string is a descriptive name for this command queue family.
+      The string is a descriptive name for this command-queue family.
       The descriptive name is purely informative and has no semantic meaning.
 
       At least one entry in the array must return the same properties returned by `CL_DEVICE_QUEUE_ON_HOST_PROPERTIES` and must have capabilities equal to `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`.
 
-      Please note that a sub-device may support different command queue families than its root-level device.
+      Please note that a sub-device may support different command-queue families than its root-level device.
 |====
 --
 
@@ -187,28 +187,28 @@ The device queries described in the Device Queries table should return the same 
 | Queue Property | Property Value | Description
 | `CL_QUEUE_FAMILY_INTEL`
   | `cl_uint`
-      | Specifies the command queue family that this command queue will submit work to.
+      | Specifies the command-queue family that this command-queue will submit work to.
 
-        The specified command queue family must be between zero and the total number of command queue families supported by the device.
-        If a command queue family is specified then a command queue index must also be specified.
+        The specified command-queue family must be between zero and the total number of command-queue families supported by the device.
+        If a command-queue family is specified then a command-queue index must also be specified.
 | `CL_QUEUE_INDEX_INTEL`
   | `cl_uint`
-      | Specifies the command queue index within the command queue family that this command queue will submit work to.
+      | Specifies the command-queue index within the command-queue family that this command-queue will submit work to.
 
-        The specified command queue index must be between zero and the total number of command queues in the command queue family for this command queue for the device.
-        If a command queue index is specified then a command queue family must also be specified.
+        The specified command-queue index must be between zero and the total number of command-queues in the command-queue family for this command-queue for the device.
+        If a command-queue index is specified then a command-queue family must also be specified.
 |====
 --
 
 (Add to the list of error conditions for *clCreateCommandQueueWithProperties*) ::
 +
 --
-*clCreateCommandQueueWithProperties* returns a valid non-zero command-queue and _errcode_ret_ is set to `CL_SUCCESS` if the command queue is created successfully.
+*clCreateCommandQueueWithProperties* returns a valid non-zero command-queue and _errcode_ret_ is set to `CL_SUCCESS` if the command-queue is created successfully.
 Otherwise, it returns a `NULL` value with one of the following error values returned in _errcode_ret_:
 
 * ...
-* `CL_INVALID_VALUE` if the property value for `CL_QUEUE_FAMILY_INTEL` specifies a command queue family greater than or equal to the number of command queue families supported by the device.
-* `CL_INVALID_VALUE` if the property value for `CL_QUEUE_INDEX_INTEL` specifies a command queue index greater than or equal to the number of queues for the command queue family for the device.
+* `CL_INVALID_VALUE` if the property value for `CL_QUEUE_FAMILY_INTEL` specifies a command-queue family greater than or equal to the number of command-queue families supported by the device.
+* `CL_INVALID_VALUE` if the property value for `CL_QUEUE_INDEX_INTEL` specifies a command-queue index greater than or equal to the number of queues for the command-queue family for the device.
 * `CL_INVALID_VALUE` if the property `CL_QUEUE_FAMILY_INTEL` is specified and the property `CL_QUEUE_INDEX_INTEL` is not specified, or if the property `CL_QUEUE_INDEX_INTEL` is specified and the property `CL_QUEUE_FAMILY_INTEL` is not specified.
 --
 
@@ -222,91 +222,91 @@ Otherwise, it returns a `NULL` value with one of the following error values retu
 | *Queue Properties* | Property Value | Description
 | `CL_QUEUE_FAMILY_INTEL`
   | `cl_uint`
-      | Returns the command queue family that this command queue will submit work to.
+      | Returns the command-queue family that this command-queue will submit work to.
 
-        If no command queue family was specified when this command queue was created then the value returned for this query is implementation-defined, but must be a command queue family with the same properties returned by `CL_DEVICE_QUEUE_ON_HOST_PROPERTIES` for the device and capabilities equal to `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`.
+        If no command-queue family was specified when this command-queue was created then the value returned for this query is implementation-defined, but must be a command-queue family with the same properties returned by `CL_DEVICE_QUEUE_ON_HOST_PROPERTIES` for the device and capabilities equal to `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`.
 | `CL_QUEUE_INDEX_INTEL`
   | `cl_uint`
-      | Returns the command queue index within the command queue family that this command queue will submit work to.
+      | Returns the command-queue index within the command-queue family that this command-queue will submit work to.
 
-        If no command queue index was specified when this command queue was created then the value returned for this query is implementation-defined, but must be between zero and the total number of queues supported by the device for the command queue family that this command queue will submit work to.
+        If no command-queue index was specified when this command-queue was created then the value returned for this query is implementation-defined, but must be between zero and the total number of queues supported by the device for the command-queue family that this command-queue will submit work to.
 |====
 --
 
-(Add a new Section 5.1.X Command Queue Families) ::
+(Add a new Section 5.1.X Command-Queue Families) ::
 +
 --
-Some OpenCL devices may support different sets of command queues with different capabilities or execution properties.
-The sets of command queues with different capabilities or execution properties are known as command queue families.
-Each command queue family may contain multiple queues with similar characteristics.
+Some OpenCL devices may support different sets of command-queues with different capabilities or execution properties.
+The sets of command-queues with different capabilities or execution properties are known as command-queue families.
+Each command-queue family may contain multiple queues with similar characteristics.
 
-Using multiple unique queues from a command queue family or queues from different command queue families may improve performance, such as by allowing commands to execute concurrently or using dedicated hardware resources.
+Using multiple unique queues from a command-queue family or queues from different command-queue families may improve performance, such as by allowing commands to execute concurrently or using dedicated hardware resources.
 
-Every OpenCL device must support at least one command queue family with "default" command queue capabilities.
-These command queue families are identified with the special command queue capability value `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`.
-Command queues created from a command queue family with default command queue capabilities have no additional restrictions and support all commands and command queue features described by standard OpenCL device queries.
+Every OpenCL device must support at least one command-queue family with "default" command-queue capabilities.
+These command-queue families are identified with the special command-queue capability value `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`.
+Command-queues created from a command-queue family with default command-queue capabilities have no additional restrictions and support all commands and command-queue features described by standard OpenCL device queries.
 
-When a command queue family does not have the default command queue capabilities, the command queue family capability value is a bitfield describing the commands and command queue features that are supported for queues created from the command queue family.
-Enqueueing an unsupported command or using an unsupported command queue feature will fail and generate an OpenCL error.
+When a command-queue family does not have the default command-queue capabilities, the command-queue family capability value is a bitfield describing the commands and command-queue features that are supported for queues created from the command-queue family.
+Enqueueing an unsupported command or using an unsupported command-queue feature will fail and generate an OpenCL error.
 
-The following table describes the supported command queue capabilities and the OpenCL commands they enable.
+The following table describes the supported command-queue capabilities and the OpenCL commands they enable.
 
 [[queue-capabilities-table]]
 [caption="Table X. "]
-.List of supported command queue capabilities
+.List of supported command-queue capabilities
 [width="100%",cols="1,2",options="header"]
 |====
 | Queue Capability | Description
 |`CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`
-| A special capability value to indicate that queues in this command queue family have no additional restrictions.
-At least one command queue family must support this capability.
+| A special capability value to indicate that queues in this command-queue family have no additional restrictions.
+At least one command-queue family must support this capability.
 
 |`CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL`
-| Indicates that queues in this command queue family support creating event objects identifying commands for event profiling, waiting on the host, or in the event wait list for another command in the same queue.
+| Indicates that queues in this command-queue family support creating event objects identifying commands for event profiling, waiting on the host, or in the event wait list for another command in the same queue.
 
 |`CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL`
-| Indicates that queues in this command queue family support creating event objects identifying commands for event profiling, waiting on the host, or in the event wait list for another command in another queue.
+| Indicates that queues in this command-queue family support creating event objects identifying commands for event profiling, waiting on the host, or in the event wait list for another command in another queue.
 When creating cross-queue events is supported, creating single-queue events must also be supported.
 
 |`CL_QUEUE_CAPABILITY_SINGLE_QUEUE_EVENT_WAIT_LIST_INTEL`
-| Indicates that queues in this command queue family support commands that wait on events that were created in the same queue.
+| Indicates that queues in this command-queue family support commands that wait on events that were created in the same queue.
 
 |`CL_QUEUE_CAPABILITY_CROSS_QUEUE_EVENT_WAIT_LIST_INTEL`
-| Indicates that queues in this command queue family support commands that wait on events that were created in another queue.
+| Indicates that queues in this command-queue family support commands that wait on events that were created in another queue.
 When waiting on cross-queue events is supported, waiting on single-queue events must also be supported.
 
 |`CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueReadBuffer`, `clEnqueueWriteBuffer`, and `clEnqueueCopyBuffer`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueReadBuffer`, `clEnqueueWriteBuffer`, and `clEnqueueCopyBuffer`.
 
 |`CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_RECT_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueReadBufferRect`, `clEnqueueWriteBufferRect`, and `clEnqueueCopyBufferRect`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueReadBufferRect`, `clEnqueueWriteBufferRect`, and `clEnqueueCopyBufferRect`.
 
 |`CL_QUEUE_CAPABILITY_MAP_BUFFER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueMapBuffer` and `clEnqueueUnmapMemObject`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueMapBuffer` and `clEnqueueUnmapMemObject`.
 
 |`CL_QUEUE_CAPABILITY_FILL_BUFFER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueFillBuffer`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueFillBuffer`.
 
 |`CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueReadImage`, `clEnqueueWriteImage`, and `clEnqueueCopyImage`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueReadImage`, `clEnqueueWriteImage`, and `clEnqueueCopyImage`.
 
 |`CL_QUEUE_CAPABILITY_MAP_IMAGE_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueMapImage` and `clEnqueueUnmapMemObject`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueMapImage` and `clEnqueueUnmapMemObject`.
 
 |`CL_QUEUE_CAPABILITY_FILL_IMAGE_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueFillImage`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueFillImage`.
 
 |`CL_QUEUE_CAPABILITY_TRANSFER_BUFFER_IMAGE_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueCopyBufferToImage`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueCopyBufferToImage`.
 
 |`CL_QUEUE_CAPABILITY_TRANSFER_IMAGE_BUFFER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueCopyImageToBuffer`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueCopyImageToBuffer`.
 
 |`CL_QUEUE_CAPABILITY_MARKER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueMarker` and `clEnqueueMarkerWithWaitList`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueMarker` and `clEnqueueMarkerWithWaitList`.
 
 |`CL_QUEUE_CAPABILITY_BARRIER_INTEL`
-| Indicates that queues in this command queue family support calls to `clEnqueueBarrier` and `clEnqueueBarrierWithWaitList`.
+| Indicates that queues in this command-queue family support calls to `clEnqueueBarrier` and `clEnqueueBarrierWithWaitList`.
 
 |====
 --
@@ -314,19 +314,19 @@ When waiting on cross-queue events is supported, waiting on single-queue events 
 (Add to the list of error conditions for all enqueue APIs) ::
 +
 --
-// This is the case where the command queue does not support waiting on any events:
+// This is the case where the command-queue does not support waiting on any events:
 * `CL_INVALID_EVENT_WAIT_LIST` if the queue capabilities for _command_queue_ is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` or does not include `CL_QUEUE_CAPABILITY_SINGLE_QUEUE_EVENT_WAIT_LIST_INTEL`, and _num_events_in_wait_list_ is not `0` or _event_wait_list_ is not `NULL`.
 
-// This is the case where the associated command queue for an event in the event
-// wait list does not support cross-queue events and the associated command queue
+// This is the case where the associated command-queue for an event in the event
+// wait list does not support cross-queue events and the associated command-queue
 // for an event is not this queue:
-* `CL_INVALID_EVENT_WAIT_LIST` if the queue capabilities for the command queue associated with an event in the event wait list is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` or does not include `CL_QUEUE_CREATE_CROSS_QUEUE_EVENTS_INTEL`, and _command_queue_ is not equal to the command queue associated with the event.
+* `CL_INVALID_EVENT_WAIT_LIST` if the queue capabilities for the command-queue associated with an event in the event wait list is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` or does not include `CL_QUEUE_CREATE_CROSS_QUEUE_EVENTS_INTEL`, and _command_queue_ is not equal to the command-queue associated with the event.
 
-// This is the case where the command queue does not support cross-queue event
-// wait lists and the associated command queue for an event is not this queue:
-* `CL_INVALID_EVENT_WAIT_LIST` if the queue capabilities for _command queue_ is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` and _command_queue_ is not equal to the command queue associated with an event.
+// This is the case where the command-queue does not support cross-queue event
+// wait lists and the associated command-queue for an event is not this queue:
+* `CL_INVALID_EVENT_WAIT_LIST` if the queue capabilities for _command_queue_ is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` and _command_queue_ is not equal to the command-queue associated with an event.
 
-// This is the case where the command queue does not support creating events:
+// This is the case where the command-queue does not support creating events:
 * `CL_INVALID_EVENT` if the queue capabilities for _command_queue_ is not `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL` or does not include `CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL` or `CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL`, and _event_ is not `NULL`.
 
 For all enqueue APIs described in the <<queue-capabilities-table,Queue Capabilities Table>>:
@@ -351,12 +351,12 @@ The name of this extension is `cl_intel_command_queue_families`.
 . What does this extension offer compared to "device partitioning"?
 +
 --
-*RESOLVED*: This extension describes command queue families and their properties
+*RESOLVED*: This extension describes command-queue families and their properties
 to control how work can be executed on a device or sub-device. It is
 complementary to device partitioning.
 --
 
-. What are the memory model implications for command queue families?
+. What are the memory model implications for command-queue families?
 +
 --
 *UNRESOLVED*
@@ -369,34 +369,34 @@ complementary to device partitioning.
 
 This special capability was switched to `CL_QUEUE_DEFAULT_CAPABILITIES_INTEL`,
 and the value of the capability was changed to zero from all-bits-set.  This
-should allow for special queue capabilities that go beyond default command queue
+should allow for special queue capabilities that go beyond default command-queue
 capabilities, if desired.
 --
 
-. Do we need a query for the number of command queue families for a device?
+. Do we need a query for the number of command-queue families for a device?
 +
 --
 *RESOLVED*
 
-No, this is not needed.  The number of command queue families can be derived
+No, this is not needed.  The number of command-queue families can be derived
 from the size returned by `CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL`.
 --
 
-. Should there be a default command queue family or command queue index for a
-command queue?
+. Should there be a default command-queue family or command-queue index for a
+command-queue?
 +
 --
 *RESOLVED*
 
-No, it's preferable to allow an implementation to vary the command queue family
-and command queue index per-command queue.  This enables an implementation to
-implement a policy to choose among different command queue families or command
-queue indices for each command queue rather than a single default if it leads to
+No, it's preferable to allow an implementation to vary the command-queue family
+and command-queue index per-command-queue.  This enables an implementation to
+implement a policy to choose among different command-queue families or command
+queue indices for each command-queue rather than a single default if it leads to
 improved performance.
 
-Note that specifying only a command queue family or a command queue index is an
-error, and an application must either specify no command queue family or command
-queue index, or both a command queue family and command queue index.
+Note that specifying only a command-queue family or a command-queue index is an
+error, and an application must either specify no command-queue family or command
+queue index, or both a command-queue family and command-queue index.
 --
 
 . Do we need a capability for cross-queue event wait lists?

--- a/extensions/cl_intel_mem_alloc_buffer_location.asciidoc
+++ b/extensions/cl_intel_mem_alloc_buffer_location.asciidoc
@@ -68,7 +68,7 @@ Overview
 
 On some devices, global memory may be partitioned into disjoint regions.  This may be to enable control over specific characteristics such as available bandwidths on memory interfaces, or performance on types of access patterns.
 
-This extension allows a user to explicitly specify the partition/region of global memory in which an allocation should reside, by passing an implementation defined numerical ID that identifies the region to the allocation function.
+This extension allows a user to explicitly specify the partition/region of global memory in which an allocation should reside, by passing an implementation-defined numerical ID that identifies the region to the allocation function.
 
 *Example Usage*
 
@@ -134,7 +134,7 @@ Modifications to the OpenCL API Specification
 
 | +CL_MEM_ALLOC_BUFFER_LOCATION_INTEL+
 | +cl_uint+
-| Identifies the ID of global memory partition to which the memory should be allocated. The range of legal values is implementation defined. If the value is not valid, or the implementation is unable to allocate memory in the requested memory type, an `CL_INVALID_PROPERTY` error will be emitted.
+| Identifies the ID of global memory partition to which the memory should be allocated. The range of legal values is implementation-defined. If the value is not valid, or the implementation is unable to allocate memory in the requested memory type, an `CL_INVALID_PROPERTY` error will be emitted.
 |====
 
 .List of supported param_names by clGetMemAllocInfoINTEL

--- a/extensions/cl_intel_required_subgroup_size.asciidoc
+++ b/extensions/cl_intel_required_subgroup_size.asciidoc
@@ -57,8 +57,8 @@ This extension is written against revision 23 of the OpenCL 2.1 API specificatio
 
 == Overview
 
-The goal of this extension is to allow programmers to optionally specify the required subgroup size for a kernel function.
-This information is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.
+The goal of this extension is to allow programmers to optionally specify the required sub-group size for a kernel function.
+This information is important for the correctness of many sub-group algorithms, and in some cases may be used by the compiler to generate more optimal code.
 
 == New API Functions
 
@@ -107,7 +107,7 @@ __attribute__((intel_reqd_sub_group_size(<int>)))
 
 | {CL_DEVICE_SUB_GROUP_SIZES_INTEL}
 | `size_t[]`
-| Returns the set of subgroup sizes supported by the device.
+| Returns the set of sub-group sizes supported by the device.
 
 |====
 
@@ -134,10 +134,10 @@ This is Table 5.22 - "*clGetKernelSubGroupInfo* parameter queries" in the OpenCL
 | {CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL}
 | `ignored`
 | `size_t`
-| Returns the subgroup size specified by the `+__attribute__((intel_reqd_sub_group_size(<int>)))+` qualifier.
+| Returns the sub-group size specified by the `+__attribute__((intel_reqd_sub_group_size(<int>)))+` qualifier.
 Refer to section 6.7.2.
 
-If the subgroup size is not specified using the above attribute qualifier then 0 is returned.
+If the sub-group size is not specified using the above attribute qualifier then 0 is returned.
 
 |====
 
@@ -145,16 +145,16 @@ If the subgroup size is not specified using the above attribute qualifier then 0
 
 === Additions to Section 6.7.2 - "Optional Attribute Qualifiers"
 
-The optional `+__attribute__((intel_reqd_sub_group_size(<int>)))+` can be used to indicate that the kernel must be compiled and executed with the specified subgroup size.
+The optional `+__attribute__((intel_reqd_sub_group_size(<int>)))+` can be used to indicate that the kernel must be compiled and executed with the specified sub-group size.
 When this attribute is present, *get_max_sub_group_size*() is guaranteed to return the specified integer value.
-This is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.
+This is important for the correctness of many sub-group algorithms, and in some cases may be used by the compiler to generate more optimal code.
 
-Note that there is no guarantee for the value of *get_sub_group_size*() even when this attribute is present, particularly when the work-group size is not evenly divisible by the required subgroup size.
+Note that there is no guarantee for the value of *get_sub_group_size*() even when this attribute is present, particularly when the work-group size is not evenly divisible by the required sub-group size.
 
-Note as well that some devices may support a limited number of subgroup sizes, and that some devices may not support all language constructs with all subgroup sizes.
-This means that some kernels may fail compilation with one required subgroup size and succeed with another required subgroup size, even if both subgroup sizes are supported by the device.
+Note as well that some devices may support a limited number of sub-group sizes, and that some devices may not support all language constructs with all sub-group sizes.
+This means that some kernels may fail compilation with one required sub-group size and succeed with another required sub-group size, even if both sub-group sizes are supported by the device.
 
-Finally, note that requiring one subgroup size (particularly, a larger subgroup size) may require more spill memory than another subgroup size, and may negatively impact application performance."
+Finally, note that requiring one sub-group size (particularly, a larger sub-group size) may require more spill memory than another sub-group size, and may negatively impact application performance."
     
 == Issues
 

--- a/extensions/cl_intel_spirv_media_block_io.asciidoc
+++ b/extensions/cl_intel_spirv_media_block_io.asciidoc
@@ -100,7 +100,7 @@ For 'Width' and 'Height', the following type is supported:
 
 === Add a new Section 7.1.X.1 - Notes and Restrictions
 
-Both *OpSubgroupImageMediaBlockReadINTEL* and *OpSubgroupImageMediaBlockWriteINTEL* must be encountered by all work items in the subgroup executing the kernel, otherwise the behavior is undefined (i.e. they can only be used in convergent control flow where all the work items in the subgroup are enabled).
+Both *OpSubgroupImageMediaBlockReadINTEL* and *OpSubgroupImageMediaBlockWriteINTEL* must be encountered by all work items in the sub-group executing the kernel, otherwise the behavior is undefined (i.e. they can only be used in convergent control flow where all the work items in the sub-group are enabled).
 
 The block 'Width' determines the maximum 'Height' for *OpSubgroupImageMediaBlockReadINTEL* and *OpSubgroupImageMediaBlockWriteINTEL*, and is summarized in the following table:
 

--- a/extensions/cl_intel_spirv_subgroups.asciidoc
+++ b/extensions/cl_intel_spirv_subgroups.asciidoc
@@ -175,11 +175,11 @@ For _Coordinate_, the following types are supported:
 
 === Add a new Section 7.1.X.3 - Notes and Restrictions
 
-The *SubgroupShuffleINTEL* instructions may be placed within non-uniform control flow and hence do not have to be encountered by all invocations in the subgroup, however _Data_ may only be shuffled among invocations encountering the *SubgroupShuffleINTEL* instruction.  Shuffling _Data_ from an invocation that does not encounter the *SubgroupShuffleINTEL* instruction will produce undefined results.
+The *SubgroupShuffleINTEL* instructions may be placed within non-uniform control flow and hence do not have to be encountered by all invocations in the sub-group, however _Data_ may only be shuffled among invocations encountering the *SubgroupShuffleINTEL* instruction.  Shuffling _Data_ from an invocation that does not encounter the *SubgroupShuffleINTEL* instruction will produce undefined results.
 
 There is no defined behavior for out-of-range shuffle indices for the *SubgroupShuffleINTEL* instructions.
 
-The *SubgroupBufferBlockIOINTEL* and *SubgroupImageBlockIOINTEL* instructions are only guaranteed to work correctly if placed strictly within uniform control flow within the subgroup.  This ensures that if any invocation executes it, all invocations will execute it.  If placed elsewhere, behavior is undefined.
+The *SubgroupBufferBlockIOINTEL* and *SubgroupImageBlockIOINTEL* instructions are only guaranteed to work correctly if placed strictly within uniform control flow within the sub-group.  This ensures that if any invocation executes it, all invocations will execute it.  If placed elsewhere, behavior is undefined.
 
 There is no defined out-of-range behavior for the *SubgroupBufferBlockIOINTEL* instructions.
 
@@ -199,7 +199,7 @@ The following restrictions apply to the *SubgroupBufferBlockIOINTEL* instruction
 
 * If the pointer _Ptr_ is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
-* Behavior is undefined if the *SubgroupSize* is smaller than *SubgruopMaxSize*; in other words, if this is a partial subgroup.
+* Behavior is undefined if the *SubgroupSize* is smaller than *SubgroupMaxSize*; in other words, if this is a partial sub-group.
 
 The following restrictions apply to the *SubgroupImageBlockIOINTEL* instructions:
 
@@ -211,7 +211,7 @@ The following restrictions apply to the *SubgroupImageBlockIOINTEL* instructions
 
 * When reading or writing a 2D image created from a buffer with the *SubgroupImageBlockIOINTEL* instructions, if the buffer is a `cl_mem` that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.  Additionally, if the _buffer_ that the sub-buffer is created from was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
 
-* Behavior is undefined if the *SubgroupSize* is smaller than *SubgruopMaxSize*; in other words, if this is a partial subgroup.
+* Behavior is undefined if the *SubgroupSize* is smaller than *SubgruopMaxSize*; in other words, if this is a partial sub-group.
 
 The following restrictions apply to the *OpSubgroupImageBlockWriteINTEL* instruction:
 
@@ -235,7 +235,7 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2018-10-29|Ben Ashbaugh|*Initial revision*
-|2|2019-09-17|Ben Ashbaugh|Added 3-component vector support for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.
+|2|2019-09-17|Ben Ashbaugh|Added 3-component vector support for shuffles, restriction for block reads and writes and partial sub-groups, and asciidoctor formatting fixes.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_intel_split_work_group_barrier.asciidoc
+++ b/extensions/cl_intel_split_work_group_barrier.asciidoc
@@ -77,10 +77,10 @@ void intel_work_group_barrier_wait(cl_mem_fence_flags flags, memory_scope scope)
 
 == Modifications to the OpenCL C Specification
 
-=== Add to Table 19 - Built-in Work-Group Synchronization Functions
+=== Add to Table 19 - Built-in Work-group Synchronization Functions
 
 [caption="Table 19. "]
-.Built-in Work-Group synchronization Functions
+.Built-in Work-group synchronization Functions
 [cols="1a,2",options="header"]
 |====
 | *Function*

--- a/extensions/cl_intel_split_work_group_barrier.asciidoc
+++ b/extensions/cl_intel_split_work_group_barrier.asciidoc
@@ -156,7 +156,7 @@ For the instruction *OpControlBarrierWaitINTEL*, the memory-order constraint in 
 *RESOLVED*: Not in this extension.
 --
 
-. Do we need to support subgroup split barriers?
+. Do we need to support sub-group split barriers?
 +
 --
 *RESOLVED*: Not in this extension.

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -62,27 +62,27 @@ This extension is written against revision 24 of the OpenCL 2.0 API specificatio
 
 == Overview
 
-The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "subgroup"), and that work items in a subgroup can take advantage of hardware features that are not available to work items in a work group.
-Specifically, this extension is designed to allow work items in a subgroup to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data.
+The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "sub-group"), and that work items in a sub-group can take advantage of hardware features that are not available to work items in a work group.
+Specifically, this extension is designed to allow work items in a sub-group to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data.
 
-There is a large amount of overlap between the functionality in this extension and the functionality in the Khronos subgroups extension `cl_khr_subgroups`, so this extension reuses many of the names, concepts, and functions already described by the `cl_khr_subgroups` extension.
-The key differences between the Intel subgroups extension and the Khronos subgroups extension are:
+There is a large amount of overlap between the functionality in this extension and the functionality in the Khronos sub-groups extension `cl_khr_subgroups`, so this extension reuses many of the names, concepts, and functions already described by the `cl_khr_subgroups` extension.
+The key differences between the Intel sub-groups extension and the Khronos sub-groups extension are:
 
-* The Khronos subgroups extension requires OpenCL 2.0, but the Intel subgroups extension may be available on OpenCL 1.2 devices.
+* The Khronos sub-groups extension requires OpenCL 2.0, but the Intel sub-groups extension may be available on OpenCL 1.2 devices.
 
-* The Khronos subgroups extension guarantees that subgroups in a work group will make independent forward progress, but the Intel extension does not guarantee that subgroups in a work group will make independent forward progress.
+* The Khronos sub-groups extension guarantees that sub-groups in a work group will make independent forward progress, but the Intel extension does not guarantee that sub-groups in a work group will make independent forward progress.
 
-* The Intel extension adds a rich set of subgroup "shuffle" functions to allow work items within a work group to interchange data without the use of local memory and work group barriers.
+* The Intel extension adds a rich set of sub-group "shuffle" functions to allow work items within a work group to interchange data without the use of local memory and work group barriers.
 
-* The Intel extension adds a set of subgroup "block read and write" functions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
+* The Intel extension adds a set of sub-group "block read and write" functions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
 
-* The Intel subgroups extension does not include the subgroup pipes functions that are included as part of the Khronos subgroups extension.
+* The Intel sub-groups extension does not include the sub-group pipes functions that are included as part of the Khronos sub-groups extension.
 
-* The Intel subgroups extension does not include the device-side kernel query functions for subgroups that are included as part of the Khronos subgroups extension.
+* The Intel sub-groups extension does not include the device-side kernel query functions for sub-groups that are included as part of the Khronos sub-groups extension.
 
 == New API Functions
 
-This function is copied unchanged from the Khronos subgroups extension: ::
+This function is copied unchanged from the Khronos sub-groups extension: ::
 +
 --
 [source]
@@ -101,7 +101,7 @@ cl_int clGetKernelSubGroupInfoKHR(
 
 == New API Enums
 
-These enums are copied unchanged from the Khronos subgroups extension: ::
+These enums are copied unchanged from the Khronos sub-groups extension: ::
 +
 --
 Accepted as the _param_name_ parameter of *clGetKernelSubGroupInfoKHR*:
@@ -115,7 +115,7 @@ CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       0x2034
 
 == New OpenCL C Functions
 
-These built-in functions are copied unchanged from the Khronos subgroups extension: ::
+These built-in functions are copied unchanged from the Khronos sub-groups extension: ::
 +
 --
 [source]
@@ -174,7 +174,7 @@ gentype sub_group_scan_inclusive_max( gentype x)
 ----
 --
 
-These built-in functions are unique to the Intel subgroups extension and are not part of the Khronos subgroups extension: ::
+These built-in functions are unique to the Intel sub-groups extension and are not part of the Khronos sub-groups extension: ::
 +
 --
 For the sub_group_shuffle, sub_group_shuffle_down, sub_group_shuffle_up, and sub_group_shuffle_xor functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
@@ -227,65 +227,65 @@ Add memory_scope_sub_group to the description of Memory Scopes: ::
 Memory Scopes ::
 Memory scopes define a hierarchy of visibilities when analyzing the ordering constraints of memory operations.
 They are defined by the values of the `memory_scope` enumeration constant.
-Current values are `memory_scope_work_item` (memory constraints only apply to a single work item and in practice only apply to image operations), `memory_scope_sub_group` (memory-ordering constraints only apply to work items executing in a subgroup), `memory_scope_work_group` ...
+Current values are `memory_scope_work_item` (memory constraints only apply to a single work item and in practice only apply to image operations), `memory_scope_sub_group` (memory-ordering constraints only apply to work items executing in a sub-group), `memory_scope_work_group` ...
 --
 
 Add memory_scope_sub_group to the description of Scope inclusion: ::
 +
 --
 Scope inclusion ::
-Two actions *A* and *B* are defined to have an inclusive scope if they have the same scope *P* such that: (1) if *P* is `memory_scope_sub_group`, and *A* and *B* are executed by work items within the same subgroup, or (2) if *P* is `memory_scope_work_group`, and *A* and *B* are executed by work items within the same work-group ...
+Two actions *A* and *B* are defined to have an inclusive scope if they have the same scope *P* such that: (1) if *P* is `memory_scope_sub_group`, and *A* and *B* are executed by work items within the same sub-group, or (2) if *P* is `memory_scope_work_group`, and *A* and *B* are executed by work items within the same work-group ...
 --
 
-Change the description for Subgroups to: ::
+Change the description for Sub-groups to: ::
 +
 --
-Subgroup ::
-Subgroups are an implementation-dependent grouping of work items within a
+Sub-group ::
+Sub-groups are an implementation-dependent grouping of work items within a
 work group.
-The size and number of subgroups is implementation-defined and not exposed in the core OpenCL 2.0 feature set.
-Subgroups execute concurrently within a work group, but are not guaranteed to make independent forward progress.
-Subgroups may synchronize internally using subgroup barrier operations without synchronizing with other subgroups.
+The size and number of sub-groups is implementation-defined and not exposed in the core OpenCL 2.0 feature set.
+Sub-groups execute concurrently within a work group, but are not guaranteed to make independent forward progress.
+Sub-groups may synchronize internally using sub-group barrier operations without synchronizing with other sub-groups.
 --
 
 === Modifications to Section 3.2.1 - "Execution Model: Mapping Work Items Onto an ND-range"
 
-Change the paragraph describing subgroups to: ::
+Change the paragraph describing sub-groups to: ::
 +
 --
-An implementation of OpenCL may divide each work group into one or more subgroups.
-The size and number of subgroups is implementation-defined and not exposed in the
+An implementation of OpenCL may divide each work group into one or more sub-groups.
+The size and number of sub-groups is implementation-defined and not exposed in the
 core OpenCL 2.0 feature set.
 --
 
 === Modifications to Section 3.2.2 - "Execution Model: Execution of Kernel Instances"
 
-Remove the last paragraph describing subgroups and independent forward progress.
+Remove the last paragraph describing sub-groups and independent forward progress.
 
 === Additions to Section 3.2 - "Execution Model"
 
-This text is largely the same as the text in the Khronos subgroups extension. Only the sentence about independent forward progress has been modified: ::
+This text is largely the same as the text in the Khronos sub-groups extension. Only the sentence about independent forward progress has been modified: ::
 +
 --
-Within a work group, work items may be divided into subgroups in an implementation-
-defined fashion.  The mapping of work items to subgroups is implementation-defined
-and may be queried at runtime.  While subgroups may be used in multi-dimensional
-work groups, each subgroup is 1-dimensional and any given work item may query which
-subgroup it is a member of.
+Within a work group, work items may be divided into sub-groups in an implementation-
+defined fashion.  The mapping of work items to sub-groups is implementation-defined
+and may be queried at runtime.  While sub-groups may be used in multi-dimensional
+work groups, each sub-group is 1-dimensional and any given work item may query which
+sub-group it is a member of.
 
-Work items are mapped into subgroups through a combination of compile-time decisions
-and the parameters of the dispatch.  The mapping to subgroups is invariant for the
+Work items are mapped into sub-groups through a combination of compile-time decisions
+and the parameters of the dispatch.  The mapping to sub-groups is invariant for the
 duration of a kernel's execution, across dispatches of a given kernel with the same
 launch parameters, and from one work group to another within the dispatch (excluding
 the trailing edge work groups in the presence of non-uniform work group sizes).  In
-addition, all subgroups within a work group will be the same size, apart from the
-subgroup with the maximum index, which may be smaller if the size of the work group 
-is not evenly divisible by the size of the subgroups.
+addition, all sub-groups within a work group will be the same size, apart from the
+sub-group with the maximum index, which may be smaller if the size of the work group 
+is not evenly divisible by the size of the sub-groups.
 
-Subgroups execute concurrently within a given work group.  Similar to work items
-within a work group, subgroups executing within a work group are not guaranteed to make
-independent forward progress.  Work items in a subgroup can internally synchronize 
-using subgroup barrier operations without synchronizing with other subgroups.
+Sub-groups execute concurrently within a given work group.  Similar to work items
+within a work group, sub-groups executing within a work group are not guaranteed to make
+independent forward progress.  Work items in a sub-group can internally synchronize 
+using sub-group barrier operations without synchronizing with other sub-groups.
 --
 
 === Additions to Section 3.3.4 - "Memory Model: Memory Consistency Model"
@@ -293,14 +293,14 @@ using subgroup barrier operations without synchronizing with other subgroups.
 Add memory_scope_sub_group to the bulleted descriptions of memory scopes: ::
 +
 --
-* `memory_scope_sub_group`: memory-ordering constraints only apply to work items executing within a single subgroup.
+* `memory_scope_sub_group`: memory-ordering constraints only apply to work items executing within a single sub-group.
 * `memory_scope_work_group`: ...
 --
 
 In the paragraph after the bulleted descriptions of memory scopes, include memory_scope_sub_group as a valid memory scope for local memory: ::
 +
 --
-\... For local memory, `memory_scope_sub_group` and `memory_scope_work_group` are valid, and may constrain visibility to the subgroup or work-group.
+\... For local memory, `memory_scope_sub_group` and `memory_scope_work_group` are valid, and may constrain visibility to the sub-group or work-group.
 --
 
 === Additions to Section 3.3.5 - "Memory Model: Overview of atomic and fence operations"
@@ -308,13 +308,13 @@ In the paragraph after the bulleted descriptions of memory scopes, include memor
 Add memory_scope_sub_group to the definition of inclusive scope: ::
 +
 --
-* *P* is `memory_scope_sub_group` and *A* and *B* are executed by work items within the same subgroup.
+* *P* is `memory_scope_sub_group` and *A* and *B* are executed by work items within the same sub-group.
 * *P* is `memory_scope_work_group` ...
 --
 
 === Additions to Section 5.9.3 - "Kernel Object Queries"
 
-This addition is copied unchanged from the Khronos subgroups extension: ::
+This addition is copied unchanged from the Khronos sub-groups extension: ::
 +
 --
 The function
@@ -368,7 +368,7 @@ _param_value_size_ret_ returns the actual size in bytes of data being
 queried by _param_name_.
 If _param_value_size_ret_ is `NULL`, it is ignored.
 
-[[cl_khr_subgroups-kernel-subgroup-info-table]]
+[[cl_khr_subgroups-kernel-sub-group-info-table]]
 .*clGetKernelSubGroupInfoKHR* parameter queries
 [width="100%",cols="<25%,<25%,<25%,<25%",options="header"]
 |====
@@ -376,9 +376,9 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
-          | Returns the maximum subgroup size for this kernel.
-            All subgroups must be the same size, while the last subgroup in
-            any work-group (i.e. the subgroup with the maximum index) could
+          | Returns the maximum sub-group size for this kernel.
+            All sub-groups must be the same size, while the last sub-group in
+            any work-group (i.e. the sub-group with the maximum index) could
             be the same or smaller size.
 
             The _input_value_ must be an array of size_t values
@@ -389,11 +389,11 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
-          | Returns the number of subgroups that will be present in each
+          | Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All work-groups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of subgroups.
+            same number of sub-groups.
 
             The _input_value_ must be an array of size_t values
             corresponding to the local work size parameter of the intended
@@ -426,7 +426,7 @@ Otherwise, it returns one of the following errors:
 
 === Additions to section 6.13.1 - "Work Item Functions"
 
-These additions are copied unchanged from the Khronos subgroups extension: ::
+These additions are copied unchanged from the Khronos sub-groups extension: ::
 +
 --
 [cols="a,",options="header",]
@@ -439,16 +439,16 @@ These additions are copied unchanged from the Khronos subgroups extension: ::
 uint get_sub_group_size( void )
 ----
 
-| Returns the number of work items in the subgroup.
-This value is no more than the maximum subgroup size and is implementation-defined based on a combination of the compiled kernel and the dispatch dimensions.
-This will be a constant value for the lifetime of the subgroup.
+| Returns the number of work items in the sub-group.
+This value is no more than the maximum sub-group size and is implementation-defined based on a combination of the compiled kernel and the dispatch dimensions.
+This will be a constant value for the lifetime of the sub-group.
 
 |[source,c]
 ----
 uint get_max_sub_group_size( void )
 ----
 
-| Returns the maximum size of a subgroup with the dispatch.
+| Returns the maximum size of a sub-group with the dispatch.
 This value will be invariant for a given set of dispatch dimensions and a kernel object compiled for a given device.
 
 |[source,c]
@@ -456,7 +456,7 @@ This value will be invariant for a given set of dispatch dimensions and a kernel
 uint get_num_sub_groups( void )
 ----
 
-| Returns the number of subgroups that the current work group is divided into.
+| Returns the number of sub-groups that the current work group is divided into.
 
 This number will be constant for the duration of a work group's execution.
 If the kernel is executed with a non-uniform work group size in any dimension, calls to this built-in may return a different values for some work groups than for other work groups.
@@ -466,7 +466,7 @@ If the kernel is executed with a non-uniform work group size in any dimension, c
 uint get_sub_group_id( void )
 ----
 
-| Returns the subgroup ID, which is a number from zero to *get_num_sub_groups* - 1.
+| Returns the sub-group ID, which is a number from zero to *get_num_sub_groups* - 1.
 
 For *clEnqueueTask*, this returns 0.
 
@@ -475,7 +475,7 @@ For *clEnqueueTask*, this returns 0.
 uint get_sub_group_local_id( void )
 ----
 
-| Returns the unique work item ID within the current subgroup.
+| Returns the unique work item ID within the current sub-group.
 The mapping from *get_local_id* to *get_sub_group_local_id* will be invariant for the lifetime of the work group.
 
 |====
@@ -494,14 +494,14 @@ uint get_enqueued_num_sub_groups( void )
 
 | Returns the same value as that returned by *get_num_sub_groups* if the kernel is executed with a uniform work group size.  This value will be constant for the entire ND-range.
 
-If the kernel is executed with a non-uniform work group size, returns the number of subgroups in a work group that makes up the uniform region of the global ND-range.
+If the kernel is executed with a non-uniform work group size, returns the number of sub-groups in a work group that makes up the uniform region of the global ND-range.
 
 |====
 --
 
 === Additions to Section 6.13.8 - "Synchronization Functions"
 
-These additions are mostly unchanged from the Khronos subgroups extension, with only minor edits for clarity: ::
+These additions are mostly unchanged from the Khronos sub-groups extension, with only minor edits for clarity: ::
 +
 --
 [cols="a,",options="header",]
@@ -515,13 +515,13 @@ void sub_group_barrier(
          cl_mem_fence_flags flags )
 ----
 
-| All work items in a subgroup executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the subgroup barrier.
-This function must be encountered by all work items in a subgroup executing the kernel.
+| All work items in a sub-group executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the sub-group barrier.
+This function must be encountered by all work items in a sub-group executing the kernel.
 These rules apply to ND-ranges implemented with uniform and non-uniform work groups.
 
-If *sub_group_barrier* is inside a conditional statement then all work items within the subgroup must enter the conditional if any work item in the subgroup enters the conditional statement and executes the *sub_group_barrier*.
+If *sub_group_barrier* is inside a conditional statement then all work items within the sub-group must enter the conditional if any work item in the sub-group enters the conditional statement and executes the *sub_group_barrier*.
 
-If *sub_group_barrier* is inside a loop, all work items within the subgroup must execute the *sub_group_barrier* for each iteration of the loop before any are allowed to continue execution beyond the *sub_group_barrier*.
+If *sub_group_barrier* is inside a loop, all work items within the sub-group must execute the *sub_group_barrier* for each iteration of the loop before any are allowed to continue execution beyond the *sub_group_barrier*.
 
 The *sub_group_barrier* function also queues a memory fence (reads and writes) to ensure correct ordering of memory operations to local or global memory.
 
@@ -553,7 +553,7 @@ void sub_group_barrier(
 The *sub_group_barrier* function also supports a variant that specifies the memory scope.
 For the sub_group_barrier variant that does not take a memory scope, the scope is `memory_scope_sub_group`.
 
-The scope argument specifies whether the memory accesses of work items in the subgroup to memory address space(s) identified by flags become visible to all  work items in the subgroup, the work group, the device, or all SVM devices.
+The scope argument specifies whether the memory accesses of work items in the sub-group to memory address space(s) identified by flags become visible to all  work items in the sub-group, the work group, the device, or all SVM devices.
 
 ...
 
@@ -567,11 +567,11 @@ The scope argument specifies whether the memory accesses of work items in the su
 Modify the bullet describing behavior for functions that do not have a memory_scope argument to say: ::
 +
 --
-* The subgroup functions that do not have a _memory_scope_ argument have the same semantics as the corresponding functions with the _memory_scope_ argument set to `memory_scope_sub_group`.
+* The sub-group functions that do not have a _memory_scope_ argument have the same semantics as the corresponding functions with the _memory_scope_ argument set to `memory_scope_sub_group`.
 Other functions that do not have a _memory_scope_ argument have the same semantics as the corresponding functions with the _memory_scope_ argument set to `memory_scope_device`.
 --
 
-The following addition is copied unchanged from the Khronos subgroups extension: ::
+The following addition is copied unchanged from the Khronos sub-groups extension: ::
 
 Add the following new value to the enumerated type memory_scope defined in Section 6.13.11.4: ::
 +
@@ -581,19 +581,19 @@ memory_scope_sub_group
 ----
 
 The `memory_scope_sub_group` specifies that the memory ordering constraints
-given by `memory_order` apply to work items in a subgroup.
+given by `memory_order` apply to work items in a sub-group.
 This memory scope can be used when performing atomic operations to global or
 local memory.
 --
 
 === Additions to Section 6.13.15 - "Work Group Functions"
 
-These additions are copied from the Khronos subgroups extension: ::
+These additions are copied from the Khronos sub-groups extension: ::
 +
 --
 The OpenCL C programming language implements the following built-in
-functions that operate on a subgroup level.
-These built-in functions must be encountered by all work items in a subgroup
+functions that operate on a sub-group level.
+These built-in functions must be encountered by all work items in a sub-group
 executing the kernel.
 We use the generic type name `gentype` to indicate the built-in data types
 `int`, `uint`, `long`, `ulong`, or `float` as the type for the arguments.
@@ -612,18 +612,18 @@ If `cl_khr_fp64` or doubles are supported, `gentype` also includes `double`.
 int sub_group_all( int predicate )
 ----
 
-| Evaluates _predicate_ for all work items in the subgroup and returns a
+| Evaluates _predicate_ for all work items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for all work items in
-  the subgroup.
+  the sub-group.
 
 |[source,c]
 ----
 int sub_group_any( int predicate )
 ----
 
-| Evaluates _predicate_ for all work items in the subgroup and returns a
+| Evaluates _predicate_ for all work items in the sub-group and returns a
   non-zero value if _predicate_ evaluates to non-zero for any work items in
-  the subgroup.
+  the sub-group.
 
 |[source,c]
 ----
@@ -632,8 +632,8 @@ gentype sub_group_broadcast(
           uint sub_group_local_id )
 ----
 
-| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the subgroup.
-_sub_group_local_id_ must be the same value for all work items in the subgroup.
+| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the sub-group.
+_sub_group_local_id_ must be the same value for all work items in the sub-group.
 
 |[source,c]
 ----
@@ -642,7 +642,7 @@ gentype sub_group_reduce_min( gentype x )
 gentype sub_group_reduce_max( gentype x )
 ----
 
-| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a subgroup.
+| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a sub-group.
 
 |[source,c]
 ----
@@ -651,10 +651,10 @@ gentype sub_group_scan_exclusive_min( gentype x )
 gentype sub_group_scan_exclusive_max( gentype x )
 ----
 
-| Performs the specified exclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified exclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |[source,c]
 ----
@@ -663,10 +663,10 @@ gentype sub_group_scan_inclusive_min( gentype x)
 gentype sub_group_scan_inclusive_max( gentype x)
 ----
 
-| Performs the specified inclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified inclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |====
 --
@@ -676,9 +676,9 @@ The scan order is defined by increasing subgroup local ID within the subgroup.
 These are new functions: ::
 +
 --
-The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
-These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
-Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
+The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a sub-group.
+These built-in functions need not be encountered by all work items in a sub-group executing the kernel, however, data may only be shuffled among work items encountering the sub-group shuffle function.
+Shuffling data from a work item that does not encounter the sub-group shuffle function will produce undefined results.
 For these functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If `cl_khr_fp16` is supported, `gentype` also includes `half`.
@@ -697,10 +697,10 @@ gentype intel_sub_group_shuffle(
               uint sub_group_local_id )
 ----
 
-| Allows data to be arbitrarily transferred between work items in a subgroup.
+| Allows data to be arbitrarily transferred between work items in a sub-group.
 The data that is returned for this work item is the value of _data_ for the work item identified by _sub_group_local_id_.
 
-_sub_group_local_id_ need not be the same value for all work items in the subgroup.
+_sub_group_local_id_ need not be the same value for all work items in the sub-group.
 There is no defined behavior for out-of-range _sub_group_local_ids_.
 
 |[source,c]
@@ -711,7 +711,7 @@ gentype intel_sub_group_shuffle_down(
               uint delta )
 ----
 
-| Allows data to be transferred from a work item in the subgroup with a higher sub_group_local_id down to a work item in the subgroup with a lower sub_group_local_id.
+| Allows data to be transferred from a work item in the sub-group with a higher sub_group_local_id down to a work item in the sub-group with a lower sub_group_local_id.
 
 There are two data sources to this built-in function: _current_ and _next_.
 To determine the result of this built-in function, first let the unsigned shuffle index be equivalent to the sum of this work item's sub_group_local_id plus the specified _delta_:
@@ -723,7 +723,7 @@ If the shuffle index is greater than or equal to the max_sub_group_size but less
 All other values of the shuffle index are considered to be out-of-range.
 There is no defined behavior for out-of-range indices.
 
-_delta_ need not be the same value for all work items in the subgroup.
+_delta_ need not be the same value for all work items in the sub-group.
 
 |[source,c]
 ----
@@ -733,7 +733,7 @@ gentype intel_sub_group_shuffle_up(
               uint delta )
 ----
 
-| Allows data to be transferred from a work item in the subgroup with a lower sub_group_local_id up to a work item in the subgroup with a higher sub_group_local_id.
+| Allows data to be transferred from a work item in the sub-group with a lower sub_group_local_id up to a work item in the sub-group with a higher sub_group_local_id.
 
 There are two data sources to this built-in function: _previous_ and _current_.
 To determine the result of this built-in function, first let the signed shuffle index be equivalent to this work item's sub_group_local_id minus the specified _delta_:
@@ -745,7 +745,7 @@ If the shuffle index is less than zero but greater than or equal to the negative
 All other values of the shuffle index are considered to be out-of-range.
 There is no defined behavior for out-of-range indices.
 
-_delta_ need not be the same value for all work items in the subgroup.
+_delta_ need not be the same value for all work items in the sub-group.
 
 |[source,c]
 ----
@@ -754,11 +754,11 @@ gentype intel_sub_group_shuffle_xor(
               uint value )
 ----
 
-| Allows data to be transferred between work items in a subgroup as a function of the work item's sub_group_local_id.
+| Allows data to be transferred between work items in a sub-group as a function of the work item's sub_group_local_id.
 The data that is returned for this work item is the value of _data_ for the work item with sub_group_local_id equal to this work item's sub_group_local_id XOR'd with the specified _value_.
 If the result of the XOR is greater than max_sub_group_size then it is considered out-of-range.
 
-_value_ need not be the same for all work items in the subgroup.
+_value_ need not be the same for all work items in the sub-group.
 There is no defined behavior for out-of-range indices.
 
 |====
@@ -769,9 +769,9 @@ There is no defined behavior for out-of-range indices.
 These are new functions: ::
 +
 --
-The OpenCL C programming language implements the following built-in functions to allow data to be read or written as a block by all work items in a subgroup.
-These built-in functions must be encountered by all work items in a subgroup executing the kernel.
-Furthermore, since these are block operations, the _pointer_, _image_, and _coordinate_ arguments to these built-in functions must be the same for all work items in the subgroup (when applicable, only the _data_ argument may be different).
+The OpenCL C programming language implements the following built-in functions to allow data to be read or written as a block by all work items in a sub-group.
+These built-in functions must be encountered by all work items in a sub-group executing the kernel.
+Furthermore, since these are block operations, the _pointer_, _image_, and _coordinate_ arguments to these built-in functions must be the same for all work items in the sub-group (when applicable, only the _data_ argument may be different).
 
 [cols="5a,4",options="header"]
 |==================================
@@ -790,7 +790,7 @@ uint8 intel_sub_group_block_read8(
         const __global uint* p )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation.
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified pointer as a block operation.
 The data is read strided, so the first value read is:
 
 `p[ sub_group_local_id ]`
@@ -821,7 +821,7 @@ uint8 intel_sub_group_block_read8(
         int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified _image_ at the specified coordinate as a block operation.
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 16-bits).
@@ -842,7 +842,7 @@ void  intel_sub_group_block_write8(
         __global uint* p, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation.
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:
 
 `p[ sub_group_local_id ]`
@@ -873,7 +873,7 @@ void  intel_sub_group_block_write8(
         int2 byte_coord, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified _image_ at the specified coordinate as a block operation.
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.
@@ -886,7 +886,7 @@ Please see the note below describing out-of-bounds behavior for these functions.
 
 |==================================
 
-Note: The subgroup image block read and write built-ins do support bounds checking, however these built-ins bounds-check to the image width in units of uints, not in units of image elements.
+Note: The sub-group image block read and write built-ins do support bounds checking, however these built-ins bounds-check to the image width in units of uints, not in units of image elements.
 This means:
 
 * If the image has an element size equal to the size of a uint (four bytes, for example `CL_RGBA` + `CL_UNORM_INT8`), the image will be correctly bounds-checked.
@@ -899,7 +899,7 @@ For this reason, extra care should be taken to avoid out-of-bounds reads and wri
 Add a new sub-section 6.13.X.1 - Restrictions: ::
 +
 --
-The following restrictions apply to the subgroup buffer block read and write functions:
+The following restrictions apply to the sub-group buffer block read and write functions:
 
 * The pointer _p_ must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
@@ -910,20 +910,20 @@ Additionally, if the _buffer_ that the sub-buffer is created from was created wi
 
 * If the pointer _p_ is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
 
-* Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.
+* Behavior is undefined if the sub-group size is smaller than the maximum sub-group size; in other words, if this is a partial sub-group.
 
-The following restrictions apply to the subgroup image block read and write functions:
+The following restrictions apply to the sub-group image block read and write functions:
 
-* The behavior of the subgroup image block read and write built-ins is undefined for images with an element size greater than four bytes (such as `CL_RGBA` + `CL_FLOAT`).
+* The behavior of the sub-group image block read and write built-ins is undefined for images with an element size greater than four bytes (such as `CL_RGBA` + `CL_FLOAT`).
 
-* When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, the image row pitch is required to be a multiple of 64-bytes, in addition to the `CL_DEVICE_IMAGE_PITCH_ALIGNMENT` requirements.
+* When reading or writing a 2D image created from a buffer with the sub-group block read and write built-ins, the image row pitch is required to be a multiple of 64-bytes, in addition to the `CL_DEVICE_IMAGE_PITCH_ALIGNMENT` requirements.
 
-* When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ must be 256-bit (32-byte) aligned.
+* When reading or writing a 2D image created from a buffer with the sub-group block read and write built-ins, if the buffer is a cl_mem that was created with `CL_MEM_USE_HOST_PTR`, then the _host_ptr_ must be 256-bit (32-byte) aligned.
 
-* When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.
+* When reading or writing a 2D image created from a buffer with the sub-group block read and write built-ins, if the buffer is a cl_mem that is a sub-buffer, then the _origin_ must be a multiple of 32-bytes.
 Additionally, if the _buffer_ that the sub-buffer is created from was created with CL_MEM_USE_HOST_PTR, then the _host_ptr_ for the _buffer_ must be 256-bit (32-byte) aligned.
 
-* Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.
+* Behavior is undefined if the sub-group size is smaller than the maximum sub-group size; in other words, if this is a partial sub-group.
 --
 
 == Issues
@@ -944,13 +944,13 @@ None.
 |========================================
 |Rev|Date|Author|Changes
 |1|2014-12-01|Ben Ashbaugh|*First public revision.*
-|2|2015-03-12|Ben Ashbaugh|Fixed minor formatting errors, added restriction for subgroup image block read and write built-ins with large image formats.
+|2|2015-03-12|Ben Ashbaugh|Fixed minor formatting errors, added restriction for sub-group image block read and write built-ins with large image formats.
 |3|2016-02-12|Ben Ashbaugh|Fixed a small bug in the shuffle up and shuffle down descriptions.
-|4|2016-08-28|Ben Ashbaugh|Added additional restrictions and programming notes for the subgroup shuffle and block read built-ins.
+|4|2016-08-28|Ben Ashbaugh|Added additional restrictions and programming notes for the sub-group shuffle and block read built-ins.
 |5|2018-11-15|Ben Ashbaugh|Converted to asciidoc.
 |6|2018-12-02|Ben Ashbaugh|Added back a section that was inadvertently removed during conversion to asciidoc.
 |7|2019-01-15|Ben Ashbaugh|Fixed a typo in the summary section of new built-in functions.
-|8|2019-09-17|Ben Ashbaugh|Added vec3 types for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.
+|8|2019-09-17|Ben Ashbaugh|Added vec3 types for shuffles, restriction for block reads and writes and partial sub-groups, and asciidoctor formatting fixes.
 |========================================
 
 //************************************************************************

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -62,17 +62,17 @@ This extension is written against revision 24 of the OpenCL 2.0 API specificatio
 
 == Overview
 
-The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "sub-group"), and that work items in a sub-group can take advantage of hardware features that are not available to work items in a work group.
-Specifically, this extension is designed to allow work items in a sub-group to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data.
+The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work-group execute together as a group (a "sub-group"), and that work items in a sub-group can take advantage of hardware features that are not available to work items in a work-group.
+Specifically, this extension is designed to allow work items in a sub-group to share data without the use of local memory and work-group barriers, and to utilize specialized hardware to load and store blocks of data.
 
 There is a large amount of overlap between the functionality in this extension and the functionality in the Khronos sub-groups extension `cl_khr_subgroups`, so this extension reuses many of the names, concepts, and functions already described by the `cl_khr_subgroups` extension.
 The key differences between the Intel sub-groups extension and the Khronos sub-groups extension are:
 
 * The Khronos sub-groups extension requires OpenCL 2.0, but the Intel sub-groups extension may be available on OpenCL 1.2 devices.
 
-* The Khronos sub-groups extension guarantees that sub-groups in a work group will make independent forward progress, but the Intel extension does not guarantee that sub-groups in a work group will make independent forward progress.
+* The Khronos sub-groups extension guarantees that sub-groups in a work-group will make independent forward progress, but the Intel extension does not guarantee that sub-groups in a work-group will make independent forward progress.
 
-* The Intel extension adds a rich set of sub-group "shuffle" functions to allow work items within a work group to interchange data without the use of local memory and work group barriers.
+* The Intel extension adds a rich set of sub-group "shuffle" functions to allow work items within a work-group to interchange data without the use of local memory and work-group barriers.
 
 * The Intel extension adds a set of sub-group "block read and write" functions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
 
@@ -242,9 +242,9 @@ Change the description for Sub-groups to: ::
 --
 Sub-group ::
 Sub-groups are an implementation-dependent grouping of work items within a
-work group.
+work-group.
 The size and number of sub-groups is implementation-defined and not exposed in the core OpenCL 2.0 feature set.
-Sub-groups execute concurrently within a work group, but are not guaranteed to make independent forward progress.
+Sub-groups execute concurrently within a work-group, but are not guaranteed to make independent forward progress.
 Sub-groups may synchronize internally using sub-group barrier operations without synchronizing with other sub-groups.
 --
 
@@ -253,7 +253,7 @@ Sub-groups may synchronize internally using sub-group barrier operations without
 Change the paragraph describing sub-groups to: ::
 +
 --
-An implementation of OpenCL may divide each work group into one or more sub-groups.
+An implementation of OpenCL may divide each work-group into one or more sub-groups.
 The size and number of sub-groups is implementation-defined and not exposed in the
 core OpenCL 2.0 feature set.
 --
@@ -267,23 +267,23 @@ Remove the last paragraph describing sub-groups and independent forward progress
 This text is largely the same as the text in the Khronos sub-groups extension. Only the sentence about independent forward progress has been modified: ::
 +
 --
-Within a work group, work items may be divided into sub-groups in an implementation-
+Within a work-group, work items may be divided into sub-groups in an implementation-
 defined fashion.  The mapping of work items to sub-groups is implementation-defined
 and may be queried at runtime.  While sub-groups may be used in multi-dimensional
-work groups, each sub-group is 1-dimensional and any given work item may query which
+work-groups, each sub-group is 1-dimensional and any given work item may query which
 sub-group it is a member of.
 
 Work items are mapped into sub-groups through a combination of compile-time decisions
 and the parameters of the dispatch.  The mapping to sub-groups is invariant for the
 duration of a kernel's execution, across dispatches of a given kernel with the same
-launch parameters, and from one work group to another within the dispatch (excluding
-the trailing edge work groups in the presence of non-uniform work group sizes).  In
-addition, all sub-groups within a work group will be the same size, apart from the
-sub-group with the maximum index, which may be smaller if the size of the work group 
+launch parameters, and from one work-group to another within the dispatch (excluding
+the trailing edge work-groups in the presence of non-uniform work-group sizes).  In
+addition, all sub-groups within a work-group will be the same size, apart from the
+sub-group with the maximum index, which may be smaller if the size of the work-group 
 is not evenly divisible by the size of the sub-groups.
 
-Sub-groups execute concurrently within a given work group.  Similar to work items
-within a work group, sub-groups executing within a work group are not guaranteed to make
+Sub-groups execute concurrently within a given work-group.  Similar to work items
+within a work-group, sub-groups executing within a work-group are not guaranteed to make
 independent forward progress.  Work items in a sub-group can internally synchronize 
 using sub-group barrier operations without synchronizing with other sub-groups.
 --
@@ -456,10 +456,10 @@ This value will be invariant for a given set of dispatch dimensions and a kernel
 uint get_num_sub_groups( void )
 ----
 
-| Returns the number of sub-groups that the current work group is divided into.
+| Returns the number of sub-groups that the current work-group is divided into.
 
-This number will be constant for the duration of a work group's execution.
-If the kernel is executed with a non-uniform work group size in any dimension, calls to this built-in may return a different values for some work groups than for other work groups.
+This number will be constant for the duration of a work-group's execution.
+If the kernel is executed with a non-uniform work-group size in any dimension, calls to this built-in may return a different values for some work-groups than for other work-groups.
 
 |[source,c]
 ----
@@ -476,7 +476,7 @@ uint get_sub_group_local_id( void )
 ----
 
 | Returns the unique work item ID within the current sub-group.
-The mapping from *get_local_id* to *get_sub_group_local_id* will be invariant for the lifetime of the work group.
+The mapping from *get_local_id* to *get_sub_group_local_id* will be invariant for the lifetime of the work-group.
 
 |====
 
@@ -492,9 +492,9 @@ If OpenCL 2.0 is supported:
 uint get_enqueued_num_sub_groups( void )
 ----
 
-| Returns the same value as that returned by *get_num_sub_groups* if the kernel is executed with a uniform work group size.  This value will be constant for the entire ND-range.
+| Returns the same value as that returned by *get_num_sub_groups* if the kernel is executed with a uniform work-group size.  This value will be constant for the entire ND-range.
 
-If the kernel is executed with a non-uniform work group size, returns the number of sub-groups in a work group that makes up the uniform region of the global ND-range.
+If the kernel is executed with a non-uniform work-group size, returns the number of sub-groups in a work-group that makes up the uniform region of the global ND-range.
 
 |====
 --
@@ -517,7 +517,7 @@ void sub_group_barrier(
 
 | All work items in a sub-group executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the sub-group barrier.
 This function must be encountered by all work items in a sub-group executing the kernel.
-These rules apply to ND-ranges implemented with uniform and non-uniform work groups.
+These rules apply to ND-ranges implemented with uniform and non-uniform work-groups.
 
 If *sub_group_barrier* is inside a conditional statement then all work items within the sub-group must enter the conditional if any work item in the sub-group enters the conditional statement and executes the *sub_group_barrier*.
 
@@ -553,7 +553,7 @@ void sub_group_barrier(
 The *sub_group_barrier* function also supports a variant that specifies the memory scope.
 For the sub_group_barrier variant that does not take a memory scope, the scope is `memory_scope_sub_group`.
 
-The scope argument specifies whether the memory accesses of work items in the sub-group to memory address space(s) identified by flags become visible to all  work items in the sub-group, the work group, the device, or all SVM devices.
+The scope argument specifies whether the memory accesses of work items in the sub-group to memory address space(s) identified by flags become visible to all  work items in the sub-group, the work-group, the device, or all SVM devices.
 
 ...
 
@@ -586,7 +586,7 @@ This memory scope can be used when performing atomic operations to global or
 local memory.
 --
 
-=== Additions to Section 6.13.15 - "Work Group Functions"
+=== Additions to Section 6.13.15 - "Work-group Functions"
 
 These additions are copied from the Khronos sub-groups extension: ::
 +
@@ -671,7 +671,7 @@ The scan order is defined by increasing sub-group local ID within the sub-group.
 |====
 --
 
-=== Add a new Section 6.13.X - "Sub Group Shuffle Functions"
+=== Add a new Section 6.13.X - "Sub-group Shuffle Functions"
 
 These are new functions: ::
 +
@@ -764,7 +764,7 @@ There is no defined behavior for out-of-range indices.
 |====
 --
 
-=== Add a new Section 6.13.X - "Sub Group Read and Write Functions"
+=== Add a new Section 6.13.X - "Sub-group Read and Write Functions"
 
 These are new functions: ::
 +

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -376,8 +376,8 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
-          | Returns the maximum sub-group size for this kernel.
-            All sub-groups must be the same size, while the last subgroup in
+          | Returns the maximum subgroup size for this kernel.
+            All subgroups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.
 
@@ -389,11 +389,11 @@ If _param_value_size_ret_ is `NULL`, it is ignored.
 | {CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR}
   | size_t *
       | size_t
-          | Returns the number of sub-groups that will be present in each
+          | Returns the number of subgroups that will be present in each
             work-group for a given local work size.
             All work-groups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
-            same number of sub-groups.
+            same number of subgroups.
 
             The _input_value_ must be an array of size_t values
             corresponding to the local work size parameter of the intended

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -248,7 +248,7 @@ Subgroups execute concurrently within a work group, but are not guaranteed to ma
 Subgroups may synchronize internally using subgroup barrier operations without synchronizing with other subgroups.
 --
 
-=== Modifications to Section 3.2.1 - "Execution Model: Mapping Work Items Onto an NDRange"
+=== Modifications to Section 3.2.1 - "Execution Model: Mapping Work Items Onto an ND-range"
 
 Change the paragraph describing subgroups to: ::
 +
@@ -492,9 +492,9 @@ If OpenCL 2.0 is supported:
 uint get_enqueued_num_sub_groups( void )
 ----
 
-| Returns the same value as that returned by *get_num_sub_groups* if the kernel is executed with a uniform work group size.  This value will be constant for the entire NDRange.
+| Returns the same value as that returned by *get_num_sub_groups* if the kernel is executed with a uniform work group size.  This value will be constant for the entire ND-range.
 
-If the kernel is executed with a non-uniform work group size, returns the number of subgroups in a work group that makes up the uniform region of the global NDRange.
+If the kernel is executed with a non-uniform work group size, returns the number of subgroups in a work group that makes up the uniform region of the global ND-range.
 
 |====
 --
@@ -517,7 +517,7 @@ void sub_group_barrier(
 
 | All work items in a subgroup executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the subgroup barrier.
 This function must be encountered by all work items in a subgroup executing the kernel.
-These rules apply to NDRanges implemented with uniform and non-uniform work groups.
+These rules apply to ND-ranges implemented with uniform and non-uniform work groups.
 
 If *sub_group_barrier* is inside a conditional statement then all work items within the subgroup must enter the conditional if any work item in the subgroup enters the conditional statement and executes the *sub_group_barrier*.
 

--- a/extensions/cl_intel_subgroups_char.asciidoc
+++ b/extensions/cl_intel_subgroups_char.asciidoc
@@ -55,16 +55,16 @@ This extension interacts with the `cl_intel_spirv_subgroups` extension.
 
 == Overview
 
-The goal of this extension is to allow programmers to improve the performance of applications operating on 8-bit data types by extending the subgroup functions described in the `cl_intel_subgroups` extension to support 8-bit integer data types (`chars` and `uchars`).
+The goal of this extension is to allow programmers to improve the performance of applications operating on 8-bit data types by extending the sub-group functions described in the `cl_intel_subgroups` extension to support 8-bit integer data types (`chars` and `uchars`).
 Specifically, the extension:
 
-* Extends the subgroup broadcast function to allow 8-bit integer values to be broadcast from one work item to all other work items in the subgroup.
+* Extends the sub-group broadcast function to allow 8-bit integer values to be broadcast from one work item to all other work items in the sub-group.
 
-* Extends the subgroup scan and reduction functions to operate on 8-bit integer data types.
+* Extends the sub-group scan and reduction functions to operate on 8-bit integer data types.
 
-* Extends the Intel subgroup shuffle functions to allow arbitrarily exchanging 8-bit integer values among work items in the subgroup.
+* Extends the Intel sub-group shuffle functions to allow arbitrarily exchanging 8-bit integer values among work items in the sub-group.
 
-* Extends the Intel subgroup block read and write functions to allow reading and writing 8-bit integer data from images and buffers.
+* Extends the Intel sub-group block read and write functions to allow reading and writing 8-bit integer data from images and buffers.
 
 == New API Functions
 
@@ -76,7 +76,7 @@ None.
 
 == New OpenCL C Functions
 
-Add `char` and `uchar` to the list of supported data types for the subgroup broadcast, scan, and reduction functions: ::
+Add `char` and `uchar` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
 --
 [source]
@@ -121,7 +121,7 @@ gentype intel_sub_group_shuffle_xor( gentype data, uint value )
 ----
 --
 
-Add `uchar` variants of the subgroup block read and write functions: ::
+Add `uchar` variants of the sub-group block read and write functions: ::
 +
 --
 [source]
@@ -150,7 +150,7 @@ void  intel_sub_group_block_write_uc16( image2d_t image, int2 byte_coord, uchar1
 ----
 --
 
-For naming consistency, also add suffixed aliases of the `uint` subgroup block read and write functions described in the `cl_intel_subgroups` extension: ::
+For naming consistency, also add suffixed aliases of the `uint` sub-group block read and write functions described in the `cl_intel_subgroups` extension: ::
 +
 --
 [source]
@@ -179,7 +179,7 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 
 === Additions to Section 6.13.15 - "Work Group Functions"
 
-Add `char` and `uchar` to the list of supported data types for the subgroup broadcast, scan, and reduction functions: ::
+Add `char` and `uchar` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
 --
 [cols="2a,1",options="header"]
@@ -201,8 +201,8 @@ uchar   intel_sub_group_broadcast(
           uint sub_group_local_id )
 ----
 
-| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the subgroup.
-_sub_group_local_id_ must be the same value for all work items in the subgroup.
+| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the sub-group.
+_sub_group_local_id_ must be the same value for all work items in the sub-group.
 
 |[source,c]
 ----
@@ -218,7 +218,7 @@ char    intel_sub_group_reduce_max( char x )
 uchar   intel_sub_group_reduce_max( uchar x )
 ----
 
-| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a subgroup.
+| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a sub-group.
 
 |[source,c]
 ----
@@ -234,10 +234,10 @@ char    intel_sub_group_scan_exclusive_max( char x )
 uchar   intel_sub_group_scan_exclusive_max( uchar x )
 ----
 
-| Performs the specified exclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified exclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |[source,c]
 ----
@@ -253,10 +253,10 @@ char    intel_sub_group_scan_inclusive_max( char x )
 uchar   intel_sub_group_scan_inclusive_max( uchar x )
 ----
 
-| Performs the specified inclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified inclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |====
 --
@@ -268,9 +268,9 @@ This section was added by the `cl_intel_subgroups` extension.
 Add `char`, `char2`, `char4`, `char8`, `char16`, `uchar`, `uchar2`, `uchar4`, `uchar8`, and `uchar16` to the list of data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
 +
 --
-The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
-These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
-Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
+The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a sub-group.
+These built-in functions need not be encountered by all work items in a sub-group executing the kernel, however, data may only be shuffled among work items encountering the sub-group shuffle function.
+Shuffling data from a work item that does not encounter the sub-group shuffle function will produce undefined results.
 For these functions, `gentype` is `float`, `float2`, `float4`, `float8`, `float16`, `char`, `char2`, `char4`, `char8`, `char16`, `uchar`, `uchar2`, `uchar4`, `uchar8`, `uchar16`, `int`, `int2`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If `cl_khr_fp16` is supported, `gentype` also includes `half`.
@@ -311,7 +311,7 @@ uint8 intel_sub_group_block_read_ui8(
         const __global uint* p )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -342,7 +342,7 @@ uint8 intel_sub_group_block_read_ui8(
         int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified image at the specified coordinate as a block operation...
 
 |[source,c]
 ----
@@ -365,7 +365,7 @@ void  intel_sub_group_block_write_ui8(
         __global uint* p, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -396,7 +396,7 @@ void  intel_sub_group_block_write_ui8(
         int2 byte_coord, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified image at the specified coordinate as a block operation...
 
 |==================================
 --
@@ -423,7 +423,7 @@ uchar16 intel_sub_group_block_read_uc16(
           const __global uchar* p )
 ----
 
-| Reads 1, 2, 4, 8, or 16 uchars of data for each work item in the subgroup from the specified pointer as a block operation.
+| Reads 1, 2, 4, 8, or 16 uchars of data for each work item in the sub-group from the specified pointer as a block operation.
 The data is read strided, so the first value read is:
 
 `p[ sub_group_local_id ]`
@@ -457,7 +457,7 @@ uchar16 intel_sub_group_block_read_uc16(
           int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, 8, or 16 uchars of data for each work item in the subgroup from the specified _image_ at the specified coordinate as a block operation.
+| Reads 1, 2, 4, 8, or 16 uchars of data for each work item in the sub-group from the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 8-bits).
@@ -480,7 +480,7 @@ void  intel_sub_group_block_write_uc16(
         __global uchar* p, uchar16 data )
 ----
 
-| Writes 1, 2, 4, 8, or 16 uchars of data for each work item in the subgroup to the specified pointer as a block operation.
+| Writes 1, 2, 4, 8, or 16 uchars of data for each work item in the sub-group to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:
 
 `p[ sub_group_local_id ]`
@@ -514,7 +514,7 @@ void  intel_sub_group_block_write_uc16(
         int2 byte_coord, uchar16 data )
 ----
 
-| Writes 1, 2, 4, 8, or 16 uchars of data for each work item in the subgroup to the specified _image_ at the specified coordinate as a block operation.
+| Writes 1, 2, 4, 8, or 16 uchars of data for each work item in the sub-group to the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.

--- a/extensions/cl_intel_subgroups_char.asciidoc
+++ b/extensions/cl_intel_subgroups_char.asciidoc
@@ -177,7 +177,7 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 
 == Modifications to the OpenCL C Specification
 
-=== Additions to Section 6.13.15 - "Work Group Functions"
+=== Additions to Section 6.13.15 - "Work-group Functions"
 
 Add `char` and `uchar` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
@@ -261,7 +261,7 @@ The scan order is defined by increasing sub-group local ID within the sub-group.
 |====
 --
 
-=== Additions to Section 6.13.X - "Sub Group Shuffle Functions"
+=== Additions to Section 6.13.X - "Sub-group Shuffle Functions"
 
 This section was added by the `cl_intel_subgroups` extension.
 
@@ -278,7 +278,7 @@ If `cl_khr_fp16` is supported, `gentype` also includes `half`.
 If `cl_khr_fp64` or doubles are supported, `gentype` also includes `double`.
 --
 
-=== Modifications to Section 6.13.X "Sub Group Read and Write Functions"
+=== Modifications to Section 6.13.X "Sub-group Read and Write Functions"
 
 This section was added by the `cl_intel_subgroups` extension.
 

--- a/extensions/cl_intel_subgroups_long.asciidoc
+++ b/extensions/cl_intel_subgroups_long.asciidoc
@@ -121,7 +121,7 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 
 == Modifications to the OpenCL C Specification
 
-=== Modifications to Section 6.13.X "Sub Group Read and Write Functions"
+=== Modifications to Section 6.13.X "Sub-group Read and Write Functions"
 
 This section was added by the `cl_intel_subgroups` extension.
 

--- a/extensions/cl_intel_subgroups_long.asciidoc
+++ b/extensions/cl_intel_subgroups_long.asciidoc
@@ -52,10 +52,10 @@ This extension interacts with the `cl_intel_spirv_subgroups` extension.
 
 == Overview
 
-The goal of this extension is to allow programmers to improve the performance of applications operating on 64-bit data types by extending the subgroup functions described in the `cl_intel_subgroups` extension to support 64-bit integer data types (`longs` and `ulongs`).
+The goal of this extension is to allow programmers to improve the performance of applications operating on 64-bit data types by extending the sub-group functions described in the `cl_intel_subgroups` extension to support 64-bit integer data types (`longs` and `ulongs`).
 Specifically, the extension:
 
-* Extends the Intel subgroup block read and write functions to allow reading and writing 64-bit integer data from images and buffers.
+* Extends the Intel sub-group block read and write functions to allow reading and writing 64-bit integer data from images and buffers.
 
 Note that `cl_intel_subgroups` and `cl_khr_subgroups` already support broadcasts, scans, and reductions for 64-bit integer types, and that `cl_intel_subgroups` already supports shuffles for 64-bit integer types.
 
@@ -69,7 +69,7 @@ None.
 
 == New OpenCL C Functions
 
-Add `ulong` variants of the subgroup block read and write functions: ::
+Add `ulong` variants of the sub-group block read and write functions: ::
 +
 --
 [source]
@@ -94,7 +94,7 @@ void  intel_sub_group_block_write_ul8( image2d_t image, int2 byte_coord, ulong8 
 ----
 --
 
-For naming consistency, also add suffixed aliases of the `uint` subgroup block read and write functions described in the `cl_intel_subgroups` extension: ::
+For naming consistency, also add suffixed aliases of the `uint` sub-group block read and write functions described in the `cl_intel_subgroups` extension: ::
 +
 --
 [source]
@@ -154,7 +154,7 @@ uint8 intel_sub_group_block_read_ui8(
         const __global uint* p )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -185,7 +185,7 @@ uint8 intel_sub_group_block_read_ui8(
         int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified image at the specified coordinate as a block operation...
 
 |[source,c]
 ----
@@ -208,7 +208,7 @@ void  intel_sub_group_block_write_ui8(
         __global uint* p, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -239,7 +239,7 @@ void  intel_sub_group_block_write_ui8(
         int2 byte_coord, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified image at the specified coordinate as a block operation...
 
 |==================================
 --
@@ -264,7 +264,7 @@ ulong8  intel_sub_group_block_read_ul8(
           const __global ulong* p )
 ----
 
-| Reads 1, 2, 4, or 8 ulongs of data for each work item in the subgroup from the specified pointer as a block operation.
+| Reads 1, 2, 4, or 8 ulongs of data for each work item in the sub-group from the specified pointer as a block operation.
 The data is read strided, so the first value read is:
 
 `p[ sub_group_local_id ]`
@@ -293,7 +293,7 @@ ulong8  intel_sub_group_block_read_ul8(
           int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 ulongs of data for each work item in the subgroup from the specified _image_ at the specified coordinate as a block operation.
+| Reads 1, 2, 4, or 8 ulongs of data for each work item in the sub-group from the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 64-bits).
@@ -314,7 +314,7 @@ void  intel_sub_group_block_write_ul8(
         __global ulong* p, ulong8 data )
 ----
 
-| Writes 1, 2, 4, 8, or 16 ulongs of data for each work item in the subgroup to the specified pointer as a block operation.
+| Writes 1, 2, 4, 8, or 16 ulongs of data for each work item in the sub-group to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:
 
 `p[ sub_group_local_id ]`
@@ -345,7 +345,7 @@ void  intel_sub_group_block_write_ul8(
         int2 byte_coord, ulong8 data )
 ----
 
-| Writes 1, 2, 4, or 8 ulongs of data for each work item in the subgroup to the specified _image_ at the specified coordinate as a block operation.
+| Writes 1, 2, 4, or 8 ulongs of data for each work item in the sub-group to the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -176,7 +176,7 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 
 == Modifications to the OpenCL C Specification
 
-=== Additions to Section 6.13.15 - "Work Group Functions"
+=== Additions to Section 6.13.15 - "Work-group Functions"
 
 Add `short` and `ushort` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
@@ -260,7 +260,7 @@ The scan order is defined by increasing sub-group local ID within the sub-group.
 |====
 --
 
-=== Additions to Section 6.13.X - "Sub Group Shuffle Functions"
+=== Additions to Section 6.13.X - "Sub-group Shuffle Functions"
 
 This section was added by the `cl_intel_subgroups` extension.
 
@@ -277,7 +277,7 @@ If `cl_khr_fp16` is supported, `gentype` also includes `half`.
 If `cl_khr_fp64` or doubles are supported, `gentype` also includes `double`.
 --
 
-=== Modifications to Section 6.13.X "Sub Group Read and Write Functions"
+=== Modifications to Section 6.13.X "Sub-group Read and Write Functions"
 
 This section was added by the `cl_intel_subgroups` extension.
 

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -58,16 +58,16 @@ This extension is written against the OpenCL API Specification Version 2.2 (revi
 
 == Overview
 
-The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the subgroup functions described in the `cl_intel_subgroups` extension to support 16-bit integer data types (`shorts` and `ushorts`).
+The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the sub-group functions described in the `cl_intel_subgroups` extension to support 16-bit integer data types (`shorts` and `ushorts`).
 Specifically, the extension:
 
-* Extends the subgroup broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the subgroup.
+* Extends the sub-group broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the sub-group.
 
-* Extends the subgroup scan and reduction functions to operate on 16-bit integer data types.
+* Extends the sub-group scan and reduction functions to operate on 16-bit integer data types.
 
-* Extends the Intel subgroup shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the subgroup.
+* Extends the Intel sub-group shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the sub-group.
 
-* Extends the Intel subgroup block read and write functions to allow reading and writing 16-bit integer data from images and buffers.
+* Extends the Intel sub-group block read and write functions to allow reading and writing 16-bit integer data from images and buffers.
 
 == New API Functions
 
@@ -79,7 +79,7 @@ None.
 
 == New OpenCL C Functions
 
-Add `short` and `ushort` to the list of supported data types for the subgroup broadcast, scan, and reduction functions: ::
+Add `short` and `ushort` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
 --
 [source]
@@ -124,7 +124,7 @@ gentype intel_sub_group_shuffle_xor( gentype data, uint value )
 ----
 --
 
-Add `ushort` variants of the subgroup block read and write functions: ::
+Add `ushort` variants of the sub-group block read and write functions: ::
 +
 --
 [source]
@@ -149,7 +149,7 @@ void  intel_sub_group_block_write_us8( image2d_t image, int2 byte_coord, ushort8
 ----
 --
 
-For naming consistency, also add suffixed aliases of the `uint` subgroup block read and write functions described in the `cl_intel_subgroups` extension: ::
+For naming consistency, also add suffixed aliases of the `uint` sub-group block read and write functions described in the `cl_intel_subgroups` extension: ::
 +
 --
 [source]
@@ -178,7 +178,7 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 
 === Additions to Section 6.13.15 - "Work Group Functions"
 
-Add `short` and `ushort` to the list of supported data types for the subgroup broadcast, scan, and reduction functions: ::
+Add `short` and `ushort` to the list of supported data types for the sub-group broadcast, scan, and reduction functions: ::
 +
 --
 [cols="2a,1",options="header"]
@@ -200,8 +200,8 @@ ushort   intel_sub_group_broadcast(
           uint sub_group_local_id )
 ----
 
-| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the subgroup.
-_sub_group_local_id_ must be the same value for all work items in the subgroup.
+| Broadcasts the value of _x_ for work item identified by _sub_group_local_id_ (value returned by  *get_sub_group_local_id*) to all work items in the sub-group.
+_sub_group_local_id_ must be the same value for all work items in the sub-group.
 
 |[source,c]
 ----
@@ -217,7 +217,7 @@ short    intel_sub_group_reduce_max( short x )
 ushort   intel_sub_group_reduce_max( ushort x )
 ----
 
-| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a subgroup.
+| Returns the result of the specified reduction operation for all values of _x_ specified by work items in a sub-group.
 
 |[source,c]
 ----
@@ -233,10 +233,10 @@ short    intel_sub_group_scan_exclusive_max( short x )
 ushort   intel_sub_group_scan_exclusive_max( ushort x )
 ----
 
-| Performs the specified exclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified exclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |[source,c]
 ----
@@ -252,10 +252,10 @@ short    intel_sub_group_scan_inclusive_max( short x )
 ushort   intel_sub_group_scan_inclusive_max( ushort x )
 ----
 
-| Performs the specified inclusive scan operation of all values _x_ specified by work items in a subgroup.
+| Performs the specified inclusive scan operation of all values _x_ specified by work items in a sub-group.
 The scan results are returned for each work item.
 
-The scan order is defined by increasing subgroup local ID within the subgroup.
+The scan order is defined by increasing sub-group local ID within the sub-group.
 
 |====
 --
@@ -267,9 +267,9 @@ This section was added by the `cl_intel_subgroups` extension.
 Add `short`, `short2`, `short3`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort3`, `ushort4`, `ushort8`, and `ushort16` to the list of data types supported by the `sub_group_shuffle`, `sub_group_shuffle_down`, `sub_group_shuffle_up`, and `sub_group_shuffle_xor` functions: ::
 +
 --
-The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
-These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
-Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
+The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a sub-group.
+These built-in functions need not be encountered by all work items in a sub-group executing the kernel, however, data may only be shuffled among work items encountering the sub-group shuffle function.
+Shuffling data from a work item that does not encounter the sub-group shuffle function will produce undefined results.
 For these functions, `gentype` is `float`, `float2`, `float3`, `float4`, `float8`, `float16`, `short`, `short2`, `short3`, `short4`, `short8`, `short16`, `ushort`, `ushort2`, `ushort3`, `ushort4`, `ushort8`, `ushort16`, `int`, `int2`, `int3`, `int4`, `int8`, `int16`, `uint`, `uint2`, `uint3`, `uint4`, `uint8`, `uint16`, `long`, or `ulong`.
 
 If `cl_khr_fp16` is supported, `gentype` also includes `half`.
@@ -310,7 +310,7 @@ uint8 intel_sub_group_block_read_ui8(
         const __global uint* p )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -341,7 +341,7 @@ uint8 intel_sub_group_block_read_ui8(
         int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation...
+| Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified image at the specified coordinate as a block operation...
 
 |[source,c]
 ----
@@ -364,7 +364,7 @@ void  intel_sub_group_block_write_ui8(
         __global uint* p, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified pointer as a block operation...
 
 |[source,c]
 ----
@@ -395,7 +395,7 @@ void  intel_sub_group_block_write_ui8(
         int2 byte_coord, uint8 data )
 ----
 
-| Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation...
+| Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified image at the specified coordinate as a block operation...
 
 |==================================
 --
@@ -420,7 +420,7 @@ ushort8  intel_sub_group_block_read_us8(
           const __global ushort* p )
 ----
 
-| Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified pointer as a block operation.
+| Reads 1, 2, 4, or 8 ushorts of data for each work item in the sub-group from the specified pointer as a block operation.
 The data is read strided, so the first value read is:
 
 `p[ sub_group_local_id ]`
@@ -451,7 +451,7 @@ ushort8  intel_sub_group_block_read_us8(
           int2 byte_coord )
 ----
 
-| Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified _image_ at the specified coordinate as a block operation.
+| Reads 1, 2, 4, or 8 ushorts of data for each work item in the sub-group from the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 16-bits).
@@ -472,7 +472,7 @@ void  intel_sub_group_block_write_us8(
         __global ushort* p, ushort8 data )
 ----
 
-| Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified pointer as a block operation.
+| Writes 1, 2, 4, or 8 ushorts of data for each work item in the sub-group to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:
 
 `p[ sub_group_local_id ]`
@@ -503,7 +503,7 @@ void  intel_sub_group_block_write_us8(
         int2 byte_coord, ushort8 data )
 ----
 
-| Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified _image_ at the specified coordinate as a block operation.
+| Writes 1, 2, 4, or 8 ushorts of data for each work item in the sub-group to the specified _image_ at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.

--- a/extensions/cl_intel_unified_shared_memory.asciidoc
+++ b/extensions/cl_intel_unified_shared_memory.asciidoc
@@ -807,7 +807,7 @@ cl_int  clEnqueueMemFillINTEL(
 
 fills a region of a memory with the specified pattern.
 
-_command_queue_ is a valid host command queue.
+_command_queue_ is a valid host command-queue.
 The memory fill command will be queued for execution on the device associated with _command_queue_.
 
 _dst_ptr_ is a pointer to the start of the memory region to fill.
@@ -864,7 +864,7 @@ cl_int  clEnqueueMemcpyINTEL(
 
 copies a region of memory from one location to another.
 
-_command_queue_ is a valid host command queue.
+_command_queue_ is a valid host command-queue.
 The memory copy command will be queued for execution on the device associated with _command_queue_.
 
 _blocking_ indicates if the copy operation is blocking or non-blocking.
@@ -926,7 +926,7 @@ If memory migration is not supported for the specified memory range then the mig
 Memory migration may only be supported at a device-specific granularity, such as a page boundary.
 In this case, the memory range may be expanded such that the start and end of the range satisfy the granularity requirements.
 
-_command_queue_ is a valid host command queue.
+_command_queue_ is a valid host command-queue.
 The memory migration command will be queued for execution on the device associated with _command_queue_.
 
 _ptr_ is a pointer to the start of the shared Unified Shared Memory allocation to migrate.
@@ -980,7 +980,7 @@ If a memory advice hint is not supported by the device it will be ignored.
 Memory advice hints may only be supported at a device-specific granularity, such as at a page boundary.
 In this case, the memory range may be expanded such that the start and end of the range satisfy the granularity requirements.
 
-_command_queue_ is a valid host command queue.
+_command_queue_ is a valid host command-queue.
 The memory advice hints will be queued for the device associated with _command_queue_.
 
 _ptr_ is a pointer to the start of the shared Unified Shared Memory allocation.
@@ -1198,7 +1198,7 @@ Trending "yes" for host USM allocations, both when the host USM allocation is fr
 +
 --
 *UNRESOLVED*:
-Trending "yes" for device USM allocations, so long as the device USM allocation is accessible by the device associated with the command queue, and the device allocation was made against the context associated with the command queue.
+Trending "yes" for device USM allocations, so long as the device USM allocation is accessible by the device associated with the command-queue, and the device allocation was made against the context associated with the command-queue.
 
 Trending "yes" for host USM allocations, both when the host USM allocation is from this context and from another context.
 

--- a/man/static/EXTENSION.txt
+++ b/man/static/EXTENSION.txt
@@ -42,7 +42,7 @@ EXTENSION - A #pragma directive to set the behavior for OpenCL extensions.
 | reflink:cl_khr_egl_event                      | Create OpenCL event objects linked to EGL fence sync objects
 | reflink:cl_khr_egl_image                      | Create derived resources from EGLImages
 | reflink:cl_khr_fp16                           | Enable Half-precision floating-point
-| reflink:cl_khr_fp64                           | Enable dobule-precision floating-point
+| reflink:cl_khr_fp64                           | Enable double-precision floating-point
 | reflink:cl_khr_gl_depth_images                | Create image objects from OpenGL depth or depth-stencil textures
 | reflink:cl_khr_gl_event                       | Link CL event objects from GL sync objects
 | reflink:cl_khr_gl_msaa_sharing                | Create image objects from OpenGL multi-sampled textures
@@ -62,7 +62,7 @@ EXTENSION - A #pragma directive to set the behavior for OpenCL extensions.
 | reflink:cl_khr_priority_hints                 | Priority hints
 | reflink:cl_khr_spir                           | Standard Portable Intermediate Representation (SPIR) support
 | reflink:cl_khr_srgb_image_writes              | Allow writing to sRGB images
-| reflink:cl_khr_subgroups                      | Implementation-controlled subgroups
+| reflink:cl_khr_subgroups                      | Implementation-controlled sub-groups
 | reflink:cl_khr_terminate_context              | Terminate an OpenCL context on a device
 | reflink:cl_khr_throttle_hints                 | Throttle hints
 | reflink:cles_khr_int64                        | 64-bit integer support

--- a/man/static/abstractDataTypes.txt
+++ b/man/static/abstractDataTypes.txt
@@ -21,7 +21,7 @@ The following table describes abstract data types supported by OpenCL.
 | The ID for a platform | `cl_platform_id`   | reflink:clGetPlatformIDs
 | The ID for a device   | `cl_device_id`     | reflink:clGetDeviceIDs
 | A context             | `cl_context`       | reflink:clCreateContext
-| A command queue       | `cl_command_queue` | reflink:clCreateCommandQueueWithProperties
+| A command-queue       | `cl_command_queue` | reflink:clCreateCommandQueueWithProperties
 | A memory object       | `cl_mem`           | reflink:clCreateBuffer
 | A program             | `cl_program`       | reflink:clCreateProgramWithSource
 | A kernel              | `cl_kernel`        | reflink:clCreateKernel

--- a/man/static/clCreateEventFromEGLSyncKHR.txt
+++ b/man/static/clCreateEventFromEGLSyncKHR.txt
@@ -41,7 +41,7 @@ The parameters of an event object linked to an EGL sync object will return
 the following values when queried with flink:clGetEventInfo:
 
   * The `CL_EVENT_COMMAND_QUEUE` of a linked event is NULL, because the
-    event is not associated with any OpenCL command queue.
+    event is not associated with any OpenCL command-queue.
   * The `CL_EVENT_COMMAND_TYPE` of a linked event is
     `CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR`, indicating that the event is
     associated with a EGL sync object, rather than an OpenCL command.

--- a/man/static/clCreateEventFromGLsyncKHR.txt
+++ b/man/static/clCreateEventFromGLsyncKHR.txt
@@ -38,7 +38,7 @@ Completion of such an event object is equivalent to waiting for completion of th
 
 The parameters of an event object linked to a GL sync object will return the following values when queried with flink:clGetEventInfo:
 
-  * The `CL_EVENT_COMMAND_QUEUE` of a linked event is NULL, because the event is not associated with any OpenCL command queue.
+  * The `CL_EVENT_COMMAND_QUEUE` of a linked event is NULL, because the event is not associated with any OpenCL command-queue.
   * The `CL_EVENT_COMMAND_TYPE` of a linked event is `CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR`, indicating that the event is associated with a GL sync object, rather than an OpenCL command.
   * The `CL_EVENT_COMMAND_EXECUTION_STATUS` of a linked event is either `CL_SUBMITTED`, indicating that the fence command associated with the sync object has not yet completed, or `CL_COMPLETE`, indicating that the fence command has completed.
 

--- a/man/static/clCreateFromEGLImageKHR.txt
+++ b/man/static/clCreateFromEGLImageKHR.txt
@@ -102,7 +102,7 @@ efficient methods.
 Attempting to access the data store of an EGLImage object after it has been
 acquired by OpenCL and before it has been released will result in undefined
 behavior. Similarly, attempting to access a shared EGLImage object from
-OpenCL before it has been acquired by the OpenCL command queue or after it
+OpenCL before it has been acquired by the OpenCL command-queue or after it
 has been released, will result in undefined behavior.
 
 == Errors

--- a/man/static/clTerminateContextKHR.txt
+++ b/man/static/clTerminateContextKHR.txt
@@ -49,7 +49,7 @@ When a context is terminated:
     `clTerminateContextKHR` was not called.
   * The behavior of callbacks will remain unchanged, and will report
     appropriate error, if executing after termination of context. This
-    behavior is similar to enqueued commands, after the command queue has
+    behavior is similar to enqueued commands, after the command-queue has
     become invalid.
 
 An implementation that supports this extension must be able to terminate

--- a/man/static/cl_khr_fp16.txt
+++ b/man/static/cl_khr_fp16.txt
@@ -40,7 +40,7 @@ The following table describes the built-in vector data types for `halfn` as defi
 
 The relational, equality, logical and logical unary reflink:operators can be used with `half` scalar and `halfn` vector types and shall produce a scalar `int` and vector `shortn` result respectively.
 
-The OpenCL compiler accepts an `h` and `H` suffix on floating point literals, indicating the literal is typed as a `half`.
+The OpenCL compiler accepts an `h` and `H` suffix on floating-point literals, indicating the literal is typed as a `half`.
 
 The macro names given in the following list must use the values specified.
 These constant expressions are suitable for use in `#if` preprocessing directives.

--- a/man/static/cl_khr_gl_depth_images.txt
+++ b/man/static/cl_khr_gl_depth_images.txt
@@ -29,7 +29,7 @@ Depth images with an image channel order of `CL_DEPTH_STENCIL` can only be creat
 For the image format given by channel order of `CL_DEPTH_STENCIL` and channel data type of `CL_UNORM_INT24`, the depth is stored as an unsigned normalized 24-bit value.
 
 For the image format given by channel order of `CL DEPTH_STENCIL` and channel data type of `CL_FLOAT`, each pixel is two 32-bit values.
-The depth is stored as a single precision floating point value followed by the stencil which is stored as a 8-bit integer value.
+The depth is stored as a single precision floating-point value followed by the stencil which is stored as a 8-bit integer value.
 
 The stencil value cannot be read or written using the read imagef and write imagef built-in functions in an OpenCL kernel.
 

--- a/man/static/convert_T.txt
+++ b/man/static/convert_T.txt
@@ -173,7 +173,7 @@ Example 2:
 ----------
 float4 f;
 
-// values implementation defined for
+// values implementation-defined for
 // f > INT_MAX, f < INT_MIN or NaN
 int4 i = convert_int4( f );
 

--- a/man/static/gl_syncInc.txt
+++ b/man/static/gl_syncInc.txt
@@ -14,7 +14,7 @@ efficient synchronization methods; for example on some platforms calling
 `glFlush` may be sufficient, or synchronization may be implicit within a
 thread, or there may be vendor-specific extensions that enable placing a
 fence in the GL command stream and waiting for completion of that fence in
-the CL command queue. Note that no synchronization methods other than
+the CL command-queue. Note that no synchronization methods other than
 `glFinish` are portable between OpenGL implementations at this time.
 
 When the extension reflink:cl_khr_egl_event is supported: Prior to calling
@@ -57,7 +57,7 @@ the requirements are implementation-dependent.
 Attempting to access the data store of an OpenGL object after it has been
 acquired by OpenCL and before it has been released will result in undefined
 behavior. Similarly, attempting to access a shared CL/GL object from OpenCL
-before it has been acquired by the OpenCL command queue, or after it has
+before it has been acquired by the OpenCL command-queue, or after it has
 been released, will result in undefined behavior.
 
 If the reflink:cl_khr_gl_event extension is supported,

--- a/man/toctail
+++ b/man/toctail
@@ -37,7 +37,7 @@
 
                     <li>Runtime APIs
                         <ul class="Level3">
-                            <li>Command Queues
+                            <li>Command-Queues
                                 <ul class="Level4">
                                     <li><a href="clCreateCommandQueueWithProperties.html" target="pagedisplay">clCreateCommandQueueWithProperties</a></li>
                                     <li><a href="clGetCommandQueueInfo.html" target="pagedisplay">clGetCommandQueueInfo</a></li>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4639,7 +4639,7 @@ server's OpenCL/api-docs repository.
             <command name="clReleaseContext"/>
             <command name="clGetContextInfo"/>
         </require>
-        <require comment="Command Queue APIs">
+        <require comment="Command-Queue APIs">
             <command name="clRetainCommandQueue"/>
             <command name="clReleaseCommandQueue"/>
             <command name="clGetCommandQueueInfo"/>
@@ -4713,7 +4713,7 @@ server's OpenCL/api-docs repository.
                  *  OpenCL 1.1 conformance test, and consequently may not work or may not work dependably.
                  *  It is likely to be non-performant. Use of this API is not advised. Use at your own risk.
                  *
-                 *  Software developers previously relying on this API are instructed to set the command queue
+                 *  Software developers previously relying on this API are instructed to set the command-queue
                  *  properties when creating the queue, instead.
                  */
             #endif /* CL_USE_DEPRECATED_OPENCL_1_0_APIS */
@@ -5097,7 +5097,7 @@ server's OpenCL/api-docs repository.
         <require comment="cl_profiling_info">
             <enum name="CL_PROFILING_COMMAND_COMPLETE"/>
         </require>
-        <require comment="Command Queue APIs">
+        <require comment="Command-Queue APIs">
             <command name="clCreateCommandQueueWithProperties"/>
         </require>
         <require comment="Pipe APIs">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4709,7 +4709,7 @@ server's OpenCL/api-docs repository.
                 /*
                  *  WARNING:
                  *     This API introduces mutable state into the OpenCL implementation. It has been REMOVED
-                 *  to better facilitate thread safety.  The 1.0 API is not thread safe. It is not tested by the
+                 *  to better facilitate thread safety.  The 1.0 API is not thread-safe. It is not tested by the
                  *  OpenCL 1.1 conformance test, and consequently may not work or may not work dependably.
                  *  It is likely to be non-performant. Use of this API is not advised. Use at your own risk.
                  *


### PR DESCRIPTION
See #474 

Couple of notes:

* We had more usage of `subgroup` than `sub-group` so I've gone with that for now, though I actually think `sub-group` is more appropriate.  There is going to be some awkwardness no matter what we choose since the Vulkan spec uses `subgroup` and the SYCL spec uses `sub-group`.
* I didn't think any of the others were as controversial, but if there is a strong preference for a different usage instead just let me know.  We should be consistent now at least!
* I updated a few vendor extensions also (from Arm, Imagination, and Intel), though I'm fine reverting these changes if these vendors would prefer to leave their extensions unchanged.