### PR TITLE
fix the OpenCL version conditions for several enums

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6445,10 +6445,10 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 and newer">
+            <require comment="cl_channel_order">
                 <enum name="CL_DEPTH_STENCIL"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_type - defined in CL.h for OpenCL 1.2 and newer">
+            <require comment="cl_channel_type">
                 <enum name="CL_UNORM_INT24"/>
             </require>
         </extension>
@@ -6679,7 +6679,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 (?) and newer">
+            <require condition="!defined(CL_VERSION_2_0)" comment="cl_channel_order - defined in CL.h for OpenCL 2.0 and newer">
                 <enum name="CL_DEPTH"/>
             </require>
         </extension>


### PR DESCRIPTION
Fixes #917 by fixing the OpenCL version conditions for several enums:

* `CL_DEPTH` was an extension enum until OpenCL 2.0
* `CL_DEPTH_STENCIL` was always only an extension enum
* `CL_UNORM_INT24` was always only an extension enum