### PR TITLE
fix a few places where the fp16 and fp64 frexp referred to a float

### DIFF
--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -222,8 +222,8 @@ all arguments and the return type.
   half__n__ **frexp** (half__n__ _x_, int__n__ *exp) +
   half **frexp** (half _x_, int *exp)
 | Extract mantissa and exponent from _x_.
-  For each component the mantissa returned is a float with magnitude in the
-  interval [1/2, 1) or 0.
+  For each component the mantissa returned is a `half` with magnitude
+  in the interval [1/2, 1) or 0.
   Each component of _x_ equals mantissa returned * 2__^exp^__.
 
 | gentype *hypot* (gentype _x_, gentype _y_)

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -210,8 +210,8 @@ all arguments and the return type.
   double **frexp** (double _x_, {local} int *exp) +
   double **frexp** (double _x_, {private} int *exp)
 | Extract mantissa and exponent from _x_.
-  For each component the mantissa returned is a float with magnitude in the
-  interval [1/2, 1) or 0.
+  For each component the mantissa returned is a `double` with magnitude
+  in the interval [1/2, 1) or 0.
   Each component of _x_ equals mantissa returned * 2__^exp^__.
 
 | gentype *hypot* (gentype _x_, gentype _y_)


### PR DESCRIPTION
fixes #954 

Fixes two issues in the extensions spec where the cl_khr_fp16 and cl_khr_fp64 descriptions of `frexp` still referred to a `float` rather than as a `half` or a `double`.