### PR TITLE
External memory import of dedicated/non-dedicated memory

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -211,7 +211,7 @@ If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_, the
 
 The properties used to create a buffer or image from an external memory handle are described by related extensions.
 When a buffer or image is created from an external memory handle, the _flags_ used to specify usage information for the buffer or image must not include {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}, and the _host_ptr_ argument must be `NULL`.
-For images created from an external memory handle, implementations will acquire information about image attributes such as format and layout at the time of creation and continue to apply those attributes for the lifetime of the image object.
+For images created from an external memory handle, implementations may acquire information about image attributes such as format and layout at the time of creation and continue to apply those attributes for the lifetime of the image object.
 
 Add to the list of error conditions for {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -211,7 +211,7 @@ If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_, the
 
 The properties used to create a buffer or image from an external memory handle are described by related extensions.
 When a buffer or image is created from an external memory handle, the _flags_ used to specify usage information for the buffer or image must not include {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}, and the _host_ptr_ argument must be `NULL`.
-For images created from an external memory handle, implementations may acquire information about image attributes such as format and layout at the time of creation and continue to apply those attributes for the lifetime of the image object.
+When images are created from an external memory handle, implementations may acquire information about image attributes such as format and layout at the time of creation. When such information is acquired at image creation time, it is used for the lifetime of the image object.
 
 Add to the list of error conditions for {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -211,7 +211,7 @@ If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_, the
 
 The properties used to create a buffer or image from an external memory handle are described by related extensions.
 When a buffer or image is created from an external memory handle, the _flags_ used to specify usage information for the buffer or image must not include {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}, and the _host_ptr_ argument must be `NULL`.
-After importing external memory, the OpenCL implementation will not detect any changes in the image format made by an external API, such as the external API re-binding the memory to a new image.
+For images created from an external memory handle, implementations will acquire information about image attributes such as format and layout at the time of creation and continue to apply those attributes for the lifetime of the image object.
 
 Add to the list of error conditions for {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -211,6 +211,7 @@ If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_, the
 
 The properties used to create a buffer or image from an external memory handle are described by related extensions.
 When a buffer or image is created from an external memory handle, the _flags_ used to specify usage information for the buffer or image must not include {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}, and the _host_ptr_ argument must be `NULL`.
+After importing external memory, the OpenCL implementation will not detect any changes in the image format made by an external API, such as the external API re-binding the memory to a new image.
 
 Add to the list of error conditions for {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
 


### PR DESCRIPTION
Specifies when OpenCL becomes aware of imported image memory layout metadata.  This is meant to clarify how OpenCL interacts with dedicated memory.