### PR TITLE
fix VME skip block type enum to match extension spec

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1029,8 +1029,7 @@ server's OpenCL/api-docs repository.
 
     <enums name="cl_intel_advanced_motion_estimation.skip_block_type" vendor="Intel">
         <enum value="0x0"           name="CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL"/>
-        <enum value="0x1"           name="CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL"/>
-        <!-- unused <enum value="0x2"         name="CL_ME_SKIP_BLOCK_TYPE_4x4_INTEL"/> -->
+        <enum value="0x4"           name="CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL"/>
     </enums>
 
     <enums name="cl_intel_advanced_motion_estimation.device_me_version" vendor="Intel">


### PR DESCRIPTION
see: https://github.com/intel/compute-runtime/issues/677

Fixes the value of the enum `CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL` from [cl_intel_advanced_motion_estimation](https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_advanced_motion_estimation.txt) to match the specification.

This is needed to fix the issue identified above after switching to the new generated headers.