### PR TITLE
remove a redundant cl_khr_external_memory error code

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -281,13 +281,12 @@ If _num_mem_objects_ is 0 and _mem_objects_ is `NULL`, the command will triviall
 {clEnqueueAcquireExternalMemObjectsKHR} returns {CL_SUCCESS} if the function is executed successfully.
 Otherwise, it returns one of the following errors:
 
-* {CL_INVALID_VALUE} if _num_mem_objects_ is zero and _mem_objects_ is not a `NULL` value or if _num_mem_objects_ is not 0 and _mem_objects_ is `NULL`.
+* {CL_INVALID_VALUE} if _num_mem_objects_ is zero and _mem_objects_ is not a `NULL` value or if _num_mem_objects_ is greater than 0 and _mem_objects_ is `NULL`.
 * {CL_INVALID_MEM_OBJECT} if any of the memory objects in _mem_objects_ is not a valid OpenCL memory object created using an external memory handle.
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
 ** if device associated with _command_queue_ is not one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _mem_objects_, or
-** if one or more of _mem_objects_ belong to a context that does not contain a device associated _command_queue_, or
-** if one or more of _mem_objects_ can not be shared with device associated with _command_queue_.
+** if one or more of _mem_objects_ belong to a context that does not contain a device associated with _command_queue_.
 * {CL_INVALID_EVENT_WAIT_LIST}
     ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not 0, or
     ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is 0, or
@@ -332,8 +331,7 @@ Otherwise, it returns one of the following errors:
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
 ** if device associated with _command_queue_ is not one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _mem_objects_, or
-** if one or more of _mem_objects_ belong to a cl_context that does not contain device associated _command_queue_, or
-** if one or more of _mem_objects_ can not be shared with device associated with _command_queue_.
+** if one or more of _mem_objects_ belong to a context that does not contain a device associated with _command_queue_.
 * {CL_INVALID_EVENT_WAIT_LIST}
     ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not 0, or
     ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is 0, or

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -316,7 +316,7 @@ Otherwise, it returns one of the following errors:
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
 ** if the device associated with _command_queue_ is not same as one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_, or
-** if one or more of _sema_objects_ belong to a context that does not contain a device associated with_command_queue_.
+** if one or more of _sema_objects_ belong to a context that does not contain a device associated with _command_queue_.
 * {CL_INVALID_VALUE} if _num_sema_objects_ is 0.
 * {CL_INVALID_SEMAPHORE_KHR} if any of the semaphore objects specified by _sema_objects_ is not valid.
 * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and any of the semaphore objects in _sema_objects_ are not the same or if the context associated with _command_queue_ and that associated with events in _event_wait_list_ are not the same.
@@ -366,8 +366,8 @@ Otherwise, it returns one of the following errors:
 
 * {CL_INVALID_COMMAND_QUEUE}
 ** if _command_queue_ is not a valid command-queue, or
-** if device associated with _command_queue_ is not same as one of devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_, or
-** if one or more of _sema_objects_ belong to a context that does not contain a device associated _command_queue_.
+** if the device associated with _command_queue_ is not same as one of the devices specified by {CL_DEVICE_HANDLE_LIST_KHR} at the time of creating one or more of _sema_objects_, or
+** if one or more of _sema_objects_ belong to a context that does not contain a device associated with _command_queue_.
 * {CL_INVALID_VALUE} if _num_sema_objects_ is 0
 * {CL_INVALID_SEMAPHORE_KHR} if any of the semaphore objects specified by _sema_objects_ is not valid.
 * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and any of the semaphore objects in _sema_objects_ are not the same or if the context associated with _command_queue_ and that associated with events in _event_wait_list_ are not the same.


### PR DESCRIPTION
See #897 and #903.

Remove the same redundant error condition from cl_khr_external_memory.

Also cleans up a few cosmetic and grammatical issues in the external semaphore spec.