### PR TITLE
Document NV error code

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -570,6 +570,7 @@ server's OpenCL/api-docs repository.
         <enum value="-70"           name="CL_INVALID_DEVICE_QUEUE"/>
         <enum value="-71"           name="CL_INVALID_SPEC_ID"/>
         <enum value="-72"           name="CL_MAX_SIZE_RESTRICTION_EXCEEDED"/>
+        <enum value="-9999"         name="CL_KERNEL_ILLEGAL_BUFFER_READ_WRITE_NV"/>
             <unused start="-73" end="-999" comment="Reserved for Khronos"/>
     </enums>
 
@@ -4389,6 +4390,7 @@ server's OpenCL/api-docs repository.
             <enum name="CL_INVALID_BUFFER_SIZE"/>
             <enum name="CL_INVALID_MIP_LEVEL"/>
             <enum name="CL_INVALID_GLOBAL_WORK_SIZE"/>
+            <enum name="CL_KERNEL_ILLEGAL_BUFFER_READ_WRITE_NV"/>
         </require>
         <require comment="cl_bool">
             <enum name="CL_FALSE"/>


### PR DESCRIPTION
It feels a bit backward to add like this, but this error code is used in production for a while but isn't defined in XML.

The name `CL_KERNEL_ILLEGAL_BUFFER_READ_WRITE_NV`... Seem to not fully describe the situation, I think I've seen it thrown in other cases.
The only thing I'm sure about is that this error is only thrown while the kernel is executing (never while compiling/linking).

I think I found this name on some random forum a while ago.
Back then I force-added it to my bindings without thinking, to get human-readable errors while testing my code.
But I can imagine, this would also be useful the same way to others...

Do I need to ping someone from NV?
Also, any naming suggestions?