### PR TITLE
fix version note links in the reference pages

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -26,6 +26,9 @@ include::config/attribs.txt[]
 // Attributes that are shared by OpenCL specifications.
 include::config/opencl.asciidoc[]
 
+// Attributes for version notes, with local links.
+include::config/version-local-links.asciidoc[]
+
 // Formatting and links for API functions and enums.
 include::api/dictionary.asciidoc[]
 

--- a/config/version-full-links.asciidoc
+++ b/config/version-full-links.asciidoc
@@ -2,7 +2,7 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-// Attributes for version notes, with local links.
+// Attributes for version notes, with full links.
 
 // "missing before"
 :missing_before_label: pass:q[missing before]

--- a/config/version-full-links.asciidoc
+++ b/config/version-full-links.asciidoc
@@ -1,0 +1,13 @@
+// Copyright 2023 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Attributes for version notes, with local links.
+
+// "missing before"
+:missing_before_label: pass:q[missing before]
+:missing_before: link:https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#unified-spec[{missing_before_label}^]
+
+// "deprecated by"
+:deprecated_by_label: pass:q[deprecated by]
+:deprecated_by: link:https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#unified-spec[{deprecated_by_label}^]

--- a/config/version-local-links.asciidoc
+++ b/config/version-local-links.asciidoc
@@ -1,0 +1,13 @@
+// Copyright 2023 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+// Attributes for version notes, with local links.
+
+// "missing before"
+:missing_before_label: pass:q[missing before]
+:missing_before: <<unified-spec,{missing_before_label}>>
+
+// "deprecated by"
+:deprecated_by_label: pass:q[deprecated by]
+:deprecated_by: <<unified-spec,{deprecated_by_label}>>

--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -201,6 +201,7 @@ class OpenCLConventions(ConventionsBase):
         """Return any extra text to add to refpage headers."""
         return 'include::{config}/attribs.txt[]\n' + \
             'include::{config}/opencl.asciidoc[]\n' + \
+            'include::{config}/version-full-links.asciidoc[]\n' + \
             'include::{apispec}/footnotes.asciidoc[]\n' + \
             'include::{cspec}/footnotes.asciidoc[]\n' + \
             'include::{cspec}/feature-dictionary.asciidoc[]\n' + \

--- a/scripts/gen_version_notes.py
+++ b/scripts/gen_version_notes.py
@@ -40,11 +40,11 @@ def FullNote(name, added_in, deprecated_by):
     if added_in == "1.0" and deprecated_by == None:
         return "\n// Intentionally empty, %s has always been present." % name
     if added_in != "1.0" and deprecated_by == None:
-        return "\nIMPORTANT: {%s} is <<unified-spec, missing before>> version %s." % (name, added_in)
+        return "\nIMPORTANT: {%s} is {missing_before} version %s." % (name, added_in)
     if added_in == "1.0" and deprecated_by != None:
-        return "\nIMPORTANT: {%s} is <<unified-spec, deprecated by>> version %s." % (name, deprecated_by)
+        return "\nIMPORTANT: {%s} is {deprecated_by} version %s." % (name, deprecated_by)
     if added_in != "1.0" and deprecated_by != None:
-        return "\nIMPORTANT: {%s} is <<unified-spec, missing before>> version %s and <<unified-spec, deprecated by>> version %s." % (name, added_in, deprecated_by)
+        return "\nIMPORTANT: {%s} is {missing_before} version %s and {deprecated_by} version %s." % (name, added_in, deprecated_by)
 
 def ShortNote(name, added_in, deprecated_by):
     # Four patterns: (1) always present in OpenCL, (2) added after 1.0, (3) in
@@ -52,11 +52,11 @@ def ShortNote(name, added_in, deprecated_by):
     if added_in == "1.0" and deprecated_by == None:
         return "// Intentionally empty, %s has always been present." % name
     if added_in != "1.0" and deprecated_by == None:
-        return "<<unified-spec, Missing before>> version %s." % added_in
+        return "{missing_before} version %s." % added_in
     if added_in == "1.0" and deprecated_by != None:
-        return "<<unified-spec, Deprecated by>> version %s." % deprecated_by
+        return "{deprecated_by} version %s." % deprecated_by
     if added_in != "1.0" and deprecated_by != None:
-        return "<<unified-spec, Missing before>> version %s and <<unified-spec, deprecated by>> version %s." % (added_in, deprecated_by)
+        return "{missing_before} version %s and {deprecated_by} version %s." % (added_in, deprecated_by)
 
 # Find feature groups that are parents of a feature/require/${entry_type}
 # hierarchy, and then find all the ${entry_type} within each hierarchy:


### PR DESCRIPTION
fixes #726 

This feels like a bit of a hack, but it's working, and the same possible solution was proposed on the issue also so maybe it's not _that_ bad?

This fixes the version note links by adding a config file defining asciidoctor attributes for "missing before" and "deprecated by" with two variants:

1. The first variant has local links that work within the same document and is included by the main OpenCL API spec.
2. The second variant has full links that will work anywhere and is included by the reference pages.