### PR TITLE
Сonsistent enum types

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -139,6 +139,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_queue_priority_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_queue_throttle_khr</name>;</type>
         <type category="define">typedef <type>intptr_t</type>         <name>cl_import_properties_arm</name>;</type>
+        <type category="define">typedef <type>intptr_t</type>         <name>cl_import_type_arm</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_svm_mem_flags_arm</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_kernel_exec_info_arm</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_svm_capabilities_arm</name>;</type>
@@ -171,6 +172,8 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>intptr_t</type>         <name>cl_device_partition_property</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_affinity_domain</name>;</type>
         <type category="define">typedef <type>intptr_t</type>         <name>cl_context_properties</name>;</type>
+        <type category="define">typedef <type>intptr_t</type>         <name>cl_context_property_diagnostics_level</name>;</type>
+        <type category="define">typedef <type>intptr_t</type>         <name>cl_context_memory_initialize_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_context_info</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_queue_properties</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_queue_properties_khr</name>;</type>
@@ -251,21 +254,33 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_fp_atomic_capabilities_ext</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_image_requirements_info_ext</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_platform_command_buffer_capabilities_khr</name>;</type>
-
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_affinity_domain_ext</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_command_termination_reason_arm</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_host_cache_policy</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_allocation_type</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_mb_block_type</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_subpixel_mode</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_sad_adjust_mode</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_search_path_type</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_device_me_version</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_device_avc_me_version</name>;</type>
+        <type category="define">typedef <type>cl_int</type>           <name>cl_command_execution_status</name>;</type>
+        <type category="define">typedef <type>cl_int</type>           <name>cl_error_code</name>;</type>
+        
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
             <member><type>IDirect3DSurface9</type>*  <name>resource</name></member>
             <member><type>HANDLE</type>              <name>shared_handle</name></member>
         </type>
         <type category="struct" name="cl_motion_estimation_desc_intel">
-            <member><type>cl_uint</type>             <name>mb_block_type</name></member>
-            <member><type>cl_uint</type>             <name>subpixel_mode</name></member>
-            <member><type>cl_uint</type>             <name>sad_adjust_mode</name></member>
-            <member><type>cl_uint</type>             <name>search_path_type</name></member>
+            <member><type>cl_mb_block_type</type>    <name>mb_block_type</name></member>
+            <member><type>cl_subpixel_mode</type>    <name>subpixel_mode</name></member>
+            <member><type>cl_sad_adjust_mode</type>  <name>sad_adjust_mode</name></member>
+            <member><type>cl_search_path_type</type> <name>search_path_type</name></member>
         </type>
         <type category="struct" name="cl_mem_ext_host_ptr">
-            <member><type>cl_uint</type>             <name>allocation_type</name></member>
-            <member><type>cl_uint</type>             <name>host_cache_policy</name></member>
+            <member><type>cl_allocation_type</type>  <name>allocation_type</name></member>
+            <member><type>cl_host_cache_policy</type><name>host_cache_policy</name></member>
         </type>
         <type category="struct" name="cl_mem_ion_host_ptr">
             <member><type>cl_mem_ext_host_ptr</type> <name>ext_host_ptr</name></member>
@@ -728,7 +743,7 @@ server's OpenCL/api-docs repository.
             <unused start="-4" end="-9999"/>
     </enums>
 
-    <enums name="clCommandExecutionStatus" vendor="Khronos">
+    <enums name="cl_command_execution_status" vendor="Khronos">
         <enum value="0x0"           name="CL_COMPLETE"/>
         <enum value="0x1"           name="CL_RUNNING"/>
         <enum value="0x2"           name="CL_SUBMITTED"/>
@@ -957,7 +972,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x8" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_arm_device_svm_capabilities.flags" vendor="ARM" type="bitmask">
+    <enums name="cl_device_svm_capabilities_arm" vendor="ARM" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="1"            name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="2"            name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM"/>
@@ -971,7 +986,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x4" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
+    <enums name="cl_context_property_diagnostics_level" comment="From cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
         <enum value="0xff"          name="CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL"/>
         <enum bitpos="0"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL"/>
         <enum bitpos="1"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL"/>
@@ -1302,7 +1317,7 @@ server's OpenCL/api-docs repository.
             <unused start="3" end="31"/>
     </enums>
 
-    <enums name="cl_device_command_buffer_capabilities_khr " vendor="Khronos" type="bitmask">
+    <enums name="cl_device_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
@@ -2283,7 +2298,7 @@ server's OpenCL/api-docs repository.
     <!-- SECTION: CL command definitions. (TBD) -->
     <commands>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D10KHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceIDsFromD3D10KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d10_device_source_khr</type> <name>d3d_device_source</name></param>
             <param><type>void</type>*                      <name>d3d_object</name></param>
@@ -2297,7 +2312,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Buffer</type>*              <name>resource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_mem</type>                     <name>clCreateFromD3D10Texture2DKHR</name></proto>
@@ -2305,7 +2320,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Texture2D</type>*           <name>resource</name></param>
             <param><type>UINT</type>                       <name>subresource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_mem</type>                     <name>clCreateFromD3D10Texture3DKHR</name></proto>
@@ -2313,10 +2328,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D10Texture3D</type>*           <name>resource</name></param>
             <param><type>UINT</type>                       <name>subresource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireD3D10ObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireD3D10ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2325,7 +2340,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseD3D10ObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseD3D10ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2334,7 +2349,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromD3D11KHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceIDsFromD3D11KHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_d3d11_device_source_khr</type> <name>d3d_device_source</name></param>
             <param><type>void</type>*                      <name>d3d_object</name></param>
@@ -2348,7 +2363,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Buffer</type>*              <name>resource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_mem</type>                     <name>clCreateFromD3D11Texture2DKHR</name></proto>
@@ -2356,7 +2371,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Texture2D</type>*           <name>resource</name></param>
             <param><type>UINT</type>                       <name>subresource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_mem</type>                     <name>clCreateFromD3D11Texture3DKHR</name></proto>
@@ -2364,10 +2379,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>ID3D11Texture3D</type>*           <name>resource</name></param>
             <param><type>UINT</type>                       <name>subresource</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireD3D11ObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireD3D11ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2376,7 +2391,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseD3D11ObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseD3D11ObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2385,7 +2400,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromDX9MediaAdapterKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceIDsFromDX9MediaAdapterKHR</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_uint</type>                    <name>num_media_adapters</name></param>
             <param><type>cl_dx9_media_adapter_type_khr</type>*  <name>media_adapter_type</name></param>
@@ -2402,10 +2417,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_dx9_media_adapter_type_khr</type> <name>adapter_type</name></param>
             <param><type>void</type>*                      <name>surface_info</name></param>
             <param><type>cl_uint</type>                    <name>plane</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireDX9MediaSurfacesKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireDX9MediaSurfacesKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2414,7 +2429,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseDX9MediaSurfacesKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseDX9MediaSurfacesKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2423,7 +2438,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromDX9INTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceIDsFromDX9INTEL</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_dx9_device_source_intel</type> <name>dx9_device_source</name></param>
             <param><type>void</type>*                      <name>dx9_object</name></param>
@@ -2439,10 +2454,10 @@ server's OpenCL/api-docs repository.
             <param><type>IDirect3DSurface9</type>*         <name>resource</name></param>
             <param><type>HANDLE</type>                     <name>sharedHandle</name></param>
             <param><type>UINT</type>                       <name>plane</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireDX9ObjectsINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireDX9ObjectsINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2451,7 +2466,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseDX9ObjectsINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseDX9ObjectsINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param><type>cl_mem</type>*                    <name>mem_objects</name></param>
@@ -2464,7 +2479,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>CLeglSyncKHR</type>               <name>sync</name></param>
             <param><type>CLeglDisplayKHR</type>            <name>display</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_mem</type>                     <name>clCreateFromEGLImageKHR</name></proto>
@@ -2473,10 +2488,10 @@ server's OpenCL/api-docs repository.
             <param><type>CLeglImageKHR</type>              <name>eglimage</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param>const <type>cl_egl_image_properties_khr</type>*  <name>properties</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireEGLObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireEGLObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2485,7 +2500,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseEGLObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseEGLObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2515,7 +2530,7 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                      <name>user_data</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                     <name>clIcdGetPlatformIDsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clIcdGetPlatformIDsKHR</name></proto>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
             <param><type>cl_platform_id</type>*            <name>platforms</name></param>
             <param><type>cl_uint</type>*                   <name>num_platforms</name></param>
@@ -2525,10 +2540,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param>const <type>void</type>*                <name>il</name></param>
             <param><type>size_t</type>                     <name>length</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clTerminateContextKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clTerminateContextKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
@@ -2536,18 +2551,18 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_device_id</type>               <name>device</name></param>
             <param>const <type>cl_queue_properties_khr</type>* <name>properties</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clReleaseDeviceEXT</name></proto>
+            <proto><type>cl_error_code</type>              <name>clReleaseDeviceEXT</name></proto>
             <param><type>cl_device_id</type>               <name>device</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clRetainDeviceEXT</name></proto>
+            <proto><type>cl_error_code</type>              <name>clRetainDeviceEXT</name></proto>
             <param><type>cl_device_id</type>               <name>device</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                     <name>clCreateSubDevicesEXT</name></proto>
+            <proto><type>cl_error_code</type>              <name>clCreateSubDevicesEXT</name></proto>
             <param><type>cl_device_id</type>               <name>in_device</name></param>
             <param>const <type>cl_device_partition_property_ext</type>*  <name>properties</name></param>
             <param><type>cl_uint</type>                    <name>num_entries</name></param>
@@ -2555,7 +2570,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                   <name>num_devices</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                     <name>clEnqueueMigrateMemObjectEXT</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueMigrateMemObjectEXT</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_mem_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2565,7 +2580,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                     <name>clGetDeviceImageInfoQCOM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceImageInfoQCOM</name></proto>
             <param><type>cl_device_id</type>               <name>device</name></param>
             <param><type>size_t</type>                     <name>image_width</name></param>
             <param><type>size_t</type>                     <name>image_height</name></param>
@@ -2576,7 +2591,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireGrallocObjectsIMG</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireGrallocObjectsIMG</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2585,7 +2600,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueGenerateMipmapIMG</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueGenerateMipmapIMG</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_mem</type>                     <name>src_image</name></param>
             <param><type>cl_mem</type>                     <name>dst_image</name></param>
@@ -2597,7 +2612,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseGrallocObjectsIMG</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseGrallocObjectsIMG</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2606,7 +2621,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0_DEPRECATED">
-            <proto><type>cl_int</type>                     <name>clGetKernelSubGroupInfoKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetKernelSubGroupInfoKHR</name></proto>
             <param><type>cl_kernel</type>                  <name>in_kernel</name></param>
             <param><type>cl_device_id</type>               <name>in_device</name></param>
             <param><type>cl_kernel_sub_group_info</type>   <name>param_name</name></param>
@@ -2617,7 +2632,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                     <name>clGetKernelSuggestedLocalWorkSizeKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetKernelSuggestedLocalWorkSizeKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_kernel</type>                  <name>kernel</name></param>
             <param><type>cl_uint</type>                    <name>work_dim</name></param>
@@ -2629,10 +2644,10 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_semaphore_khr</type>           <name>clCreateSemaphoreWithPropertiesKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param>const <type>cl_semaphore_properties_khr</type>* <name>sema_props</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueWaitSemaphoresKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueWaitSemaphoresKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_sema_objects</name></param>
             <param>const <type>cl_semaphore_khr</type>*    <name>sema_objects</name></param>
@@ -2642,7 +2657,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSignalSemaphoresKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSignalSemaphoresKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_sema_objects</name></param>
             <param>const <type>cl_semaphore_khr</type>*    <name>sema_objects</name></param>
@@ -2652,7 +2667,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetSemaphoreInfoKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetSemaphoreInfoKHR</name></proto>
             <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
             <param><type>cl_semaphore_info_khr</type>      <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -2660,15 +2675,15 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clReleaseSemaphoreKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clReleaseSemaphoreKHR</name></proto>
             <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clRetainSemaphoreKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clRetainSemaphoreKHR</name></proto>
             <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetSemaphoreHandleForTypeKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetSemaphoreHandleForTypeKHR</name></proto>
             <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
             <param><type>cl_device_id</type>               <name>device</name></param>
             <param><type>cl_external_semaphore_handle_type_khr</type> <name>handle_type</name></param>
@@ -2677,7 +2692,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>handle_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_mem_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2686,7 +2701,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseExternalMemObjectsKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseExternalMemObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_mem_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2701,7 +2716,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_import_properties_arm</type>* <name>properties</name></param>
             <param><type>void</type>*                      <name>memory</name></param>
             <param><type>size_t</type>                     <name>size</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>void</type>*                      <name>clSVMAllocARM</name></proto>
@@ -2716,18 +2731,18 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                      <name>svm_pointer</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSVMFreeARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSVMFreeARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_svm_pointers</name></param>
             <param><type>void</type>*                      <name>svm_pointers</name>[]</param>
-            <param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue queue, cl_uint num_svm_pointers, void * svm_pointers[], void *user_data)</param>
+            <param>void (CL_CALLBACK*                      <name>pfn_free_func</name>)(cl_command_queue queue, cl_uint num_svm_pointers, void* svm_pointers[], void* user_data)</param>
             <param><type>void</type>*                      <name>user_data</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*            <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSVMMemcpyARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSVMMemcpyARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_bool</type>                    <name>blocking_copy</name></param>
             <param><type>void</type>*                      <name>dst_ptr</name></param>
@@ -2738,7 +2753,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSVMMemFillARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSVMMemFillARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>void</type>*                      <name>svm_ptr</name></param>
             <param>const <type>void</type>*                <name>pattern</name></param>
@@ -2749,7 +2764,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSVMMapARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSVMMapARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_bool</type>                    <name>blocking_map</name></param>
             <param><type>cl_map_flags</type>               <name>flags</name></param>
@@ -2760,7 +2775,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueSVMUnmapARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueSVMUnmapARM</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>void</type>*                      <name>svm_ptr</name></param>
             <param><type>cl_uint</type>                    <name>num_events_in_wait_list</name></param>
@@ -2768,13 +2783,13 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clSetKernelArgSVMPointerARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clSetKernelArgSVMPointerARM</name></proto>
             <param><type>cl_kernel</type>                  <name>kernel</name></param>
             <param><type>cl_uint</type>                    <name>arg_index</name></param>
             <param>const <type>void</type>*                <name>arg_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clSetKernelExecInfoARM</name></proto>
+            <proto><type>cl_error_code</type>              <name>clSetKernelExecInfoARM</name></proto>
             <param><type>cl_kernel</type>                  <name>kernel</name></param>
             <param><type>cl_kernel_exec_info_arm</type>    <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -2786,10 +2801,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_accelerator_type_intel</type>  <name>accelerator_type</name></param>
             <param><type>size_t</type>                     <name>descriptor_size</name></param>
             <param>const <type>void</type>*                <name>descriptor</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetAcceleratorInfoINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetAcceleratorInfoINTEL</name></proto>
             <param><type>cl_accelerator_intel</type>       <name>accelerator</name></param>
             <param><type>cl_accelerator_info_intel</type>  <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -2797,21 +2812,21 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clRetainAcceleratorINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clRetainAcceleratorINTEL</name></proto>
             <param><type>cl_accelerator_intel</type>       <name>accelerator</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clReleaseAcceleratorINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clReleaseAcceleratorINTEL</name></proto>
             <param><type>cl_accelerator_intel</type>       <name>accelerator</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
             <proto><type>cl_event</type>                   <name>clCreateEventFromGLsyncKHR</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_GLsync</type>                  <name>sync</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clGetGLContextInfoKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetGLContextInfoKHR</name></proto>
             <param>const <type>cl_context_properties</type>*  <name>properties</name></param>
             <param><type>cl_gl_context_info</type>         <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -2823,7 +2838,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>cl_GLuint</type>                  <name>bufobj</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_mem</type>                     <name>clCreateFromGLTexture</name></proto>
@@ -2832,23 +2847,23 @@ server's OpenCL/api-docs repository.
             <param><type>cl_GLenum</type>                  <name>target</name></param>
             <param><type>cl_GLint</type>                   <name>miplevel</name></param>
             <param><type>cl_GLuint</type>                  <name>texture</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_mem</type>                     <name>clCreateFromGLRenderbuffer</name></proto>
             <param><type>cl_context</type>                 <name>context</name></param>
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>cl_GLuint</type>                  <name>renderbuffer</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clGetGLObjectInfo</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetGLObjectInfo</name></proto>
             <param><type>cl_mem</type>                     <name>memobj</name></param>
             <param><type>cl_gl_object_type</type>*         <name>gl_object_type</name></param>
             <param><type>cl_GLuint</type>*                 <name>gl_object_name</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clGetGLTextureInfo</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetGLTextureInfo</name></proto>
             <param><type>cl_mem</type>                     <name>memobj</name></param>
             <param><type>cl_gl_texture_info</type>         <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -2856,7 +2871,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireGLObjects</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireGLObjects</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2865,7 +2880,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseGLObjects</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseGLObjects</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2880,7 +2895,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_GLenum</type>                  <name>target</name></param>
             <param><type>cl_GLint</type>                   <name>miplevel</name></param>
             <param><type>cl_GLuint</type>                  <name>texture</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>cl_mem</type>                     <name>clCreateFromGLTexture3D</name></proto>
@@ -2889,10 +2904,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_GLenum</type>                  <name>target</name></param>
             <param><type>cl_GLint</type>                   <name>miplevel</name></param>
             <param><type>cl_GLuint</type>                  <name>texture</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clGetDeviceIDsFromVA_APIMediaAdapterINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetDeviceIDsFromVA_APIMediaAdapterINTEL</name></proto>
             <param><type>cl_platform_id</type>             <name>platform</name></param>
             <param><type>cl_va_api_device_source_intel</type> <name>media_adapter_type</name></param>
             <param><type>void</type>*                      <name>media_adapter</name></param>
@@ -2907,10 +2922,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>               <name>flags</name></param>
             <param><type>VASurfaceID</type>*               <name>surface</name></param>
             <param><type>cl_uint</type>                    <name>plane</name></param>
