### PR TITLE
Clarify the definition of prerequisites to commands

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -198,10 +198,12 @@ A command submitted to a device will not launch until prerequisites that
 constrain the order of commands have been resolved.
 These prerequisites have three sources:
 
-  * They may arise from commands submitted to a command-queue that constrain
-    the order in which commands are launched.
-    For example, commands that follow a command-queue barrier will not
-    launch until all commands prior to the barrier are complete.
+  * The first source of prerequisites is implicit dependencies between commands
+    enqueued to the same command-queue which arise as follows:
+  ** Commands enqueued after a command-queue barrier have this barrier command
+     a prerequisite.
+  ** Commands enqueued in an in-order command-queue have the command enqueued
+     before them as a prerequisite.
   * The second source of prerequisites is dependencies between commands
     expressed through events.
     A command may include an optional list of events.

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -200,8 +200,8 @@ These prerequisites have three sources:
 
   * The first source of prerequisites is implicit dependencies between commands
     enqueued to the same command-queue which arise as follows:
-  ** Commands enqueued after a command-queue barrier have this barrier command
-     a prerequisite.
+  ** Commands enqueued after a command-queue barrier have the preceding barrier command
+      as a prerequisite.
   ** Commands enqueued in an in-order command-queue have the command enqueued
      before them as a prerequisite.
   * The second source of prerequisites is dependencies between commands


### PR DESCRIPTION
- Reword the first source of prerequisites so the wording is symmetrical with respect to the others (i.e. the first/second/third ...).
- Broaden the first source of prerequisites to cover all implicit dependencies and provide an exhaustive list of how they arise: either because of barriers or because of ordering in in-order command-queues.


Change-Id: Ic464066261fe13756347bafb4878cd6ffb5a8427