### PR TITLE
cl_khr_semaphore: Delete stale comment

### DIFF
--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -175,8 +175,6 @@ CL_COMMAND_SEMAPHORE_WAIT_KHR                               0x2042
 CL_COMMAND_SEMAPHORE_SIGNAL_KHR                             0x2043
 ----
 
-// TODO: This error code is already allocated.  Use -1141 instead?
-
 The following error codes can be returned by APIs introduced as part of this specification or the specifications that depend on this:
 [source]
 ----


### PR DESCRIPTION
Delete state TODO.  The error code as written is correct.  Fixes point 1 is issues #957 