-            <param><type>cl_int</type>*                    <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*             <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueAcquireVA_APIMediaSurfacesINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueAcquireVA_APIMediaSurfacesINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2919,7 +2934,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                  <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clEnqueueReleaseVA_APIMediaSurfacesINTEL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clEnqueueReleaseVA_APIMediaSurfacesINTEL</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
             <param><type>cl_uint</type>                    <name>num_objects</name></param>
             <param>const <type>cl_mem</type>*              <name>mem_objects</name></param>
@@ -2933,7 +2948,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>alignment</name></param>
-            <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                  <name>errcode_ret</name></param>
         </command>
         <command>
             <proto><type>void</type>*                           <name>clDeviceMemAllocINTEL</name></proto>
@@ -2942,7 +2957,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>alignment</name></param>
-            <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                  <name>errcode_ret</name></param>
         </command>
         <command>
             <proto><type>void</type>*                           <name>clSharedMemAllocINTEL</name></proto>
@@ -2951,35 +2966,35 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_mem_properties_intel</type>*  <name>properties</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>cl_uint</type>                         <name>alignment</name></param>
-            <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                  <name>errcode_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clMemFreeINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clMemFreeINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param><type>void</type>*                           <name>ptr</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clMemBlockingFreeINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clMemBlockingFreeINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param><type>void</type>*                           <name>ptr</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clGetMemAllocInfoINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clGetMemAllocInfoINTEL</name></proto>
             <param><type>cl_context</type>                      <name>context</name></param>
             <param>const <type>void</type>*                     <name>ptr</name></param>
-            <param><type>cl_mem_info_intel</type>               <name>param_name</name></param>
+            <param><type>cl_mem_info</type>               <name>param_name</name></param>
             <param><type>size_t</type>                          <name>param_value_size</name></param>
             <param><type>void</type>*                           <name>param_value</name></param>
             <param><type>size_t</type>*                         <name>param_value_size_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clSetKernelArgMemPointerINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clSetKernelArgMemPointerINTEL</name></proto>
             <param><type>cl_kernel</type>                       <name>kernel</name></param>
             <param><type>cl_uint</type>                         <name>arg_index</name></param>
             <param>const <type>void</type>*                     <name>arg_value</name></param>
         </command>
         <command comment="Deprecated">
-            <proto><type>cl_int</type>                          <name>clEnqueueMemsetINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clEnqueueMemsetINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param><type>void</type>*                           <name>dst_ptr</name></param>
             <param><type>cl_int</type>                          <name>value</name></param>
@@ -2989,7 +3004,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                       <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clEnqueueMemFillINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clEnqueueMemFillINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param><type>void</type>*                           <name>dst_ptr</name></param>
             <param>const <type>void</type>*                     <name>pattern</name></param>
@@ -3000,7 +3015,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                       <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clEnqueueMemcpyINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clEnqueueMemcpyINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param><type>cl_bool</type>                         <name>blocking</name></param>
             <param><type>void</type>*                           <name>dst_ptr</name></param>
@@ -3011,7 +3026,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                       <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clEnqueueMigrateMemINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clEnqueueMigrateMemINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
@@ -3021,7 +3036,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                       <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                          <name>clEnqueueMemAdviseINTEL</name></proto>
+            <proto><type>cl_error_code</type>                   <name>clEnqueueMemAdviseINTEL</name></proto>
             <param><type>cl_command_queue</type>                <name>command_queue</name></param>
             <param>const <type>void</type>*                     <name>ptr</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
@@ -3037,29 +3052,29 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>                    <name>flags</name></param>
             <param><type>size_t</type>                          <name>size</name></param>
             <param><type>void</type>*                           <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                  <name>errcode_ret</name></param>
         </command>
         <command>
             <proto><type>cl_command_buffer_khr</type>                    <name>clCreateCommandBufferKHR</name></proto>
             <param><type>cl_uint</type>                                  <name>num_queues</name></param>
             <param>const <type>cl_command_queue</type>*                  <name>queues</name></param>
             <param>const <type>cl_command_buffer_properties_khr</type>*  <name>properties</name></param>
-            <param><type>cl_int</type>*                                  <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                           <name>errcode_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clFinalizeCommandBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clFinalizeCommandBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clRetainCommandBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clRetainCommandBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clReleaseCommandBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clReleaseCommandBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clEnqueueCommandBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clEnqueueCommandBufferKHR</name></proto>
             <param><type>cl_uint</type>                   <name>num_queues</name></param>
             <param><type>cl_command_queue</type>*         <name>queues</name></param>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
@@ -3068,7 +3083,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                 <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandBarrierWithWaitListKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandBarrierWithWaitListKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
@@ -3077,7 +3092,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandCopyBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandCopyBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
@@ -3091,7 +3106,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandCopyBufferRectKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandCopyBufferRectKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
@@ -3109,7 +3124,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandCopyBufferToImageKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandCopyBufferToImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
@@ -3123,7 +3138,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandCopyImageKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandCopyImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>src_image</name></param>
@@ -3137,7 +3152,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandCopyImageToBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandCopyImageToBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>src_image</name></param>
@@ -3151,7 +3166,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandFillBufferKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandFillBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>buffer</name></param>
@@ -3165,7 +3180,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                    <name>clCommandFillImageKHR</name></proto>
+            <proto><type>cl_error_code</type>             <name>clCommandFillImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
             <param><type>cl_mem</type>                    <name>image</name></param>
@@ -3178,7 +3193,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*   <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                                     <name>clCommandNDRangeKernelKHR</name></proto>
+            <proto><type>cl_error_code</type>                              <name>clCommandNDRangeKernelKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>                      <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>                           <name>command_queue</name></param>
             <param>const <type>cl_ndrange_kernel_command_properties_khr</type>*  <name>properties</name></param>
@@ -3193,7 +3208,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mutable_command_khr</type>*                    <name>mutable_handle</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                     <name>clGetCommandBufferInfoKHR</name></proto>
+            <proto><type>cl_error_code</type>              <name>clGetCommandBufferInfoKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>      <name>command_buffer</name></param>
             <param><type>cl_command_buffer_info_khr</type> <name>param_name</name></param>
             <param><type>size_t</type>                     <name>param_value_size</name></param>
@@ -3201,12 +3216,12 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>param_value_size_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                             <name>clUpdateMutableCommandsKHR</name></proto>
+            <proto><type>cl_error_code</type>                      <name>clUpdateMutableCommandsKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>              <name>command_buffer</name></param>
             <param>const <type>cl_mutable_base_config_khr</type>*  <name>mutable_config</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                       <name>clGetMutableCommandInfoKHR</name></proto>
+            <proto><type>cl_error_code</type>                <name>clGetMutableCommandInfoKHR</name></proto>
             <param><type>cl_mutable_command_khr</type>       <name>command</name></param>
             <param><type>cl_mutable_command_info_khr</type>  <name>param_name</name></param>
             <param><type>size_t</type>                       <name>param_value_size</name></param>
@@ -3222,21 +3237,21 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                       <name>num_handles</name></param>
             <param>const <type>cl_mutable_command_khr</type>* <name>handles</name></param>
             <param><type>cl_mutable_command_khr</type>*       <name>handles_ret</name></param>
-            <param><type>cl_int</type>*                       <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                     <name>clSetContentSizeBufferPoCL</name></proto>
+            <proto><type>cl_error_code</type>              <name>clSetContentSizeBufferPoCL</name></proto>
             <param><type>cl_mem</type>                     <name>buffer</name></param>
             <param><type>cl_mem</type>                     <name>content_size_buffer</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetPlatformIDs</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetPlatformIDs</name></proto>
             <param><type>cl_uint</type>                                 <name>num_entries</name></param>
             <param><type>cl_platform_id</type>*                         <name>platforms</name></param>
             <param><type>cl_uint</type>*                                <name>num_platforms</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetPlatformInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetPlatformInfo</name></proto>
             <param><type>cl_platform_id</type>                          <name>platform</name></param>
             <param><type>cl_platform_info</type>                        <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3244,7 +3259,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetDeviceIDs</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetDeviceIDs</name></proto>
             <param><type>cl_platform_id</type>                          <name>platform</name></param>
             <param><type>cl_device_type</type>                          <name>device_type</name></param>
             <param><type>cl_uint</type>                                 <name>num_entries</name></param>
@@ -3252,7 +3267,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                                <name>num_devices</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetDeviceInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetDeviceInfo</name></proto>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_device_info</type>                          <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3260,7 +3275,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clCreateSubDevices</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clCreateSubDevices</name></proto>
             <param><type>cl_device_id</type>                            <name>in_device</name></param>
             <param>const <type>cl_device_partition_property</type>*     <name>properties</name></param>
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
@@ -3268,27 +3283,27 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                                <name>num_devices_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clRetainDevice</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainDevice</name></proto>
             <param><type>cl_device_id</type>                            <name>device</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clReleaseDevice</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseDevice</name></proto>
             <param><type>cl_device_id</type>                            <name>device</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
-            <proto><type>cl_int</type>                                  <name>clSetDefaultDeviceCommandQueue</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetDefaultDeviceCommandQueue</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
-            <proto><type>cl_int</type>                                  <name>clGetDeviceAndHostTimer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetDeviceAndHostTimer</name></proto>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_ulong</type>*                               <name>device_timestamp</name></param>
             <param><type>cl_ulong</type>*                               <name>host_timestamp</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
-            <proto><type>cl_int</type>                                  <name>clGetHostTimer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetHostTimer</name></proto>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_ulong</type>*                               <name>host_timestamp</name></param>
         </command>
@@ -3299,7 +3314,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_device_id</type>*                     <name>devices</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char* errinfo, const void* private_info, size_t cb, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_context</type>                              <name>clCreateContextFromType</name></proto>
@@ -3307,18 +3322,18 @@ server's OpenCL/api-docs repository.
             <param><type>cl_device_type</type>                          <name>device_type</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(const char* errinfo, const void* private_info, size_t cb, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainContext</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainContext</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseContext</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseContext</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetContextInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetContextInfo</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_context_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3326,7 +3341,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                                  <name>clSetContextDestructorCallback</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetContextDestructorCallback</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_context context, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
@@ -3336,18 +3351,18 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param>const <type>cl_queue_properties</type>*              <name>properties</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainCommandQueue</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainCommandQueue</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseCommandQueue</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseCommandQueue</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetCommandQueueInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetCommandQueueInfo</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_command_queue_info</type>                   <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3360,7 +3375,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_mem</type>                                  <name>clCreateBufferWithProperties</name></proto>
@@ -3369,7 +3384,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>size_t</type>                                  <name>size</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
             <proto><type>cl_mem</type>                                  <name>clCreateSubBuffer</name></proto>
@@ -3377,7 +3392,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>cl_buffer_create_type</type>                   <name>buffer_create_type</name></param>
             <param>const <type>void</type>*                             <name>buffer_create_info</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_mem</type>                                  <name>clCreateImage</name></proto>
@@ -3386,7 +3401,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_image_format</type>*                  <name>image_format</name></param>
             <param>const <type>cl_image_desc</type>*                    <name>image_desc</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_mem</type>                                  <name>clCreateImageWithProperties</name></proto>
@@ -3396,7 +3411,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_image_format</type>*                  <name>image_format</name></param>
             <param>const <type>cl_image_desc</type>*                    <name>image_desc</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
             <proto><type>cl_mem</type>                                  <name>clCreatePipe</name></proto>
@@ -3405,18 +3420,18 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>pipe_packet_size</name></param>
             <param><type>cl_uint</type>                                 <name>pipe_max_packets</name></param>
             <param>const <type>cl_pipe_properties</type>*               <name>properties</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainMemObject</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainMemObject</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseMemObject</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseMemObject</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetSupportedImageFormats</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetSupportedImageFormats</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
             <param><type>cl_mem_object_type</type>                      <name>image_type</name></param>
@@ -3425,7 +3440,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*                                <name>num_image_formats</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetMemObjectInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetMemObjectInfo</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param><type>cl_mem_info</type>                             <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3433,7 +3448,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetImageInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetImageInfo</name></proto>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_image_info</type>                           <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3441,7 +3456,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clGetPipeInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetPipeInfo</name></proto>
             <param><type>cl_mem</type>                                  <name>pipe</name></param>
             <param><type>cl_pipe_info</type>                            <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3449,13 +3464,13 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clSetMemObjectDestructorCallback</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetMemObjectDestructorCallback</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_mem memobj, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clSetMemObjectDestructorAPPLE</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetMemObjectDestructorAPPLE</name></proto>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_mem memobj, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
@@ -3476,18 +3491,18 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_sampler</type>                              <name>clCreateSamplerWithProperties</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param>const <type>cl_sampler_properties</type>*            <name>sampler_properties</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainSampler</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainSampler</name></proto>
             <param><type>cl_sampler</type>                              <name>sampler</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseSampler</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseSampler</name></proto>
             <param><type>cl_sampler</type>                              <name>sampler</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetSamplerInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetSamplerInfo</name></proto>
             <param><type>cl_sampler</type>                              <name>sampler</name></param>
             <param><type>cl_sampler_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3500,7 +3515,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>count</name></param>
             <param>const <type>char</type>**                            <name>strings</name></param>
             <param>const <type>size_t</type>*                           <name>lengths</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_program</type>                              <name>clCreateProgramWithBinary</name></proto>
@@ -3509,8 +3524,8 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_device_id</type>*                     <name>device_list</name></param>
             <param>const <type>size_t</type>*                           <name>lengths</name></param>
             <param>const <type>unsigned char</type>**                   <name>binaries</name></param>
-            <param><type>cl_int</type>*                                 <name>binary_status</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>binary_status</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
             <proto><type>cl_program</type>                              <name>clCreateProgramWithBuiltInKernels</name></proto>
@@ -3518,25 +3533,25 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
             <param>const <type>cl_device_id</type>*                     <name>device_list</name></param>
             <param>const <type>char</type>*                             <name>kernel_names</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
             <proto><type>cl_program</type>                              <name>clCreateProgramWithIL</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param>const <type>void</type>*                             <name>il</name></param>
             <param><type>size_t</type>                                  <name>length</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainProgram</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainProgram</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseProgram</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseProgram</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clBuildProgram</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clBuildProgram</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
             <param>const <type>cl_device_id</type>*                     <name>device_list</name></param>
@@ -3545,7 +3560,7 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clCompileProgram</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clCompileProgram</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_uint</type>                                 <name>num_devices</name></param>
             <param>const <type>cl_device_id</type>*                     <name>device_list</name></param>
@@ -3566,27 +3581,27 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_program</type>*                       <name>input_programs</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_2_2_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_2_2_DEPRECATED">
-            <proto><type>cl_int</type>                                  <name>clSetProgramReleaseCallback</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetProgramReleaseCallback</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_program program, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_2">
-            <proto><type>cl_int</type>                                  <name>clSetProgramSpecializationConstant</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetProgramSpecializationConstant</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_uint</type>                                 <name>spec_id</name></param>
             <param><type>size_t</type>                                  <name>spec_size</name></param>
             <param>const <type>void</type>*                             <name>spec_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clUnloadPlatformCompiler</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clUnloadPlatformCompiler</name></proto>
             <param><type>cl_platform_id</type>                          <name>platform</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetProgramInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetProgramInfo</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_program_info</type>                         <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3594,7 +3609,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetProgramBuildInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetProgramBuildInfo</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_program_build_info</type>                   <name>param_name</name></param>
@@ -3606,10 +3621,10 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_kernel</type>                               <name>clCreateKernel</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param>const <type>char</type>*                             <name>kernel_name</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clCreateKernelsInProgram</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clCreateKernelsInProgram</name></proto>
             <param><type>cl_program</type>                              <name>program</name></param>
             <param><type>cl_uint</type>                                 <name>num_kernels</name></param>
             <param><type>cl_kernel</type>*                              <name>kernels</name></param>
@@ -3618,38 +3633,38 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
             <proto><type>cl_kernel</type>                               <name>clCloneKernel</name></proto>
             <param><type>cl_kernel</type>                               <name>source_kernel</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainKernel</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainKernel</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseKernel</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseKernel</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clSetKernelArg</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetKernelArg</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>arg_index</name></param>
             <param><type>size_t</type>                                  <name>arg_size</name></param>
             <param>const <type>void</type>*                             <name>arg_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clSetKernelArgSVMPointer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetKernelArgSVMPointer</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>arg_index</name></param>
             <param>const <type>void</type>*                             <name>arg_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clSetKernelExecInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetKernelExecInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_kernel_exec_info</type>                     <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param>const <type>void</type>*                             <name>param_value</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetKernelInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetKernelInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_kernel_info</type>                          <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3657,7 +3672,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clGetKernelArgInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetKernelArgInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>arg_index</name></param>
             <param><type>cl_kernel_arg_info</type>                      <name>param_name</name></param>
@@ -3666,7 +3681,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetKernelWorkGroupInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetKernelWorkGroupInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_kernel_work_group_info</type>               <name>param_name</name></param>
@@ -3675,7 +3690,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
-            <proto><type>cl_int</type>                                  <name>clGetKernelSubGroupInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetKernelSubGroupInfo</name></proto>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_kernel_sub_group_info</type>                <name>param_name</name></param>
@@ -3686,12 +3701,12 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clWaitForEvents</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clWaitForEvents</name></proto>
             <param><type>cl_uint</type>                                 <name>num_events</name></param>
             <param>const <type>cl_event</type>*                         <name>event_list</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetEventInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetEventInfo</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_event_info</type>                           <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3701,30 +3716,30 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
             <proto><type>cl_event</type>                                <name>clCreateUserEvent</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clRetainEvent</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clRetainEvent</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clReleaseEvent</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clReleaseEvent</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clSetUserEventStatus</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetUserEventStatus</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
-            <param><type>cl_int</type>                                  <name>execution_status</name></param>
+            <param><type>cl_command_execution_status</type>             <name>execution_status</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clSetEventCallback</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetEventCallback</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
-            <param><type>cl_int</type>                                  <name>command_exec_callback_type</name></param>
-            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_event event, cl_int event_command_status, void *user_data)</param>
+            <param><type>cl_command_execution_status</type>             <name>command_exec_callback_type</name></param>
+            <param>void (CL_CALLBACK*                                   <name>pfn_notify</name>)(cl_event event, cl_command_execution_status event_command_status, void* user_data)</param>
             <param><type>void</type>*                                   <name>user_data</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clGetEventProfilingInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetEventProfilingInfo</name></proto>
             <param><type>cl_event</type>                                <name>event</name></param>
             <param><type>cl_profiling_info</type>                       <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -3732,15 +3747,15 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clFlush</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clFlush</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clFinish</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clFinish</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueReadBuffer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueReadBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
