### PR TITLE
update the provisional extension notification text

### DIFF
--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -25,6 +25,8 @@ This extension adds the ability to record and replay buffers of OpenCL commands.
 | 2023-05-11 | 0.9.4     | Add clCommandSVMMemcpyKHR and clCommandSVMMemFillKHR command entries (provisional).
 |====
 
+include::provisional_notice.asciidoc[]
+
 ==== Dependencies
 
 This extension is written against the OpenCL Specification version 3.0.6.
@@ -2016,5 +2018,3 @@ Add to Table 37, _Event Command Types_:
 --
 *UNRESOLVED*
 --
-
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_command_buffer_multi_device.asciidoc
+++ b/ext/cl_khr_command_buffer_multi_device.asciidoc
@@ -23,6 +23,8 @@ providing execution of heterogeneous task graphs from command-queues associated 
 | 2024-04-30 | 0.9.1     | Added clCommandSVMMemcpyKHR and clCommandSVMMemFillKHR as affected functions (provisional).
 |====
 
+include::provisional_notice.asciidoc[]
+
 ==== Dependencies
 
 This extension requires the `cl_khr_command_buffer` extension version 0.9.3.

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -22,6 +22,8 @@ commands between command-buffer enqueues.
 | 2022-08-31 | 0.9.0     | First assigned version (provisional).
 |====
 
+include::provisional_notice.asciidoc[]
+
 ==== Dependencies
 
 This extension requires the `cl_khr_command_buffer` extension version 0.9.0.

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -36,7 +36,7 @@ Other related extensions define specific external memory types that may be impor
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 |====
 
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
+include::provisional_notice.asciidoc[]
 
 ==== Dependencies
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -42,7 +42,7 @@ Other related extensions define specific external semaphores that may be importe
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 |====
 
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
+include::provisional_notice.asciidoc[]
 
 ==== Dependencies
 

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -41,7 +41,7 @@ In particular, this extension defines:
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 |====
 
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
+include::provisional_notice.asciidoc[]
 
 ==== Dependencies
 

--- a/ext/provisional_notice.asciidoc
+++ b/ext/provisional_notice.asciidoc
@@ -2,4 +2,11 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
-NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/
+[NOTE]
+====
+This is a provisional OpenCL extension specification that has been Ratified under the Khronos Intellectual Property Framework.
+It is being made publicly available as a provisional extension to enable review and feedback from the community.
+While it is a provisional extension features may be added, removed, or changed in non-backward compatible ways.
+
+If you have feedback please create an issue on: https://github.com/KhronosGroup/OpenCL-Docs/
+====

--- a/ext/provisional_notice.asciidoc
+++ b/ext/provisional_notice.asciidoc
@@ -1,0 +1,5 @@
+// Copyright 2023 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+
+NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/


### PR DESCRIPTION
fixes #971 

* Factors the provisional extension notification text into a separate file to avoid copy-paste.
* Updates the provisional extension text to reflect that provisional extensions are published on the OpenCL registry but may change in non-backward compatible ways.
* Includes the provisional extension text consistently in all provisional extensions, below the version table information.