### PR TITLE
Semaphore re-export

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -218,6 +218,13 @@ Following new properties are added to the list of possible supported properties 
 Add to the list of error conditions for {clCreateSemaphoreWithPropertiesKHR}:
 
 * {CL_INVALID_DEVICE} if one or more devices identified by properties {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} can not import the requested external semaphore handle type.
+* {CL_INVALID_VALUE} if more than one semaphore handle type is specified in the {CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR} list.
+
+If _props_list_ specifies a {cl_external_semaphore_handle_type_khr_TYPE} followed by a handle as well as
+{CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR} followed by a export handle type, then export handle type must match
+the {cl_external_semaphore_handle_type_khr_TYPE}. It is always possible to export a semaphore with the same handle type
+as the import handle type. However, the application must explicitly specify the export handle type in _props_list_ of
+{clCreateSemaphoreWithPropertiesKHR} if it intends to export the semaphore.
 
 Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
 
@@ -549,7 +556,7 @@ cl_semaphore_properties_khr sema_props[] = {
     (cl_semaphore_properties_khr)CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR, 
     (cl_semaphore_properties_khr)CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
     CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR,
-    (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR, 
+    (cl_semaphore_properties_khr)CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR,
     (cl_semaphore_properties_khr)devices[1],
     CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR,
     0

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -219,12 +219,9 @@ Add to the list of error conditions for {clCreateSemaphoreWithPropertiesKHR}:
 
 * {CL_INVALID_DEVICE} if one or more devices identified by properties {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} can not import the requested external semaphore handle type.
 * {CL_INVALID_VALUE} if more than one semaphore handle type is specified in the {CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR} list.
-
-If _props_list_ specifies a {cl_external_semaphore_handle_type_khr_TYPE} followed by a handle as well as
-{CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR} followed by a export handle type, then export handle type must match
-the {cl_external_semaphore_handle_type_khr_TYPE}. It is always possible to export a semaphore with the same handle type
-as the import handle type. However, the application must explicitly specify the export handle type in _props_list_ of
-{clCreateSemaphoreWithPropertiesKHR} if it intends to export the semaphore.
+* {CL_INVALID_OPERATION} If _props_list_ specifies a {cl_external_semaphore_handle_type_khr_TYPE} followed by a handle as well as
+{CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR}. Exporting a semaphore handle from a semaphore that was created by importing
+an external semaphore handle is not permitted.
 
 Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
 


### PR DESCRIPTION
Do not allow the re-exporting of imported semaphore handles.