@@ -3752,7 +3767,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clEnqueueReadBufferRect</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueReadBufferRect</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
@@ -3769,7 +3784,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueWriteBuffer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueWriteBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
@@ -3781,7 +3796,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clEnqueueWriteBufferRect</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueWriteBufferRect</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
@@ -3798,7 +3813,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clEnqueueFillBuffer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueFillBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>buffer</name></param>
             <param>const <type>void</type>*                             <name>pattern</name></param>
@@ -3810,7 +3825,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueCopyBuffer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueCopyBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_buffer</name></param>
             <param><type>cl_mem</type>                                  <name>dst_buffer</name></param>
@@ -3822,7 +3837,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_1">
-            <proto><type>cl_int</type>                                  <name>clEnqueueCopyBufferRect</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueCopyBufferRect</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_buffer</name></param>
             <param><type>cl_mem</type>                                  <name>dst_buffer</name></param>
@@ -3838,7 +3853,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueReadImage</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueReadImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_read</name></param>
@@ -3852,7 +3867,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueWriteImage</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueWriteImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_write</name></param>
@@ -3866,7 +3881,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clEnqueueFillImage</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueFillImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>image</name></param>
             <param>const <type>void</type>*                             <name>fill_color</name></param>
@@ -3877,7 +3892,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueCopyImage</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueCopyImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_image</name></param>
             <param><type>cl_mem</type>                                  <name>dst_image</name></param>
@@ -3889,7 +3904,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueCopyImageToBuffer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueCopyImageToBuffer</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_image</name></param>
             <param><type>cl_mem</type>                                  <name>dst_buffer</name></param>
@@ -3901,7 +3916,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueCopyBufferToImage</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueCopyBufferToImage</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>src_buffer</name></param>
             <param><type>cl_mem</type>                                  <name>dst_image</name></param>
@@ -3923,7 +3938,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>void</type>*                                   <name>clEnqueueMapImage</name></proto>
@@ -3938,10 +3953,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueUnmapMemObject</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueUnmapMemObject</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_mem</type>                                  <name>memobj</name></param>
             <param><type>void</type>*                                   <name>mapped_ptr</name></param>
@@ -3950,7 +3965,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clEnqueueMigrateMemObjects</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueMigrateMemObjects</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_mem_objects</name></param>
             <param>const <type>cl_mem</type>*                           <name>mem_objects</name></param>
@@ -3960,7 +3975,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueNDRangeKernel</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueNDRangeKernel</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>work_dim</name></param>
@@ -3972,7 +3987,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueNativeKernel</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueNativeKernel</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param>void (CL_CALLBACK*                                   <name>user_func</name>)(void*)</param>
             <param><type>void</type>*                                   <name>args</name></param>
@@ -3985,21 +4000,21 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clEnqueueMarkerWithWaitList</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueMarkerWithWaitList</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                                  <name>clEnqueueBarrierWithWaitList</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueBarrierWithWaitList</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
             <param>const <type>cl_event</type>*                         <name>event_wait_list</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMFree</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMFree</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_svm_pointers</name></param>
             <param><type>void</type>*                                   <name>svm_pointers</name>[]</param>
@@ -4010,7 +4025,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMMemcpy</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMMemcpy</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_copy</name></param>
             <param><type>void</type>*                                   <name>dst_ptr</name></param>
@@ -4021,7 +4036,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMMemFill</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMMemFill</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>void</type>*                                   <name>svm_ptr</name></param>
             <param>const <type>void</type>*                             <name>pattern</name></param>
@@ -4032,7 +4047,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMMap</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMMap</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_bool</type>                                 <name>blocking_map</name></param>
             <param><type>cl_map_flags</type>                            <name>flags</name></param>
@@ -4043,7 +4058,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_0">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMUnmap</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMUnmap</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>void</type>*                                   <name>svm_ptr</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -4051,7 +4066,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_2_1">
-            <proto><type>cl_int</type>                                  <name>clEnqueueSVMMigrateMem</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueSVMMigrateMem</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_svm_pointers</name></param>
             <param>const <type>void</type>**                            <name>svm_pointers</name></param>
@@ -4067,7 +4082,7 @@ server's OpenCL/api-docs repository.
             <param>const <type>char</type>*                             <name>func_name</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0_DEPRECATED">
-            <proto><type>cl_int</type>                                  <name>clSetCommandQueueProperty</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clSetCommandQueueProperty</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_command_queue_properties</type>             <name>properties</name></param>
             <param><type>cl_bool</type>                                 <name>enable</name></param>
@@ -4082,7 +4097,7 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>image_height</name></param>
             <param><type>size_t</type>                                  <name>image_row_pitch</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>cl_mem</type> <name>clCreateImage3D</name></proto>
@@ -4095,25 +4110,25 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>                                  <name>image_row_pitch</name></param>
             <param><type>size_t</type>                                  <name>image_slice_pitch</name></param>
             <param><type>void</type>*                                   <name>host_ptr</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
-            <proto><type>cl_int</type> <name>clEnqueueMarker</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueMarker</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
-            <proto><type>cl_int</type> <name>clEnqueueWaitForEvents</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueWaitForEvents</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_uint</type>                                 <name>num_events</name></param>
             <param>const <type>cl_event</type>*                         <name>event_list</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
-            <proto><type>cl_int</type> <name>clEnqueueBarrier</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueBarrier</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
-            <proto><type>cl_int</type> <name>clUnloadCompiler</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clUnloadCompiler</name></proto>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_1_DEPRECATED">
             <proto><type>void</type>*  <name>clGetExtensionFunctionAddress</name></proto>
@@ -4124,7 +4139,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_context</type>                              <name>context</name></param>
             <param><type>cl_device_id</type>                            <name>device</name></param>
             <param><type>cl_command_queue_properties</type>             <name>properties</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_2_DEPRECATED">
             <proto><type>cl_sampler</type> <name>clCreateSampler</name></proto>
@@ -4132,10 +4147,10 @@ server's OpenCL/api-docs repository.
             <param><type>cl_bool</type>                                 <name>normalized_coords</name></param>
             <param><type>cl_addressing_mode</type>                      <name>addressing_mode</name></param>
             <param><type>cl_filter_mode</type>                          <name>filter_mode</name></param>
-            <param><type>cl_int</type>*                                 <name>errcode_ret</name></param>
+            <param><type>cl_error_code</type>*                          <name>errcode_ret</name></param>
         </command>
         <command prefix="CL_API_PREFIX__VERSION_1_1_DEPRECATED" suffix="CL_API_SUFFIX__VERSION_1_2_DEPRECATED">
-            <proto><type>cl_int</type> <name>clEnqueueTask</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clEnqueueTask</name></proto>
             <param><type>cl_command_queue</type>                        <name>command_queue</name></param>
             <param><type>cl_kernel</type>                               <name>kernel</name></param>
             <param><type>cl_uint</type>                                 <name>num_events_in_wait_list</name></param>
@@ -4143,28 +4158,28 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*                               <name>event</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                                  <name>clGetLayerInfo</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetLayerInfo</name></proto>
             <param><type>cl_layer_info</type>                           <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                                  <name>clInitLayer</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clInitLayer</name></proto>
             <param><type>cl_uint</type>                                 <name>num_entries</name></param>
             <param>const <type>cl_icd_dispatch</type>*                  <name>target_dispatch</name></param>
             <param><type>cl_uint</type>*                                <name>num_entries_ret</name></param>
             <param>const <type>cl_icd_dispatch</type>**                 <name>layer_dispatch_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>                                  <name>clGetICDLoaderInfoOCLICD</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetICDLoaderInfoOCLICD</name></proto>
             <param><type>cl_icdl_info</type>                            <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
             <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>              <name>clGetSupportedGLTextureFormatsINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clGetSupportedGLTextureFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
             <param><type>cl_mem_object_type</type>  <name>image_type</name></param>
@@ -4173,7 +4188,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*            <name>num_texture_formats</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>              <name>clGetSupportedDX9MediaSurfaceFormatsINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clGetSupportedDX9MediaSurfaceFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
             <param><type>cl_mem_object_type</type>  <name>image_type</name></param>
@@ -4183,7 +4198,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*            <name>num_surface_formats</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>              <name>clGetSupportedD3D10TextureFormatsINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clGetSupportedD3D10TextureFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
             <param><type>cl_mem_object_type</type>  <name>image_type</name></param>
@@ -4192,7 +4207,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*            <name>num_texture_formats</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>              <name>clGetSupportedD3D11TextureFormatsINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clGetSupportedD3D11TextureFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
             <param><type>cl_mem_object_type</type>  <name>image_type</name></param>
@@ -4202,7 +4217,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*            <name>num_texture_formats</name></param>
         </command>
         <command>
-            <proto><type>cl_int</type>              <name>clGetSupportedVA_APIMediaSurfaceFormatsINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clGetSupportedVA_APIMediaSurfaceFormatsINTEL</name></proto>
             <param><type>cl_context</type>          <name>context</name></param>
             <param><type>cl_mem_flags</type>        <name>flags</name></param>
             <param><type>cl_mem_object_type</type>  <name>image_type</name></param>
@@ -4212,7 +4227,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_uint</type>*            <name>num_surface_formats</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>              <name>clEnqueueReadHostPipeINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clEnqueueReadHostPipeINTEL</name></proto>
             <param><type>cl_command_queue</type>    <name>command_queue</name></param>
             <param><type>cl_program</type>          <name>program</name></param>
             <param>const <type>char</type>*         <name>pipe_symbol</name></param>
@@ -4224,7 +4239,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*           <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
-            <proto><type>cl_int</type>              <name>clEnqueueWriteHostPipeINTEL</name></proto>
+            <proto><type>cl_error_code</type>       <name>clEnqueueWriteHostPipeINTEL</name></proto>
             <param><type>cl_command_queue</type>    <name>command_queue</name></param>
             <param><type>cl_program</type>          <name>program</name></param>
             <param>const <type>char</type>*         <name>pipe_symbol</name></param>
@@ -4236,7 +4251,7 @@ server's OpenCL/api-docs repository.
             <param><type>cl_event</type>*           <name>event</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                                  <name>clGetImageRequirementsInfoEXT</name></proto>
+            <proto><type>cl_error_code</type>                           <name>clGetImageRequirementsInfoEXT</name></proto>
             <param><type>cl_context</type>                              <name>context</name></param>
             <param>const <type>cl_mem_properties</type>*                <name>properties</name></param>
             <param><type>cl_mem_flags</type>                            <name>flags</name></param>
@@ -4299,7 +4314,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_image_format"/>
             <type name="cl_buffer_region"/>
         </require>
-        <require comment="Constants">
+        <require etype="constants">
             <enum name="CL_CHAR_BIT"/>
             <enum name="CL_CHAR_MAX"/>
             <enum name="CL_CHAR_MIN"/>
@@ -4341,7 +4356,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_MAXFLOAT"/>
             <enum name="CL_INFINITY"/>
         </require>
-        <require comment="Error codes">
+        <require group="cl_error_code">
             <enum name="CL_SUCCESS"/>
             <enum name="CL_DEVICE_NOT_FOUND"/>
             <enum name="CL_DEVICE_NOT_AVAILABLE"/>
@@ -4390,25 +4405,25 @@ server's OpenCL/api-docs repository.
             <enum name="CL_INVALID_MIP_LEVEL"/>
             <enum name="CL_INVALID_GLOBAL_WORK_SIZE"/>
         </require>
-        <require comment="cl_bool">
+        <require group="cl_bool">
             <enum name="CL_FALSE"/>
             <enum name="CL_TRUE"/>
         </require>
-        <require comment="cl_platform_info">
+        <require group="cl_platform_info">
             <enum name="CL_PLATFORM_PROFILE"/>
             <enum name="CL_PLATFORM_VERSION"/>
             <enum name="CL_PLATFORM_NAME"/>
             <enum name="CL_PLATFORM_VENDOR"/>
             <enum name="CL_PLATFORM_EXTENSIONS"/>
         </require>
-        <require comment="cl_device_type - bitfield">
+        <require group="cl_device_type" etype="bitfield">
             <enum name="CL_DEVICE_TYPE_DEFAULT"/>
             <enum name="CL_DEVICE_TYPE_CPU"/>
             <enum name="CL_DEVICE_TYPE_GPU"/>
             <enum name="CL_DEVICE_TYPE_ACCELERATOR"/>
             <enum name="CL_DEVICE_TYPE_ALL"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_TYPE"/>
             <enum name="CL_DEVICE_VENDOR_ID"/>
             <enum name="CL_DEVICE_MAX_COMPUTE_UNITS"/>
@@ -4458,7 +4473,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_EXTENSIONS"/>
             <enum name="CL_DEVICE_PLATFORM"/>
         </require>
-        <require comment="cl_device_fp_config - bitfield">
+        <require group="cl_device_fp_config" etype="bitfield">
             <enum name="CL_FP_DENORM"/>
             <enum name="CL_FP_INF_NAN"/>
             <enum name="CL_FP_ROUND_TO_NEAREST"/>
@@ -4466,38 +4481,39 @@ server's OpenCL/api-docs repository.
             <enum name="CL_FP_ROUND_TO_INF"/>
             <enum name="CL_FP_FMA"/>
         </require>
-        <require comment="cl_device_mem_cache_type">
+        <require group="cl_device_mem_cache_type">
             <enum name="CL_NONE"/>
             <enum name="CL_READ_ONLY_CACHE"/>
             <enum name="CL_READ_WRITE_CACHE"/>
         </require>
-        <require comment="cl_device_local_mem_type">
+        <require group="cl_device_local_mem_type">
             <enum name="CL_LOCAL"/>
             <enum name="CL_GLOBAL"/>
         </require>
-        <require comment="cl_device_exec_capabilities - bitfield">
+        <require group="cl_device_exec_capabilities" etype="bitfield">
             <enum name="CL_EXEC_KERNEL"/>
             <enum name="CL_EXEC_NATIVE_KERNEL"/>
         </require>
-        <require comment="cl_command_queue_properties - bitfield">
+        <require group="cl_command_queue_properties" etype="bitfield">
+            <enum name="CL_NONE"/>
             <enum name="CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE"/>
             <enum name="CL_QUEUE_PROFILING_ENABLE"/>
         </require>
-        <require comment="cl_context_info">
+        <require group="cl_context_info" comment="For getting info from existing context">
             <enum name="CL_CONTEXT_REFERENCE_COUNT"/>
             <enum name="CL_CONTEXT_DEVICES"/>
             <enum name="CL_CONTEXT_PROPERTIES"/>
         </require>
-        <require comment="cl_context_properties">
+        <require group="cl_context_properties" comment="For creating context with properties">
             <enum name="CL_CONTEXT_PLATFORM"/>
         </require>
-        <require comment="cl_command_queue_info">
+        <require group="cl_command_queue_info">
             <enum name="CL_QUEUE_CONTEXT"/>
             <enum name="CL_QUEUE_DEVICE"/>
             <enum name="CL_QUEUE_REFERENCE_COUNT"/>
             <enum name="CL_QUEUE_PROPERTIES"/>
         </require>
-        <require comment="cl_mem_flags and cl_svm_mem_flags - bitfield">
+        <require group="cl_mem_flags" etype="bitfield">
             <enum name="CL_MEM_READ_WRITE"/>
             <enum name="CL_MEM_WRITE_ONLY"/>
             <enum name="CL_MEM_READ_ONLY"/>
@@ -4505,13 +4521,21 @@ server's OpenCL/api-docs repository.
             <enum name="CL_MEM_ALLOC_HOST_PTR"/>
             <enum name="CL_MEM_COPY_HOST_PTR"/>
         </require>
-        <require comment="cl_profiling_info">
+        <require group="cl_svm_mem_flags" etype="bitfield">
+            <enum name="CL_MEM_READ_WRITE"/>
+            <enum name="CL_MEM_WRITE_ONLY"/>
+            <enum name="CL_MEM_READ_ONLY"/>
+            <enum name="CL_MEM_USE_HOST_PTR"/>
+            <enum name="CL_MEM_ALLOC_HOST_PTR"/>
+            <enum name="CL_MEM_COPY_HOST_PTR"/>
+        </require>
+        <require group="cl_profiling_info">
             <enum name="CL_PROFILING_COMMAND_QUEUED"/>
             <enum name="CL_PROFILING_COMMAND_SUBMIT"/>
             <enum name="CL_PROFILING_COMMAND_START"/>
             <enum name="CL_PROFILING_COMMAND_END"/>
         </require>
-        <require comment="cl_channel_order">
+        <require group="cl_channel_order">
             <enum name="CL_R"/>
             <enum name="CL_A"/>
             <enum name="CL_RG"/>
@@ -4523,7 +4547,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_INTENSITY"/>
             <enum name="CL_LUMINANCE"/>
         </require>
-        <require comment="cl_channel_type">
+        <require group="cl_channel_type">
             <enum name="CL_SNORM_INT8"/>
             <enum name="CL_SNORM_INT16"/>
             <enum name="CL_UNORM_INT8"/>
@@ -4540,12 +4564,12 @@ server's OpenCL/api-docs repository.
             <enum name="CL_HALF_FLOAT"/>
             <enum name="CL_FLOAT"/>
         </require>
-        <require comment="cl_mem_object_type">
+        <require group="cl_mem_object_type">
             <enum name="CL_MEM_OBJECT_BUFFER"/>
             <enum name="CL_MEM_OBJECT_IMAGE2D"/>
             <enum name="CL_MEM_OBJECT_IMAGE3D"/>
         </require>
-        <require comment="cl_mem_info">
+        <require group="cl_mem_info">
             <enum name="CL_MEM_TYPE"/>
             <enum name="CL_MEM_FLAGS"/>
             <enum name="CL_MEM_SIZE"/>
@@ -4554,7 +4578,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_MEM_REFERENCE_COUNT"/>
             <enum name="CL_MEM_CONTEXT"/>
         </require>
-        <require comment="cl_image_info">
+        <require group="cl_image_info">
             <enum name="CL_IMAGE_FORMAT"/>
             <enum name="CL_IMAGE_ELEMENT_SIZE"/>
             <enum name="CL_IMAGE_ROW_PITCH"/>
@@ -4563,28 +4587,28 @@ server's OpenCL/api-docs repository.
             <enum name="CL_IMAGE_HEIGHT"/>
             <enum name="CL_IMAGE_DEPTH"/>
         </require>
