### PR TITLE
Clarify clReleaseSemaphoreKHR

### DIFF
--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -465,7 +465,8 @@ Otherwise, it returns one of the following errors:
 
 After the reference count becomes zero and commands queued for execution on a
 command-queue(s) that use _sema_object_ have finished, the semaphore object is
-deleted.
+deleted. Undefined behavior may occur if _sema_object_ has a pending signal and
+{clEnqueueWaitSemaphoresKHR} has not been called for _sema_object_.
 Using this function to release a reference that was not obtained by creating the
 object via {clCreateSemaphoreWithPropertiesKHR} or by calling
 {clRetainSemaphoreKHR} causes undefined behavior.


### PR DESCRIPTION
If a semaphore is deleted while there is a pending signal, specify the behavior.