### PR TITLE
format the cl_khr_fp64 extension name manually

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -322,7 +322,7 @@ The following table describes the list of built-in scalar data types.
       type that cannot be completed.
 |====
 
-If the double-precision floating-point extension {cl_khr_fp64} or the
+If the double-precision floating-point extension *cl_khr_fp64* or the
 {opencl_c_fp64} feature is not supported, implementations may
 implicitly cast double-precision floating-point literals to
 single-precision literals. The use of double-precision literals without


### PR DESCRIPTION
Looks like my search-and-replace macros unintentionally picked up the `cl_khr_fp64` extension and tried to use an asciidoctor dictionary for it even though we haven't added dictionaries for extension names.  Format it manually, instead.