-        <require comment="cl_addressing_mode">
+        <require group="cl_addressing_mode">
             <enum name="CL_ADDRESS_NONE"/>
             <enum name="CL_ADDRESS_CLAMP_TO_EDGE"/>
             <enum name="CL_ADDRESS_CLAMP"/>
             <enum name="CL_ADDRESS_REPEAT"/>
         </require>
-        <require comment="cl_filter_mode">
+        <require group="cl_filter_mode">
             <enum name="CL_FILTER_NEAREST"/>
             <enum name="CL_FILTER_LINEAR"/>
         </require>
-        <require comment="cl_sampler_info">
+        <require group="cl_sampler_info">
             <enum name="CL_SAMPLER_REFERENCE_COUNT"/>
             <enum name="CL_SAMPLER_CONTEXT"/>
             <enum name="CL_SAMPLER_NORMALIZED_COORDS"/>
             <enum name="CL_SAMPLER_ADDRESSING_MODE"/>
             <enum name="CL_SAMPLER_FILTER_MODE"/>
         </require>
-        <require comment="cl_map_flags - bitfield">
+        <require group="cl_map_flags" etype="bitfield">
             <enum name="CL_MAP_READ"/>
             <enum name="CL_MAP_WRITE"/>
         </require>
-        <require comment="cl_program_info">
+        <require group="cl_program_info">
             <enum name="CL_PROGRAM_REFERENCE_COUNT"/>
             <enum name="CL_PROGRAM_CONTEXT"/>
             <enum name="CL_PROGRAM_NUM_DEVICES"/>
@@ -4593,38 +4617,38 @@ server's OpenCL/api-docs repository.
             <enum name="CL_PROGRAM_BINARY_SIZES"/>
             <enum name="CL_PROGRAM_BINARIES"/>
         </require>
-        <require comment="cl_program_build_info">
+        <require group="cl_program_build_info">
             <enum name="CL_PROGRAM_BUILD_STATUS"/>
             <enum name="CL_PROGRAM_BUILD_OPTIONS"/>
             <enum name="CL_PROGRAM_BUILD_LOG"/>
         </require>
-        <require comment="cl_build_status">
+        <require group="cl_build_status">
             <enum name="CL_BUILD_SUCCESS"/>
             <enum name="CL_BUILD_NONE"/>
             <enum name="CL_BUILD_ERROR"/>
             <enum name="CL_BUILD_IN_PROGRESS"/>
         </require>
-        <require comment="cl_kernel_info">
+        <require group="cl_kernel_info">
             <enum name="CL_KERNEL_FUNCTION_NAME"/>
             <enum name="CL_KERNEL_NUM_ARGS"/>
             <enum name="CL_KERNEL_REFERENCE_COUNT"/>
             <enum name="CL_KERNEL_CONTEXT"/>
             <enum name="CL_KERNEL_PROGRAM"/>
         </require>
-        <require comment="cl_kernel_work_group_info">
+        <require group="cl_kernel_work_group_info">
             <enum name="CL_KERNEL_WORK_GROUP_SIZE"/>
             <enum name="CL_KERNEL_COMPILE_WORK_GROUP_SIZE"/>
             <enum name="CL_KERNEL_LOCAL_MEM_SIZE"/>
             <enum name="CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE"/>
             <enum name="CL_KERNEL_PRIVATE_MEM_SIZE"/>
         </require>
-        <require comment="cl_event_info">
+        <require group="cl_event_info">
             <enum name="CL_EVENT_COMMAND_QUEUE"/>
             <enum name="CL_EVENT_COMMAND_TYPE"/>
             <enum name="CL_EVENT_REFERENCE_COUNT"/>
             <enum name="CL_EVENT_COMMAND_EXECUTION_STATUS"/>
         </require>
-        <require comment="cl_command_type">
+        <require group="cl_command_type">
             <enum name="CL_COMMAND_NDRANGE_KERNEL"/>
             <enum name="CL_COMMAND_TASK"/>
             <enum name="CL_COMMAND_NATIVE_KERNEL"/>
@@ -4643,13 +4667,13 @@ server's OpenCL/api-docs repository.
             <enum name="CL_COMMAND_ACQUIRE_GL_OBJECTS"/>
             <enum name="CL_COMMAND_RELEASE_GL_OBJECTS"/>
         </require>
-        <require comment="command execution status">
+        <require group="cl_command_execution_status">
             <enum name="CL_COMPLETE"/>
             <enum name="CL_RUNNING"/>
             <enum name="CL_SUBMITTED"/>
             <enum name="CL_QUEUED"/>
         </require>
-        <require comment="cl_khronos_vendor_id">
+        <require group="cl_khronos_vendor_id">
             <!-- The cl_khronos_vendor_id type was added in OpenCL 3.0, but the
                  concept of assigned vendor IDs has existed since OpenCL 1.0.
                  These enums can be used in any OpenCL version because the type
@@ -4762,7 +4786,7 @@ server's OpenCL/api-docs repository.
             <command name="clUnloadCompiler"/>
             <command name="clGetExtensionFunctionAddress"/>
         </require>
-        <require comment="OpenCL 1.0 cl_device_info enums that were deprecated in OpenCL 1.2">
+        <require group="cl_device_info" comment="OpenCL 1.0 cl_device_info enums that were deprecated in OpenCL 1.2">
             <enum name="CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE"/>
         </require>
         <require comment="OpenCL 1.0 APIs that were deprecated in OpenCL 2.0">
@@ -4770,7 +4794,7 @@ server's OpenCL/api-docs repository.
             <command name="clCreateSampler"/>
             <command name="clEnqueueTask"/>
         </require>
-        <require comment="OpenCL 1.0 cl_device_info enums that were deprecated in OpenCL 2.0">
+        <require group="cl_device_info" comment="OpenCL 1.0 cl_device_info enums that were deprecated in OpenCL 2.0">
             <enum name="CL_DEVICE_QUEUE_PROPERTIES"/>
         </require>
     </feature>
@@ -4779,19 +4803,19 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_buffer_create_type"/>
         </require>
-        <require comment="Constants">
+        <require etype="constants">
             <enum name="CL_NAN"/>
             <enum name="CL_HUGE_VALF"/>
             <enum name="CL_HUGE_VAL"/>
             <enum name="CL_MAXFLOAT"/>
             <enum name="CL_INFINITY"/>
         </require>
-        <require comment="Error codes">
+        <require group="cl_error_code">
             <enum name="CL_MISALIGNED_SUB_BUFFER_OFFSET"/>
             <enum name="CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST"/>
             <enum name="CL_INVALID_PROPERTY"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF"/>
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR"/>
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT"/>
@@ -4801,34 +4825,34 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE"/>
             <enum name="CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF"/>
         </require>
-        <require comment="cl_device_fp_config - bitfield">
+        <require group="cl_device_fp_config" etype="bitfield">
             <enum name="CL_FP_SOFT_FLOAT"/>
         </require>
-        <require comment="cl_context_info">
+        <require group="cl_context_info">
             <enum name="CL_CONTEXT_NUM_DEVICES"/>
         </require>
-        <require comment="cl_channel_order">
+        <require group="cl_channel_order">
             <enum name="CL_Rx"/>
             <enum name="CL_RGx"/>
             <enum name="CL_RGBx"/>
         </require>
-        <require comment="cl_mem_info">
+        <require group="cl_mem_info">
             <enum name="CL_MEM_ASSOCIATED_MEMOBJECT"/>
             <enum name="CL_MEM_OFFSET"/>
         </require>
-        <require comment="cl_addressing_mode">
+        <require group="cl_addressing_mode">
             <enum name="CL_ADDRESS_MIRRORED_REPEAT"/>
         </require>
-        <require comment="cl_event_info">
+        <require group="cl_event_info">
             <enum name="CL_EVENT_CONTEXT"/>
         </require>
-        <require comment="cl_command_type">
+        <require group="cl_command_type">
             <enum name="CL_COMMAND_READ_BUFFER_RECT"/>
             <enum name="CL_COMMAND_WRITE_BUFFER_RECT"/>
             <enum name="CL_COMMAND_COPY_BUFFER_RECT"/>
             <enum name="CL_COMMAND_USER"/>
         </require>
-        <require comment="cl_buffer_create_type">
+        <require group="cl_buffer_create_type">
             <enum name="CL_BUFFER_CREATE_TYPE_REGION"/>
         </require>
         <require comment="Memory Object APIs">
@@ -4845,10 +4869,10 @@ server's OpenCL/api-docs repository.
             <command name="clEnqueueWriteBufferRect"/>
             <command name="clEnqueueCopyBufferRect"/>
         </require>
-        <require comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 2.0">
+        <require group="cl_device_info" comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 2.0">
             <enum name="CL_DEVICE_HOST_UNIFIED_MEMORY"/>
         </require>
-        <require comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 3.0">
+        <require group="cl_device_info" comment="OpenCL 1.1 cl_device_info enums that were deprecated in OpenCL 3.0">
             <enum name="CL_DEVICE_OPENCL_C_VERSION"/>
         </require>
     </feature>
@@ -4865,7 +4889,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_kernel_arg_type_qualifier"/>
             <type name="cl_image_desc"/>
         </require>
-        <require comment="Constants">
+        <require etype="constants">
             <enum name="CL_DBL_DIG"/>
             <enum name="CL_DBL_MANT_DIG"/>
             <enum name="CL_DBL_MAX_10_EXP"/>
@@ -4877,7 +4901,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DBL_MIN"/>
             <enum name="CL_DBL_EPSILON"/>
         </require>
-        <require comment="Error codes">
+        <require group="cl_error_code">
             <enum name="CL_COMPILE_PROGRAM_FAILURE"/>
             <enum name="CL_LINKER_NOT_AVAILABLE"/>
             <enum name="CL_LINK_PROGRAM_FAILURE"/>
@@ -4888,20 +4912,20 @@ server's OpenCL/api-docs repository.
             <enum name="CL_INVALID_LINKER_OPTIONS"/>
             <enum name="CL_INVALID_DEVICE_PARTITION_COUNT"/>
         </require>
-        <require comment="cl_command_type">
+        <require group="cl_command_type">
             <enum name="CL_COMMAND_BARRIER"/>
             <enum name="CL_COMMAND_MIGRATE_MEM_OBJECTS"/>
             <enum name="CL_COMMAND_FILL_BUFFER"/>
             <enum name="CL_COMMAND_FILL_IMAGE"/>
         </require>
-        <require comment="cl_bool">
+        <require group="cl_bool">
             <enum name="CL_BLOCKING"/>
             <enum name="CL_NON_BLOCKING"/>
         </require>
-        <require comment="cl_device_type - bitfield">
+        <require group="cl_device_type" etype="bitfield">
             <enum name="CL_DEVICE_TYPE_CUSTOM"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_DOUBLE_FP_CONFIG"/>
             <enum name="CL_DEVICE_LINKER_AVAILABLE"/>
             <enum name="CL_DEVICE_BUILT_IN_KERNELS"/>
@@ -4916,19 +4940,19 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_PREFERRED_INTEROP_USER_SYNC"/>
             <enum name="CL_DEVICE_PRINTF_BUFFER_SIZE"/>
         </require>
-        <require comment="cl_device_fp_config - bitfield">
+        <require group="cl_device_fp_config" etype="bitfield">
             <enum name="CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT"/>
         </require>
-        <require comment="cl_context_properties">
+        <require group="cl_context_properties">
             <enum name="CL_CONTEXT_INTEROP_USER_SYNC"/>
         </require>
-        <require comment="cl_device_partition_property">
+        <require group="cl_device_partition_property">
             <enum name="CL_DEVICE_PARTITION_EQUALLY"/>
             <enum name="CL_DEVICE_PARTITION_BY_COUNTS"/>
             <enum name="CL_DEVICE_PARTITION_BY_COUNTS_LIST_END"/>
             <enum name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN"/>
         </require>
-        <require comment="cl_device_affinity_domain">
+        <require group="cl_device_affinity_domain" etype="bitfield">
             <enum name="CL_DEVICE_AFFINITY_DOMAIN_NUMA"/>
             <enum name="CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE"/>
             <enum name="CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE"/>
@@ -4936,71 +4960,76 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE"/>
             <enum name="CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE"/>
         </require>
-        <require comment="cl_mem_flags and cl_svm_mem_flags - bitfield">
+        <require group="cl_mem_flags" etype="bitfield">
             <enum name="CL_MEM_HOST_WRITE_ONLY"/>
             <enum name="CL_MEM_HOST_READ_ONLY"/>
             <enum name="CL_MEM_HOST_NO_ACCESS"/>
         </require>
-        <require comment="cl_mem_migration_flags - bitfield">
+        <require group="cl_svm_mem_flags" etype="bitfield">
+            <enum name="CL_MEM_HOST_WRITE_ONLY"/>
+            <enum name="CL_MEM_HOST_READ_ONLY"/>
+            <enum name="CL_MEM_HOST_NO_ACCESS"/>
+        </require>
+        <require group="cl_mem_migration_flags" etype="bitfield">
             <enum name="CL_MIGRATE_MEM_OBJECT_HOST"/>
             <enum name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED"/>
         </require>
-        <require comment="cl_mem_object_type">
+        <require group="cl_mem_object_type">
             <enum name="CL_MEM_OBJECT_IMAGE2D_ARRAY"/>
             <enum name="CL_MEM_OBJECT_IMAGE1D"/>
             <enum name="CL_MEM_OBJECT_IMAGE1D_ARRAY"/>
             <enum name="CL_MEM_OBJECT_IMAGE1D_BUFFER"/>
         </require>
-        <require comment="cl_image_info">
+        <require group="cl_image_info">
             <enum name="CL_IMAGE_ARRAY_SIZE"/>
             <enum name="CL_IMAGE_NUM_MIP_LEVELS"/>
             <enum name="CL_IMAGE_NUM_SAMPLES"/>
         </require>
-        <require comment="cl_map_flags - bitfield">
+        <require group="cl_map_flags" etype="bitfield">
             <enum name="CL_MAP_WRITE_INVALIDATE_REGION"/>
         </require>
-        <require comment="cl_program_info">
+        <require group="cl_program_info">
             <enum name="CL_PROGRAM_NUM_KERNELS"/>
             <enum name="CL_PROGRAM_KERNEL_NAMES"/>
         </require>
-        <require comment="cl_program_build_info">
+        <require group="cl_program_build_info">
             <enum name="CL_PROGRAM_BINARY_TYPE"/>
         </require>
-        <require comment="cl_program_binary_type">
+        <require group="cl_program_binary_type">
             <enum name="CL_PROGRAM_BINARY_TYPE_NONE"/>
             <enum name="CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT"/>
             <enum name="CL_PROGRAM_BINARY_TYPE_LIBRARY"/>
             <enum name="CL_PROGRAM_BINARY_TYPE_EXECUTABLE"/>
         </require>
-        <require comment="cl_kernel_info">
+        <require group="cl_kernel_info">
             <enum name="CL_KERNEL_ATTRIBUTES"/>
         </require>
-        <require comment="cl_kernel_arg_info">
+        <require group="cl_kernel_arg_info">
             <enum name="CL_KERNEL_ARG_ADDRESS_QUALIFIER"/>
             <enum name="CL_KERNEL_ARG_ACCESS_QUALIFIER"/>
             <enum name="CL_KERNEL_ARG_TYPE_NAME"/>
             <enum name="CL_KERNEL_ARG_TYPE_QUALIFIER"/>
             <enum name="CL_KERNEL_ARG_NAME"/>
         </require>
-        <require comment="cl_kernel_arg_address_qualifier">
+        <require group="cl_kernel_arg_address_qualifier">
             <enum name="CL_KERNEL_ARG_ADDRESS_GLOBAL"/>
             <enum name="CL_KERNEL_ARG_ADDRESS_LOCAL"/>
             <enum name="CL_KERNEL_ARG_ADDRESS_CONSTANT"/>
             <enum name="CL_KERNEL_ARG_ADDRESS_PRIVATE"/>
         </require>
-        <require comment="cl_kernel_arg_access_qualifier">
+        <require group="cl_kernel_arg_access_qualifier">
             <enum name="CL_KERNEL_ARG_ACCESS_READ_ONLY"/>
             <enum name="CL_KERNEL_ARG_ACCESS_WRITE_ONLY"/>
             <enum name="CL_KERNEL_ARG_ACCESS_READ_WRITE"/>
             <enum name="CL_KERNEL_ARG_ACCESS_NONE"/>
         </require>
-        <require comment="cl_kernel_arg_type_qualifier">
+        <require group="cl_kernel_arg_type_qualifier" etype="bitfield">
             <enum name="CL_KERNEL_ARG_TYPE_NONE"/>
             <enum name="CL_KERNEL_ARG_TYPE_CONST"/>
             <enum name="CL_KERNEL_ARG_TYPE_RESTRICT"/>
             <enum name="CL_KERNEL_ARG_TYPE_VOLATILE"/>
         </require>
-        <require comment="cl_kernel_work_group_info">
+        <require group="cl_kernel_work_group_info">
             <enum name="CL_KERNEL_GLOBAL_WORK_SIZE"/>
         </require>
         <require comment="Platform APIs">
@@ -5030,7 +5059,7 @@ server's OpenCL/api-docs repository.
         <require comment="Extension function access">
             <command name="clGetExtensionFunctionAddressForPlatform"/>
         </require>
-        <require comment="OpenCL 1.2 cl_image_info enums that were deprecated in OpenCL 2.0">
+        <require group="cl_image_info" comment="OpenCL 1.2 cl_image_info enums that were deprecated in OpenCL 2.0">
             <enum name="CL_IMAGE_BUFFER"/>
         </require>
     </feature>
@@ -5045,11 +5074,11 @@ server's OpenCL/api-docs repository.
             <type name="cl_sampler_properties"/>
             <type name="cl_kernel_exec_info"/>
         </require>
-        <require comment="Error codes">
+        <require group="cl_error_code">
             <enum name="CL_INVALID_PIPE_SIZE"/>
             <enum name="CL_INVALID_DEVICE_QUEUE"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_QUEUE_ON_HOST_PROPERTIES"/>
             <enum name="CL_DEVICE_IMAGE_PITCH_ALIGNMENT"/>
             <enum name="CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT"/>
@@ -5069,25 +5098,30 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT"/>
             <enum name="CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT"/>
         </require>
-        <require comment="cl_command_queue_properties - bitfield">
+        <require group="cl_command_queue_properties" etype="bitfield">
             <enum name="CL_QUEUE_ON_DEVICE"/>
             <enum name="CL_QUEUE_ON_DEVICE_DEFAULT"/>
         </require>
