### PR TITLE
Fix broken refpage links for CL_VERSION_X_Y macros

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3398,7 +3398,7 @@ supported with `{global}` address space qualifier.
 [[preprocessor-directives-and-macros]]
 == Preprocessor Directives and Macros
 
-[open,refpage='preprocessorDirectives',desc='Preprocessor Directives and Macros',type='freeform',spec='clang',anchor='preprocessor-directives-and-macros',xrefs='clBuildProgram mathConstants EXTENSION FP_CONTRACT']
+[open,refpage='preprocessorDirectives',desc='Preprocessor Directives and Macros',type='freeform',spec='clang',anchor='preprocessor-directives-and-macros',xrefs='clBuildProgram mathConstants EXTENSION FP_CONTRACT',alias='CL_VERSION_1_0 CL_VERSION_1_1 CL_VERSION_1_2']
 --
 
 The preprocessing directives defined by the C99 specification are supported.


### PR DESCRIPTION
Aliases them all to the preprocessorDirectives page.

This will need to be tried out on a running Apache server since it amounts to modifying .htaccess to do rewrites of the aliases.