### PR TITLE
External memory import: Add assume linear query (#861)

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -108,7 +108,7 @@ Accepted value for the _param_name_ parameter to {clGetDeviceInfo} to query exte
 [source]
 ----
 CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR                      0x204F
-CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR        0x????
+CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR        0x2052
 ----
 
 New properties accepted as _properties_ to {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
@@ -185,12 +185,14 @@ Following new enums are added to the list of supported _param_names_ by {clGetDe
       | Returns the list of importable external memory handle types supported by _device_.
 | {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR}
   | {cl_external_memory_handle_type_khr_TYPE}[]
-      | Returns the list of importable external memory handle types supported by _device_, that are assumed to have linear layout when no other layout information is provided.
+      | Returns the list of importable external memory handle types supported by _device_, that are assumed to apply linear layout to imported images when no other tiling information is provided.
 |====
 
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR} must return a non-empty list of external memory handle types for at least one of the devices in the platform.
 
-{clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.  External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} may have any memory layout.
+{clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout when no other tiling information is provided.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.
+
+External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} may have any memory layout. The layout interpretation of images imported with these handle types is implementation defined.
 
 Following new properties are added to the list of supported properties by {clCreateBufferWithProperties} and {clCreateImageWithProperties}.
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -30,6 +30,7 @@ Other related extensions define specific external memory types that may be impor
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
+| 2023-08-29 | 0.9.3     | Added query for {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} (provisional).
 | 2023-08-01 | 0.9.2     | Changed device handle list enum to the memory-specific {CL_MEM_DEVICE_HANDLE_LIST_KHR} (provisional).
 | 2023-05-04 | 0.9.1     | Clarified device handle list enum cannot be specified without an external memory handle (provisional).
 | 2021-09-10 | 0.9.0     | Initial version (provisional).

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -107,8 +107,8 @@ Accepted value for the _param_name_ parameter to {clGetDeviceInfo} to query exte
 
 [source]
 ----
-CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR                      0x204F
-CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR        0x2052
+CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR                           0x204F
+CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR      0x2052
 ----
 
 New properties accepted as _properties_ to {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
@@ -183,16 +183,16 @@ Following new enums are added to the list of supported _param_names_ by {clGetDe
 | {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}
   | {cl_external_memory_handle_type_khr_TYPE}[]
       | Returns the list of importable external memory handle types supported by _device_.
-| {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR}
+| {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR}
   | {cl_external_memory_handle_type_khr_TYPE}[]
       | Returns the list of importable external memory handle types supported by _device_, that are assumed to apply linear layout to imported images when no other tiling information is provided.
 |====
 
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR} must return a non-empty list of external memory handle types for at least one of the devices in the platform.
 
-{clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout when no other tiling information is provided.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.
+{clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout when no other tiling information is provided.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.
 
-External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} may have any memory layout. The layout interpretation of images imported with these handle types is implementation defined.
+External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} may have any memory layout. The layout interpretation of images imported with these handle types is implementation defined.
 
 Following new properties are added to the list of supported properties by {clCreateBufferWithProperties} and {clCreateImageWithProperties}.
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -108,6 +108,7 @@ Accepted value for the _param_name_ parameter to {clGetDeviceInfo} to query exte
 [source]
 ----
 CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR                      0x204F
+CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR        0x????
 ----
 
 New properties accepted as _properties_ to {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
@@ -182,9 +183,14 @@ Following new enums are added to the list of supported _param_names_ by {clGetDe
 | {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}
   | {cl_external_memory_handle_type_khr_TYPE}[]
       | Returns the list of importable external memory handle types supported by _device_.
+| {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR}
+  | {cl_external_memory_handle_type_khr_TYPE}[]
+      | Returns the list of importable external memory handle types supported by _device_, that are assumed to have linear layout when no other layout information is provided.
 |====
 
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR} must return a non-empty list of external memory handle types for at least one of the devices in the platform.
+
+{clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.  External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} may have any memory layout.
 
 Following new properties are added to the list of supported properties by {clCreateBufferWithProperties} and {clCreateImageWithProperties}.
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7010,8 +7010,6 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
-            </require>
-            <require comment="cl_device_info">
                 <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR"/>
             </require>
             <require comment="cl_mem_properties">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1847,7 +1847,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x204E"        name="CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x204F"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>
-        <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR"/>
+        <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR"/>
         <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR"/>
             <unused start="0x2054" end="0x2054"/>
         <enum value="0x2055"        name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
@@ -7010,7 +7010,7 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
-                <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR"/>
+                <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR"/>
             </require>
             <require comment="cl_mem_properties">
                 <enum name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1847,7 +1847,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x204E"        name="CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x204F"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>
-            <unused start="0x2052" end="0x2052"/>
+        <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR"/>
         <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR"/>
             <unused start="0x2054" end="0x2054"/>
         <enum value="0x2055"        name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
@@ -7010,6 +7010,9 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR"/>
             </require>
             <require comment="cl_mem_properties">
                 <enum name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>


### PR DESCRIPTION
Add query to clGetDeviceInfo for external memory handle types that are assumed to be linear.