-        <require comment="cl_device_svm_capabilities">
+        <require group="cl_device_svm_capabilities" etype="bitfield">
             <enum name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER"/>
             <enum name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER"/>
             <enum name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM"/>
             <enum name="CL_DEVICE_SVM_ATOMICS"/>
         </require>
-        <require comment="cl_command_queue_info">
+        <require group="cl_command_queue_info">
             <enum name="CL_QUEUE_SIZE"/>
         </require>
-        <require comment="cl_mem_flags and cl_svm_mem_flags - bitfield">
+        <require group="cl_mem_flags" etype="bitfield">
             <enum name="CL_MEM_SVM_FINE_GRAIN_BUFFER"/>
             <enum name="CL_MEM_SVM_ATOMICS"/>
             <enum name="CL_MEM_KERNEL_READ_AND_WRITE"/>
         </require>
-        <require comment="cl_channel_order">
+        <require group="cl_svm_mem_flags" etype="bitfield">
+            <enum name="CL_MEM_SVM_FINE_GRAIN_BUFFER"/>
+            <enum name="CL_MEM_SVM_ATOMICS"/>
+            <enum name="CL_MEM_KERNEL_READ_AND_WRITE"/>
+        </require>
+        <require group="cl_channel_order">
             <enum name="CL_DEPTH"/>
             <enum name="CL_sRGB"/>
             <enum name="CL_sRGBx"/>
@@ -5095,39 +5129,39 @@ server's OpenCL/api-docs repository.
             <enum name="CL_sBGRA"/>
             <enum name="CL_ABGR"/>
         </require>
-        <require comment="cl_mem_object_type">
+        <require group="cl_mem_object_type">
             <enum name="CL_MEM_OBJECT_PIPE"/>
         </require>
-        <require comment="cl_mem_info">
+        <require group="cl_mem_info">
             <enum name="CL_MEM_USES_SVM_POINTER"/>
         </require>
-        <require comment="cl_pipe_info">
+        <require group="cl_pipe_info">
             <enum name="CL_PIPE_PACKET_SIZE"/>
             <enum name="CL_PIPE_MAX_PACKETS"/>
         </require>
-        <require comment="cl_sampler_info">
+        <require group="cl_sampler_properties">
             <enum name="CL_SAMPLER_MIP_FILTER_MODE"/>
             <enum name="CL_SAMPLER_LOD_MIN"/>
             <enum name="CL_SAMPLER_LOD_MAX"/>
         </require>
-        <require comment="cl_program_build_info">
+        <require group="cl_program_build_info">
             <enum name="CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE"/>
         </require>
-        <require comment="cl_kernel_arg_type_qualifier">
+        <require group="cl_kernel_arg_type_qualifier" etype="bitfield">
             <enum name="CL_KERNEL_ARG_TYPE_PIPE"/>
         </require>
-        <require comment="cl_kernel_exec_info">
+        <require group="cl_kernel_exec_info">
             <enum name="CL_KERNEL_EXEC_INFO_SVM_PTRS"/>
             <enum name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM"/>
         </require>
-        <require comment="cl_command_type">
+        <require group="cl_command_type">
             <enum name="CL_COMMAND_SVM_FREE"/>
             <enum name="CL_COMMAND_SVM_MEMCPY"/>
             <enum name="CL_COMMAND_SVM_MEMFILL"/>
             <enum name="CL_COMMAND_SVM_MAP"/>
             <enum name="CL_COMMAND_SVM_UNMAP"/>
         </require>
-        <require comment="cl_profiling_info">
+        <require group="cl_profiling_info">
             <enum name="CL_PROFILING_COMMAND_COMPLETE"/>
         </require>
         <require comment="Command-Queue APIs">
@@ -5161,24 +5195,24 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_kernel_sub_group_info"/>
         </require>
-        <require comment="cl_platform_info">
+        <require group="cl_platform_info">
             <enum name="CL_PLATFORM_HOST_TIMER_RESOLUTION"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_IL_VERSION"/>
             <enum name="CL_DEVICE_MAX_NUM_SUB_GROUPS"/>
             <enum name="CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS"/>
         </require>
-        <require comment="cl_command_queue_info">
+        <require group="cl_command_queue_info">
             <enum name="CL_QUEUE_DEVICE_DEFAULT"/>
         </require>
-        <require comment="cl_channel_type">
+        <require group="cl_channel_type">
             <enum name="CL_UNORM_INT_101010_2"/>
         </require>
-        <require comment="cl_program_info">
+        <require group="cl_program_info">
             <enum name="CL_PROGRAM_IL"/>
         </require>
-        <require comment="cl_kernel_sub_group_info">
+        <require group="cl_kernel_sub_group_info">
             <enum name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
             <enum name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
             <enum name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE"/>
@@ -5205,7 +5239,7 @@ server's OpenCL/api-docs repository.
     </feature>
 
     <feature api="opencl" name="CL_VERSION_2_2" number="2.2" comment="OpenCL core API interface definitions">
-        <require comment="Error codes">
+        <require group="cl_error_code">
             <enum name="CL_INVALID_SPEC_ID"/>
             <enum name="CL_MAX_SIZE_RESTRICTION_EXCEEDED"/>
         </require>
@@ -5215,7 +5249,7 @@ server's OpenCL/api-docs repository.
         <require comment="OpenCL 2.2 Program Object APIs that were deprecated in OpenCL 3.0">
             <command name="clSetProgramReleaseCallback"/>
         </require>
-        <require comment="OpenCL 2.2 cl_program_info enums that were deprecated in OpenCL 3.0">
+        <require group="cl_program_info" comment="OpenCL 2.2 cl_program_info enums that were deprecated in OpenCL 3.0">
             <enum name="CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT"/>
             <enum name="CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT"/>
         </require>
@@ -5230,7 +5264,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_version"/>
             <type name="cl_name_version"/>
         </require>
-        <require comment="cl_device_atomic_capabilities - bitfield">
+        <require group="cl_device_atomic_capabilities" etype="bitfield">
             <enum name="CL_DEVICE_ATOMIC_ORDER_RELAXED"/>
             <enum name="CL_DEVICE_ATOMIC_ORDER_ACQ_REL"/>
             <enum name="CL_DEVICE_ATOMIC_ORDER_SEQ_CST"/>
@@ -5239,15 +5273,15 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_ATOMIC_SCOPE_DEVICE"/>
             <enum name="CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES"/>
         </require>
-        <require comment="cl_device_device_enqueue_capabilities - bitfield">
+        <require group="cl_device_device_enqueue_capabilities" etype="bitfield">
             <enum name="CL_DEVICE_QUEUE_SUPPORTED"/>
             <enum name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
         </require>
-        <require comment="cl_platform_info">
+        <require group="cl_platform_info">
             <enum name="CL_PLATFORM_NUMERIC_VERSION"/>
             <enum name="CL_PLATFORM_EXTENSIONS_WITH_VERSION"/>
         </require>
-        <require comment="cl_device_info">
+        <require group="cl_device_info">
             <enum name="CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES"/>
             <enum name="CL_DEVICE_ATOMIC_FENCE_CAPABILITIES"/>
             <enum name="CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT"/>
@@ -5264,22 +5298,22 @@ server's OpenCL/api-docs repository.
             <enum name="CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE"/>
             <enum name="CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED"/>
         </require>
-        <require comment="cl_pipe_info">
+        <require group="cl_pipe_info">
             <enum name="CL_PIPE_PROPERTIES"/>
         </require>
-        <require comment="cl_sampler_info">
+        <require group="cl_sampler_info">
             <enum name="CL_SAMPLER_PROPERTIES"/>
         </require>
-        <require comment="cl_command_queue_info">
+        <require group="cl_command_queue_info">
             <enum name="CL_QUEUE_PROPERTIES_ARRAY"/>
         </require>
-        <require comment="cl_mem_info">
+        <require group="cl_mem_info">
             <enum name="CL_MEM_PROPERTIES"/>
         </require>
-        <require comment="cl_command_type">
+        <require group="cl_command_type">
             <enum name="CL_COMMAND_SVM_MIGRATE_MEM"/>
         </require>
-        <require comment="Misc API enums">
+        <require etype="constants" comment="Misc API enums">
             <enum name="CL_VERSION_MAJOR_BITS"/>
             <enum name="CL_VERSION_MINOR_BITS"/>
             <enum name="CL_VERSION_PATCH_BITS"/>
@@ -5306,31 +5340,33 @@ server's OpenCL/api-docs repository.
                 <type name="cl_d3d10_device_source_khr"/>
                 <type name="cl_d3d10_device_set_khr"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_D3D10_DEVICE_KHR"/>
                 <enum name="CL_INVALID_D3D10_RESOURCE_KHR"/>
                 <enum name="CL_D3D10_RESOURCE_ALREADY_ACQUIRED_KHR"/>
                 <enum name="CL_D3D10_RESOURCE_NOT_ACQUIRED_KHR"/>
             </require>
-            <require comment="cl_d3d10_device_source_khr">
+            <require group="cl_d3d10_device_source_khr">
                 <enum name="CL_D3D10_DEVICE_KHR"/>
                 <enum name="CL_D3D10_DXGI_ADAPTER_KHR"/>
             </require>
-            <require comment="cl_d3d10_device_set_khr">
+            <require group="cl_d3d10_device_set_khr">
                 <enum name="CL_PREFERRED_DEVICES_FOR_D3D10_KHR"/>
                 <enum name="CL_ALL_DEVICES_FOR_D3D10_KHR"/>
             </require>
-            <require comment="cl_context_info">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_D3D10_DEVICE_KHR"/>
+            </require>
+            <require group="cl_context_info">
                 <enum name="CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_D3D10_RESOURCE_KHR"/>
             </require>
-            <require comment="cl_image_info">
+            <require group="cl_image_info">
                 <enum name="CL_IMAGE_D3D10_SUBRESOURCE_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR"/>
             </require>
@@ -5353,31 +5389,33 @@ server's OpenCL/api-docs repository.
                 <type name="cl_d3d11_device_source_khr"/>
                 <type name="cl_d3d11_device_set_khr"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_D3D11_DEVICE_KHR"/>
                 <enum name="CL_INVALID_D3D11_RESOURCE_KHR"/>
                 <enum name="CL_D3D11_RESOURCE_ALREADY_ACQUIRED_KHR"/>
                 <enum name="CL_D3D11_RESOURCE_NOT_ACQUIRED_KHR"/>
             </require>
-            <require comment="cl_d3d11_device_source_khr">
+            <require group="cl_d3d11_device_source_khr">
                 <enum name="CL_D3D11_DEVICE_KHR"/>
                 <enum name="CL_D3D11_DXGI_ADAPTER_KHR"/>
             </require>
-            <require comment="cl_d3d11_device_set_khr">
+            <require group="cl_d3d11_device_set_khr">
                 <enum name="CL_PREFERRED_DEVICES_FOR_D3D11_KHR"/>
                 <enum name="CL_ALL_DEVICES_FOR_D3D11_KHR"/>
             </require>
-            <require comment="cl_context_info">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_D3D11_DEVICE_KHR"/>
+            </require>
+            <require group="cl_context_info">
                 <enum name="CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_D3D11_RESOURCE_KHR"/>
             </require>
-            <require comment="cl_image_info">
+            <require group="cl_image_info">
                 <enum name="CL_IMAGE_D3D11_SUBRESOURCE_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR"/>
             </require>
@@ -5401,34 +5439,34 @@ server's OpenCL/api-docs repository.
             <require condition="defined(_WIN32)">
                 <type name="cl_dx9_surface_info_khr"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_DX9_MEDIA_ADAPTER_KHR"/>
                 <enum name="CL_INVALID_DX9_MEDIA_SURFACE_KHR"/>
                 <enum name="CL_DX9_MEDIA_SURFACE_ALREADY_ACQUIRED_KHR"/>
                 <enum name="CL_DX9_MEDIA_SURFACE_NOT_ACQUIRED_KHR"/>
             </require>
-            <require comment="cl_media_adapter_type_khr">
+            <require group="cl_dx9_media_adapter_type_khr">
                 <enum name="CL_ADAPTER_D3D9_KHR"/>
                 <enum name="CL_ADAPTER_D3D9EX_KHR"/>
                 <enum name="CL_ADAPTER_DXVA_KHR"/>
             </require>
-            <require comment="cl_media_adapter_set_khr">
+            <require group="cl_dx9_media_adapter_set_khr">
                 <enum name="CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR"/>
                 <enum name="CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR"/>
             </require>
-            <require comment="cl_context_info">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_ADAPTER_D3D9_KHR"/>
                 <enum name="CL_CONTEXT_ADAPTER_D3D9EX_KHR"/>
                 <enum name="CL_CONTEXT_ADAPTER_DXVA_KHR"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR"/>
                 <enum name="CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR"/>
             </require>
-            <require comment="cl_image_info">
+            <require group="cl_image_info">
                 <enum name="CL_IMAGE_DX9_MEDIA_PLANE_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR"/>
             </require>
@@ -5443,12 +5481,12 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="Command type for events created with clEnqueueAcquireEGLObjectsKHR">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR"/>
                 <enum name="CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_EGL_OBJECTS_KHR"/>
             </require>
-            <require comment="Error type for clCreateFromEGLImageKHR">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_EGL_OBJECT_KHR"/>
                 <enum name="CL_EGL_RESOURCE_NOT_ACQUIRED_KHR"/>
             </require>
@@ -5485,7 +5523,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_device_info - defined in CL.h for OpenCL 1.2 and newer">
+            <require group="cl_device_info" condition="!defined(CL_VERSION_1_2)">
                 <enum name="CL_DEVICE_DOUBLE_FP_CONFIG"/>
             </require>
         </extension>
@@ -5493,7 +5531,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_HALF_FP_CONFIG"/>
             </require>
         </extension>
@@ -5519,10 +5557,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_PLATFORM_NOT_FOUND_KHR"/>
             </require>
             <require>
@@ -5537,11 +5575,11 @@ server's OpenCL/api-docs repository.
                 <type name="cl_layer_info"/>
                 <type name="cl_layer_api_version"/>
             </require>
-            <require comment="cl_layer_info">
+            <require group="cl_layer_info">
                 <enum name="CL_LAYER_API_VERSION"/>
                 <enum name="CL_LAYER_NAME"/>
             </require>
-            <require comment="Misc API enums">
+            <require etype="constants" comment="Misc API enums">
                 <enum name="CL_LAYER_API_VERSION_100"/>
             </require>
             <require>
@@ -5556,7 +5594,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_icdl_info"/>
             </require>
-            <require comment="cl_icdl_info">
+            <require group="cl_icdl_info">
                 <enum name="CL_ICDL_OCL_VERSION"/>
                 <enum name="CL_ICDL_VERSION"/>
                 <enum name="CL_ICDL_NAME"/>
@@ -5570,10 +5608,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_IL_VERSION_KHR"/>
             </require>
-            <require comment="cl_program_info">
+            <require group="cl_program_info">
                 <enum name="CL_PROGRAM_IL_KHR"/>
             </require>
             <require>
@@ -5581,7 +5619,7 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_khr_image2d_from_buffer" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR"/>
                 <enum name="CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR"/>
             </require>
@@ -5590,7 +5628,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="Interop tokens">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
             </require>
         </extension>
@@ -5601,16 +5639,16 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_device_terminate_capability_khr"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
             </require>
-            <require comment="cl_context_properties">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_TERMINATE_KHR"/>
             </require>
-            <require comment="cl_device_terminate_capability_khr">
+            <require group="cl_device_terminate_capability_khr" etype="bitfield">
                 <enum name="CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_CONTEXT_TERMINATED_KHR"/>
             </require>
             <require>
@@ -5621,10 +5659,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SPIR_VERSIONS"/>
             </require>
-            <require comment="cl_program_binary_type">
+            <require group="cl_program_binary_type">
                 <enum name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE"/>
             </require>
         </extension>
@@ -5643,7 +5681,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV"/>
                 <enum name="CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV"/>
                 <enum name="CL_DEVICE_REGISTERS_PER_BLOCK_NV"/>
@@ -5657,7 +5695,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_PROFILING_TIMER_OFFSET_AMD"/>
                 <enum name="CL_DEVICE_TOPOLOGY_AMD"/>
                 <enum name="CL_DEVICE_BOARD_NAME_AMD"/>
@@ -5685,7 +5723,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_context_properties">
+            <require group="cl_context_properties">
                 <enum name="CL_PRINTF_CALLBACK_ARM"/>
                 <enum name="CL_PRINTF_BUFFERSIZE_ARM"/>
             </require>
@@ -5697,36 +5735,34 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_device_partition_property_ext"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_DEVICE_PARTITION_FAILED_EXT"/>
                 <enum name="CL_INVALID_PARTITION_COUNT_EXT"/>
                 <enum name="CL_INVALID_PARTITION_NAME_EXT"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_PARENT_DEVICE_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_TYPES_EXT"/>
                 <enum name="CL_DEVICE_AFFINITY_DOMAINS_EXT"/>
                 <enum name="CL_DEVICE_REFERENCE_COUNT_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_STYLE_EXT"/>
             </require>
-            <require comment="cl_device_partition_property_ext">
+            <require group="cl_device_partition_property_ext">
                 <enum name="CL_DEVICE_PARTITION_EQUALLY_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_BY_COUNTS_EXT"/>
+                <enum name="CL_PARTITION_BY_COUNTS_LIST_END_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_BY_NAMES_EXT"/>
+                <enum name="CL_PARTITION_BY_NAMES_LIST_END_EXT"/>
                 <enum name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT"/>
+                <enum name="CL_PROPERTIES_LIST_END_EXT"/>
             </require>
-            <require comment="cl_device_partition_property_ext - affinity domains">
+            <require group="cl_affinity_domain_ext">
                 <enum name="CL_AFFINITY_DOMAIN_L1_CACHE_EXT"/>
                 <enum name="CL_AFFINITY_DOMAIN_L2_CACHE_EXT"/>
                 <enum name="CL_AFFINITY_DOMAIN_L3_CACHE_EXT"/>
                 <enum name="CL_AFFINITY_DOMAIN_L4_CACHE_EXT"/>
                 <enum name="CL_AFFINITY_DOMAIN_NUMA_EXT"/>
                 <enum name="CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT"/>
-            </require>
-            <require comment="cl_device_partition_property_ext - list terminators">
-                <enum name="CL_PROPERTIES_LIST_END_EXT"/>
-                <enum name="CL_PARTITION_BY_COUNTS_LIST_END_EXT"/>
-                <enum name="CL_PARTITION_BY_NAMES_LIST_END_EXT"/>
             </require>
             <require>
                 <command name="clReleaseDeviceEXT"/>
