### PR TITLE
fix a few numerical compliance bugs in the SPIR-V environment spec

### DIFF
--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -165,9 +165,9 @@ there was sufficient range, meets ULP error tolerance.
 
 ==== ULP Values for Math Instructions - Full Profile
 
-The ULP Values for Math Instructions table below describes the minimum
-accuracy of floating-point math arithmetic instructions for full profile
-devices given as ULP values.
+The ULP Values for Math Instructions - Full Profile table below
+describes the minimum accuracy of floating-point math arithmetic instructions
+given as ULP values for the full profile.
 
 [[ulp_values_for_math_instructions]]
 .ULP Values for Math Instructions - Full Profile
@@ -295,12 +295,12 @@ devices given as ULP values.
 | \<= 2 ulp
 
 | *OpExtInst* *distance*
-// See ext/cl_khr_fp16.asciidoc for derivation
-| \<= 2n ulp, for gentype with vector width _n_
-// See OpenCL_C.txt derivation
-| \<= 2.5 + 2n ulp, for gentype with vector width _n_
 // See ext/cl_khr_fp64.asciidoc for derivation
 | \<= 5.5 + 2n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2.5 + 2n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 2n ulp, for gentype with vector width _n_
 
 // n + n-1  Number of operations from n multiples and (n-1) additions
 // 2n - 1
@@ -415,12 +415,12 @@ devices given as ULP values.
 | Correctly rounded
 
 | *OpExtInst* *length*
-// See ext/cl_khr_fp16.asciidoc for derivation
-| \<= 0.25 + 0.5n ulp, for gentype with vector width _n_
-// See OpenCL_C.txt derivation
-| \<= 2.75 + 0.5n ulp, for gentype with vector width _n_
 // See ext/cl_khr_fp64.asciidoc for derivation
 | \<= 5.5 + n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2.75 + 0.5n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 0.25 + 0.5n ulp, for gentype with vector width _n_
 
 | *OpExtInst* *lgamma*
 | Implementation-defined
@@ -496,12 +496,12 @@ devices given as ULP values.
 | 0 ulp
 
 | *OpExtInst* *normalize*
-// See ext/cl_khr_fp16.asciidoc for derivation
-| \<= 1 + n ulp, for gentype with vector width _n_
-// See OpenCL_C.txt derivation
-| \<= 2 + n ulp, for gentype with vector width _n_
 // See ext/cl_khr_fp64.asciidoc for derivation
 | \<= 4.5 + n ulp, for gentype with vector width _n_
+// See OpenCL_C.txt derivation
+| \<= 2 + n ulp, for gentype with vector width _n_
+// See ext/cl_khr_fp16.asciidoc for derivation
+| \<= 1 + n ulp, for gentype with vector width _n_
 
 | *OpExtInst* *pow*
 | \<= 16 ulp
@@ -775,12 +775,13 @@ devices given as ULP values.
 |
 | Implementation-defined
 |
+
 |====
 
 ==== ULP Values for Math Instructions - Embedded Profile
 
-The ULP Values for Math instructions for Embedded Profile table below
-describes the minimum accuracy of floating-point math arithmetic operations
+The ULP Values for Math instructions - Embedded Profile table below
+describes the minimum accuracy of floating-point math arithmetic instructions
 given as ULP values for the embedded profile.
 
 [[ulp_values_for_math_instructions_for_embedded_profile]]
@@ -898,10 +899,25 @@ given as ULP values for the embedded profile.
 | \<= 4 ulp
 | \<= 2 ulp
 
+| *OpExtInst* *cross*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
+
 | *OpExtInst* *degrees*
 | \<= 2 ulp
 | \<= 2 ulp
 | \<= 2 ulp
+
+| *OpExtInst* *distance*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
+
+| *OpDot*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
 
 | *OpExtInst* *erfc*
 | \<= 16 ulp
@@ -1008,6 +1024,11 @@ given as ULP values for the embedded profile.
 | Correctly rounded
 | Correctly rounded
 
+| *OpExtInst* *length*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
+
 | *OpExtInst* *lgamma*
 | Implementation-defined
 | Implementation-defined
@@ -1077,6 +1098,11 @@ given as ULP values for the embedded profile.
 | 0 ulp
 | 0 ulp
 | 0 ulp
+
+| *OpExtInst* *normalize*
+| Implementation-defined
+| Implementation-defined
+| Implementation-defined
 
 | *OpExtInst* *pow*
 | \<= 16 ulp
@@ -1262,6 +1288,21 @@ given as ULP values for the embedded profile.
 | *OpExtInst* *half_tan*
 |
 | \<= 8192 ulp
+|
+
+| *OpExtInst* *fast_distance*
+|
+| Implementation-defined
+|
+
+| *OpExtInst* *fast_length*
+|
+| Implementation-defined
+|
+
+| *OpExtInst* *fast_normalize*
+|
+| Implementation-defined
 |
 
 | *OpExtInst* *native_cos*

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -285,9 +285,9 @@ devices given as ULP values.
 
 // 3 operations from the 2 multiplications and 1 subtraction per component
 | *OpExtInst* *cross*
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
+| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 | absolute error tolerance of 'max * max * (3 * HALF_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
-| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
-| absolute error tolerance of 'max * max * (3 * FLT_EPSILON)' per vector component, where _max_ is the maximum input operand magnitude
 
 | *OpExtInst* *degrees*
 | \<= 2 ulp
@@ -304,10 +304,10 @@ devices given as ULP values.
 
 // n + n-1  Number of operations from n multiples and (n-1) additions
 // 2n - 1
-| *OpExtInst* *dot*
+| *OpDot*
+| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
+| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 | absolute error tolerance of 'max * max * (2n - 1) * HALF_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
-| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
-| absolute error tolerance of 'max * max * (2n - 1) * FLT_EPSILON', for vector width _n_ and maximum input operand magnitude _max_ across all vector components
 
 | *OpExtInst* *erfc*
 | \<= 16 ulp


### PR DESCRIPTION
Fixes internal issue 331.

* There is no dot extended instruction, use OpDot instead.
* Use HALF_EPSLION only for fp16, not for fp64.