### PR TITLE
filter CL_VERSION_X_Y macros from reference page see also

### DIFF
--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -239,3 +239,12 @@ class OpenCLConventions(ConventionsBase):
         Vulkan, so these checks are not appropriate."""
 
         return True
+
+    def filter_ref(self, name):
+        """Returns True if the reference should be filtered and not included in
+           the reference pages.
+        """
+        # Do not include CL_VERSION_X_Y macro references
+        if name.startswith('CL_VERSION_'):
+            return True
+        return False

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -103,13 +103,6 @@ def macroPrefix(name):
     return 'reflink:' + name
 
 
-def filterRef(name):
-    # Do not include CL_VERSION_X_Y macro references
-    if name.startswith('CL_VERSION_'):
-        return True
-    return False
-
-
 def seeAlsoList(apiName, explicitRefs=None, apiAliases=[]):
     """Return an asciidoc string with a list of 'See Also' references for the
     API entity 'apiName', based on the relationship mapping in the api module.
@@ -146,8 +139,8 @@ def seeAlsoList(apiName, explicitRefs=None, apiAliases=[]):
                 if dependency is not None:
                     refs.add(dependency)
 
-    # Remove CL_VERSION_X_Y macro references
-    refs = set([ref for ref in refs if not filterRef(ref)])
+    # Filter references based on API conventions
+    refs = set([ref for ref in refs if not conventions.filter_ref(ref)])
 
     if len(refs) == 0:
         return None

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -103,6 +103,13 @@ def macroPrefix(name):
     return 'reflink:' + name
 
 
+def filterRef(name):
+    # Do not include CL_VERSION_X_Y macro references
+    if name.startswith('CL_VERSION_'):
+        return True
+    return False
+
+
 def seeAlsoList(apiName, explicitRefs=None, apiAliases=[]):
     """Return an asciidoc string with a list of 'See Also' references for the
     API entity 'apiName', based on the relationship mapping in the api module.
@@ -138,6 +145,9 @@ def seeAlsoList(apiName, explicitRefs=None, apiAliases=[]):
                 refs.add(base)
                 if dependency is not None:
                     refs.add(dependency)
+
+    # Remove CL_VERSION_X_Y macro references
+    refs = set([ref for ref in refs if not filterRef(ref)])
 
     if len(refs) == 0:
         return None


### PR DESCRIPTION
fixes #981 

Instead of trying to make the CL_VERSION_X_Y macros link to the right page, just filter them from the "see also" list, because they aren't adding much value.

I tried to make this somewhat general if we decide to filter other references later, also.  I'm open to suggestions how to do this better though, if desired.