@@ -5741,10 +5777,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_mem_migration_flags_ext"/>
             </require>
-            <require comment="cl_mem_migration_flags_ext">
+            <require group="cl_mem_migration_flags_ext" etype="bitfield">
                 <enum name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_MIGRATE_MEM_OBJECT_EXT"/>
             </require>
             <require>
@@ -5759,18 +5795,20 @@ server's OpenCL/api-docs repository.
                 <type name="cl_image_pitch_info_qcom"/>
                 <type name="cl_mem_ext_host_ptr"/>
             </require>
-            <require comment="cl_mem_flags">
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_EXT_HOST_PTR_QCOM"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM"/>
                 <enum name="CL_DEVICE_PAGE_SIZE_QCOM"/>
             </require>
-            <require comment="cl_image_pitch_info_qcom">
+            <require group="cl_image_pitch_info_qcom">
+                <enum name="CL_IMAGE_ROW_PITCH"/>
                 <enum name="CL_IMAGE_ROW_ALIGNMENT_QCOM"/>
+                <enum name="CL_IMAGE_SLICE_PITCH"/>
                 <enum name="CL_IMAGE_SLICE_ALIGNMENT_QCOM"/>
             </require>
-            <require comment="cl_uint host_cache_policy">
+            <require group="cl_host_cache_policy">
                 <enum name="CL_MEM_HOST_UNCACHED_QCOM"/>
                 <enum name="CL_MEM_HOST_WRITEBACK_QCOM"/>
                 <enum name="CL_MEM_HOST_WRITETHROUGH_QCOM"/>
@@ -5784,7 +5822,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_uint host_cache_policy">
+            <require group="cl_host_cache_policy">
                 <enum name="CL_MEM_HOST_IOCOHERENT_QCOM"/>
             </require>
         </extension>
@@ -5796,7 +5834,7 @@ server's OpenCL/api-docs repository.
                 <type name="cl_mem_ext_host_ptr"/>
                 <type name="cl_mem_ion_host_ptr"/>
             </require>
-            <require comment="cl_uint allocation_type">
+            <require group="cl_allocation_type">
                 <enum name="CL_MEM_ION_HOST_PTR_QCOM"/>
             </require>
         </extension>
@@ -5808,7 +5846,7 @@ server's OpenCL/api-docs repository.
                 <type name="cl_mem_ext_host_ptr"/>
                 <type name="cl_mem_android_native_buffer_host_ptr"/>
             </require>
-            <require comment="cl_uint allocation_type">
+            <require group="cl_allocation_type">
                 <enum name="CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM"/>
             </require>
         </extension>
@@ -5816,7 +5854,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_channel_order">
+            <require group="cl_channel_order">
                 <enum name="CL_NV21_IMG"/>
                 <enum name="CL_YV12_IMG"/>
             </require>
@@ -5825,7 +5863,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_mem_flags">
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_USE_UNCACHED_CPU_MEMORY_IMG"/>
                 <enum name="CL_MEM_USE_CACHED_CPU_MEMORY_IMG"/>
             </require>
@@ -5834,7 +5872,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_sampler_properties">
+            <require group="cl_sampler_properties">
                 <enum name="CL_SAMPLER_MIP_FILTER_MODE_KHR"/>
                 <enum name="CL_SAMPLER_LOD_MIN_KHR"/>
                 <enum name="CL_SAMPLER_LOD_MAX_KHR"/>
@@ -5844,14 +5882,14 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG"/>
                 <enum name="CL_INVALID_GRALLOC_OBJECT_IMG"/>
             </require>
-            <require comment="cl_mem_flags">
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_USE_GRALLOC_PTR_IMG"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG"/>
                 <enum name="CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG"/>
             </require>
@@ -5867,7 +5905,7 @@ server's OpenCL/api-docs repository.
             <require condition="!defined(CL_VERSION_2_1)" comment="defined in CL.h for OpenCL 2.1 and newer">
                 <type name="cl_kernel_sub_group_info"/>
             </require>
-            <require comment="cl_kernel_sub_group_info">
+            <require group="cl_kernel_sub_group_info">
                 <enum name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR"/>
                 <enum name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
             </require>
@@ -5882,10 +5920,10 @@ server's OpenCL/api-docs repository.
             <require comment="To be used by clGetEventInfo">
                 <type name="cl_queue_priority_khr"/>
             </require>
-            <require comment="cl_queue_properties">
+            <require group="cl_queue_properties">
                 <enum name="CL_QUEUE_PRIORITY_KHR"/>
             </require>
-            <require comment="cl_queue_priority_khr">
+            <require group="cl_queue_priority_khr">
                 <enum name="CL_QUEUE_PRIORITY_HIGH_KHR"/>
                 <enum name="CL_QUEUE_PRIORITY_MED_KHR"/>
                 <enum name="CL_QUEUE_PRIORITY_LOW_KHR"/>
@@ -5898,10 +5936,10 @@ server's OpenCL/api-docs repository.
             <require comment="To be used by clGetEventInfo">
                 <type name="cl_queue_throttle_khr"/>
             </require>
-            <require comment="cl_queue_properties">
+            <require group="cl_queue_properties">
                 <enum name="CL_QUEUE_THROTTLE_KHR"/>
             </require>
-            <require comment="cl_queue_throttle_khr">
+            <require group="cl_queue_throttle_khr">
                 <enum name="CL_QUEUE_THROTTLE_HIGH_KHR"/>
                 <enum name="CL_QUEUE_THROTTLE_MED_KHR"/>
                 <enum name="CL_QUEUE_THROTTLE_LOW_KHR"/>
@@ -5911,7 +5949,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
             </require>
         </extension>
@@ -5922,16 +5960,20 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_import_properties_arm"/>
             </require>
-            <require comment="cl_import_properties_arm">
+            <require group="cl_import_properties_arm">
                 <enum name="CL_IMPORT_TYPE_ARM"/>
-                <enum name="CL_IMPORT_TYPE_HOST_ARM"/>
-                <enum name="CL_IMPORT_TYPE_DMA_BUF_ARM"/>
                 <enum name="CL_IMPORT_TYPE_PROTECTED_ARM"/>
-                <enum name="CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM"/>
                 <enum name="CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM"/>
-                <enum name="CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM"/>
                 <enum name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_PLANE_INDEX_ARM"/>
                 <enum name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_LAYER_INDEX_ARM"/>
+            </require>
+            <require group="cl_import_type_arm">
+                <enum name="CL_IMPORT_TYPE_HOST_ARM"/>
+                <enum name="CL_IMPORT_TYPE_DMA_BUF_ARM"/>
+                <enum name="CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM"/>
+            </require>
+            <require etype="constants">
+                <enum name="CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM"/>
             </require>
             <require>
                 <comment>
@@ -5962,30 +6004,30 @@ server's OpenCL/api-docs repository.
                 <type name="cl_kernel_exec_info_arm"/>
                 <type name="cl_device_svm_capabilities_arm"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SVM_CAPABILITIES_ARM"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_USES_SVM_POINTER_ARM"/>
             </require>
-            <require comment="cl_kernel_exec_info_arm">
+            <require group="cl_kernel_exec_info_arm">
                 <enum name="CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM"/>
                 <enum name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_SVM_FREE_ARM"/>
                 <enum name="CL_COMMAND_SVM_MEMCPY_ARM"/>
                 <enum name="CL_COMMAND_SVM_MEMFILL_ARM"/>
                 <enum name="CL_COMMAND_SVM_MAP_ARM"/>
                 <enum name="CL_COMMAND_SVM_UNMAP_ARM"/>
             </require>
-            <require comment="cl_device_svm_capabilities_arm">
+            <require group="cl_device_svm_capabilities_arm" etype="bitfield">
                 <enum name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM"/>
                 <enum name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM"/>
                 <enum name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM"/>
                 <enum name="CL_DEVICE_SVM_ATOMICS_ARM"/>
             </require>
-            <require comment="cl_svm_mem_flags_arm">
+            <require group="cl_svm_mem_flags_arm" etype="bitfield">
                 <enum name="CL_MEM_SVM_FINE_GRAIN_BUFFER_ARM"/>
                 <enum name="CL_MEM_SVM_ATOMICS_ARM"/>
             </require>
@@ -6005,7 +6047,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"/>
             </require>
         </extension>
@@ -6014,12 +6056,12 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
                 <type name="CL/cl_platform.h"/>
             </require>
-            <require comment="cl_command_queue_properties - bitfield">
+            <require group="cl_command_queue_properties" etype="bitfield">
                 <enum name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_device_partition_by_names" supported="opencl">
-            <require>
+            <require group="cl_device_partition_property">
                 <enum name="CL_DEVICE_PARTITION_BY_NAMES_INTEL"/>
                 <enum name="CL_PARTITION_BY_NAMES_LIST_END_INTEL"/>
             </require>
@@ -6030,13 +6072,13 @@ server's OpenCL/api-docs repository.
                 <type name="cl_accelerator_type_intel"/>
                 <type name="cl_accelerator_info_intel"/>
             </require>
-            <require comment="cl_accelerator_info_intel">
+            <require group="cl_accelerator_info_intel">
                 <enum name="CL_ACCELERATOR_DESCRIPTOR_INTEL"/>
                 <enum name="CL_ACCELERATOR_REFERENCE_COUNT_INTEL"/>
                 <enum name="CL_ACCELERATOR_CONTEXT_INTEL"/>
                 <enum name="CL_ACCELERATOR_TYPE_INTEL"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_ACCELERATOR_INTEL"/>
                 <enum name="CL_INVALID_ACCELERATOR_TYPE_INTEL"/>
                 <enum name="CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL"/>
@@ -6053,59 +6095,59 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_motion_estimation_desc_intel"/>
             </require>
-            <require comment="cl_accelerator_type_intel">
+            <require group="cl_accelerator_type_intel">
                 <enum name="CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL"/>
             </require>
-            <require comment="cl_uint mb_block_type">
+            <require group="cl_mb_block_type">
                 <enum name="CL_ME_MB_TYPE_16x16_INTEL"/>
                 <enum name="CL_ME_MB_TYPE_8x8_INTEL"/>
                 <enum name="CL_ME_MB_TYPE_4x4_INTEL"/>
             </require>
-            <require comment="cl_uint subpixel_mode">
+            <require group="cl_subpixel_mode">
                 <enum name="CL_ME_SUBPIXEL_MODE_INTEGER_INTEL"/>
                 <enum name="CL_ME_SUBPIXEL_MODE_HPEL_INTEL"/>
                 <enum name="CL_ME_SUBPIXEL_MODE_QPEL_INTEL"/>
             </require>
-            <require comment="cl_uint sad_adjust_mode">
+            <require group="cl_sad_adjust_mode">
                 <enum name="CL_ME_SAD_ADJUST_MODE_NONE_INTEL"/>
                 <enum name="CL_ME_SAD_ADJUST_MODE_HAAR_INTEL"/>
             </require>
-            <require comment="cl_uint search_path_type">
+            <require group="cl_search_path_type">
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_2_2_INTEL"/>
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_4_4_INTEL"/>
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_16_12_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_advanced_motion_estimation" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_ME_VERSION_INTEL"/>
             </require>
-            <require>
-                <enum name="CL_ME_VERSION_LEGACY_INTEL"/>
+            <require group="cl_device_me_version">
+                <enum name="CL_ME_VERSION_LEGACY_INTEL" comment="Extension text doesn't say anything about this value"/>
                 <enum name="CL_ME_VERSION_ADVANCED_VER_1_INTEL"/>
                 <enum name="CL_ME_VERSION_ADVANCED_VER_2_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_CHROMA_INTRA_PREDICT_ENABLED_INTEL"/>
                 <enum name="CL_ME_LUMA_INTRA_PREDICT_ENABLED_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL"/>
                 <enum name="CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_COST_PENALTY_NONE_INTEL"/>
                 <enum name="CL_ME_COST_PENALTY_LOW_INTEL"/>
                 <enum name="CL_ME_COST_PENALTY_NORMAL_INTEL"/>
                 <enum name="CL_ME_COST_PENALTY_HIGH_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_COST_PRECISION_QPEL_INTEL"/>
                 <enum name="CL_ME_COST_PRECISION_HPEL_INTEL"/>
                 <enum name="CL_ME_COST_PRECISION_PEL_INTEL"/>
                 <enum name="CL_ME_COST_PRECISION_DPEL_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
                 <enum name="CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
                 <enum name="CL_ME_LUMA_PREDICTOR_MODE_DC_INTEL"/>
@@ -6117,18 +6159,18 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL"/>
                 <enum name="CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_CHROMA_PREDICTOR_MODE_DC_INTEL"/>
                 <enum name="CL_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
                 <enum name="CL_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
                 <enum name="CL_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_FORWARD_INPUT_MODE_INTEL"/>
                 <enum name="CL_ME_BACKWARD_INPUT_MODE_INTEL"/>
                 <enum name="CL_ME_BIDIRECTION_INPUT_MODE_INTEL"/>
             </require>
-            <require>
+            <require etype="OpenCL-C only">
                 <enum name="CL_ME_BIDIR_WEIGHT_QUARTER_INTEL"/>
                 <enum name="CL_ME_BIDIR_WEIGHT_THIRD_INTEL"/>
                 <enum name="CL_ME_BIDIR_WEIGHT_HALF_INTEL"/>
@@ -6137,18 +6179,21 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_simultaneous_sharing" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"/>
                 <enum name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_egl_image_yuv" supported="opencl">
-            <require comment="cl_egl_image_properties_khr">
+            <require group="cl_egl_image_properties_khr">
+                <enum name="CL_EGL_YUV_PLANE_INTEL"/>
+            </require>
+            <require group="cl_image_info">
                 <enum name="CL_EGL_YUV_PLANE_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_packed_yuv" supported="opencl">
-            <require comment="cl_channel_order">
+            <require group="cl_channel_order">
                 <enum name="CL_YUYV_INTEL"/>
                 <enum name="CL_UYVY_INTEL"/>
                 <enum name="CL_YVYU_INTEL"/>
@@ -6156,13 +6201,13 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_required_subgroup_size" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"/>
             </require>
-            <require comment="cl_kernel_work_group_info">
+            <require group="cl_kernel_work_group_info">
                 <enum name="CL_KERNEL_SPILL_MEM_SIZE_INTEL"/>
             </require>
-            <require comment="cl_kernel_sub_group_info">
+            <require group="cl_kernel_sub_group_info">
                 <enum name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"/>
             </require>
         </extension>
@@ -6170,8 +6215,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_diagnostics_verbose_level"/>
             </require>
-            <require comment="cl_context_properties">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL"/>
+            </require>
+            <require group="cl_context_property_diagnostics_level" etype="bitfield">
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL"/>
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL"/>
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL"/>
@@ -6179,46 +6226,46 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_planar_yuv" supported="opencl">
-            <require comment="cl_channel_order">
+            <require group="cl_channel_order">
                 <enum name="CL_NV12_INTEL"/>
             </require>
-            <require comment="cl_mem_flags">
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_NO_ACCESS_INTEL"/>
                 <enum name="CL_MEM_ACCESS_FLAGS_UNRESTRICTED_INTEL"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL"/>
                 <enum name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
             </require>
         </extension>
         <extension name="cl_intel_device_side_avc_motion_estimation" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_AVC_ME_VERSION_INTEL"/>
                 <enum name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL"/>
                 <enum name="CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL"/>
             </require>
-            <require comment="returned by CL_DEVICE_AVC_ME_VERSION_INTEL">
+            <require group="cl_device_avc_me_version">
                 <enum name="CL_AVC_ME_VERSION_0_INTEL"/>
                 <enum name="CL_AVC_ME_VERSION_1_INTEL"/>
             </require>
-            <require comment="Inter macro-block major shape values">
+            <require comment="Inter macro-block major shape values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_MAJOR_16x16_INTEL"/>
                 <enum name="CL_AVC_ME_MAJOR_16x8_INTEL"/>
                 <enum name="CL_AVC_ME_MAJOR_8x16_INTEL"/>
                 <enum name="CL_AVC_ME_MAJOR_8x8_INTEL"/>
             </require>
-            <require comment="Inter macro-block minor shape values">
+            <require comment="Inter macro-block minor shape values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_MINOR_8x8_INTEL"/>
                 <enum name="CL_AVC_ME_MINOR_8x4_INTEL"/>
                 <enum name="CL_AVC_ME_MINOR_4x8_INTEL"/>
                 <enum name="CL_AVC_ME_MINOR_4x4_INTEL"/>
             </require>
-            <require comment="Inter macro-block major direction values">
+            <require comment="Inter macro-block major direction values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_MAJOR_FORWARD_INTEL"/>
                 <enum name="CL_AVC_ME_MAJOR_BACKWARD_INTEL"/>
                 <enum name="CL_AVC_ME_MAJOR_BIDIRECTIONAL_INTEL"/>
             </require>
-            <require comment="Inter (IME) partition mask values">
+            <require comment="Inter (IME) partition mask values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_PARTITION_MASK_ALL_INTEL"/>
                 <enum name="CL_AVC_ME_PARTITION_MASK_16x16_INTEL"/>
                 <enum name="CL_AVC_ME_PARTITION_MASK_16x8_INTEL"/>
@@ -6228,7 +6275,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_AVC_ME_PARTITION_MASK_4x8_INTEL"/>
                 <enum name="CL_AVC_ME_PARTITION_MASK_4x4_INTEL"/>
             </require>
-            <require comment="Search window configuration">
+            <require comment="Search window configuration" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL"/>
                 <enum name="CL_AVC_ME_SEARCH_WINDOW_SMALL_INTEL"/>
                 <enum name="CL_AVC_ME_SEARCH_WINDOW_TINY_INTEL"/>
@@ -6242,39 +6289,39 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_AVC_ME_SEARCH_WINDOW_4x4_RADIUS_INTEL"/>
                 <enum name="CL_AVC_ME_SEARCH_WINDOW_2x2_RADIUS_INTEL"/>
             </require>
-            <require comment="SAD adjustment mode">
+            <require comment="SAD adjustment mode" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SAD_ADJUST_MODE_NONE_INTEL"/>
                 <enum name="CL_AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL"/>
             </require>
-            <require comment="Pixel resolution">
+            <require comment="Pixel resolution" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL"/>
                 <enum name="CL_AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"/>
                 <enum name="CL_AVC_ME_SUBPIXEL_MODE_QPEL_INTEL"/>
             </require>
