### PR TITLE
fix nextafter description

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4811,7 +4811,7 @@ all arguments and the return type, unless otherwise specified.
     | Returns a quiet NaN.
       The _nancode_ may be placed in the significand of the resulting NaN.
 | gentype *nextafter*(gentype _x_, gentype _y_)
-    | Computes the next representable single-precision floating-point value
+    | Computes the next representable floating-point value
       following _x_ in the direction of _y_.
       Thus, if _y_ is less than _x_, *nextafter*() returns the largest
       representable floating-point number less than _x_.


### PR DESCRIPTION
Fixes #951 

The description of nextafter should not specifically describe single-precision floating-point numbers because it also works with doubles (and halfs, when cl_khr_fp16 is supported).