### PR TITLE
add an error condition when unmapping a SVM region that was not mapped

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4883,7 +4883,8 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
   * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
     in _event_wait_list_ are not the same.
-  * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
+  * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL` or if the region given by
+    _svm_ptr_ was not specified in a previous call to {clEnqueueSVMMap}.
   * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
     _num_events_in_wait_list_ > 0, or if _event_wait_list_ is not `NULL` and
     _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_


### PR DESCRIPTION
fixes #890 

Adds an error condition (`CL_INVALID_VALUE`) when attempting to unmap a SVM region that was not mapped.