### PR TITLE
adds type and enums for cl_khr_initialize_memory

### DIFF
--- a/ext/cl_khr_initialize_memory.asciidoc
+++ b/ext/cl_khr_initialize_memory.asciidoc
@@ -45,14 +45,14 @@ Add a new context property to _table 4.5_ in _section 4.4_.
 | Description
 
 | {CL_CONTEXT_MEMORY_INITIALIZE_KHR}
-| `cl_context_memory_initialize_khr`
+| {cl_context_memory_initialize_khr_TYPE}
 | Describes which memory types for the context must be initialized.
   This is a bit-field, where the following values are currently supported:
 
-  `CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR` -- Initialize local memory to
+  {CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR} -- Initialize local memory to
   zeros.
 
-  `CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR` -- Initialize private memory to
+  {CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR} -- Initialize private memory to
   zeros.
 
 |====

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -207,6 +207,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_profiling_info</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_sampler_properties</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_kernel_exec_info</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_context_memory_initialize_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_terminate_capability_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_unified_shared_memory_capabilities_intel</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_mem_properties_intel</name>;</type>
@@ -832,6 +833,12 @@ server's OpenCL/api-docs repository.
         <enum bitpos="29"           name="CL_QUEUE_NO_SYNC_OPERATIONS_INTEL"/>
         <enum bitpos="30"           name="CL_QUEUE_RESERVED_QCOM"/>
         <enum bitpos="31"           name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
+    </enums>
+
+    <enums name="cl_context_memory_initialize_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR"/>
+        <enum bitpos="1"            name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
+            <unused start="1" end="31"/>
     </enums>
 
     <enums name="cl_device_terminate_capability_khr" vendor="Khronos" type="bitmask">
@@ -5590,8 +5597,15 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
-            <require comment="Interop tokens">
+            <require>
+                <type name="cl_context_memory_initialize_khr"/>
+            </require>
+            <require comment="cl_context_properties">
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
+            </require>
+            <require comment="cl_device_terminate_capability_khr">
+                <enum name="CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR"/>
+                <enum name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
             </require>
         </extension>
         <extension name="cl_khr_terminate_context" supported="opencl">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -838,7 +838,9 @@ server's OpenCL/api-docs repository.
     <enums name="cl_context_memory_initialize_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR"/>
         <enum bitpos="1"            name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
-            <unused start="1" end="31"/>
+        <!-- Note: This bitmask is passed as a context property, and a context
+             property is an intptr_t, so the highest assigned bit must be 31. -->
+            <unused start="2" end="31"/>
     </enums>
 
     <enums name="cl_device_terminate_capability_khr" vendor="Khronos" type="bitmask">
@@ -5603,7 +5605,7 @@ server's OpenCL/api-docs repository.
             <require comment="cl_context_properties">
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
             </require>
-            <require comment="cl_device_terminate_capability_khr">
+            <require comment="cl_context_memory_initialize_khr">
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR"/>
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
             </require>


### PR DESCRIPTION
Fixes #872 
Fixes #921 

Adds the extension type and enums for `cl_khr_initialize_memory`.  Specifically, adds:

* `cl_context_memory_initialize_khr` as a bitfield type
* `CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR` and `CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR` as bits for this bitfield type

I couldn't find any place that defined how this type should work or what the bitfield bits should be so I took my best guess based on other code on GitHub.

Note that there is a weird potential mismatch between `cl_context_properties`, which is currently an `intptr_t` and hence possibly something other than 64 bites, and the new extension type, which is a `cl_bitfield` and hence unconditionally 64 bits.  I don't think this will be a problem, but calling it out for completeness.  See also: https://github.com/KhronosGroup/OpenCL-Docs/issues/323

We will want to regenerate headers after this changes are merged.