### PR TITLE
A few editorial fixes to cl_ext_image_requirements_info and cl_ext_image_from_buffer

### DIFF
--- a/extensions/cl_ext_image_from_buffer.asciidoc
+++ b/extensions/cl_ext_image_from_buffer.asciidoc
@@ -56,7 +56,7 @@ object.
 
 == New API Enums
 
-Accepted value for the _param_name_ parameter to *clGetImageRequirementsInfoEXT*:
+Accepted value for the _param_name_ parameter to {clGetImageRequirementsInfoEXT}:
 
 [source,c]
 ----
@@ -265,7 +265,7 @@ None.
   - For all image types (one format per element size)
   - For a few different row/pitch sizes (image dimensions being equal or not)
     - Create an image from a buffer
-    - Check that the returned values for {CL_IMAGE_ROW_PITCH} and {CL_IMAGE_SLICE_PICTH} are correct.
+    - Check that the returned values for {CL_IMAGE_ROW_PITCH} and {CL_IMAGE_SLICE_PITCH} are correct.
 
 . Test clGetMemObjectInfo
   - For all image types (1 format only)

--- a/extensions/cl_ext_image_requirements_info.asciidoc
+++ b/extensions/cl_ext_image_requirements_info.asciidoc
@@ -34,7 +34,7 @@ include::../copyrights.txt[]
 
 == Status
 
-Draft spec, NOT APPROVED!!
+Shipping.
 
 == Version
 
@@ -77,7 +77,7 @@ typedef cl_uint cl_image_requirements_info_ext;
 
 == New API Enums
 
-Accepted value for the _param_name_ parameter to *clGetImageRequirementsInfoEXT*:
+Accepted value for the _param_name_ parameter to {clGetImageRequirementsInfoEXT}:
 
 [source,c]
 ----
@@ -91,7 +91,8 @@ CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT         0x12B6
 ----
 
 == Modifications to the OpenCL API Specification
-Modify Section 5.3.1, *Creating Image Objects*) ::
+
+(Modify Section 5.3.1, *Creating Image Objects*) ::
 +
 --
 The following text:
@@ -115,7 +116,7 @@ compatible with those used to create the image.
 The following text:
 --
 If the buffer object specified by mem_object was created with {CL_MEM_USE_HOST_PTR},
-the _host_ptr_ specified to *clCreateBuffer* or *clCreateBufferWithProperties* must
+the _host_ptr_ specified to {clCreateBuffer} or {clCreateBufferWithProperties} must
 be aligned to the maximum of the {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT} value for
 all devices in the context associated with the buffer specified by mem_object that
 support images.
@@ -125,7 +126,7 @@ is replaced with:
 
 --
 If the buffer object specified by mem_object was created with {CL_MEM_USE_HOST_PTR},
-the _host_ptr_ specified to *clCreateBuffer* or *clCreateBufferWithProperties* must
+the _host_ptr_ specified to {clCreateBuffer} or {clCreateBufferWithProperties} must
 be aligned to the {CL_IMAGE_REQUIREMENTS_BASE_ADDRESS_ALIGNMENT_EXT} value for the
 returned for parameters compatible with those used to create the image.
 --
@@ -135,7 +136,6 @@ returned for parameters compatible with those used to create the image.
 (Modify Section 5.3, *Image Objects*) ::
 +
 --
-
 
 (Add a new subsection 5.3.X, *Querying image requirements*) ::
 +
@@ -240,7 +240,7 @@ include::{generated}/api/protos/clGetImageRequirementsInfoEXT.txt[]
   except `mem_object` may be `0` to require that the value returned be supported
   for all possible values of the members that are set to `0`. +
   If _image_desc_ is not `NULL`, then _image_type_ must be either `0`,
-  `CL_MEM_OBJECT_IMAGE2D`, `CL_MEM_OBJECT_IMAGE2D_ARRAY`, or `CL_MEM_OBJECT_IMAGE3D`,
+  {CL_MEM_OBJECT_IMAGE2D}, {CL_MEM_OBJECT_IMAGE2D_ARRAY}, or {CL_MEM_OBJECT_IMAGE3D},
   otherwise {CL_INVALID_IMAGE_DESCRIPTOR} is returned. +
   TODO: should we require _image_height_ to be `0`?
 
@@ -256,7 +256,7 @@ include::{generated}/api/protos/clGetImageRequirementsInfoEXT.txt[]
   except `mem_object` may be `0` to require that the value returned be supported
   for all possible values of the members that are set to `0`. +
   If _image_desc_ is not `NULL`, then _image_type_ must be either `0` or
-  `CL_MEM_OBJECT_IMAGE3D`, otherwise {CL_INVALID_IMAGE_DESCRIPTOR} is returned. +
+  {CL_MEM_OBJECT_IMAGE3D}, otherwise {CL_INVALID_IMAGE_DESCRIPTOR} is returned. +
   TODO: should we require _image_depth_ to be `0`?
 
 | {CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT}
@@ -271,7 +271,7 @@ include::{generated}/api/protos/clGetImageRequirementsInfoEXT.txt[]
   except `mem_object` may be `0` to require that the value returned be supported
   for all possible values of the members that are set to `0`. +
   If _image_desc_ is not `NULL`, then _image_type_ must be either `0`,
-  `CL_MEM_OBJECT_IMAGE1D_ARRAY` or `CL_MEM_OBJECT_IMAGE2D_ARRAY`, otherwise
+  {CL_MEM_OBJECT_IMAGE1D_ARRAY} or {CL_MEM_OBJECT_IMAGE2D_ARRAY}, otherwise
   {CL_INVALID_IMAGE_DESCRIPTOR} is returned. +
   TODO: should we require _image_array_size_ to be `0`?
 |====
@@ -371,7 +371,7 @@ When `cl_khr_image2d_from_buffer` is supported:
 ** Check that the {CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT} query can be performed successfully
 ** Check that the value is smaller than or equal to the value returned for {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE}.
 
-. General negative testing for *clGetImageRequirementsInfoEXT*
+. General negative testing for {clGetImageRequirementsInfoEXT}
 ** Write tests for all possible testable generic error codes.
 
 == Issues


### PR DESCRIPTION

- Fix status of cl_ext_image_requirements_info
- Use macros for all commands and enums
- Fix mismatched parenthesis

See https://github.com/KhronosGroup/OpenCL-Registry/pull/141


Change-Id: I36ae9926e1da3fcf9c74d221888d30ab61c75b4e