### PR TITLE
document USM error conditions for clSetKernelExecInfo

### DIFF
--- a/extensions/cl_intel_unified_shared_memory.asciidoc
+++ b/extensions/cl_intel_unified_shared_memory.asciidoc
@@ -788,6 +788,13 @@ The new _param_name_ values described below may be used with the existing *clSet
 
 |====
 
+The following errors may be returned by *clSetKernelExecInfo* for these new _param_name_ values:
+
+* `CL_INVALID_OPERATION` if _param_name_ is `CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL` and no devices in the context associated with _kernel_ support Unified Shared Memory.
+* `CL_INVALID_OPERATION` if _param_name_ is `CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL` and no devices in the context associated with _kernel_ support host Unified Shared Memory allocations.
+* `CL_INVALID_OPERATION` if _param_name_ is `CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL` and no devices in the context associated with _kernel_ support device Unified Shared Memory allocations.
+* `CL_INVALID_OPERATION` if _param_name_ is `CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL` and no devices in the context associated with _kernel_ support shared Unified Shared Memory allocations.
+
 ==== Filling and Copying Unified Shared Memory
 
 The function
@@ -1281,6 +1288,7 @@ Note that there is no similar SVM "rect" memcpy.
 |S|2020-08-26|Maciej Dziuban|Added initial placement flags for shared allocations.
 |1.0.0|2021-11-07|Ben Ashbaugh|Added version and other minor updates prior to posting on the OpenCL registry.
 |1.0.0|2022-11-08|Ben Ashbaugh|Added new issues regarding error behavior for clSetKernelArgMemPointerINTEL and rect copies.
+|1.0.1|2023-08-28|Ben Ashbaugh|Documented error conditions for clSetKernelExecInfo.
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
Adds a few error conditions to the `cl_intel_unified_shared_memory` extension.

Specifically, describes expected error behavior for clSetKernelExecInfo when devices in a context do not support different types of USM, or do not support USM at all.