-            <require comment="Cost precision values">
+            <require comment="Cost precision values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_COST_PRECISION_QPEL_INTEL"/>
                 <enum name="CL_AVC_ME_COST_PRECISION_HPEL_INTEL"/>
                 <enum name="CL_AVC_ME_COST_PRECISION_PEL_INTEL"/>
                 <enum name="CL_AVC_ME_COST_PRECISION_DPEL_INTEL"/>
             </require>
-            <require comment="Inter bidirectional weights">
+            <require comment="Inter bidirectional weights" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL"/>
                 <enum name="CL_AVC_ME_BIDIR_WEIGHT_THIRD_INTEL"/>
                 <enum name="CL_AVC_ME_BIDIR_WEIGHT_HALF_INTEL"/>
                 <enum name="CL_AVC_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL"/>
                 <enum name="CL_AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL"/>
             </require>
-            <require comment="Inter border reached values">
+            <require comment="Inter border reached values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_BORDER_REACHED_LEFT_INTEL"/>
                 <enum name="CL_AVC_ME_BORDER_REACHED_RIGHT_INTEL"/>
                 <enum name="CL_AVC_ME_BORDER_REACHED_TOP_INTEL"/>
                 <enum name="CL_AVC_ME_BORDER_REACHED_BOTTOM_INTEL"/>
             </require>
-            <require comment="Inter skip block partition type">
+            <require comment="Inter skip block partition type" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL"/>
                 <enum name="CL_AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL"/>
             </require>
-            <require comment="Inter skip motion vector mask">
+            <require comment="Inter skip motion vector mask" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL"/>
@@ -6290,27 +6337,27 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_AVC_ME_SKIP_BLOCK_8x8_3_FORWARD_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL"/>
             </require>
-            <require comment="Block based skip type values">
+            <require comment="Block based skip type values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL"/>
                 <enum name="CL_AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL"/>
             </require>
-            <require comment="cl_intel_device_side_avc_motion_estimation.??">
+            <require comment="cl_intel_device_side_avc_motion_estimation.??" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_INTRA_16x16_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_8x8_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_4x4_INTEL"/>
             </require>
-            <require comment="Luma intra partition mask values">
+            <require comment="Luma intra partition mask values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL"/>
             </require>
-            <require comment="Intra neighbor availability mask values">
+            <require comment="Intra neighbor availability mask values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_INTRA_NEIGHBOR_LEFT_MASK_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_MASK_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_RIGHT_MASK_ENABLE_INTEL"/>
                 <enum name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_LEFT_MASK_ENABLE_INTEL"/>
             </require>
-            <require comment="Luma intra modes">
+            <require comment="Luma intra modes" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
                 <enum name="CL_AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
                 <enum name="CL_AVC_ME_LUMA_PREDICTOR_MODE_DC_INTEL"/>
@@ -6322,23 +6369,23 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL"/>
                 <enum name="CL_AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL"/>
             </require>
-            <require comment="Chroma intra modes">
+            <require comment="Chroma intra modes" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_CHROMA_PREDICTOR_MODE_DC_INTEL"/>
                 <enum name="CL_AVC_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
                 <enum name="CL_AVC_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
                 <enum name="CL_AVC_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL"/>
             </require>
-            <require comment="Reference image select values">
+            <require comment="Reference image select values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_FRAME_FORWARD_INTEL"/>
                 <enum name="CL_AVC_ME_FRAME_BACKWARD_INTEL"/>
                 <enum name="CL_AVC_ME_FRAME_DUAL_INTEL"/>
             </require>
-            <require comment="Slice type values">
+            <require comment="Slice type values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_SLICE_TYPE_PRED_INTEL"/>
                 <enum name="CL_AVC_ME_SLICE_TYPE_BPRED_INTEL"/>
                 <enum name="CL_AVC_ME_SLICE_TYPE_INTRA_INTEL"/>
             </require>
-            <require comment="Interlaced image field polarity values">
+            <require comment="Interlaced image field polarity values" etype="OpenCL-C only">
                 <enum name="CL_AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL"/>
                 <enum name="CL_AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL"/>
             </require>
@@ -6347,7 +6394,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_GLsync"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR"/>
             </require>
             <require>
@@ -6362,29 +6409,29 @@ server's OpenCL/api-docs repository.
                 <type name="cl_va_api_device_source_intel"/>
                 <type name="cl_va_api_device_set_intel"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_VA_API_MEDIA_ADAPTER_INTEL"/>
                 <enum name="CL_INVALID_VA_API_MEDIA_SURFACE_INTEL"/>
                 <enum name="CL_VA_API_MEDIA_SURFACE_ALREADY_ACQUIRED_INTEL"/>
                 <enum name="CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL"/>
             </require>
-            <require comment="cl_va_api_device_source_intel">
+            <require group="cl_va_api_device_source_intel">
                 <enum name="CL_VA_API_DISPLAY_INTEL"/>
             </require>
-            <require comment="cl_va_api_device_set_intel">
+            <require group="cl_va_api_device_set_intel">
                 <enum name="CL_PREFERRED_DEVICES_FOR_VA_API_INTEL"/>
                 <enum name="CL_ALL_DEVICES_FOR_VA_API_INTEL"/>
             </require>
-            <require comment="cl_context_info">
+            <require group="cl_context_info">
                 <enum name="CL_CONTEXT_VA_API_DISPLAY_INTEL"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_VA_API_MEDIA_SURFACE_INTEL"/>
             </require>
-            <require comment="cl_image_info">
+            <require group="cl_image_info">
                 <enum name="CL_IMAGE_VA_API_PLANE_INTEL"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL"/>
                 <enum name="CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL"/>
             </require>
@@ -6403,34 +6450,34 @@ server's OpenCL/api-docs repository.
                 <type name="cl_dx9_device_source_intel"/>
                 <type name="cl_dx9_device_set_intel"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_DX9_DEVICE_INTEL"/>
                 <enum name="CL_INVALID_DX9_RESOURCE_INTEL"/>
                 <enum name="CL_DX9_RESOURCE_ALREADY_ACQUIRED_INTEL"/>
                 <enum name="CL_DX9_RESOURCE_NOT_ACQUIRED_INTEL"/>
             </require>
-            <require comment="cl_dx9_device_source_intel">
+            <require group="cl_dx9_device_source_intel">
                 <enum name="CL_D3D9_DEVICE_INTEL"/>
                 <enum name="CL_D3D9EX_DEVICE_INTEL"/>
                 <enum name="CL_DXVA_DEVICE_INTEL"/>
             </require>
-            <require comment="cl_dx9_device_set_intel">
+            <require group="cl_dx9_device_set_intel">
                 <enum name="CL_PREFERRED_DEVICES_FOR_DX9_INTEL"/>
                 <enum name="CL_ALL_DEVICES_FOR_DX9_INTEL"/>
             </require>
-            <require comment="cl_context_info">
+            <require group="cl_context_properties">
                 <enum name="CL_CONTEXT_D3D9_DEVICE_INTEL"/>
                 <enum name="CL_CONTEXT_D3D9EX_DEVICE_INTEL"/>
                 <enum name="CL_CONTEXT_DXVA_DEVICE_INTEL"/>
             </require>
-            <require comment="cl_mem_info">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_DX9_RESOURCE_INTEL"/>
                 <enum name="CL_MEM_DX9_SHARED_HANDLE_INTEL"/>
             </require>
-            <require comment="cl_image_info">
+            <require group="cl_image_info">
                 <enum name="CL_IMAGE_DX9_PLANE_INTEL"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL"/>
                 <enum name="CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL"/>
             </require>
@@ -6445,10 +6492,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 and newer">
+            <require group="cl_channel_order" condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 and newer">
                 <enum name="CL_DEPTH_STENCIL"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_type - defined in CL.h for OpenCL 1.2 and newer">
+            <require group="cl_channel_type" condition="!defined(CL_VERSION_1_2)" comment="cl_channel_type - defined in CL.h for OpenCL 1.2 and newer">
                 <enum name="CL_UNORM_INT24"/>
             </require>
         </extension>
@@ -6456,7 +6503,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_gl_texture_info">
+            <require group="cl_gl_texture_info">
                 <!-- <enum name="GL_TEXTURE_2D_MULTISAMPLE"/> -->
                 <!-- <enum name="GL_TEXTURE_2D_MULTISAMPLE_ARRAY"/> -->
                 <enum name="CL_GL_NUM_SAMPLES"/>
@@ -6469,38 +6516,38 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_gl_context_info"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR"/>
             </require>
-            <require comment="cl_gl_context_info">
+            <require group="cl_gl_context_info">
                 <enum name="CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR"/>
                 <enum name="CL_DEVICES_FOR_GL_CONTEXT_KHR"/>
             </require>
-            <require comment="Additional cl_context_properties">
+            <require group="cl_context_properties">
                 <enum name="CL_GL_CONTEXT_KHR"/>
-                <enum name="CL_EGL_DISPLAY_KHR"/>
-                <enum name="CL_GLX_DISPLAY_KHR"/>
-                <enum name="CL_WGL_HDC_KHR"/>
-                <enum name="CL_CGL_SHAREGROUP_KHR"/>
+                <enum name="CL_EGL_DISPLAY_KHR" comment="For embedded"/>
+                <enum name="CL_GLX_DISPLAY_KHR" comment="For Linux"/>
+                <enum name="CL_WGL_HDC_KHR" comment="For Windows"/>
+                <enum name="CL_CGL_SHAREGROUP_KHR" comment="For macOS"/>
             </require>
             <require>
                 <type name="cl_gl_object_type"/>
                 <type name="cl_gl_texture_info"/>
                 <type name="cl_gl_platform_info" comment="Unused"/>
             </require>
-            <require comment="cl_gl_object_type">
+            <require group="cl_gl_object_type">
                 <enum name="CL_GL_OBJECT_BUFFER"/>
                 <enum name="CL_GL_OBJECT_TEXTURE2D"/>
                 <enum name="CL_GL_OBJECT_TEXTURE3D"/>
                 <enum name="CL_GL_OBJECT_RENDERBUFFER"/>
             </require>
-            <require condition="defined(CL_VERSION_1_2)" comment="cl_gl_object_type">
+            <require group="cl_gl_object_type" condition="defined(CL_VERSION_1_2)">
                 <enum name="CL_GL_OBJECT_TEXTURE2D_ARRAY"/>
                 <enum name="CL_GL_OBJECT_TEXTURE1D"/>
                 <enum name="CL_GL_OBJECT_TEXTURE1D_ARRAY"/>
                 <enum name="CL_GL_OBJECT_TEXTURE_BUFFER"/>
             </require>
-            <require comment="cl_gl_texture_info">
+            <require group="cl_gl_texture_info">
                 <enum name="CL_GL_TEXTURE_TARGET"/>
                 <enum name="CL_GL_MIPMAP_LEVEL"/>
             </require>
@@ -6532,46 +6579,47 @@ server's OpenCL/api-docs repository.
                 <type name="cl_unified_shared_memory_type_intel"/>
                 <type name="cl_mem_advice_intel"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL"/>
                 <enum name="CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL"/>
                 <enum name="CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"/>
                 <enum name="CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"/>
                 <enum name="CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL"/>
             </require>
-            <require comment="cl_unified_shared_memory_capabilities_intel - bitfield">
+            <require group="cl_device_unified_shared_memory_capabilities_intel" etype="bitfield">
                 <enum name="CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL"/>
                 <enum name="CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL"/>
                 <enum name="CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL"/>
                 <enum name="CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL"/>
             </require>
-            <require comment="cl_mem_properties_intel">
+            <require group="cl_mem_properties_intel">
                 <enum name="CL_MEM_ALLOC_FLAGS_INTEL"/>
             </require>
-            <require comment="cl_mem_alloc_flags_intel - bitfield">
+            <require group="cl_mem_alloc_flags_intel" etype="bitfield">
                 <enum name="CL_MEM_ALLOC_WRITE_COMBINED_INTEL"/>
                 <enum name="CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL"/>
                 <enum name="CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL"/>
             </require>
-            <require comment="cl_mem_alloc_info_intel">
+            <require group="cl_mem_info">
                 <enum name="CL_MEM_ALLOC_TYPE_INTEL"/>
                 <enum name="CL_MEM_ALLOC_BASE_PTR_INTEL"/>
                 <enum name="CL_MEM_ALLOC_SIZE_INTEL"/>
                 <enum name="CL_MEM_ALLOC_DEVICE_INTEL"/>
+                <enum name="CL_MEM_ALLOC_FLAGS_INTEL"/>
             </require>
-            <require comment="cl_unified_shared_memory_type_intel">
+            <require group="cl_unified_shared_memory_type_intel">
                 <enum name="CL_MEM_TYPE_UNKNOWN_INTEL"/>
                 <enum name="CL_MEM_TYPE_HOST_INTEL"/>
                 <enum name="CL_MEM_TYPE_DEVICE_INTEL"/>
                 <enum name="CL_MEM_TYPE_SHARED_INTEL"/>
             </require>
-            <require comment="cl_kernel_exec_info">
+            <require group="cl_kernel_exec_info">
                 <enum name="CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL"/>
                 <enum name="CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL"/>
                 <enum name="CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL"/>
                 <enum name="CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_MEMFILL_INTEL"/>
                 <enum name="CL_COMMAND_MEMCPY_INTEL"/>
                 <enum name="CL_COMMAND_MIGRATEMEM_INTEL"/>
@@ -6597,11 +6645,11 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_khr_device_uuid" supported="opencl">
-            <require comment="Size Constants">
+            <require etype="constants">
                 <enum name="CL_UUID_SIZE_KHR"/>
                 <enum name="CL_LUID_SIZE_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_UUID_KHR"/>
                 <enum name="CL_DRIVER_UUID_KHR"/>
                 <enum name="CL_DEVICE_LUID_VALID_KHR"/>
@@ -6618,7 +6666,7 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_mem_channel_property" supported="opencl">
-            <require comment="cl_mem_properties_intel">
+            <require group="cl_mem_properties_intel">
                 <enum name="CL_MEM_CHANNEL_INTEL"/>
             </require>
         </extension>
@@ -6626,10 +6674,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_mem_properties_intel">
+            <require group="cl_mem_properties_intel">
                 <enum name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
             </require>
-            <require comment="cl_mem_alloc_info_intel">
+            <require group="cl_mem_info_intel">
                 <enum name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
             </require>
         </extension>
@@ -6637,7 +6685,7 @@ server's OpenCL/api-docs repository.
             <require comment="Types">
                 <type name="cl_device_scheduling_controls_capabilities_arm"/>
             </require>
-            <require comment="cl_device_scheduling_controls_capabilities_arm">
+            <require group="cl_device_scheduling_controls_capabilities_arm" etype="bitfield">
                 <enum name="CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM"/>
                 <enum name="CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM"/>
                 <enum name="CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"/>
@@ -6646,32 +6694,32 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_SCHEDULING_WARP_THROTTLING_ARM"/>
                 <enum name="CL_DEVICE_SCHEDULING_COMPUTE_UNIT_BATCH_QUEUE_SIZE_ARM"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM"/>
                 <enum name="CL_DEVICE_SUPPORTED_REGISTER_ALLOCATIONS_ARM"/>
                 <enum name="CL_DEVICE_MAX_WARP_COUNT_ARM"/>
             </require>
-            <require comment="cl_kernel_exec_info">
+            <require group="cl_kernel_exec_info">
                 <enum name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM"/>
                 <enum name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"/>
                 <enum name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"/>
                 <enum name="CL_KERNEL_EXEC_INFO_COMPUTE_UNIT_MAX_QUEUED_BATCHES_ARM"/>
             </require>
-            <require comment="cl_kernel_info">
+            <require group="cl_kernel_info">
                 <enum name="CL_KERNEL_MAX_WARP_COUNT_ARM"/>
             </require>
-            <require comment="cl_queue_properties">
+            <require group="cl_queue_properties">
                 <enum name="CL_QUEUE_KERNEL_BATCHING_ARM"/>
                 <enum name="CL_QUEUE_DEFERRED_FLUSH_ARM"/>
             </require>
         </extension>
         <extension name="cl_ext_cxx_for_opencl" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
             </require>
         </extension>
         <extension name="cl_intel_mem_force_host_memory" supported="opencl">
-            <require comment="cl_mem_flags">
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_FORCE_HOST_MEMORY_INTEL"/>
             </require>
         </extension>
@@ -6679,12 +6727,12 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 (?) and newer">
+            <require group="cl_channel_order" condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 (?) and newer">
                 <enum name="CL_DEPTH"/>
             </require>
         </extension>
         <extension name="cl_khr_extended_versioning" supported="opencl">
-            <require>
+            <require etype="constants">
                 <enum name="CL_VERSION_MAJOR_BITS_KHR"/>
                 <enum name="CL_VERSION_MINOR_BITS_KHR"/>
                 <enum name="CL_VERSION_PATCH_BITS_KHR"/>
@@ -6702,18 +6750,18 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL_MAKE_VERSION_KHR"/>
             </require>
-            <require>
+            <require etype="constants">
                 <enum name="CL_NAME_VERSION_MAX_NAME_SIZE_KHR"/>
             </require>
             <require>
                 <type name="cl_version_khr"/>
                 <type name="cl_name_version_khr"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_NUMERIC_VERSION_KHR"/>
                 <enum name="CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_NUMERIC_VERSION_KHR"/>
                 <enum name="CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR"/>
                 <enum name="CL_DEVICE_EXTENSIONS_WITH_VERSION_KHR"/>
@@ -6725,11 +6773,11 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_mipmap_filter_mode_img"/>
             </require>
-            <require comment="cl_mipmap_filter_mode_img">
+            <require group="cl_mipmap_filter_mode_img">
                 <enum name="CL_MIPMAP_FILTER_ANY_IMG"/>
                 <enum name="CL_MIPMAP_FILTER_BOX_IMG"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_GENERATE_MIPMAP_IMG"/>
             </require>
             <require>
@@ -6740,10 +6788,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_mem_properties">
+            <require group="cl_mem_properties">
                 <enum name="CL_MEM_ALLOC_FLAGS_IMG"/>
             </require>
-            <require comment="cl_mem_alloc_flags_img">
+            <require group="cl_mem_alloc_flags_img" etype="bitfield">
                 <enum name="CL_MEM_ALLOC_RELAX_REQUIREMENTS_IMG"/>
             </require>
         </extension>
