### PR TITLE
fix a few enum typos where underscores were replaced by spaces

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -207,7 +207,7 @@ These prerequisites have three sources:
     expressed through events.
     A command may include an optional list of events.
     The command will wait and not launch until all the events in the list
-    are in the state CL COMPLETE.
+    are in the state {CL_COMPLETE}.
     By this mechanism, event objects define order constraints between
     commands and coordinate execution between the host and one or more
     devices.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -7949,7 +7949,7 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_NAME.asciidoc[]
       | Returns the name specified for the argument given by _arg_index_.
 |====
 
-{clGetKernelArgInfo} returns CL SUCCESS if the function is executed
+{clGetKernelArgInfo} returns {CL_SUCCESS} if the function is executed
 successfully.
 Otherwise, it returns one of the following errors:
 

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -133,7 +133,7 @@ the required type, or if _adapter_type_ is set to a media adapter type and
 _surface_info_ does not contain a valid reference to a media surface on that
 adapter, by {clGetMemObjectInfo} when _param_name_ is a surface or handle
 when the image was not created from an appropriate media surface, and from
-{clGetImageInfo} when _param_name_ is CL IMAGE_DX9_MEDIA_PLANE KHR and image
+{clGetImageInfo} when _param_name_ is {CL_IMAGE_DX9_MEDIA_PLANE_KHR} and image
 was not created from an appropriate media surface.
 
 ----

--- a/ext/cl_khr_gl_depth_images.asciidoc
+++ b/ext/cl_khr_gl_depth_images.asciidoc
@@ -80,7 +80,7 @@ For the image format given by channel order of CL_DEPTH_STENCIL and channel
 data type of CL_UNORM_INT24, the depth is stored as an unsigned normalized
 24-bit value.
 
-For the image format given by channel order of CL DEPTH_STENCIL and channel
+For the image format given by channel order of CL_DEPTH_STENCIL and channel
 data type of CL_FLOAT, each pixel is two 32-bit values.
 The depth is stored as a single precision floating-point value followed by
 the stencil which is stored as a 8-bit integer value.

--- a/ext/cl_khr_initialize_memory.asciidoc
+++ b/ext/cl_khr_initialize_memory.asciidoc
@@ -62,7 +62,7 @@ Add a new context property to _table 4.5_ in _section 4.4_.
 
 Updates to _section 6.9_ -- Restrictions
 
-If the context is created with CL CONTEXT MEMORY INITIALIZE KHR, appropriate
+If the context is created with {CL_CONTEXT_MEMORY_INITIALIZE_KHR}, appropriate
 memory locations as specified by the bit-field is initialized with zeroes,
 prior to the start of execution of any kernel.
 The driver chooses when, prior to kernel execution, the initialization of

--- a/man/static/cl_khr_gl_depth_images.txt
+++ b/man/static/cl_khr_gl_depth_images.txt
@@ -28,7 +28,7 @@ Depth images with an image channel order of `CL_DEPTH_STENCIL` can only be creat
 
 For the image format given by channel order of `CL_DEPTH_STENCIL` and channel data type of `CL_UNORM_INT24`, the depth is stored as an unsigned normalized 24-bit value.
 
-For the image format given by channel order of `CL DEPTH_STENCIL` and channel data type of `CL_FLOAT`, each pixel is two 32-bit values.
+For the image format given by channel order of `CL_DEPTH_STENCIL` and channel data type of `CL_FLOAT`, each pixel is two 32-bit values.
 The depth is stored as a single precision floating-point value followed by the stencil which is stored as a 8-bit integer value.
 
 The stencil value cannot be read or written using the read imagef and write imagef built-in functions in an OpenCL kernel.

--- a/man/static/cl_khr_initialize_memory.txt
+++ b/man/static/cl_khr_initialize_memory.txt
@@ -43,7 +43,7 @@ Add a new context property to table 4.5 in section 4.4 (see flink:clCreateContex
 
 Updates to section 6.9 - Restrictions:
 
-If the context is created with `CL CONTEXT MEMORY INITIALIZE KHR`, appropriate memory locations as specified by the bit-field is initialized with zeroes, prior to the start of execution of any kernel.
+If the context is created with `CL_CONTEXT_MEMORY_INITIALIZE_KHR`, appropriate memory locations as specified by the bit-field is initialized with zeroes, prior to the start of execution of any kernel.
 The driver chooses when, prior to kernel execution, the initialization of local and/or private memory is performed.
 The only requirement is there should be no values set from outside the context, which can be read during a kernel execution.
 


### PR DESCRIPTION
Not sure how or when this happened, but it looks like several enums had spaces instead of underscores, so `CL SUCCESS` instead of `CL_SUCCESS`.  Fixed all of these to use underscores instead, and to use asciidoctor dictionaries where appropriate.