### PR TITLE
add description metadata

### DIFF
--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -19,6 +19,10 @@ Khronos{R} OpenCL Working Group
 :docinfo: shared-header
 :docinfodir: config
 :title-logo-image: image:images/OpenCL.png[top="25%",width="55%"]
+:description: OpenCL(TM) is an open, royalty-free standard for cross-platform \
+parallel programming of diverse accelerators. \
+This document describes the OpenCL API.
+
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -20,6 +20,9 @@ Khronos{R} OpenCL Working Group
 :docinfo: shared-header
 :docinfodir: config
 :title-logo-image: image:images/OpenCL.png[top="25%",width="55%"]
+:description: OpenCL(TM) is an open, royalty-free standard for cross-platform \
+parallel programming of diverse accelerators. \
+This document describes the OpenCL C language.
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -18,6 +18,9 @@ Khronos{R} OpenCL Working Group
 :docinfo: shared-header
 :docinfodir: config
 :title-logo-image: image:images/OpenCL.png[top="25%",width="55%"]
+:description: OpenCL(TM) is an open, royalty-free standard for cross-platform \
+parallel programming of diverse accelerators. \
+This document describes the OpenCL SPIR-V environment.
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -21,6 +21,9 @@ ifndef::backend-html5[:toclevels: 2]
 :docinfo: shared-header
 :docinfodir: config
 :title-logo-image: image:images/OpenCL.png[top="25%",width="55%"]
+:description: OpenCL(TM) is an open, royalty-free standard for cross-platform \
+parallel programming of diverse accelerators. \
+This document describes OpenCL extensions.
 
 // Various special / math symbols. This is easier to edit with than Unicode.
 include::config/attribs.txt[]


### PR DESCRIPTION
fixes #994 

This PR adds an asciidoctor "description" attribute that gets assigned to the HTML `<meta>` description element.

Best practices seem to be to keep the description approximately 150 characters long, so I've tried to adhere to that.