@@ -6751,21 +6799,21 @@ server's OpenCL/api-docs repository.
             <require comment="Types">
                 <type name="cl_device_controlled_termination_capabilities_arm"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_COMMAND_TERMINATED_ITSELF_WITH_FAILURE_ARM"/>
             </require>
-            <require comment="cl_device_controlled_termination_capabilities_arm">
+            <require group="cl_device_controlled_termination_capabilities_arm" etype="bitfield">
                 <enum name="CL_DEVICE_CONTROLLED_TERMINATION_SUCCESS_ARM"/>
                 <enum name="CL_DEVICE_CONTROLLED_TERMINATION_FAILURE_ARM"/>
                 <enum name="CL_DEVICE_CONTROLLED_TERMINATION_QUERY_ARM"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM"/>
             </require>
-            <require comment="cl_event_info">
+            <require group="cl_event_info">
                 <enum name="CL_EVENT_COMMAND_TERMINATION_REASON_ARM"/>
             </require>
-            <require comment="cl_command_termination_reason_arm">
+            <require group="cl_command_termination_reason_arm">
                 <enum name="CL_COMMAND_TERMINATION_COMPLETION_ARM"/>
                 <enum name="CL_COMMAND_TERMINATION_CONTROLLED_SUCCESS_ARM"/>
                 <enum name="CL_COMMAND_TERMINATION_CONTROLLED_FAILURE_ARM"/>
@@ -6779,20 +6827,24 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_command_queue_capabilities_intel"/>
             </require>
-            <require>
+            <require etype="constants">
                 <enum name="CL_QUEUE_FAMILY_MAX_NAME_SIZE_INTEL"/>
             </require>
             <require>
                 <type name="cl_queue_family_properties_intel"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL"/>
             </require>
-            <require comment="cl_queue_properties">
+            <require group="cl_queue_properties">
                 <enum name="CL_QUEUE_FAMILY_INTEL"/>
                 <enum name="CL_QUEUE_INDEX_INTEL"/>
             </require>
-            <require comment="cl_command_queue_capabilities_intel">
+            <require group="cl_command_queue_info">
+                <enum name="CL_QUEUE_FAMILY_INTEL"/>
+                <enum name="CL_QUEUE_INDEX_INTEL"/>
+            </require>
+            <require group="cl_command_queue_capabilities_intel" etype="bitfield">
                 <enum name="CL_QUEUE_DEFAULT_CAPABILITIES_INTEL"/>
                 <enum name="CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL"/>
                 <enum name="CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL"/>
@@ -6819,7 +6871,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_device_pci_bus_info_khr"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_PCI_BUS_INFO_KHR"/>
             </require>
         </extension>
@@ -6838,11 +6890,11 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_device_feature_capabilities_intel"/>
             </require>
-            <require comment="cl_device_feature_capabilities_intel">
+            <require group="cl_device_feature_capabilities_intel" etype="bitfield">
                 <enum name="CL_DEVICE_FEATURE_FLAG_DP4A_INTEL"/>
                 <enum name="CL_DEVICE_FEATURE_FLAG_DPAS_INTEL"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_IP_VERSION_INTEL"/>
                 <enum name="CL_DEVICE_ID_INTEL"/>
                 <enum name="CL_DEVICE_NUM_SLICES_INTEL"/>
@@ -6860,11 +6912,11 @@ server's OpenCL/api-docs repository.
                 <type name="cl_device_integer_dot_product_capabilities_khr"/>
                 <type name="cl_device_integer_dot_product_acceleration_properties_khr"/>
             </require>
-            <require comment="cl_device_integer_dot_product_capabilities_khr">
+            <require group="cl_device_integer_dot_product_capabilities_khr" etype="bitfield">
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR"/>
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_CAPABILITIES_KHR"/>
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR"/>
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
@@ -6881,31 +6933,33 @@ server's OpenCL/api-docs repository.
                 <type name="cl_semaphore_type_khr"/>
                 <type name="cl_semaphore_payload_khr"/>
             </require>
-            <require comment="cl_semaphore_type">
+            <require group="cl_semaphore_type_khr">
                 <enum name="CL_SEMAPHORE_TYPE_BINARY_KHR"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SEMAPHORE_TYPES_KHR"/>
             </require>
-            <require comment="cl_semaphore_info_khr">
+            <require group="cl_semaphore_info_khr">
                 <enum name="CL_SEMAPHORE_CONTEXT_KHR"/>
                 <enum name="CL_SEMAPHORE_REFERENCE_COUNT_KHR"/>
                 <enum name="CL_SEMAPHORE_PROPERTIES_KHR"/>
                 <enum name="CL_SEMAPHORE_PAYLOAD_KHR"/>
+                <enum name="CL_SEMAPHORE_TYPE_KHR"/>
+                <enum name="CL_DEVICE_HANDLE_LIST_KHR"/>
             </require>
-            <require comment="cl_semaphore_info_khr or cl_semaphore_properties_khr">
+            <require group="cl_semaphore_properties_khr">
                 <enum name="CL_SEMAPHORE_TYPE_KHR"/>
                 <enum name="CL_DEVICE_HANDLE_LIST_KHR"/>
                 <enum name="CL_DEVICE_HANDLE_LIST_END_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_SEMAPHORE_WAIT_KHR"/>
                 <enum name="CL_COMMAND_SEMAPHORE_SIGNAL_KHR"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_SEMAPHORE_KHR"/>
             </require>
             <require>
@@ -6925,17 +6979,20 @@ server's OpenCL/api-docs repository.
                 <type name="cl_semaphore_khr"/>
                 <type name="cl_external_semaphore_handle_type_khr"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
             </require>
-            <require comment="cl_semaphore_properties_khr">
+            <require group="cl_semaphore_properties_khr">
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR"/>
+            </require>
+            <require group="cl_semaphore_info_khr">
+                <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
             </require>
             <require>
                 <command name="clGetSemaphoreHandleForTypeKHR"/>
@@ -6945,7 +7002,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_semaphore_handle_type_khr">
+            <require group="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR"/>
             </require>
         </extension>
@@ -6953,7 +7010,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_semaphore_handle_type_khr">
+            <require group="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
@@ -6961,7 +7018,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_semaphore_handle_type_khr">
+            <require group="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_SYNC_FD_KHR"/>
             </require>
         </extension>
@@ -6969,7 +7026,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_semaphore_handle_type_khr">
+            <require group="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR"/>
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
             </require>
@@ -6981,17 +7038,17 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_external_memory_handle_type_khr"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
             </require>
-            <require comment="cl_mem_properties">
+            <require group="cl_mem_properties">
                 <enum name="CL_DEVICE_HANDLE_LIST_KHR"/>
                 <enum name="CL_DEVICE_HANDLE_LIST_END_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR"/>
             </require>
@@ -7004,7 +7061,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_memory_handle_type_khr">
+            <require group="cl_external_memory_handle_type_khr">
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR"/>
             </require>
         </extension>
@@ -7012,7 +7069,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_memory_handle_type_khr">
+            <require group="cl_external_memory_handle_type_khr">
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KHR"/>
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_D3D11_TEXTURE_KMT_KHR"/>
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR"/>
@@ -7023,7 +7080,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_memory_handle_type_khr">
+            <require group="cl_external_memory_handle_type_khr">
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
@@ -7031,7 +7088,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="cl_external_memory_handle_type_khr">
+            <require group="cl_external_memory_handle_type_khr">
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR"/>
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
             </require>
@@ -7086,28 +7143,28 @@ server's OpenCL/api-docs repository.
                 <type name="cl_ndrange_kernel_command_properties_khr"/>
                 <type name="cl_mutable_command_khr"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
                 <enum name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
             </require>
-            <require comment="cl_device_command_buffer_capabilities_khr - bitfield">
+            <require group="cl_device_command_buffer_capabilities_khr" etype="bitfield">
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR"/>
             </require>
-            <require comment="cl_command_buffer_properties_khr">
+            <require group="cl_command_buffer_properties_khr">
                <enum name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
             </require>
-            <require comment="cl_command_buffer_flags_khr - bitfield">
+            <require group="cl_command_buffer_flags_khr" etype="bitfield">
                <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_COMMAND_BUFFER_KHR"/>
                 <enum name="CL_INVALID_SYNC_POINT_WAIT_LIST_KHR"/>
                 <enum name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
             </require>
-            <require comment="cl_command_buffer_info_khr">
+            <require group="cl_command_buffer_info_khr">
                <enum name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
                <enum name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
                <enum name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
@@ -7115,13 +7172,13 @@ server's OpenCL/api-docs repository.
                <enum name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
                <enum name="CL_COMMAND_BUFFER_CONTEXT_KHR"/>
             </require>
-            <require comment="cl_command_buffer_state_khr">
+            <require group="cl_command_buffer_state_khr">
                <enum name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>
                <enum name="CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR"/>
                <enum name="CL_COMMAND_BUFFER_STATE_PENDING_KHR"/>
                <enum name="CL_COMMAND_BUFFER_STATE_INVALID_KHR"/>
             </require>
-            <require comment="cl_command_type">
+            <require group="cl_command_type">
                 <enum name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
             </require>
             <require>
@@ -7143,7 +7200,7 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_arm_protected_memory_allocation" supported="opencl">
-            <require>
+            <require group="cl_mem_flags" etype="bitfield">
                 <enum name="CL_MEM_PROTECTED_ALLOC_ARM"/>
             </require>
         </extension>
@@ -7154,7 +7211,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_device_fp_atomic_capabilities_ext"/>
             </require>
-            <require comment="cl_device_fp_atomic_capabilities_ext">
+            <require group="cl_device_fp_atomic_capabilities_ext" etype="bitfield">
                 <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT"/>
                 <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT"/>
                 <enum name="CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT"/>
@@ -7162,7 +7219,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT"/>
                 <enum name="CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
                 <enum name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
                 <enum name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
@@ -7172,11 +7229,11 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="clGetEventInfo response when param_name is CL_EVENT_COMMAND_TYPE">
+            <require group="cl_command_type" comment="clGetEventInfo response when param_name is CL_EVENT_COMMAND_TYPE">
                 <enum name="CL_COMMAND_READ_HOST_PIPE_INTEL"/>
                 <enum name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"/>
             </require>
-            <require comment="clGetProgramInfo param_name">
+            <require group="cl_program_info">
                 <enum name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"/>
                 <enum name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"/>
             </require>
@@ -7189,7 +7246,7 @@ server's OpenCL/api-docs repository.
             <require comment="Types">
                 <type name="cl_image_requirements_info_ext"/>
             </require>
-            <require comment="cl_image_requirements_info_ext">
+            <require group="cl_image_requirements_info_ext">
                 <enum name="CL_IMAGE_REQUIREMENTS_BASE_ADDRESS_ALIGNMENT_EXT"/>
                 <enum name="CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT"/>
                 <enum name="CL_IMAGE_REQUIREMENTS_SIZE_EXT"/>
@@ -7203,15 +7260,15 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_intel_queue_no_sync_operations" supported="opencl">
-            <require comment="cl_command_queue_properties">
+            <require group="cl_command_queue_properties" etype="bitfield">
                 <enum name="CL_QUEUE_NO_SYNC_OPERATIONS_INTEL"/>
             </require>
         </extension>
         <extension name="cl_arm_job_slot_selection" supported="opencl">
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_JOB_SLOTS_ARM"/>
             </require>
-            <require comment="cl_queue_properties">
+            <require group="cl_queue_properties">
                 <enum name="CL_QUEUE_JOB_SLOT_ARM"/>
             </require>
         </extension>
@@ -7228,27 +7285,27 @@ server's OpenCL/api-docs repository.
                 <type name="cl_mutable_dispatch_config_khr"/>
                 <type name="cl_mutable_base_config_khr"/>
             </require>
-            <require comment="cl_command_buffer_flags_khr - bitfield">
+            <require group="cl_command_buffer_flags_khr" etype="bitfield">
                <enum name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
             </require>
-            <require comment="Error codes">
+            <require group="cl_error_code">
                 <enum name="CL_INVALID_MUTABLE_COMMAND_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
                 <enum name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
             </require>
-            <require comment="cl_ndrange_kernel_command_properties_khr">
+            <require group="cl_ndrange_kernel_command_properties_khr">
                <enum name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
             </require>
 
-            <require comment="cl_mutable_dispatch_fields_khr - bitfield">
+            <require group="cl_mutable_dispatch_fields_khr" etype="bitfield">
                 <enum name="CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR"/>
                 <enum name="CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR"/>
                 <enum name="CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR"/>
                 <enum name="CL_MUTABLE_DISPATCH_ARGUMENTS_KHR"/>
                 <enum name="CL_MUTABLE_DISPATCH_EXEC_INFO_KHR"/>
             </require>
-            <require comment="cl_mutable_command_info_khr">
+            <require group="cl_mutable_command_info_khr">
                <enum name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
                <enum name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
                <enum name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
@@ -7259,7 +7316,7 @@ server's OpenCL/api-docs repository.
                <enum name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR"/>
                <enum name="CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR"/>
             </require>
-            <require comment="cl_command_buffer_structure_type_khr">
+            <require group="cl_command_buffer_structure_type_khr">
                 <enum name="CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR"/>
                 <enum name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
             </require>
@@ -7269,12 +7326,12 @@ server's OpenCL/api-docs repository.
             </require>
         </extension>
         <extension name="cl_ext_image_from_buffer" condition="defined(CL_VERSION_3_0)" supported="opencl">
-            <require comment="cl_image_requirements_info_ext">
+            <require group="cl_image_requirements_info_ext">
                 <enum name="CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT"/>
             </require>
         </extension>
         <extension name="cl_intel_create_mem_object_properties" supported="opencl">
-            <require comment="cl_mem_properties">
+            <require group="cl_mem_properties">
                 <enum name="CL_MEM_LOCALLY_UNCACHED_RESOURCE_INTEL"/>
                 <enum name="CL_MEM_DEVICE_ID_INTEL"/>
             </require>
@@ -7286,22 +7343,23 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_platform_command_buffer_capabilities_khr"/>
             </require>
-            <require comment="cl_platform_info">
+            <require group="cl_platform_info">
                 <enum name="CL_PLATFORM_COMMAND_BUFFER_CAPABILITIES_KHR"/>
             </require>
-            <require comment="cl_platform_command_buffer_capabilities_khr - bitfield">
+            <require group="cl_platform_command_buffer_capabilities_khr" etype="bitfield">
                 <enum name="CL_COMMAND_BUFFER_PLATFORM_UNIVERSAL_SYNC_KHR"/>
                 <enum name="CL_COMMAND_BUFFER_PLATFORM_REMAP_QUEUES_KHR"/>
                 <enum name="CL_COMMAND_BUFFER_PLATFORM_AUTOMATIC_REMAP_KHR"/>
             </require>
-            <require comment="cl_device_info">
+            <require group="cl_device_info">
+                <enum name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
                 <enum name="CL_DEVICE_COMMAND_BUFFER_NUM_SYNC_DEVICES_KHR"/>
                 <enum name="CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR"/>
             </require>
-            <require comment="cl_device_command_buffer_capabilities_khr - bitfield">
+            <require group="cl_device_command_buffer_capabilities_khr" etype="bitfield">
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR"/>
             </require>
-            <require comment="cl_command_buffer_flags_khr - bitfield">
+            <require group="cl_command_buffer_flags_khr" etype="bitfield">
                <enum name="CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR"/>
             </require>
             <require>


### PR DESCRIPTION
### History

I first tried to rectify the idea of #779.

But there are enum types, like `cl_mem_flags` and `cl_svm_mem_flags`, which have their value sets intersecting. I don't know how to describe that using `<enums name="..."`, because `<enum>` tags are unique and sorted by value.

This is, however, already described in `<require>` tags:
```
        <require comment="cl_mem_flags and cl_svm_mem_flags - bitfield">
            <enum name="CL_MEM_READ_WRITE"/>
            <enum name="CL_MEM_WRITE_ONLY"/>
            <enum name="CL_MEM_READ_ONLY"/>
            <enum name="CL_MEM_USE_HOST_PTR"/>
            <enum name="CL_MEM_ALLOC_HOST_PTR"/>
            <enum name="CL_MEM_COPY_HOST_PTR"/>
        </require>
```
And after I've checked all of it, I can say - `comment` attributes actually more consistent. Even despite being a horrible abuse and a few cases like:
```
            <require condition="!defined(CL_VERSION_1_2)" comment="cl_device_info - defined in CL.h for OpenCL 1.2 and newer">
```
Making it hard to parse out the enum type name...
(this is what caused me to find #917)

---

### This PR

So I've thrown away most changes #779 (my version of it) did to to `<enums>` tags for this PR and focused on replacing the `comment` attribute with something consistent:
```
        <require group="cl_device_type" etype="bitfield">
```
And also on using the defined enum types where they should be (like structs).

The `etype` is supposed to be `enum` or `bitfield`, where `enum` can be omitted, but can also be specified explicitly.
(I'll reflect this in `registry.rnc`, but would like to hear some feedback first)
I didn't find any cases where explicit `etype="enum"` would be useful, but I have some ideas concerning other changes I'd like to make further PRs for:

---

### Other changes

Most notable of them is info from state tables, they are [here](https://github.com/SunSerega/OpenCL-Docs/tree/changes/clear) ([current commit](https://github.com/SunSerega/OpenCL-Docs/commit/d4d1ac4f8c57aa709d9d4d511d36d21c3c674292)) ([compare](https://github.com/KhronosGroup/OpenCL-Docs/compare/main...SunSerega:OpenCL-Docs:changes/clear)).
But only after translating this from my internal binding fixers to `etype="obj info"` and `etype="property list"` did I think that there are much better ways to express this in XML. Well, I'd like to hear what others think before Iimit ideas to what I'm thinking of replacing it with.
Regardless, that branch is currently a mess, only good as proof of concept, because I'm currently using it for my bindings.

Other changes that probably should be in separate PR are the rename `clCommandExecutionStatus`=>`cl_command_execution_status` (for consistency of naming convention) and the addition of `cl_error_code` as a proper enum type, instead of `Error codes` comments.
But it felt awkward to separate because that would leave some stray `comment` attribute abuse cases in this PR.

Also, if anyone thinks there is value in how I merged main into #779 - it can be found [here](https://github.com/SunSerega/OpenCL-Docs/tree/changes/original) ([current commit](https://github.com/SunSerega/OpenCL-Docs/commit/3c65fe3b790a4bc747dec416c1fa501f38f73671)) ([compare](https://github.com/KhronosGroup/OpenCL-Docs/compare/main...SunSerega:OpenCL-Docs:changes/original)), in an even bigger mess of changes.