### PR TITLE
add old command queue APIs to the reference page table of contents

### DIFF
--- a/man/toctail
+++ b/man/toctail
@@ -39,10 +39,12 @@
                         <ul class="Level3">
                             <li>Command-Queues
                                 <ul class="Level4">
+                                    <li><a href="clCreateCommandQueue.html" target="pagedisplay">clCreateCommandQueue</a></li>
                                     <li><a href="clCreateCommandQueueWithProperties.html" target="pagedisplay">clCreateCommandQueueWithProperties</a></li>
                                     <li><a href="clGetCommandQueueInfo.html" target="pagedisplay">clGetCommandQueueInfo</a></li>
                                     <li><a href="clReleaseCommandQueue.html" target="pagedisplay">clReleaseCommandQueue</a></li>
                                     <li><a href="clRetainCommandQueue.html" target="pagedisplay">clRetainCommandQueue</a></li>
+                                    <li><a href="clSetCommandQueueProperty.html" target="pagedisplay">clSetCommandQueueProperty</a></li>
                                     <li><a href="clSetDefaultDeviceCommandQueue.html" target="pagedisplay">clSetDefaultDeviceCommandQueue</a></li>
                                 </ul>
                             </li>


### PR DESCRIPTION
Found while working on #980.  The older clCreateCommandQueue and clSetCommandQueueProperties APIs have generated HTML pages but they weren't appearing in the TOC.  This changes adds them to the TOC so they are easier to find (even if these APIs are deprecated and their use is discouraged).