### PR TITLE
cl_khr_semaphore: Enforce one device semaphores (#973)

### DIFF
--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -269,14 +269,13 @@ Otherwise, it returns a `NULL` value with one of the following error values retu
 
 * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
 * {CL_INVALID_PROPERTY} if a property name in _sema_props_ is not a supported property name, if the value specified for a supported property name is not valid, or if the same property name is specified more than once.
-* {CL_INVALID_DEVICE} if {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is specified as part of _sema_props_, but it does not identify a valid device or if a device identified by {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not one of the devices within _context_.
+* {CL_INVALID_DEVICE} if {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is specified as part of _sema_props_, but it does not identify exactly one valid device or if a device identified by {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not one of the devices within _context_.
 * {CL_INVALID_VALUE}
 ** if _sema_props_ is `NULL`, or
 ** if _sema_props_ do not specify <property, value> pairs for minimum set of properties (i.e. {CL_SEMAPHORE_TYPE_KHR}) required for successful creation of a {cl_semaphore_khr_TYPE}, or
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
-* {CL_INVALID_DEVICE} if _sema_props_ specifies multiple devices with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}
-* {CL_INVALID_DEVICE} if _context_ is a multiple device context and _sema_props_ does not specify exactly one device with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}.
+* {CL_INVALID_DEVICE} if _context_ is a multiple device context and _sema_props_ does not specify {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} as one of the properties.
 
 ==== Waiting on and signaling semaphores
 

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -257,10 +257,10 @@ Following new properties are added to the list of possible supported properties 
       | Specifies the type of semaphore to create. This property is always required.
 | {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}
   | {cl_device_id_TYPE}[]
-      | Specifies the list of OpenCL devices (terminated with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR}) to associate with the semaphore.
+      | Specifies the list of OpenCL devices (terminated with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR}) to associate with the semaphore. Only a single device is permitted in the list.
 |====
 
-If {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not specified as part of _sema_props_, the semaphore object created by {clCreateSemaphoreWithPropertiesKHR} is by default accessible to all devices in the _context_.
+If {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not specified as part of _sema_props_, the semaphore object created by {clCreateSemaphoreWithPropertiesKHR} is by default accessible to all devices in the _context_.  For a multi-device context {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} must be specified in _sema_props_.
 
 _errcode_ret_ returns an appropriate error code. If _errcode_ret_ is `NULL`, no error code is returned.
 
@@ -275,6 +275,8 @@ Otherwise, it returns a `NULL` value with one of the following error values retu
 ** if _sema_props_ do not specify <property, value> pairs for minimum set of properties (i.e. {CL_SEMAPHORE_TYPE_KHR}) required for successful creation of a {cl_semaphore_khr_TYPE}, or
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
+* {CL_INVALID_DEVICE} if _sema_props_ specifies multiple devices with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}
+* {CL_INVALID_DEVICE} if _context_ is a multiple device context and _sema_props_ does not specify exactly one device with {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}.
 
 ==== Waiting on and signaling semaphores
 

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -268,14 +268,13 @@ _errcode_ret_ returns an appropriate error code. If _errcode_ret_ is `NULL`, no 
 Otherwise, it returns a `NULL` value with one of the following error values returned in _errcode_ret_:
 
 * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-* {CL_INVALID_PROPERTY} if a property name in _sema_props_ is not a supported property name, if the value specified for a supported property name is not valid, or if the same property name is specified more than once.
+* {CL_INVALID_PROPERTY} if a property name in _sema_props_ is not a supported property name, if the value specified for a supported property name is not valid, or if the same property name is specified more than once. Additionally, if _context_ is a multiple device context and _sema_props_ does not specify {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}.
 * {CL_INVALID_DEVICE} if {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is specified as part of _sema_props_, but it does not identify exactly one valid device or if a device identified by {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not one of the devices within _context_.
 * {CL_INVALID_VALUE}
 ** if _sema_props_ is `NULL`, or
 ** if _sema_props_ do not specify <property, value> pairs for minimum set of properties (i.e. {CL_SEMAPHORE_TYPE_KHR}) required for successful creation of a {cl_semaphore_khr_TYPE}, or
 * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources required by the OpenCL implementation on the host.
-* {CL_INVALID_DEVICE} if _context_ is a multiple device context and _sema_props_ does not specify {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} as one of the properties.
 
 ==== Waiting on and signaling semaphores
 


### PR DESCRIPTION
Only permit semaphores to be associated with a single device.  Add an error code for invalid use.