### PR TITLE
Remove text relaxing core semaphore requirement for external semaphores

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -219,9 +219,6 @@ Add to the list of error conditions for {clCreateSemaphoreWithPropertiesKHR}:
 
 * {CL_INVALID_DEVICE} if one or more devices identified by properties {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} can not import the requested external semaphore handle type.
 
-{clCreateSemaphoreWithPropertiesKHR} may return a NULL value on some implementations if _sema_props_ does not contain an external semaphore handle type to import.
-Such implementations are required to return a valid semaphore when a supported external memory handle type and valid external semaphore handle is specified.
-
 Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
 
 .List of supported param_names by {clGetSemaphoreInfoKHR}


### PR DESCRIPTION
cl_khr_external_semaphore requires cl_khr_semaphore and cl_khr_semaphore requires support for base semaphores. However, cl_khr_external_semaphore allows relaxing core cl_khr_semaphore requirement to support base semaphores if importing external semaphores is supported.

Clean up the text related to above and make it mandatory to support core semaphores to honor dependency of
cl_khr_semaphore.

Fixes #944