### PR TITLE
clarify that SVM is optional for all OpenCL 3.0 devices

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1051,8 +1051,9 @@ There are three types of SVM in OpenCL
               | No
 |====
 
-Coarse-Grained buffer SVM is required in the core OpenCL specification.
-The two finer grained approaches are optional features in OpenCL.
+Coarse-Grained buffer SVM is a required feature for OpenCL 2.0, 2.1, or 2.2
+devices and an optional feature for OpenCL 3.0 or newer devices.
+Fine-Grained SVM is an optional feature for all OpenCL devices.
 The various SVM mechanisms to access host memory from the work-items
 associated with a kernel instance are <<svm-summary-table, summarized
 above>>.


### PR DESCRIPTION
fixes #912 

Clarifies that all forms of SVM including coarse-grained buffer SVM are optional for OpenCL 3.0 devices.

This was stated clearly in most places in the spec but one place was never updated from the OpenCL 2.x specification and still stated that coarse-grained buffer SVM was required.