### PR TITLE
cl_semaphore_khr: Query if semaphore is exportable

### DIFF
--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -40,7 +40,7 @@ Other related extensions define specific external semaphores that may be importe
 |====
 | *Date*     | *Version* | *Description*
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
-| 2023-11-16 | 0.9.2     | Added CL_SEMAPHORE_EXPORTABLE_KHR.
+| 2023-11-16 | 0.9.1     | Added CL_SEMAPHORE_EXPORTABLE_KHR.
 |====
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -244,7 +244,7 @@ Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
         semaphore does not support any handle types for exporting.
 | {CL_SEMAPHORE_EXPORTABLE_KHR}
     | {cl_bool_TYPE}
-        | Returns CL_TRUE if the semaphore is exportable and CL_FALSE otherwise.
+        | Returns {CL_TRUE} if the semaphore is exportable and {CL_FALSE} otherwise.
 |====
 
 === Exporting semaphore external handles

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -40,6 +40,7 @@ Other related extensions define specific external semaphores that may be importe
 |====
 | *Date*     | *Version* | *Description*
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
+| 2023-11-16 | 0.9.2     | Added CL_SEMAPHORE_EXPORTABLE_KHR.
 |====
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
@@ -127,6 +128,13 @@ Following new attributes can be passed as part of {cl_semaphore_properties_khr_T
 ----
 CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR                                0x203F
 CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR                       0
+----
+
+The following new attribute that can be passed as part of {cl_semaphore_info_khr_TYPE}:
+
+[source]
+----
+CL_SEMAPHORE_EXPORTABLE_KHR                                         0x2054
 ----
 
 External semaphore handle type added by `cl_khr_external_semaphore_dx_fence`:
@@ -234,6 +242,9 @@ Add to the list of supported _param_names_ by {clGetSemaphoreInfoKHR}:
       | Returns the list of external semaphore handle types that may be used for
         exporting. The size of this query may be 0 indicating that this
         semaphore does not support any handle types for exporting.
+| {CL_SEMAPHORE_EXPORTABLE_KHR}
+    | {cl_bool_TYPE}
+        | Returns CL_TRUE if the semaphore is exportable and CL_FALSE otherwise.
 |====
 
 === Exporting semaphore external handles

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -155,8 +155,6 @@ CL_SEMAPHORE_PROPERTIES_KHR                                 0x203B
 CL_SEMAPHORE_PAYLOAD_KHR                                    0x203C
 ----
 
-// TODO: Do we need to define CL_SEMAPHORE_DEVICE_HANDLE_LIST here or should it be in the external semaphore spec instead?
-
 New attributes that can be passed as part of {cl_semaphore_info_khr_TYPE} or {cl_semaphore_properties_khr_TYPE}:
 
 [source]

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1848,7 +1848,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>
         <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR"/>
         <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR"/>
-            <unused start="0x2054" end="0x2054"/>
+        <enum value="0x2054"        name="CL_SEMAPHORE_EXPORTABLE_KHR"/>
         <enum value="0x2055"        name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
         <enum value="0x2056"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR"/>
         <enum value="0x2057"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
@@ -6984,6 +6984,9 @@ server's OpenCL/api-docs repository.
             <require comment="cl_semaphore_properties_khr">
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR"/>
+            </require>
+            <require comment="cl_semaphore_info_khr">
+                <enum name="CL_SEMAPHORE_EXPORTABLE_KHR"/>
             </require>
             <require>
                 <command name="clGetSemaphoreHandleForTypeKHR"/>


### PR DESCRIPTION
Add query to clGetSemaphoreInfoKHR that returns CL_TRUE if a semaphore is exportable.