### PR TITLE
add rewrite rule for cl_mem_properties

### DIFF
--- a/man/rewritehead
+++ b/man/rewritehead
@@ -86,6 +86,7 @@ RewriteRule ^cl_program.html$ abstractDataTypes.html
 RewriteRule ^cl_sampler.html$ abstractDataTypes.html
 
 # Data types used in APIs, but not otherwise described in the specification
+RewriteRule ^cl_mem_properties.html$ clCreateBuffer.html
 RewriteRule ^cl_pipe_properties.html$ clCreatePipe.html
 RewriteRule ^cl_queue_properties.html$ clCreateCommandQueueWithProperties.html
 


### PR DESCRIPTION
Adds a redirect from the nonexistent `cl_mem_properties.html` to the `clCreateBuffer.html` page, which also includes `clCreateBufferWithProperties` and hence is as good of a page for `cl_mem_properties` as any.

With #984 I believe this fixes all of the broken links in the OpenCL reference pages.