### PR TITLE
cl_khr_external_memory: add error when CL_DEVICE_HANDLE_LIST_KHR is specified without an external memory handle

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -30,6 +30,7 @@ Other related extensions define specific external memory types that may be impor
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
+| 2023-05-04 | 0.9.1     | {CL_DEVICE_HANDLE_LIST_KHR} cannot be specified without an external memory handle (provisional).
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 |====
 
@@ -211,6 +212,8 @@ Add to the list of error conditions for {clCreateBufferWithProperties} and {clCr
   ** if _properties_ includes a supported external memory handle and _flags_ includes {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}.
 * {CL_INVALID_HOST_PTR}
   ** if _properties_ includes a supported external memory handle and _host_ptr_ is not `NULL`.
+* {CL_INVALID_PROPERTY}
+  ** if _properties_ does not include a supported external memory handle and {CL_DEVICE_HANDLE_LIST_KHR} is specified as part of _properties_.
 
 Add images created from an external memory handle to the description of `image_row_pitch` and `image_slice_pitch` for {cl_image_desc_TYPE}:
 


### PR DESCRIPTION
Fixes #916