### PR TITLE
Remove redundant error condition in cl_khr_external_semaphore

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -235,10 +235,6 @@ Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
         semaphore does not support any handle types for exporting.
 |====
 
-Add to the list of error conditions for {clEnqueueWaitSemaphoresKHR} and {clEnqueueSignalSemaphoresKHR}:
-
-* {CL_INVALID_COMMAND_QUEUE} if one or more of _sema_objects_ can not be shared with the device associated with _command_queue_.
-
 === Exporting semaphore external handles
 
 To export an external handle from a semaphore, call the function


### PR DESCRIPTION
cl_khr_semaphore has the following condition:

* {CL_INVALID_COMMAND_QUEUE} if the device associated with _command_queue_ is not same as one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_

cl_khr_external_semaphore has the following condition:

* {CL_INVALID_DEVICE} if one or more devices identified by properties {CL_DEVICE_HANDLE_LIST_KHR} can not import the requested external semaphore handle type.