### PR TITLE
Add a few missing uses of types and enums to XML

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4299,6 +4299,18 @@ server's OpenCL/api-docs repository.
             <type name="cl_image_format"/>
             <type name="cl_buffer_region"/>
         </require>
+        <require comment="API data types">
+            <type name="cl_char"/>
+            <type name="cl_uchar"/>
+            <type name="cl_short"/>
+            <type name="cl_ushort"/>
+            <type name="cl_int"/>
+            <type name="cl_uint"/>
+            <type name="cl_long"/>
+            <type name="cl_ulong"/>
+            <type name="cl_float"/>
+            <type name="cl_half"/>
+        </require>
         <require comment="Constants">
             <enum name="CL_CHAR_BIT"/>
             <enum name="CL_CHAR_MAX"/>
@@ -4340,6 +4352,32 @@ server's OpenCL/api-docs repository.
             <enum name="CL_HUGE_VAL"/>
             <enum name="CL_MAXFLOAT"/>
             <enum name="CL_INFINITY"/>
+            <enum name="CL_M_E"/>
+            <enum name="CL_M_LOG2E"/>
+            <enum name="CL_M_LOG10E"/>
+            <enum name="CL_M_LN2"/>
+            <enum name="CL_M_LN10"/>
+            <enum name="CL_M_PI"/>
+            <enum name="CL_M_PI_2"/>
+            <enum name="CL_M_PI_4"/>
+            <enum name="CL_M_1_PI"/>
+            <enum name="CL_M_2_PI"/>
+            <enum name="CL_M_2_SQRTPI"/>
+            <enum name="CL_M_SQRT2"/>
+            <enum name="CL_M_SQRT1_2"/>
+            <enum name="CL_M_E_F"/>
+            <enum name="CL_M_LOG2E_F"/>
+            <enum name="CL_M_LOG10E_F"/>
+            <enum name="CL_M_LN2_F"/>
+            <enum name="CL_M_LN10_F"/>
+            <enum name="CL_M_PI_F"/>
+            <enum name="CL_M_PI_2_F"/>
+            <enum name="CL_M_PI_4_F"/>
+            <enum name="CL_M_1_PI_F"/>
+            <enum name="CL_M_2_PI_F"/>
+            <enum name="CL_M_2_SQRTPI_F"/>
+            <enum name="CL_M_SQRT2_F"/>
+            <enum name="CL_M_SQRT1_2_F"/>
         </require>
         <require comment="Error codes">
             <enum name="CL_SUCCESS"/>
@@ -4864,6 +4902,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_kernel_arg_access_qualifier"/>
             <type name="cl_kernel_arg_type_qualifier"/>
             <type name="cl_image_desc"/>
+            <type name="cl_double"/>
         </require>
         <require comment="Constants">
             <enum name="CL_DBL_DIG"/>
@@ -5039,6 +5078,7 @@ server's OpenCL/api-docs repository.
         <require>
             <type name="cl_device_svm_capabilities"/>
             <type name="cl_queue_properties"/>
+            <type name="cl_properties"/>
             <type name="cl_svm_mem_flags"/>
             <type name="cl_pipe_properties"/>
             <type name="cl_pipe_info"/>
@@ -5484,6 +5524,7 @@ server's OpenCL/api-docs repository.
         <extension name="cl_khr_fp64" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
+                <type name="cl_double"/>
             </require>
             <require condition="!defined(CL_VERSION_1_2)" comment="cl_device_info - defined in CL.h for OpenCL 1.2 and newer">
                 <enum name="CL_DEVICE_DOUBLE_FP_CONFIG"/>
@@ -5495,6 +5536,18 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_HALF_FP_CONFIG"/>
+            </require>
+            <require comment="Constants">
+                <enum name="CL_HALF_DIG"/>
+                <enum name="CL_HALF_MANT_DIG"/>
+                <enum name="CL_HALF_MAX_10_EXP"/>
+                <enum name="CL_HALF_MAX_EXP"/>
+                <enum name="CL_HALF_MIN_10_EXP"/>
+                <enum name="CL_HALF_MIN_EXP"/>
+                <enum name="CL_HALF_RADIX"/>
+                <enum name="CL_HALF_MAX"/>
+                <enum name="CL_HALF_MIN"/>
+                <enum name="CL_HALF_EPSILON"/>
             </require>
         </extension>
         <extension name="cl_APPLE_SetMemObjectDestructor" comment="not registered" supported="opencl">
@@ -5518,6 +5571,7 @@ server's OpenCL/api-docs repository.
         <extension name="cl_khr_icd" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
+                <type name="cl_icd_dispatch"/>
             </require>
             <require comment="cl_platform_info">
                 <enum name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
@@ -6444,6 +6498,9 @@ server's OpenCL/api-docs repository.
         <extension name="cl_khr_gl_depth_images" requires="cl_khr_gl_sharing" comment="no API - reuses tokens from core API" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
+                <type name="cl_GLint"/>
+                <type name="cl_GLenum"/>
+                <type name="cl_GLuint"/>
             </require>
             <require condition="!defined(CL_VERSION_1_2)" comment="cl_channel_order - defined in CL.h for OpenCL 1.2 and newer">
                 <enum name="CL_DEPTH_STENCIL"/>


### PR DESCRIPTION
- OpenCL 1.0 requires cl_char, etc types
- OpenCL 1.2 and cl_khr+_fp64 require cl_double
- cl_khr_fp16 requires CL_HALF_* constants
- cl_khr_icd requires cl_icd_dispatch
- OpenCL 1.0 requires all the CL_M_* constants. The specification does not state which version defines which constant (see #731)
- cl_khr_gl_sharing requires all cl_GL* types


Change-Id: I8eb34ab1eccf727700662ff5f61823d0e8c48ea1