### PR TITLE
Add mechanism to specify named win32 NT handles.

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -158,6 +158,7 @@ External memory handle types added by `cl_khr_external_memory_win32`:
 ----
 CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR         0x2061
 CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR     0x2062
+CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR    0x2069
 ----
 
 === Modifications to existing APIs added by this spec
@@ -395,6 +396,7 @@ The `cl_khr_external_memory_win32` extension extends {cl_external_memory_handle_
 --
     * {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR} specifies an NT handle that has only limited valid usage outside of OpenCL and other compatible APIs. It must be compatible with the functions DuplicateHandle, CloseHandle, CompareObjectHandles, GetHandleInformation, and SetHandleInformation. It owns a reference to the underlying memory resource represented by its memory object.
     * {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR} specifies a global share handle that has only limited valid usage outside of OpenCL and other compatible APIs. It is not compatible with any native APIs. It does not own a reference to the underlying memory resource represented by its memory object, and will therefore become invalid when all memory objects associated with it are destroyed.
+    * {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR} specifies an NT handle name that has only limited valid usage outside of OpenCL and other compatible APIs. It must be compatible with the functions DuplicateHandle, CloseHandle, CompareObjectHandles, GetHandleInformation, and SetHandleInformation. It owns a reference to the underlying memory resource represented by its memory object.
 --
 
 For these extensions, importing memory object payloads from Windows handles does not transfer ownership of the handle to the OpenCL implementation. For handle types defined as NT handles, the application must release handle ownership using the CloseHandle system call when the handle is no longer needed. For handle types defined as NT handles, the imported memory object holds a reference to its payload.

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -156,6 +156,7 @@ External semaphore handle types added by `cl_khr_external_semaphore_win32`:
 ----
 CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR                   0x2056
 CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR               0x2057
+CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR              0x2068
 ----
 
 === Modifications to existing APIs added by this spec
@@ -404,6 +405,7 @@ The `cl_khr_external_semaphore_win32` extension extends {cl_external_semaphore_h
 --
     * {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR} specifies an NT handle that has only limited valid usage outside of OpenCL and other compatible APIs. It must be compatible with the functions DuplicateHandle, CloseHandle, CompareObjectHandles, GetHandleInformation, and SetHandleInformation. It owns a reference to the underlying synchronization primitive represented by its semaphore object.
     * {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR} specifies a global share handle that has only limited valid usage outside of OpenCL and other compatible APIs. It is not compatible with any native APIs. It does not own a reference to the underlying synchronization primitive represented by its semaphore object, and will therefore become invalid when all semaphore objects associated with it are destroyed.
+    * {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR} specifies an NT handle name that has only limited valid usage outside of OpenCL and other compatible APIs. It must be compatible with the functions DuplicateHandle, CloseHandle, CompareObjectHandles, GetHandleInformation, and SetHandleInformation. It owns a reference to the underlying synchronization primitive represented by its semaphore object.
 --
 
 Transference and permanence properties for handle types added by `cl_khr_external_semaphore_win32`:
@@ -416,6 +418,9 @@ Transference and permanence properties for handle types added by `cl_khr_externa
   |  Reference
       | Temporary, Permanent
 | {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR}
+  |  Reference
+      | Temporary, Permanent
+| {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR}
   |  Reference
       | Temporary, Permanent
 |====

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1862,7 +1862,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x2065"        name="CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR"/>
         <enum value="0x2066"        name="CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR"/>
         <enum value="0x2067"        name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR"/>
-            <unused start="0x2068" end="0x2FFF" comment="Reserved to Khronos for interop"/>
+        <enum value="0x2068"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
+        <enum value="0x2069"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
+            <unused start="0x206A" end="0x2FFF" comment="Reserved to Khronos for interop"/>
     </enums>
 
     <enums start="0x3000" end="0x3FFF" name="enums.3000" vendor="Khronos" comment="Platform IDs. Allocate individually.">


### PR DESCRIPTION
Currently, cl_khr_external_semaphore and cl_khr_external_memory define properties
to specify external win32 NT handle via pointer. Win32 NT handles can also be specified 
via named strings. 

Add properties to specify external Win32 NT handles via named strings too.

Fixes #943