### PR TITLE
cl_khr_external_semaphore_khr: semaphore re-import

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -339,7 +339,7 @@ imported payload, the semaphore's prior permanent payload will be restored.
 Please refer to handle specific specifications for more details on transference and
 permanence requirements specific to handle type.
 
-To import a handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} into an existing semaphore, call the function
+To import a handle of type _handle_type_ into an existing semaphore, call the function
 
 include::{generated}/api/protos/clImportSemaphoreKHR.txt[]
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -524,11 +524,11 @@ int fd = getFdForExternalSemaphore();
 // Create clSema of type cl_semaphore_khr usable only on device 1
 // assuming the semaphore was imported from the same device.
 cl_semaphore_properties_khr sema_props[] = {
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR,
     (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
     (cl_semaphore_properties_khr)fd,
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR,
     (cl_semaphore_properties_khr)devices[1],
     CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR,
     0
@@ -596,9 +596,9 @@ clCreateContext(..., 2, devices, ...);
 
 // Create clSema of type cl_semaphore_khr usable only on device 1
 cl_semaphore_properties_khr sema_props[] = {
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_KHR,
     (cl_semaphore_properties_khr)CL_SEMAPHORE_TYPE_BINARY_KHR,
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR,
     (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
     CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR,
     (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR,

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -104,6 +104,14 @@ cl_int clGetSemaphoreHandleForTypeKHR(
     size_t *handle_size_ret);
 ----
 
+API function added by `cl_khr_external_semaphore_sync_fd` 
+
+----    
+cl_int clImportSemaphoreSyncFdKHR(
+    cl_semaphore_khr sema_object,
+    int fd);
+----
+
 === New API Enums
 
 Accepted value for the _param_name_ parameter to {clGetPlatformInfo} to query external semaphore handle types that may be imported or exported by all devices in an OpenCL platform:
@@ -328,6 +336,25 @@ imported payload, the semaphore's prior permanent payload will be restored.
 
 Please refer to handle specific specifications for more details on transference and
 permanence requirements specific to handle type.
+
+The `cl_khr_external_semaphore_sync_fd` extension adds {clImportSemaphoreSyncFdKHR}, which allows importing an external handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} into an existing binary semaphore.  The semaphore must have been created with {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} in _props_list_ of {clCreateSemaphoreWithPropertiesKHR}.
+
+To import a handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} into an existing semaphore, call the function
+
+include::{generated}/api/protos/clImportSemaphoreSyncFdKHR.txt[]
+
+_sema_object_ specifies a valid semaphore object with importable properties.
+
+_fd_ specifies a valid sync fd handle
+
+If the handle _fd_ is not compatible with the devices specified to {clCreateSemaphoreWithPropertiesKHR} in _props_list_, undefined behavior will result. {clImportSemaphoreSyncFdKHR} returns {CL_SUCCESS} if _fd_ is imported successfully.
+Otherwise, it returns one of the following errors:
+
+* {CL_INVALID_SEMAPHORE_KHR}
+** if _sema_object_ is not a valid semaphore
+* {CL_INVALID_VALUE} if the requested external semaphore handle type was not specified when _sema_object_ was created.
+* {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
+* {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 
 === Descriptions of External Semaphore Handle Types
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -89,6 +89,12 @@ Vivek Kini, NVIDIA +
 [source]
 ----
 typedef cl_uint cl_external_semaphore_handle_type_khr;
+----
+
+The `cl_khr_external_semaphore_sync_fd` extension adds:
+
+[source]
+----
 typedef cl_properties cl_semaphore_import_properties_khr;
 ----
 
@@ -105,11 +111,13 @@ cl_int clGetSemaphoreHandleForTypeKHR(
     size_t *handle_size_ret);
 ----
 
+The `cl_khr_external_semaphore_sync_fd` extension adds:
+
 ----    
-cl_int clImportSemaphoreKHR(
+cl_int clReImportSemaphoreSyncFdKHR(
     cl_semaphore_khr sema_object,
     cl_semaphore_import_properties_khr *import_props,
-    void *handle_ptr);
+    int fd);
 ----
 
 === New API Enums
@@ -337,27 +345,6 @@ imported payload, the semaphore's prior permanent payload will be restored.
 Please refer to handle specific specifications for more details on transference and
 permanence requirements specific to handle type.
 
-To import a handle into an existing semaphore, call the function
-
-include::{generated}/api/protos/clImportSemaphoreKHR.txt[]
-
-_sema_object_ specifies a valid semaphore object with importable properties.
-
-_import_props_  Must be `NULL`.  Reserved for future use.
-
-_handle_ptr_ is a pointer to the imported external handle.
-
-Calling {clImportSemaphoreKHR} is equivalent to destroying _sema_object_ and re-creating it with the original _sema_props_
-from {clCreateSemaphoreWithPropertiesKHR}, except a handle specified by _handle_ptr_ will be imported.
-The semaphore _sema_object_ must have originally imported an external handle, and _handle_ is assumed to be of the same type.
-
-* {CL_INVALID_SEMAPHORE_KHR}
-** if _sema_object_ is not a valid semaphore
-* {CL_INVALID_SEMAPHORE_KHR} if an external semaphore handle type was not imported when _sema_object_ was created.
-* {CL_INVALID_VALUE} if _handle_ptr_ is NULL.
-* {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
-* {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
-
 === Descriptions of External Semaphore Handle Types
 
 This section describes the external semaphore handle types that are added by related extensions.
@@ -406,6 +393,27 @@ Transference and permanence properties for handle types added by `cl_khr_externa
 |====
 
 For these extensions, importing a semaphore payload from a file descriptor transfers ownership of the file descriptor from the application to the OpenCL implementation. The application must not perform any operations on the file descriptor after a successful import.
+
+A handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} may be re-imported into an existing semaphore using {clReImportSemaphoreSyncFdKHR}:
+
+include::{generated}/api/protos/clReImportSemaphoreSyncFdKHR.txt[]
+
+_sema_object_ specifies a valid semaphore object with importable properties.
+
+_import_props_  Must be `NULL`.  Reserved for future use.
+
+_fd_ external file descriptor handle to import
+
+Calling {clReImportSemaphoreSyncFdKHR} is equivalent to destroying _sema_object_ and re-creating it with the original _sema_props_
+from {clCreateSemaphoreWithPropertiesKHR}, except a handle specified by _fd_ will be imported.
+The semaphore _sema_object_ must have originally imported an external handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR}.
+
+* {CL_INVALID_SEMAPHORE_KHR}
+** if _sema_object_ is not a valid semaphore
+* {CL_INVALID_SEMAPHORE_KHR} if a {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} handle was not imported when _sema_object_ was created.
+* {CL_INVALID_VALUE} if _fd_ is invalid.
+* {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
+* {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 
 ==== NT Handle Types
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -89,6 +89,7 @@ Vivek Kini, NVIDIA +
 [source]
 ----
 typedef cl_uint cl_external_semaphore_handle_type_khr;
+typedef cl_properties cl_semaphore_import_properties_khr;
 ----
 
 === New API Functions
@@ -107,11 +108,8 @@ cl_int clGetSemaphoreHandleForTypeKHR(
 ----    
 cl_int clImportSemaphoreKHR(
     cl_semaphore_khr sema_object,
-    cl_semaphore_properties_khr *import_props,
-    cl_external_semaphore_handle_type_khr handle_type,
-    size_t handle_size,
-    void *handle_ptr,
-    size_t *handle_size_ret);
+    cl_semaphore_import_properties_khr *import_props,
+    void *handle_ptr);
 ----
 
 === New API Enums
@@ -339,7 +337,7 @@ imported payload, the semaphore's prior permanent payload will be restored.
 Please refer to handle specific specifications for more details on transference and
 permanence requirements specific to handle type.
 
-To import a handle of type _handle_type_ into an existing semaphore, call the function
+To import a handle into an existing semaphore, call the function
 
 include::{generated}/api/protos/clImportSemaphoreKHR.txt[]
 
@@ -347,25 +345,16 @@ _sema_object_ specifies a valid semaphore object with importable properties.
 
 _import_props_  Must be `NULL`.  Reserved for future use.
 
-_handle_type_ specifies the type of semaphore handle being imported, and must be one of the
-handle types imported when _sema_object_ was created.
-
-_handle_size_ specifies the size of memory pointed by _handle_ptr_.
-
 _handle_ptr_ is a pointer to the imported external handle.
-If _handle_ptr_ is `NULL`, _handle_size_ret_ must not be `NULL`.
-
-_handle_size_ret_ returns the actual size in bytes for the external handle.
-If _handle_size_ret_ is `NULL`, it is ignored.
 
 Calling {clImportSemaphoreKHR} is equivalent to destroying _sema_object_ and re-creating it with the original _sema_props_
-from {clCreateSemaphoreWithPropertiesKHR}, except _handle_ will be imported.
-The semaphore _sema_object_ must have originally imported a handle of type _handle_type_.
+from {clCreateSemaphoreWithPropertiesKHR}, except a handle specified by _handle_ptr_ will be imported.
+The semaphore _sema_object_ must have originally imported an external handle, and _handle_ is assumed to be of the same type.
 
 * {CL_INVALID_SEMAPHORE_KHR}
 ** if _sema_object_ is not a valid semaphore
-* {CL_INVALID_VALUE} if the requested external semaphore handle type was not specified when _sema_object_ was created.
-* {CL_INVALID_VALUE} if _handle_size_ is not equal to the expected size of the external handle.
+* {CL_INVALID_SEMAPHORE_KHR} if an external semaphore handle type was not imported when _sema_object_ was created.
+* {CL_INVALID_VALUE} if _handle_ptr_ is NULL.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -104,12 +104,14 @@ cl_int clGetSemaphoreHandleForTypeKHR(
     size_t *handle_size_ret);
 ----
 
-API function added by `cl_khr_external_semaphore_sync_fd` 
-
 ----    
-cl_int clImportSemaphoreSyncFdKHR(
+cl_int clImportSemaphoreKHR(
     cl_semaphore_khr sema_object,
-    int fd);
+    cl_semaphore_properties_khr *import_props,
+    cl_external_semaphore_handle_type_khr handle_type,
+    size_t handle_size,
+    void *handle_ptr,
+    size_t *handle_size_ret);
 ----
 
 === New API Enums
@@ -337,22 +339,33 @@ imported payload, the semaphore's prior permanent payload will be restored.
 Please refer to handle specific specifications for more details on transference and
 permanence requirements specific to handle type.
 
-The `cl_khr_external_semaphore_sync_fd` extension adds {clImportSemaphoreSyncFdKHR}, which allows importing an external handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} into an existing binary semaphore.  The semaphore must have been created with {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} in _props_list_ of {clCreateSemaphoreWithPropertiesKHR}.
-
 To import a handle of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR} into an existing semaphore, call the function
 
-include::{generated}/api/protos/clImportSemaphoreSyncFdKHR.txt[]
+include::{generated}/api/protos/clImportSemaphoreKHR.txt[]
 
 _sema_object_ specifies a valid semaphore object with importable properties.
 
-_fd_ specifies a valid sync fd handle
+_import_props_  Must be `NULL`.  Reserved for future use.
 
-If the handle _fd_ is not compatible with the devices specified to {clCreateSemaphoreWithPropertiesKHR} in _props_list_, undefined behavior will result. {clImportSemaphoreSyncFdKHR} returns {CL_SUCCESS} if _fd_ is imported successfully.
-Otherwise, it returns one of the following errors:
+_handle_type_ specifies the type of semaphore handle being imported, and must be one of the
+handle types imported when _sema_object_ was created.
+
+_handle_size_ specifies the size of memory pointed by _handle_ptr_.
+
+_handle_ptr_ is a pointer to the imported external handle.
+If _handle_ptr_ is `NULL`, _handle_size_ret_ must not be `NULL`.
+
+_handle_size_ret_ returns the actual size in bytes for the external handle.
+If _handle_size_ret_ is `NULL`, it is ignored.
+
+Calling {clImportSemaphoreKHR} is equivalent to destroying _sema_object_ and re-creating it with the original _sema_props_
+from {clCreateSemaphoreWithPropertiesKHR}, except _handle_ will be imported.
+The semaphore _sema_object_ must have originally imported a handle of type _handle_type_.
 
 * {CL_INVALID_SEMAPHORE_KHR}
 ** if _sema_object_ is not a valid semaphore
 * {CL_INVALID_VALUE} if the requested external semaphore handle type was not specified when _sema_object_ was created.
+* {CL_INVALID_VALUE} if _handle_size_ is not equal to the expected size of the external handle.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -41,6 +41,7 @@ Other related extensions define specific external semaphores that may be importe
 | *Date*     | *Version* | *Description*
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 | 2023-11-16 | 0.9.1     | Added CL_SEMAPHORE_EXPORTABLE_KHR.
+| 2023-11-21 | 0.9.2     | Added re-import function call to cl_khr_external_semaphore_sync_fd
 |====
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
@@ -95,7 +96,7 @@ The `cl_khr_external_semaphore_sync_fd` extension adds:
 
 [source]
 ----
-typedef cl_properties cl_semaphore_import_properties_khr;
+typedef cl_properties cl_semaphore_reimport_properties_khr;
 ----
 
 === New API Functions
@@ -116,7 +117,7 @@ The `cl_khr_external_semaphore_sync_fd` extension adds:
 ----    
 cl_int clReImportSemaphoreSyncFdKHR(
     cl_semaphore_khr sema_object,
-    cl_semaphore_import_properties_khr *import_props,
+    cl_semaphore_reimport_properties_khr *reimport_props,
     int fd);
 ----
 
@@ -400,7 +401,7 @@ include::{generated}/api/protos/clReImportSemaphoreSyncFdKHR.txt[]
 
 _sema_object_ specifies a valid semaphore object with importable properties.
 
-_import_props_  Must be `NULL`.  Reserved for future use.
+_reimport_props_  Must be `NULL`.  Reserved for future use.
 
 _fd_ external file descriptor handle to import
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2690,10 +2690,14 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                      <name>handle_ptr</name></param>
             <param><type>size_t</type>*                    <name>handle_size_ret</name></param>
         </command>
-        <command suffix="CL_API_SUFFIX__VERSION_1_2">
-            <proto><type>cl_int</type>                     <name>clImportSemaphoreSyncFdKHR</name></proto>
-            <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
-            <param><type>int</type>                        <name>fd</name></param>
+        <command suffix="CL_API_SUFFIX__VERSION_3_0">
+            <proto><type>cl_int</type>                                  <name>clImportSemaphoreKHR</name></proto>
+            <param><type>cl_semaphore_khr</type>                        <name>sema_object</name></param>
+            <param><type>cl_semaphore_properties_khr*</type>            <name>import_props</name></param>
+            <param><type>cl_external_semaphore_handle_type_khr</type>   <name>handle_type</name></param>
+            <param><type>size_t</type>                                  <name>handle_size</name></param>
+            <param><type>void*</type>                                   <name>handle_ptr</name></param>
+            <param><type>size_t*</type>                                 <name>handle_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                     <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
@@ -7021,7 +7025,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_SYNC_FD_KHR"/>
             </require>
             <require>
-                <command name="clImportSemaphoreSyncFdKHR"/>
+                <command name="clImportSemaphoreKHR"/>
             </require>
         </extension>
         <extension name="cl_khr_external_semaphore_win32" supported="opencl">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2690,6 +2690,11 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                      <name>handle_ptr</name></param>
             <param><type>size_t</type>*                    <name>handle_size_ret</name></param>
         </command>
+        <command suffix="CL_API_SUFFIX__VERSION_1_2">
+            <proto><type>cl_int</type>                     <name>clImportSemaphoreSyncFdKHR</name></proto>
+            <param><type>cl_semaphore_khr</type>           <name>sema_object</name></param>
+            <param><type>int</type>                        <name>fd</name></param>
+        </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                     <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
             <param><type>cl_command_queue</type>           <name>command_queue</name></param>
@@ -7014,6 +7019,9 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_SYNC_FD_KHR"/>
+            </require>
+            <require>
+                <command name="clImportSemaphoreSyncFdKHR"/>
             </require>
         </extension>
         <extension name="cl_khr_external_semaphore_win32" supported="opencl">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -232,6 +232,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_feature_capabilities_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_integer_dot_product_capabilities_khr</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_semaphore_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>    <name>cl_semaphore_import_properties_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_semaphore_info_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_semaphore_type_khr</name>;</type>
         <type category="define">typedef <type>cl_ulong</type>         <name>cl_semaphore_payload_khr</name>;</type>
@@ -2693,11 +2694,8 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                                  <name>clImportSemaphoreKHR</name></proto>
             <param><type>cl_semaphore_khr</type>                        <name>sema_object</name></param>
-            <param><type>cl_semaphore_properties_khr*</type>            <name>import_props</name></param>
-            <param><type>cl_external_semaphore_handle_type_khr</type>   <name>handle_type</name></param>
-            <param><type>size_t</type>                                  <name>handle_size</name></param>
+            <param><type>cl_semaphore_import_properties_khr*</type>     <name>import_props</name></param>
             <param><type>void*</type>                                   <name>handle_ptr</name></param>
-            <param><type>size_t*</type>                                 <name>handle_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                     <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
@@ -6981,6 +6979,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_semaphore_khr"/>
                 <type name="cl_external_semaphore_handle_type_khr"/>
+                <type name="cl_semaphore_import_properties_khr"/>
             </require>
             <require comment="cl_platform_info">
                 <enum name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
@@ -6993,6 +6992,8 @@ server's OpenCL/api-docs repository.
             <require comment="cl_semaphore_properties_khr">
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR"/>
+            </require>
+            <require comment="cl_semaphore_import_properties_khr">
             </require>
             <require comment="cl_semaphore_info_khr">
                 <enum name="CL_SEMAPHORE_EXPORTABLE_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -232,7 +232,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_feature_capabilities_intel</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_integer_dot_product_capabilities_khr</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_semaphore_properties_khr</name>;</type>
-        <type category="define">typedef <type>cl_properties</type>    <name>cl_semaphore_import_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>    <name>cl_semaphore_reimport_properties_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_semaphore_info_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_semaphore_type_khr</name>;</type>
         <type category="define">typedef <type>cl_ulong</type>         <name>cl_semaphore_payload_khr</name>;</type>
@@ -2694,7 +2694,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                                  <name>clReImportSemaphoreSyncFdKHR</name></proto>
             <param><type>cl_semaphore_khr</type>                        <name>sema_object</name></param>
-            <param><type>cl_semaphore_import_properties_khr*</type>     <name>import_props</name></param>
+            <param><type>cl_semaphore_reimport_properties_khr*</type>   <name>reimport_props</name></param>
             <param><type>int</type>                                     <name>fd</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
@@ -7022,7 +7022,7 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
             </require>
             <require>
-                <type name="cl_semaphore_import_properties_khr"/>
+                <type name="cl_semaphore_reimport_properties_khr"/>
             </require>
             <require comment="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_SYNC_FD_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2692,10 +2692,10 @@ server's OpenCL/api-docs repository.
             <param><type>size_t</type>*                    <name>handle_size_ret</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
-            <proto><type>cl_int</type>                                  <name>clImportSemaphoreKHR</name></proto>
+            <proto><type>cl_int</type>                                  <name>clReImportSemaphoreSyncFdKHR</name></proto>
             <param><type>cl_semaphore_khr</type>                        <name>sema_object</name></param>
             <param><type>cl_semaphore_import_properties_khr*</type>     <name>import_props</name></param>
-            <param><type>void*</type>                                   <name>handle_ptr</name></param>
+            <param><type>int</type>                                     <name>fd</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                     <name>clEnqueueAcquireExternalMemObjectsKHR</name></proto>
@@ -6979,7 +6979,6 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_semaphore_khr"/>
                 <type name="cl_external_semaphore_handle_type_khr"/>
-                <type name="cl_semaphore_import_properties_khr"/>
             </require>
             <require comment="cl_platform_info">
                 <enum name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
@@ -7022,11 +7021,14 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="CL/cl.h"/>
             </require>
+            <require>
+                <type name="cl_semaphore_import_properties_khr"/>
+            </require>
             <require comment="cl_external_semaphore_handle_type_khr">
                 <enum name="CL_SEMAPHORE_HANDLE_SYNC_FD_KHR"/>
             </require>
             <require>
-                <command name="clImportSemaphoreKHR"/>
+                <command name="clReImportSemaphoreSyncFdKHR"/>
             </require>
         </extension>
         <extension name="cl_khr_external_semaphore_win32" supported="opencl">


### PR DESCRIPTION
Add clImportSemaphoreSyncFD API call.  Sync fd semaphores must re-import the sync_fd after every wait.  Add an API call to make this re-import possible, without creating a new OpenCL semaphores.  See issue #888.