### PR TITLE
Use hexapdf instead of ghostscript for PDF optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - gem install coderay -v 1.1.1
   - gem install rouge -v 3.19.0
   - gem install ttfunk -v 1.5.1
+  - gem install hexapdf -v 0.27.0
   - gem install asciidoctor-pdf -v 1.5.0
   - gem install asciidoctor-mathematical -v 0.3.5
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ RM	    = rm -f
 RMRF	    = rm -rf
 MKDIR	    = mkdir -p
 CP	    = cp
-GS_EXISTS   := $(shell command -v gs 2> /dev/null)
 GITHEAD     = ./.git/logs/HEAD
 
 # Target directories for output files
@@ -163,6 +162,10 @@ icdinst: icdinsthtml icdinstpdf
 
 html: apihtml envhtml exthtml extensionshtml cxxhtml chtml icdinsthtml
 
+# PDF optimizer - usage $(OPTIMIZEPDF) in.pdf out.pdf
+# OPTIMIZEPDFOPTS=--compress-pages is slightly better, but much slower
+OPTIMIZEPDF = hexapdf optimize $(OPTIMIZEPDFOPTS)
+
 pdf: apipdf envpdf extpdf extensionspdf cxxpdf cpdf icdinstpdf
 
 # Spec targets.
@@ -192,13 +195,7 @@ $(PDFDIR)/$(APISPEC).pdf: $(APISPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(APISPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(APISPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # Environment spec
 
@@ -218,13 +215,7 @@ $(PDFDIR)/$(ENVSPEC).pdf: $(ENVSPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(ENVSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(ENVSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # Extensions spec
 EXTSPEC = OpenCL_Ext
@@ -242,13 +233,7 @@ $(PDFDIR)/$(EXTSPEC).pdf: $(EXTSPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(EXTSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(EXTSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # Individual extensions spec(s)
 EXTDIR = extensions
@@ -280,13 +265,7 @@ $(PDFDIR)/$(EXTENSIONSSPEC).pdf: $(EXTENSIONSSPECSRC) $(GENDEPENDS)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(EXTDIR)/$(EXTENSIONSSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(EXTENSIONSSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # Language Extensions spec
 CEXTDOC = OpenCL_LangExt
@@ -304,13 +283,7 @@ $(PDFDIR)/$(CEXTDOC).pdf: $(CEXTDOCSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CEXTDOC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(CEXTDOC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # C++ (cxx) spec
 CXXSPEC = OpenCL_Cxx
@@ -328,13 +301,7 @@ $(PDFDIR)/$(CXXSPEC).pdf: $(CXXSPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CXXSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(CXXSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # C spec
 CSPEC = OpenCL_C
@@ -352,13 +319,7 @@ $(PDFDIR)/$(CSPEC).pdf: $(CSPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(CSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # C++ for OpenCL doc
 CXX4OPENCLDOC = CXX_for_OpenCL
@@ -376,13 +337,7 @@ $(PDFDIR)/$(CXX4OPENCLDOC).pdf: $(CXX4OPENCLDOCSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(CXX4OPENCL_ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(CXX4OPENCLDOC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(CXX4OPENCLDOC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # ICD installation guidelines
 ICDINSTSPEC = OpenCL_ICD_Installation
@@ -400,13 +355,7 @@ $(PDFDIR)/$(ICDINSTSPEC).pdf: $(ICDINSTSPECSRC)
 	$(QUIET)$(MKDIR) $(PDFDIR)
 	$(QUIET)$(MKDIR) $(PDFMATHDIR)
 	$(QUIET)$(ASCIIDOCTOR) -b pdf $(ADOCOPTS) $(ADOCPDFOPTS) -o $@ $(ICDINSTSPEC).txt
-ifndef GS_EXISTS
-	$(QUIET) echo "Warning: Ghostscript not installed, skipping pdf optimization"
-else
-	$(QUIET)$(CURDIR)/config/optimize-pdf $@
-	$(QUIET)rm $@
-	$(QUIET)mv $(PDFDIR)/$(ICDINSTSPEC)-optimized.pdf $@
-endif
+	$(QUIET)$(OPTIMIZEPDF) $@ $@.out.pdf && mv $@.out.pdf $@
 
 # Clean generated and output files
 

--- a/README.adoc
+++ b/README.adoc
@@ -246,6 +246,8 @@ scheme.
 
 This section describes the software components used by the OpenCL spec
 toolchain.
+The specified versions are known to work.
+Later compatible versions will probably work as well.
 
 Before building the OpenCL specs, you must install the following tools:
 
@@ -260,10 +262,6 @@ Before building the OpenCL specs, you must install the following tools:
     Any version supporting the following operations should work:
   ** `git symbolic-ref --short HEAD`
   ** `git log -1 --format="%H"`
-  * Ghostscript (ghostscript, version: 9.10).
-    This is for the PDF build, and it can still progress without it.
-    Ghostscript is used to optimize the size of the PDF, so will be a lot
-    smaller if it is included.
   * ttf Fonts.
     These are needed the PDF build for latexmath rendering.
     See https://github.com/asciidoctor/asciidoctor-mathematical/blob/master/README.md#dependencies[Font Dependencies for asciidoctor-mathematical].
@@ -277,6 +275,7 @@ parts you don't use) completely before trying to install.
 
   * Asciidoctor (asciidoctor, version: 2.0.16)
   * Coderay (coderay, version: 1.1.1)
+  * hexapdf (version: 0.27.0)
   * rouge (rouge, version 3.19.0)
   * ttfunk (ttfunk, version: 1.5.1)
   * Asciidoctor PDF (asciidoctor-pdf, version: 1.5.0)
@@ -444,6 +443,7 @@ echo "2.3.3" > ~/.rbenv/version
 
 gem install asciidoctor -v 2.0.16
 gem install coderay -v 1.1.1
+gem install hexapdf -v 0.27.0
 gem install rouge -v 3.19.0
 gem install ttfunk -v 1.5.1
 gem install asciidoctor-pdf -v 1.5.0
@@ -656,6 +656,7 @@ command, once the platform is set up:
 ----
 gem install asciidoctor -v 2.0.16
 gem install coderay -v 1.1.1
+gem install hexapdf -v 0.27.0
 gen install rouge -v 3.19.0
 gem install ttfunk -v 1.5.1
 
@@ -687,6 +688,7 @@ by Khronos.
 [[history]]
 == Revision History
 
+  * 2023-11-05 - Add hexapdf, remove ghostscript
   * 2020-03-13 - Updated package versions to match Travis build.
   * 2019-06-20 - Add directions for publishing OpenCL 2.2 reference pages,
     generated from the spec sources in this repository, in the


### PR DESCRIPTION
Resulting PDFs tend to be considerably smaller, and also runs about 15% faster when doing a full PDF build (2:39 vs. 3:06 on my machine).

The hexapdf tool does need to be installed in the build environment - it is in the khronosgroup/docker-images:asciidoctor-spec Docker image.