### PR TITLE
Reserve enums used by cl_ext_yuv_images

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -900,6 +900,7 @@ server's OpenCL/api-docs repository.
         <enum bitpos="2"            name="CL_MAP_WRITE_INVALIDATE_REGION"/>
             <unused start="3" end="31"/>
             <unused start="32" end="33" comment="Reserved for cl_ext_yuv_images #722"/>
+            <unused start="34" end="63"/>
     </enums>
 
     <enums name="cl_mem_migration_flags" vendor="Khronos" type="bitmask">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -899,6 +899,7 @@ server's OpenCL/api-docs repository.
         <enum bitpos="1"            name="CL_MAP_WRITE"/>
         <enum bitpos="2"            name="CL_MAP_WRITE_INVALIDATE_REGION"/>
             <unused start="3" end="31"/>
+            <unused start="32" end="33" comment="Reserved for cl_ext_yuv_images #722"/>
     </enums>
 
     <enums name="cl_mem_migration_flags" vendor="Khronos" type="bitmask">
@@ -1530,7 +1531,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x1097"        name="CL_QUEUE_THROTTLE_KHR"/>
         <enum value="0x1098"        name="CL_QUEUE_PROPERTIES_ARRAY"/>
             <unused start="0x1099" end="0x109F" comment="Reserved for cl_command_queue_info"/>
-            <unused start="0x10A0" end="0x10AF" comment="Reserved for core API tokens"/>
+            <unused start="0x10A0" end="0x10AB" comment="Reserved for core API tokens"/>
+            <unused start="0x10AC" end="0x10AF" comment="Reserved for cl_ext_yuv_images #722"/>
         <enum value="0x10B0"        name="CL_R"/>
         <enum value="0x10B1"        name="CL_A"/>
         <enum value="0x10B2"        name="CL_RG"/>
@@ -1551,7 +1553,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x10C1"        name="CL_sRGBA"/>
         <enum value="0x10C2"        name="CL_sBGRA"/>
         <enum value="0x10C3"        name="CL_ABGR"/>
-            <unused start="0x10C4" end="0x10CF" comment="Reserved for cl_channel_order"/>
+            <unused start="0x10C4" end="0x10CE" comment="Reserved for cl_ext_yuv_images #722"/>
+            <unused start="0x10CF" end="0x10CF" comment="Reserved for cl_channel_order"/>
         <enum value="0x10D0"        name="CL_SNORM_INT8"/>
         <enum value="0x10D1"        name="CL_SNORM_INT16"/>
         <enum value="0x10D2"        name="CL_UNORM_INT8"/>
@@ -1569,7 +1572,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x10DE"        name="CL_FLOAT"/>
         <enum value="0x10DF"        name="CL_UNORM_INT24"/>
         <enum value="0x10E0"        name="CL_UNORM_INT_101010_2"/>
-            <unused start="0x10E1" end="0x10EF" comment="Reserved for cl_channel_type"/>
+            <unused start="0x10E1" end="0x10E2" comment="Reserved for cl_ext_yuv_images #722"/>
+            <unused start="0x10E3" end="0x10EF" comment="Reserved for cl_channel_type"/>
         <enum value="0x10F0"        name="CL_MEM_OBJECT_BUFFER"/>
         <enum value="0x10F1"        name="CL_MEM_OBJECT_IMAGE2D"/>
         <enum value="0x10F2"        name="CL_MEM_OBJECT_IMAGE3D"/>
@@ -1602,7 +1606,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x1118"        name="CL_IMAGE_BUFFER"/>
         <enum value="0x1119"        name="CL_IMAGE_NUM_MIP_LEVELS"/>
         <enum value="0x111A"        name="CL_IMAGE_NUM_SAMPLES"/>
-            <unused start="0x111B" end="0x111F" comment="Reserved for cl_image_info"/>
+            <unused start="0x111B" end="0x111C" comment="Reserved for cl_ext_yuv_images #722"/>
+            <unused start="0x111D" end="0x111F" comment="Reserved for cl_image_info"/>
         <enum value="0x1120"        name="CL_PIPE_PACKET_SIZE"/>
         <enum value="0x1121"        name="CL_PIPE_MAX_PACKETS"/>
         <enum value="0x1122"        name="CL_PIPE_PROPERTIES"/>


### PR DESCRIPTION
Covers all enums currently used by #722.