### PR TITLE
remove footnote back-links to avoid duplicate anchors

### DIFF
--- a/cxx/annotation.txt
+++ b/cxx/annotation.txt
@@ -6,19 +6,19 @@
 
 '''''
 [[ftn2]]
-<<ftnref2,[2]>> The `double` data type is an optional type that is supported if `CL_DEVICE_DOUBLE_FP_CONFIG` in table 4.3 for a device is not zero.
+[2] The `double` data type is an optional type that is supported if `CL_DEVICE_DOUBLE_FP_CONFIG` in table 4.3 for a device is not zero.
 
 [[ftn3]]
-<<ftnref3,[3]>> The question mark ? in numerical selector refers to special undefined component of vector; reading from it results in undefined value, writing to it is discarded.
+[3] The question mark ? in numerical selector refers to special undefined component of vector; reading from it results in undefined value, writing to it is discarded.
 
 [[ftn4]]
-<<ftnref4,[4]>> Only if the *cl_khr_fp16* extension is enabled and has been supported
+[4] Only if the *cl_khr_fp16* extension is enabled and has been supported
 
 [[ftn5]]
-<<ftnref5,[5]>> For conversions to floating-point format, when a finite source value exceeds the maximum representable finite floating-point destination value, the rounding mode will affect whether the result is the maximum finite floating-point value or infinity of same sign as the source value, per IEEE-754 rules for rounding.
+[5] For conversions to floating-point format, when a finite source value exceeds the maximum representable finite floating-point destination value, the rounding mode will affect whether the result is the maximum finite floating-point value or infinity of same sign as the source value, per IEEE-754 rules for rounding.
 
 [[ftn6]]
-<<ftnref6,[6]>> The `as_type<T>` function is intended to reflect the organization of data in register.
+[6] The `as_type<T>` function is intended to reflect the organization of data in register.
 The `as_type<T>` construct is intended to compile to no instructions on devices that use a shared register file designed to operate on both the operand and result types.
 Note that while differences in memory organization are expected to largely be limited to those arising from endianness, the register based representation may also differ due to size of the element in register.
 (For example, an architecture may load a char into a 32-bit register, or a char vector into a SIMD vector register with fixed 32-bit element size.)
@@ -27,91 +27,91 @@ So, for example if an implementation stores all single precision data as double 
 If data stored in different address spaces do not have the same endianness, then the "dominant endianness" of the device should prevail.
 
 [[ftn7]]
-<<ftnref7,[7]>> `memory_order_consume` is not supported in OpenCL {cpp}
+[7] `memory_order_consume` is not supported in OpenCL {cpp}
 
 [[ftn8]]
-<<ftnref8,[8]>> This value for `memory_scope` can only be used with `atomic_fence` with flags set to `mem_fence::image`.
+[8] This value for `memory_scope` can only be used with `atomic_fence` with flags set to `mem_fence::image`.
 
 [[ftn9]]
-<<ftnref9,[9]>> We can't require {cpp14} atomics since host programs can be implemented in other programming languages and versions of C or {cpp}, but we do require that the host programs use atomics and that those atomics be compatible with those in {cpp14}.
+[9] We can't require {cpp14} atomics since host programs can be implemented in other programming languages and versions of C or {cpp}, but we do require that the host programs use atomics and that those atomics be compatible with those in {cpp14}.
 
 [[ftn10]]
-<<ftnref10,[10]>> The `atomic_long` and `atomic_ulong` types are supported if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
+[10] The `atomic_long` and `atomic_ulong` types are supported if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
 
 [[ftn11]]
-<<ftnref11,[11]>> The `atomic_double` type is only supported if double precision is supported and the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
+[11] The `atomic_double` type is only supported if double precision is supported and the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
 
 [[ftn12]]
-<<ftnref12,[12]>> If the device address space is 64-bits, the data types `atomic_intptr_t`, `atomic_uintptr_t`, `atomic_size_t` and `atomic_ptrdiff_t` are supported only if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
+[12] If the device address space is 64-bits, the data types `atomic_intptr_t`, `atomic_uintptr_t`, `atomic_size_t` and `atomic_ptrdiff_t` are supported only if the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions are supported and have been enabled.
 
 [[ftn13]]
-<<ftnref13,[13]>> The `\*_ms` types are supported only if the *cl_khr_gl_msaa_sharing* and *cl_khr_gl_depth_images* extensions are supported and have been enabled.
+[13] The `\*_ms` types are supported only if the *cl_khr_gl_msaa_sharing* and *cl_khr_gl_depth_images* extensions are supported and have been enabled.
 
 [[ftn14]]
-<<ftnref14,[14]>> Immediate meaning not side effects resulting from child kernels. The side effects would include stores to global memory and pipe reads and writes.
+[14] Immediate meaning not side effects resulting from child kernels. The side effects would include stores to global memory and pipe reads and writes.
 
 [[ftn15]]
-<<ftnref15,[15]>> This acts as a memory synchronization point between work-items in a work-group and child kernels enqueued by work-items in the work-group.
+[15] This acts as a memory synchronization point between work-items in a work-group and child kernels enqueued by work-items in the work-group.
 
 // Footnote 16 removed - duplicated footnote 17
 
 [[ftn17]]
-<<ftnref17,[17]>> i.e. the `global_work_size` values specified to `clEnqueueNDRangeKernel` are not evenly divisible by the `local_work_size` values for each dimension.
+[17] i.e. the `global_work_size` values specified to `clEnqueueNDRangeKernel` are not evenly divisible by the `local_work_size` values for each dimension.
 
 [[ftn18]]
-<<ftnref18,[18]>> Only if double precision is supported and has been enabled.
+[18] Only if double precision is supported and has been enabled.
 
 [[ftn19]]
-<<ftnref19,[19]>> Refer to the <<order-and-scope, _Memory order and scope_>> section for description of `memory_scope`.
+[19] Refer to the <<order-and-scope, _Memory order and scope_>> section for description of `memory_scope`.
 
 [[ftn20]]
-<<ftnref20,[20]>> The `min()` operator is there to prevent `fract(-small)` from returning 1.0.
+[20] The `min()` operator is there to prevent `fract(-small)` from returning 1.0.
 It returns the largest positive floating-point number less than 1.0.
 
 [[ftn21]]
-<<ftnref21,[21]>> fmin and fmax behave as defined by {cpp14} and may not match the IEEE 754-2008 definition for minNum and maxNum with regard to signaling NaNs.
+[21] fmin and fmax behave as defined by {cpp14} and may not match the IEEE 754-2008 definition for minNum and maxNum with regard to signaling NaNs.
 Specifically, signaling NaNs may behave as quiet NaNs.
 
 [[ftn22]]
-<<ftnref22,[22]>> The user is cautioned that for some usages, e.g. `mad(a, b, -a*b)`, the definition of `mad()` in the embedded profile is loose enough that almost any result is allowed from `mad()` for some values of `a` and `b`.
+[22] The user is cautioned that for some usages, e.g. `mad(a, b, -a*b)`, the definition of `mad()` in the embedded profile is loose enough that almost any result is allowed from `mad()` for some values of `a` and `b`.
 
 [[ftn23]]
-<<ftnref23,[23]>> Frequently vector operations need n + 1 bits temporarily to calculate a result.
+[23] Frequently vector operations need n + 1 bits temporarily to calculate a result.
 The rhadd instruction gives you an extra bit without needing to upsample and downsample. This can be a profound performance win.
 
 [[ftn24]]
-<<ftnref24,[24]>> The primary purpose of the printf function is to help in debugging OpenCL kernels.
+[24] The primary purpose of the printf function is to help in debugging OpenCL kernels.
 
 [[ftn25]]
-<<ftnref25,[25]>> Note that _0_ is taken as a flag, not as the beginning of a field width.
+[25] Note that _0_ is taken as a flag, not as the beginning of a field width.
 
 [[ftn26]]
-<<ftnref26,[26]>> The results of all floating conversions of a negative zero, and of negative values that round to zero, include a minus sign.
+[26] The results of all floating conversions of a negative zero, and of negative values that round to zero, include a minus sign.
 
 [[ftn27]]
-<<ftnref27,[27]>> When applied to infinite and NaN values, the -, +, and space flag characters have their usual meaning; the # and _0_ flag characters have no effect.
+[27] When applied to infinite and NaN values, the -, +, and space flag characters have their usual meaning; the # and _0_ flag characters have no effect.
 
 [[ftn28]]
-<<ftnref28,[28]>> Binary implementations can choose the hexadecimal digit to the left of the decimal-point character so that subsequent digits align to nibble (4-bit) boundaries.
+[28] Binary implementations can choose the hexadecimal digit to the left of the decimal-point character so that subsequent digits align to nibble (4-bit) boundaries.
 
 [[ftn29]]
-<<ftnref29,[29]>> No special provisions are made for multibyte characters.
+[29] No special provisions are made for multibyte characters.
 The behavior of printf with the _s_ conversion specifier is undefined if the argument value is not a pointer to a literal string.
 
 [[ftn30]]
-<<ftnref30,[30]>> Except for the embedded profile whether either round to zero or round to nearest rounding mode may be supported for single precision floating-point.
+[30] Except for the embedded profile whether either round to zero or round to nearest rounding mode may be supported for single precision floating-point.
 
 [[ftn31]]
-<<ftnref31,[31]>> The ULP values for built-in math functions `lgamma` and `lgamma_r` is currently undefined.
+[31] The ULP values for built-in math functions `lgamma` and `lgamma_r` is currently undefined.
 
 [[ftn32]]
-<<ftnref32,[32]>> 0 ulp is used for math functions that do not require rounding.
+[32] 0 ulp is used for math functions that do not require rounding.
 
 [[ftn33]]
-<<ftnref33,[33]>> On some implementations, `powr()` or `pown()` may perform faster than `pow()`.
+[33] On some implementations, `powr()` or `pown()` may perform faster than `pow()`.
 If `x` is known to be `>= 0`, consider using `powr()` in place of `pow()`, or if `y` is known to be an integer, consider using `pown()` in place of `pow()`.
 
 // Footnote 34 removed - duplicated footnote 32
 
 [[ftn35]]
-<<ftnref35,[35]>> Here `TYPE_MIN` and `TYPE_MIN_EXP` should be substituted by constants appropriate to the floating-point type under consideration, such as `FLT_MIN` and `FLT_MIN_EXP` for float.
+[35] Here `TYPE_MIN` and `TYPE_MIN_EXP` should be substituted by constants appropriate to the floating-point type under consideration, such as `FLT_MIN` and `FLT_MIN_EXP` for float.

--- a/cxx/lang/builtin_data_types.txt
+++ b/cxx/lang/builtin_data_types.txt
@@ -47,7 +47,7 @@ The following data types are supported.
 | A 32-bit floating-point.
   The float data type must conform to the IEEE 754 single precision storage format.
 
-| `double` [[ftnref2]] <<ftn2,[2]>>
+| `double` <<ftn2,[2]>>
 | A 64-bit floating-point.
   The double data type must conform to the IEEE 754 double precision storage format.
 

--- a/cxx/numerical_compliance/edge_case_behavior.txt
+++ b/cxx/numerical_compliance/edge_case_behavior.txt
@@ -143,4 +143,4 @@ If subnormals are flushed to zero, a device may choose to conform to the followi
 
 For clarity, subnormals or denormals are defined to be the set of representable numbers in the range 0 < x < `TYPE_MIN` and `-TYPE_MIN` < x < -0.
 They do not include {plusmn}0.
-A non-zero number is said to be sub-normal before rounding if after normalization, its radix-2 exponent is less than `(TYPE_MIN_EXP - 1)`. [[ftnref35]] <<ftn35,[35]>>
+A non-zero number is said to be sub-normal before rounding if after normalization, its radix-2 exponent is less than `(TYPE_MIN_EXP - 1)`. <<ftn35,[35]>>

--- a/cxx/numerical_compliance/relative_error_as_ulps.txt
+++ b/cxx/numerical_compliance/relative_error_as_ulps.txt
@@ -25,7 +25,7 @@ Currently hosted at
 https://hal.inria.fr/inria-00070503/document[https://hal.inria.fr/inria-00070503/document].
 ====
 
-<<ulp_values_for_single_precision_builtin_math_functions,ULP values for single precision built-in math functions>> [[ftnref31]] <<ftn31,[31]>> table describes the minimum accuracy of single precision floating-point arithmetic operations given as ULP values.
+<<ulp_values_for_single_precision_builtin_math_functions,ULP values for single precision built-in math functions>> <<ftn31,[31]>> table describes the minimum accuracy of single precision floating-point arithmetic operations given as ULP values.
 The reference value used to compute the ULP value of an arithmetic operation is the infinitely precise result.
 
 [[ulp_values_for_single_precision_builtin_math_functions]]
@@ -33,7 +33,7 @@ The reference value used to compute the ULP value of an arithmetic operation is 
 [width="100%",cols="50%,50%",options="header"]
 |====
 | *Function*
-| *Min Accuracy - ULP values [[ftnref32]] <<ftn32,[32]>>*
+| *Min Accuracy - ULP values <<ftn32,[32]>>*
 
 | _x_ + _y_
 | Correctly rounded
@@ -696,7 +696,7 @@ The reference value used to compute the ULP value of an arithmetic operation is 
   Undefined for x < 0 and non-integer y.
   Undefined for x < 0 and y outside the domain [-2^24^, 2^24^].
   For x > 0 or x < 0 and even y, derived implementations implement this as exp2( y * log2( fabs(x) ) ).
-  For x < 0 and odd y, derived implementations implement this as -exp2( y * log2( fabs(x) ) [[ftnref33]] <<ftn33,[33]>>.
+  For x < 0 and odd y, derived implementations implement this as -exp2( y * log2( fabs(x) ) <<ftn33,[33]>>.
   For x == 0 and nonzero y, derived implementations return zero.
   For non-derived implementations, the error is \<= 8192 ULP.
 

--- a/cxx/numerical_compliance/rounding_modes.txt
+++ b/cxx/numerical_compliance/rounding_modes.txt
@@ -13,6 +13,6 @@ IEEE 754 defines four possible rounding modes:
   * Round toward -infinity.
   * Round toward zero.
 
-_Round to nearest even_ is currently the only rounding mode required [[ftnref30]] <<ftn30,[30]>> by the OpenCL specification for single precision and double precision operations and is therefore the default rounding mode.
+_Round to nearest even_ is currently the only rounding mode required <<ftn30,[30]>> by the OpenCL specification for single precision and double precision operations and is therefore the default rounding mode.
 In addition, only static selection of rounding mode is supported.
 Static and dynamic selection of rounding mode is not supported.

--- a/cxx/stdlib/atomic_operations.txt
+++ b/cxx/stdlib/atomic_operations.txt
@@ -386,11 +386,11 @@ enum memory_scope
 
 }
 ----
-An enumeration `memory_order` is described in section [atomics.order] of {cpp14} specification. [[ftnref7]] <<ftn7,[7]>>
+An enumeration `memory_order` is described in section [atomics.order] of {cpp14} specification. <<ftn7,[7]>>
 
 The enumerated type `memory_scope` specifies whether the memory ordering constraints given by `memory_order` apply to work-items in a work-group or work-items of a kernel(s) executing on the device or across devices (in the case of shared virtual memory). Its enumeration constants are as follows:
 
-  * `memory_scope_work_item` [[ftnref8]] <<ftn8,[8]>>
+  * `memory_scope_work_item` <<ftn8,[8]>>
   * `memory_scope_sub_group`
   * `memory_scope_work_group`
   * `memory_scope_device`
@@ -402,7 +402,7 @@ Atomic operations to local memory only guarantee memory ordering in the work-gro
 NOTE: With fine-grained system SVM, sharing happens at the granularity of individual loads and stores anywhere in host memory.
 Memory consistency is always guaranteed at synchronization points, but to obtain finer control over consistency, the OpenCL atomics functions may be used to ensure that the updates to individual data values made by
 one unit of execution are visible to other execution units.
-In particular, when a host thread needs fine control over the consistency of memory that is shared with one or more OpenCL devices, it must use atomic and fence operations that are compatible with the {cpp14} atomic operations [[ftnref9]] <<ftn9,[9]>>.
+In particular, when a host thread needs fine control over the consistency of memory that is shared with one or more OpenCL devices, it must use atomic and fence operations that are compatible with the {cpp14} atomic operations <<ftn9,[9]>>.
 
 [[atomic-lock-free-property]]
 ==== Atomic lock-free property
@@ -755,7 +755,7 @@ An application that wants to use 64-bit atomic types will need to define `cl_khr
 [[restrictions-3]]
 ==== Restrictions
 
-* The generic `atomic<T>` class template is only available if `T` is `int`, `uint`, `long`, `ulong` [[ftnref10]] <<ftn10,[10]>>, `float`, `double` [[ftnref11]] <<ftn11,[11]>>, `intptr_t` [[ftnref12]] <<ftn12,[12]>>, `uintptr_t`, `size_t`, `ptrdiff_t`.
+* The generic `atomic<T>` class template is only available if `T` is `int`, `uint`, `long`, `ulong` <<ftn10,[10]>>, `float`, `double` <<ftn11,[11]>>, `intptr_t` <<ftn12,[12]>>, `uintptr_t`, `size_t`, `ptrdiff_t`.
 * The `atomic_bool`, `atomic_char`, `atomic_uchar`, `atomic_short`, `atomic_ushort`, `atomic_intmax_t` and `atomic_uintmax_t` types are not supported by OpenCL {cpp}.
 * OpenCL {cpp} requires that the built-in atomic functions on atomic types are lock-free.
 * The atomic data types cannot be declared inside a kernel or non-kernel function unless they are declared as `static` keyword or in `local<T>` and `global<T>` containers.

--- a/cxx/stdlib/common.txt
+++ b/cxx/stdlib/common.txt
@@ -11,7 +11,7 @@ Descriptions are always per-component.
 
 The built-in common functions are implemented using the round to nearest even rounding mode.
 
-Here `gentype` matches: `half__n__` [[ftnref4]] <<ftn4,[4]>>, `float__n__` or `double__n__` [[ftnref18]] <<ftn18,[18]>>
+Here `gentype` matches: `half__n__` <<ftn4,[4]>>, `float__n__` or `double__n__` <<ftn18,[18]>>
 
 [[header-opencl_common-synopsis]]
 ==== Header <opencl_common> Synopsis

--- a/cxx/stdlib/conversions.txt
+++ b/cxx/stdlib/conversions.txt
@@ -48,7 +48,7 @@ T convert_cast(T const& arg);
 [[data-types]]
 ==== Data Types
 
-Conversions are available for the following scalar types: `bool`, `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `half` [[ftnref4]] <<ftn4,[4]>>, `float`, `double`, and built-in vector types derived therefrom.
+Conversions are available for the following scalar types: `bool`, `char`, `uchar`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `half` <<ftn4,[4]>>, `float`, `double`, and built-in vector types derived therefrom.
 The operand and result type must have the same number of elements.
 The operand and result type may be the same type in which case the conversion has no effect on the type or value of an expression.
 
@@ -70,7 +70,7 @@ Conversions may have an optional rounding mode specified as described in the tab
 | `rtn`           | Round toward negative infinity
 |====
 
-If a rounding mode is not specified, conversions to integer type use the `rtz` (round toward zero) rounding mode and conversions to floating-point type [[ftnref5]] <<ftn5,[5]>> uses the `rte` rounding mode.
+If a rounding mode is not specified, conversions to integer type use the `rtz` (round toward zero) rounding mode and conversions to floating-point type <<ftn5,[5]>> uses the `rte` rounding mode.
 
 [[out-of-range-behavior-and-saturated-conversions]]
 ==== Out-of-Range Behavior and Saturated Conversions

--- a/cxx/stdlib/device_enqueue.txt
+++ b/cxx/stdlib/device_enqueue.txt
@@ -416,8 +416,8 @@ It is defined as follows:
 | `no_wait`
     | Indicates that the enqueued kernels do not need to wait for the parent kernel to finish execution before they begin execution.
 | `wait_kernel`
-    | Indicates that all work-items of the parent kernel must finish executing and all immediate [[ftnref14]] <<ftn14,[14]>> side effects committed before the enqueued child kernel may begin execution.
-| `wait_work_group` [[ftnref15]] <<ftn15,[15]>>
+    | Indicates that all work-items of the parent kernel must finish executing and all immediate <<ftn14,[14]>> side effects committed before the enqueued child kernel may begin execution.
+| `wait_work_group` <<ftn15,[15]>>
     | Indicates that the enqueued kernels wait only for the work-group that enqueued the kernels to finish before they begin execution.
 |====
 

--- a/cxx/stdlib/geometric.txt
+++ b/cxx/stdlib/geometric.txt
@@ -12,9 +12,9 @@ The geometric functions are implemented using the round to nearest even rounding
 
 `float__n__` is `float`, `float2`, `float3` or `float4`.
 
-`half__n__` [[ftnref4]] <<ftn4,[4]>> is `half`, `half2`, `half3` or `half4`.
+`half__n__` <<ftn4,[4]>> is `half`, `half2`, `half3` or `half4`.
 
-`double__n__` [[ftnref18]] <<ftn18,[18]>> is `double`, `double2`, `double3` or `double4`.
+`double__n__` <<ftn18,[18]>> is `double`, `double2`, `double3` or `double4`.
 
 [[header-opencl_geometric-synopsis]]
 ==== Header <opencl_geometric> Synopsis

--- a/cxx/stdlib/images_and_samplers.txt
+++ b/cxx/stdlib/images_and_samplers.txt
@@ -6,7 +6,7 @@
 === Images and Samplers Library
 
 This section describes the image and sampler types and functions that can be used to read from and/or write to an image.
-`image1d`, `image1d_buffer`, `image1d_array`, `image2d`, `image2d_array`, `image3d`, `image2d_depth`, `image2d_array_depth`, `image2d_ms`, `image2d_array_ms`, `image2d_depth_ms`, `image2d_array_depth_ms` [[ftnref13]] <<ftn13,[13]>> and `sampler` follow the rules for marker types (see the <<marker-types, _Marker Types_>> section).
+`image1d`, `image1d_buffer`, `image1d_array`, `image2d`, `image2d_array`, `image3d`, `image2d_depth`, `image2d_array_depth`, `image2d_ms`, `image2d_array_ms`, `image2d_depth_ms`, `image2d_array_depth_ms` <<ftn13,[13]>> and `sampler` follow the rules for marker types (see the <<marker-types, _Marker Types_>> section).
 The image and sampler types can only be used if the device support images i.e. `CL_DEVICE_IMAGE_SUPPORT` as described in table 4.3 in OpenCL 2.2 specification is `CL_TRUE`.
 
 [[image-and-sampler-host-types]]
@@ -154,7 +154,7 @@ struct image: marker_type
 
 We can classify images into four categories: depth images which have the `Depth` template parameter set to `true`, multi-sample depth images which have the `Depth` and `MS` template parameters set to `true`, multi-sample which have the `MS` template parameter set to `true`, and the normal images which have the `Depth` and `MS` template parameters set to `false`.
 
-  * For non-multisample depth images the only valid element types are: `float` and `half` [[ftnref14]] <<ftn4,[4]>>
+  * For non-multisample depth images the only valid element types are: `float` and `half` <<ftn4,[4]>>
   * For normal images the only valid element types are: `float4`, `half4` <<ftn4,[4]>>, `int4` and `uint4`
   * For multi-sample 2D and multi-sample 2D array images the only valid element types are: `float4`, `int4` and `uint4`
   * For multi-sample 2D depth and multi-sample 2D array depth images the only valid element type is: `float`

--- a/cxx/stdlib/integer.txt
+++ b/cxx/stdlib/integer.txt
@@ -167,7 +167,7 @@ The intermediate sum does not modulo overflow.
 [[rhadd]]
 ===== rhadd
 
-`rhadd` [[ftnref23]] <<ftn23,[23]>>:
+`rhadd` <<ftn23,[23]>>:
 [source]
 ----
 gentype rhadd(gentype x, gentype y);

--- a/cxx/stdlib/math.txt
+++ b/cxx/stdlib/math.txt
@@ -17,7 +17,7 @@ The description is per-component.
 
 The built-in math functions are not affected by the prevailing rounding mode in the calling environment, and always return the same value as they would if called with the round to nearest even rounding mode.
 
-Here `gentype` matches: `half__n__` [[ftnref4]] <<ftn4,[4]>>, `float__n__` or `double__n__` [[ftnref18]] <<ftn18,[18]>>
+Here `gentype` matches: `half__n__` <<ftn4,[4]>>, `float__n__` or `double__n__` <<ftn18,[18]>>
 
 [[header-opencl_math-synopsis]]
 ==== Header <opencl_math> Synopsis
@@ -593,7 +593,7 @@ Modulus. Returns `x - y * trunc (x/y)`.
 [[fract]]
 ===== fract
 
-`fract` [[ftnref20]] <<ftn20,[20]>>:
+`fract` <<ftn20,[20]>>:
 [source]
 ----
 gentype fract(gentype x, gentype *iptr);
@@ -728,7 +728,7 @@ If both arguments are NaNs, `fmax()` returns a `NaN`.
 [[fmin]]
 ===== fmin
 
-`fmin` [[ftnref21]] <<ftn21,[21]>>:
+`fmin` <<ftn21,[21]>>:
 [source]
 ----
 gentype fmin(gentype x, gentype y);
@@ -817,7 +817,7 @@ The function may compute `a * b + c` with reduced accuracy
     in the embedded profile. It is implemented either as a correctly rounded fma,
     or as a multiply followed by an add, both of which are correctly rounded. 
     On some hardware the mad instruction may provide better performance
-    than expanded computation of `a * b + c`. [[ftnref22]] <<ftn22,[22]>>
+    than expanded computation of `a * b + c`. <<ftn22,[22]>>
 
 [[tgamma]]
 ===== tgamma

--- a/cxx/stdlib/printf.txt
+++ b/cxx/stdlib/printf.txt
@@ -5,7 +5,7 @@
 [[printf]]
 === printf
 
-The OpenCL {cpp} programming language implements the `printf` [[ftnref24]] <<ftn24,[24]>> function.
+The OpenCL {cpp} programming language implements the `printf` <<ftn24,[24]>> function.
 This function is defined in header _<opencl_printf>_.
 
 [[header-opencl_printf-synopsis]]
@@ -61,7 +61,7 @@ After the *%*, the following appear in sequence:
   * Zero or more _flags_ (in any order) that modify the meaning of the conversion specification.
   * An optional minimum _field width_.
     If the converted value has fewer characters than the field width, it is padded with spaces (by default) on the left (or right, if the left adjustment flag, described later, has been given) to the field width.
-    The field width takes the form of a nonnegative decimal integer. [[ftnref25]] <<ftn25,[25]>>
+    The field width takes the form of a nonnegative decimal integer. <<ftn25,[25]>>
   * An optional _precision_ that gives the minimum number of digits to appear for the _d_, _i_, _o_, _u_, _x_, and _X_ conversions, the number of digits to appear after the decimal-point character for _a_, _A_, _e_, _E_, _f_, and _F_ conversions, the maximum number of significant digits for the _g_ and _G_ conversions, or the maximum number of bytes to be written for _s_ conversions.
     The precision takes the form of a period (.) followed by an optional decimal integer; if only the period is specified, the precision is taken as zero.
     If a precision appears with any other conversion specifier, the behavior is undefined.
@@ -83,7 +83,7 @@ The result of the conversion is left-justified within the field.
 
 _+_::
 The result of a signed conversion always begins with a plus or minus sign.
-(It begins with a sign only when a negative value is converted if this flag is not specified.) [[ftnref26]] <<ftn26,[26]>>
+(It begins with a sign only when a negative value is converted if this flag is not specified.) <<ftn26,[26]>>
 
 _space_::
 If the first character of a signed conversion is not a sign, or if a signed conversion results in no characters, a space is prefixed to the result.
@@ -182,7 +182,7 @@ If a decimal-point character appears, at least one digit appears before it.
 The value is rounded to the appropriate number of digits.
 A `double`, `half__n__`, `float__n__` or `double__n__` argument representing an infinity is converted in one of the styles _[-]_**inf** or _[-]_**infinity** - which style is implementation-defined.
 A `double`, `half__n__`, `float__n__` or `double__n__` argument representing a NaN is converted in one of the styles _[-]_**nan** or _[-]_**nan**(_n-char-sequence_) - which style, and the meaning of any _n-char-sequence_, is implementation-defined.
-The _F_ conversion specifier produces *INF*, *INFINITY*, or *NAN* instead of *inf*, *infinity*, or *nan*, respectively. [[ftnref27]] <<ftn27,[27]>>
+The _F_ conversion specifier produces *INF*, *INFINITY*, or *NAN* instead of *inf*, *infinity*, or *nan*, respectively. <<ftn27,[27]>>
 
 __e__,{nbsp}__E__::
 A `double`, `half__n__`, `float__n__` or `double__n__` argument representing a floating-point number is converted in the style _[-]d_**.**_ddd_**e**_{plusmn}dd_, where there is one digit (which is nonzero if the argument is nonzero) before the decimal-point character and the number of digits after it is equal to the precision; if the precision is missing, it is taken as 6; if the precision is zero and the _#_ flag is not specified, no decimal-point character appears.
@@ -204,7 +204,7 @@ Finally, unless the _#_ flag is used, any trailing zeros are removed from the fr
 A `double`, `half__n__`, `float__n__` or `double__n__` argument representing an infinity or NaN is converted in the style of an _f_ or _F_ conversion specifier.
 
 __a__,{nbsp}__A__::
-A `double`, `half__n__`, `float__n__` or `double__n__` argument representing a floating-point number is converted in the style _[-]_**0x**_h_**.**_hhhh_**p**_{plusmn}d_, where there is one hexadecimal digit (which is nonzero if the argument is a normalized floating-point number and is otherwise unspecified) before the decimal-point character [[ftnref28]] <<ftn28,[28]>> and the number of hexadecimal digits after it is equal to the precision; if the precision is missing, then the precision is sufficient for an exact representation of the value; if the precision is zero and the _#_ flag is not specified, no decimal point character appears.
+A `double`, `half__n__`, `float__n__` or `double__n__` argument representing a floating-point number is converted in the style _[-]_**0x**_h_**.**_hhhh_**p**_{plusmn}d_, where there is one hexadecimal digit (which is nonzero if the argument is a normalized floating-point number and is otherwise unspecified) before the decimal-point character <<ftn28,[28]>> and the number of hexadecimal digits after it is equal to the precision; if the precision is missing, then the precision is sufficient for an exact representation of the value; if the precision is zero and the _#_ flag is not specified, no decimal point character appears.
 The letters *abcdef* are used for _a_ conversion and the letters *ABCDEF* for _A_ conversion.
 The _A_ conversion specifier produces a number with *X* and *P* instead of *x* and *p*.
 The exponent always contains at least one digit, and only as many more digits as necessary to represent the decimal exponent of 2.
@@ -218,7 +218,7 @@ _c_::
 The `int` argument is converted to an `uchar` and the resulting character is written.
 
 _s_::
-The argument shall be a literal string. [[ftnref29]] <<ftn29,[29]>>
+The argument shall be a literal string. <<ftn29,[29]>>
 Characters from the literal string array are written up to (but not including) the terminating null character.
 If the precision is specified, no more than that many bytes are written.
 If the precision is not specified or is greater than the size of the array, the array shall contain a null character.

--- a/cxx/stdlib/reinterpreting_data.txt
+++ b/cxx/stdlib/reinterpreting_data.txt
@@ -24,7 +24,7 @@ T as_type(U const& arg);
 [[reinterpreting-types]]
 ==== Reinterpreting Types
 
-All data types described in <<device_builtin_scalar_data_types,Device built-in scalar data types>> and <<device_builtin_vector_data_types,Device built-in vector data types>> tables (except `bool` and `void`) may be also reinterpreted as another data type of the same size using the `as_type()` [[ftnref6]] <<ftn6,[6]>> function for scalar and vector data types.
+All data types described in <<device_builtin_scalar_data_types,Device built-in scalar data types>> and <<device_builtin_vector_data_types,Device built-in vector data types>> tables (except `bool` and `void`) may be also reinterpreted as another data type of the same size using the `as_type()` <<ftn6,[6]>> function for scalar and vector data types.
 When the operand and result type contain the same number of elements, the bits in the operand shall be returned directly without modification as the new type.
 The usual type promotion for function arguments shall not be performed.
 

--- a/cxx/stdlib/relational.txt
+++ b/cxx/stdlib/relational.txt
@@ -7,7 +7,7 @@
 
 The relational and equality operators (`<`, `\<=`, `>`, `>=`, `!=`, `==`) can be used with scalar and vector built-in types and produce a scalar or vector boolean result respectively as described in the <<expressions, _Expressions_>> section.
 
-Here `gentype` matches: `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `half__n__` [[ftnref4]] <<ftn4,[4]>>, `float__n__` and `double__n__` [[ftnref18]] <<ftn18,[18]>>.
+Here `gentype` matches: `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `half__n__` <<ftn4,[4]>>, `float__n__` and `double__n__` <<ftn18,[18]>>.
 
 The relational functions `isequal`, `isgreater`, `isgreaterequal`, `isless`, `islessequal`, and `islessgreater` always return `false` if either argument is not a number (NaN).
 `isnotequal` returns `true` if one or both arguments are not a number (NaN).

--- a/cxx/stdlib/vector_data_load_and_store.txt
+++ b/cxx/stdlib/vector_data_load_and_store.txt
@@ -8,7 +8,7 @@
 Functions described in this section allow user to read and write vector types from a pointer to memory.
 The results of these functions are undefined if the address being read from or written to is not correctly aligned as described in following subsections.
 
-Here `gentype` matches: `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `half__n__` [[ftnref4]] <<ftn4,[4]>>, `float__n__` and `double__n__` [[ftnref18]] <<ftn18,[18]>>.
+Here `gentype` matches: `char__n__`, `uchar__n__`, `short__n__`, `ushort__n__`, `int__n__`, `uint__n__`, `long__n__`, `ulong__n__`, `half__n__` <<ftn4,[4]>>, `float__n__` and `double__n__` <<ftn18,[18]>>.
 
 [[header-opencl_vector_load_store]]
 ==== Header <opencl_vector_load_store> Synopsis

--- a/cxx/stdlib/work_group.txt
+++ b/cxx/stdlib/work_group.txt
@@ -8,7 +8,7 @@
 The OpenCL {cpp} library implements the following functions that operate on a work-group level.
 These built-in functions must be encountered by all work-items in a work-group executing the kernel.
 
-Here `gentype` matches: `int`, `uint`, `long`, `ulong`, `float`, `half` [[ftnref4]] <<ftn4,[4]>> or `double` [[ftnref18]] <<ftn18,[18]>>.
+Here `gentype` matches: `int`, `uint`, `long`, `ulong`, `float`, `half` <<ftn4,[4]>> or `double` <<ftn18,[18]>>.
 
 [[header-opencl_work_group-synopsis]]
 ==== Header <opencl_work_group> Synopsis

--- a/cxx/stdlib/work_item.txt
+++ b/cxx/stdlib/work_item.txt
@@ -80,7 +80,7 @@ size_t get_local_size(uint dimindx)
 
 Returns the number of local work-items specified in dimension identified by `dimindx`.
 This value is at most the value given by the `local_work_size` argument to `clEnqueueNDRangeKernel` if `local_work_size` is not `NULL`; otherwise the OpenCL implementation chooses an appropriate `local_work_size` value which is returned by this function.
-If the kernel is executed with a non-uniform work-group size [[ftnref19]] <<ftn19,[19]>>, calls to this built-in from some work-groups may return different values than calls to this built-in from other work-groups.
+If the kernel is executed with a non-uniform work-group size <<ftn19,[19]>>, calls to this built-in from some work-groups may return different values than calls to this built-in from other work-groups.
 
 Valid values of `dimindx` are `0` to `get_work_dim()-1`.
 For other values of `dimindx`, `get_local_size()` returns `1`.


### PR DESCRIPTION
Fixes #28 
Fixes #928 

Removes the asciidoctor footnote reference back-links to avoid duplicate anchor warnings.