### PR TITLE
[RFC] Updated cl_khr_defined_builtin_kernel

### DIFF
--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -1,0 +1,330 @@
+// Copyright 2018-2022 The Khronos Group. This work is licensed under a
+// Creative Commons Attribution 4.0 International License; see
+// http://creativecommons.org/licenses/by/4.0/
+= cl_khr_defined_builtin_kernels =
+
+:source-highlighter: coderay
+
+[[cl_khr_defined_builtin_kernels]]
+== Khronos-Defined Built-in Kernels (Early Draft)
+
+The purpose of this extension is to provide a standardized set of built-in
+kernels with well-defined semantics useful for accelerating applications
+from various domains.  The extension specification is designed to rapidly
+expand and "live" via addition of new well-defined built-in kernel
+definitions and updating of previously defined ones.
+
+=== General Information
+
+==== Name Strings
+
+`cl_khr_defined_builtin_kernels`
+
+==== Version History
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
+|====
+
+==== Dependencies
+
+This extension is written against the OpenCL Specification version 3.0.12.
+
+This extension requires OpenCL 1.2 or later.
+
+==== Contributors
+
+Pekka Jääskeläinen, Intel and Tampere University. +
+Topi Leppänen, Tampere University. +
+Jan Solanti, Tampere University. +
+Ben Ashbaugh, Intel. +
+
+=== Overview
+
+OpenCL 1.2 specifies a built-in kernel (BiK) as a kernel that is executed on
+an OpenCL device or custom device by fixed-function hardware or in firmware.
+Applications can query the built-in kernels supported by a device or custom
+device.
+
+BiKs are referred to by a name (a C string) without any semantics attached
+to the functionality. The semantics behind the name is completely device
+specific, typically documented in vendor-specific extension specifications.
+
+The goal for this extension is to lower the bar for utilizing hardware
+accelerated functions in drivers by providing a library of
+well-defined BiKs with good coverage for common acceleration needs
+and which is designed to easily evolve over time.
+
+The device drivers that implement this extension can freely choose which
+subset of defined BiKs they implement and advertise to the clients. The
+clients can use the BiKs to accelerate their applications by manually
+executing invoking the BiKs. The extension is designed to also support using
+automated task graph lowering tooling later.
+
+==== Background
+
+ASIC-based coarse-grained hardware accelerators are specialized logic meant to
+speed up execution of workloads of interest, or to provide improvements in
+energy-efficiency. Examples of contemporary workloads that are beneficially hardware
+accelerated over software-based implementations include video coding, deep learning,
+cryptography, software-defined radio and graphics rendering.
+
+FPGAs form a special case somewhere between instruction-set architectures and fixed
+function hardware accelerators. While advances in high-level synthesis tools
+have attempted to bridge the programmability gap between GPU and FPGA programming,
+FPGAs are still considered as devices which are challenging to achieve efficient
+implementations with. Due to extensive manual optimization work required for efficient
+implementations of the accelerated functionality, defining FPGA designs as
+a system of "hardware accelerator IPs" is still a widely used "application abstraction".
+FPGAs can be thus seen as a platform that can realize and integrate any
+hardware accelerator implementable with the programmable fabric.
+
+The means to utilize hardware accelerators have typically been
+vendor-specific and abstracted behind domain-specific libraries.
+The overhead with the "bunch of libraries"-approach is seen in the lowest level
+of integration: The libraries utilize a low level library (typically
+vendor-specific) to interface with the actual hardware, and thus does not
+integrate efficiently with other libraries or software-programmable processors
+that might be available on the same chip.
+
+==== Rationale
+
+OpenCL's built-in kernel abstraction allows pushing both hardware
+accelerated and software defined kernels to the same command-queues,
+providing a powerful means for asynchronous execution of heterogeneous
+task graphs on diverse heterogeneous platforms. The ability to invoke hardware
+accelerators while being able to synchronize and optimize data transfers at
+the lowest levels of the driver stack can provide significant latency benefits,
+especially when combined with the command-buffering mechanism.
+
+However, the BiK abstraction works well only when it is widely adopted by
+vendors, and when multiple vendors implement the same definitions. Otherwise
+each vendor specifies and implements their own BiKs closely matching their
+own hardware accelerator properties, resulting in lack of cross-vendor
+portability in the API abstraction presented to the upper layers of
+heterogeneous computing software stacks.
+
+This extension standardizes a set of well-defined BiKs the clients can
+call from higher level programming stacks built with different languages
+and multiple libraries, possibly mix accelerator calls with calls to software kernel
+commands, and rely on the driver stack to optimize the execution (especially
+the synchronization and communication) as a low level heterogeneous task graph.
+It aims to promote the use of BiKs as a programming model for hardware accelerated
+functionality, to improve cross-vendor portability of hardware accelerated computing.
+
+=== Modifications to section 4.2 of the OpenCL API Specification
+
+Modify *Table 5*, _Device Queries_, of section 4.2, by adding the following
+sentences to the description cell of `CL_DEVICE_BUILT_IN_KERNELS`:
+
+[quote]
+The semantics of the returned built-in kernels are undefined or defined in
+vendor-specific documentation, unless the name starts with prefix `khr_',
+which means it's a built-in kernel with semantics defined in Appendix I.
+
+=== Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification
+
+This chapter describes standard built-in kernels (BiK) with well-defined
+semantics. A conformant device can report to support zero or more of the built-in
+kernels via `CL_DEVICE_BUILT_IN_KERNELS` or `CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION` device queries.
+
+The general client-side abstraction of the defined built-in kernels is similar to a call
+to a C function of which implementation is hidden. The device driver can invoke one or
+more physical hardware accelerators combined with firmware to implement the semantics
+as efficiently as possible.
+
+It is the driver's responsibility to handle efficient synchronization and communication
+to the hardware accelerator, the internal accelerator state management and resource sharing
+across multiple OpenCL contexts.
+
+==== Standard Built-in Kernels ====
+
+The following list of recognized built-ins is organized according to their application
+domain and handled data types. It is expected to grow and update while preserving backwards
+compatibility.
+
+[caption="Table A.I.1. "]
+.Standard Built-in Kernels and Their Semantics. *The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.*
+[cols="1,3,2,2"]
+|===
+4+| *General linear algebra*
+// https://netlib.org/blas/blasqr.pdf
+| Name | Description | NDRange Dimensions | Arguments
+| *khr_blas_gemm_float*
+| xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.
+a|
+[start=1]
+. The height.
+. The width.
+a|
+[start=0]
+. int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)
+. int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)
+. float: scalar (alpha) to multiply the matrix multiplication result elements with
+. float* (input): matrix A
+. int: leading dimension of A (0 = row-major, 1 = column-major)
+. float* (input): matrix B
+. int: leading dimension of B (0 = row-major, 1 = column-major)
+. float: scalar (beta) to multiply the C matrix elements with before adding it to the result
+. float* (input&output): matrix C which is added to the matrix multiplication result, and stores the output
+. int: leading dimension of C (0 = row-major, 1 = column-major)
+4+| OpenCL C Semantics
+4+a|
+[source,c]
+----
+__kernel void __khr_blas_gemm_float(
+   int transA, int transB, float alpha, const global float *A, int ldA,
+   const global float *B, int ldB,
+   float beta, global float *C, int ldC) {
+   // TBD: An example implementation that can be used for verification
+   // and as a fallback SW implementation.
+}
+----
+
+4+| *OpenVX Neural Network Extension Compatible Kernels*
+// Copied from https://registry.khronos.org/OpenVX/extensions/vx_khr_nn/1.2/html/d6/d9a/group__group__cnn.html#ga69764625f436c14d739fc467515c1584
+| Name | Description | NDRange Dimensions | Arguments
+| *khr_openvx_nn_extension_convolution_uchar*
+| Convolution for 8bit unsigned integer inputs and weights.
+a|
+[start=1]
+. Batch size.
+. Width.
+. Height.
+a|
+[start=0]
+. uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].
+. uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].
+. uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2) 
+. size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.
+. size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.
+. int: Rounding method for calculating output dimensions. 
+. int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.
+. size_t: Number of elements padded at each side in the x dimension of the input.
+. size_t: Number of elements padded at each side in the y dimension of the input.
+. int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.
+. uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)
+
+4+| OpenCL C Semantics
+4+a|
+[source,c]
+----
+__kernel void __khr_openvx_nn_extension_convolution_uchar(
+   const uchar *input, const uchar *weights, const uchar *biases,
+   size_t dilation_x, size_t dilation_y,
+   int down_scale_rounding, int overflow_policy, size_t padding_x, size_t padding_y,
+   int rounding_policy, uchar *output) {
+   // TBD.
+}
+----
+
+4+| *Direct Input/Output Operations*
+4+| Kernels for accessing data sources and destinations directly without host involvement.
+| Name | Description | NDRange Dimensions | Arguments
+| *khr_io_stream_in_uchar*
+| Non-blocking read of data from a sensor/stream associated with the device.
+a| -
+a|
+[start=0]
+. uchar* [out]: The data.
+. size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the `cl_pocl_content_size` extension to optimize data transfers with.)
+
+4+| OpenCL C Semantics
+4+a|
+[source,c]
+----
+__kernel void __khr_io_stream_in_uchar(
+   uchar *output, size_t *num) {
+   // It is not feasible to describe this kernel in OpenCL C as I/O devices
+   // are not representable with it.
+}
+----
+
+| *khr_io_stream_out_uchar*
+| Non-blocking write of data to an output/sink associated with the device.
+| -
+a|
+[start=0]
+. uchar* [in]: The data to write.
+. size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).
+4+| OpenCL C Semantics
+4+a|
+[source,c]
+----
+__kernel void __khr_io_stream_out_uchar(
+   uchar *input, size_t *num) {
+   // It is not feasible to describe this kernel in OpenCL C as I/O devices
+   // are not representable with it.
+}
+----
+
+| *khr_io_stream_in_blocking_uchar*
+| Blocking read of data from a sensor/stream associated with the device.
+a| -
+a|
+[start=0]
+. uchar* [out]: The data.
+* size_t* [in]: How many bytes to read before returning.
+
+4+| OpenCL C Semantics
+4+a|
+[source,c]
+----
+__kernel void __khr_io_stream_in_blocking_uchar(uchar *output, size_t *num) {
+   while (*num) {
+       size_t num_read = *num;
+       __khr_io_stream_in_uchar(output, &num_read);
+       num -= num_read;
+       output += num_read;
+   }
+}
+----
+
+|===
+
+==== Launching BiKs from the Device Side ====
+
+BiKs are primarily meant to be launched as kernel commands via host-side command queues.
+Optionally, they can be callable from device-side via
+`enqueue_kernel`: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: `cl_khr_bik_BUILTIN_KERNEL_NAME`. In case a BiK macro is defined, a kernel with a naming convention `__khr_BUILTIN_KERNEL_NAME()` can be enqueued by the program at device side as software-defined kernels.
+
+
+=== Open questions
+
+. Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.
++
+--
+*UNRESOLVED*
+
+--
+
+. Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
++
+--
+*UNRESOLVED*
+
+--
+
+. Different accelerators prefer different channel orders (NHWC vs. NCHW...) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM's row/column order) or is it better to have different BiK variations for each?
++
+--
+*UNRESOLVED*
+
+--
+
+. How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.
++
+--
+*UNRESOLVED*
+
+--
+
+. Since the defined built-in kernel concept is basically just a C-like API inside another API, should it be made more generic and thus directly usable for SYCL and Vulkan as well?
++
+--
+*UNRESOLVED*
+
+--
+

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -26,7 +26,7 @@ definitions and updating of previously defined ones.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
-| 2022-10-23 | 0.2.0     |
+| 2023-11-21 | 0.2.0     |
 Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.
 |====
@@ -37,10 +37,10 @@ This extension is written against the OpenCL Specification version 3.0.12.
 
 This extension requires OpenCL 1.2 or later.
 
-This extension requires cl_khr_tensor.
+This extension requires cl_exp_tensor.
 
 [NOTE]
-cl_khr_tensor is unpublished, work-in-progress
+cl_exp_tensor is unpublished, work-in-progress
 extension. Briefly, It will bring concept of tensor, N-dimensional
 data structure whose data layout is opaque to applications.
 
@@ -432,25 +432,21 @@ clCreateDefinedBuiltInKernelDescriptor.
 
 [source,c]
 ----
-// TBD. Similarly in cl_qcom_ml_ops, tensors have type
-// (cl_channel_type) and a number of dimensions (rank) and dimension
-// sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
-// "unlimited".
-cl_tensor_desc lhs_tensor_desc = TBD;
-cl_tensor_desc rhs_tensor_desc = TBD;
-cl_tensor_desc res_tensor_desc = TBD;
+constexpr size_t b = 64, m = 100, n = 200, k = 50;
+cl_int err;
+cl_tensor lhs_tensor = clCreateTensor(context, nullptr, 3, {b, m, k}, CL_TENSOR_FLOAT, err);
+cl_tensor rhs_tensor = clCreateTensor(context, nullptr, 3, {b, k, n}, CL_TENSOR_FLOAT, err);
+cl_tensor res_tensor = clCreateTensor(context, nullptr, 3, {b, m, n}, CL_TENSOR_FLOAT, err);
 
 cl_dkb_attributes_matmul matmul_attrs = {
-  lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
-  1, 0 // = Transpose lhs tensor
-}
+  lhs_tensor, rhs_tensor, res_tensor, 1, 0 // = Transpose lhs tensor
+};
 
 cl_dbk_mode_properties matmul_props = {
   // Request a matmul instance that meets this precision.
   CL_DBK_PROPERTY_MAX_RELATIVE_ERROR, 100, // in ULPs.
-}
+};
 
-cl_uint err;
 std::vector<cl_dbk_descriptor> kernel_descriptions;
 cl_dbk_descriptor matmul_desc =
   clCreateDefinedBuiltInKernelDescriptor(
@@ -460,11 +456,14 @@ cl_dbk_descriptor matmul_desc =
 } else if (err == CL_DBK_UNAVAILABLE) {
   // Kernel attributes are valid but the kernel is not supported in at least
   // one of the devices.
+  ...
 } else if (err == CL_DBK_UNMET_MAX_RELATIVE_ERROR) {
   // E.g. Kernel is supported but is not precise enough.
+  ...
 } else if (err == CL_DBK_UNSUPPORTED_MODE_PROPERTY) {
   // cl_dbk_mode_properties has a property not listed in the description of the
   // defined built-in kernel.
+  ...
 } else
   kernel_descriptions.push_back(matmul_desc);
 
@@ -476,25 +475,39 @@ cl_program dbk_lib = clCreateProgramWithDefinedBuiltInKernels(
 ...
 
 cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
-  dkb_lib, matmul_desc, err);
+  dkb_lib, matmul_desc, &err);
 
-// TBD: allocate space for tensors. Perhaps like cl_qcom_ml_ops: query
-// tensor sizes after the final program has been created or after
-// command buffer (with DBKs within) is finalized. Implementation
-// determines the optimal data layout (opaque to the application) for
-// the tensors based on their usage.  Application uses the tensor
-// sizes to create cl_mem buffers which are bound to the tensors.
-cl_tensor lhs_tensor = TBD;
-cl_tensor rhs_tensor = TBD;
-cl_tensor res_tensor = TBD;
-
-// Transfer data to input tensors
-
+// Set tensor kernel arguments before binding storage to the tensors. This
+// gives clCreateBufferWithProperties() opportunity to reason about tensors'
+// uses for determining the optimal memory layout (opaque to application) and
+// the space neededfor the tensors.
 clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &lhs_tensor);
 clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &rhs_tensor);
 clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &res_tensor);
 
+// Allocate storage for tensors.
+cl_mem lhs_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, lhs_tensor, 0}, CL_MEM_READ_ONLY, 0, nullptr, &err);
+cl_mem rhs_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, rhs_tensor, 0}, CL_MEM_READ_ONLY, 0, nullptr, &err);
+cl_mem res_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, res_tensor, 0}, CL_MEM_WRITE_ONLY, 0, nullptr, &err);
+
+// Transfer data to input tensors, execute DBK, and import results
+// from the output tensor.
+
+std::vector<float> lhs_data = ...;
+std::vector<float> rhs_data = ...;
+std::vector<float> res_data(b * m * n);
+
+clEnqueueExportToTensor(cmd_q, lhs_tensor, false, {0, 0, 0}, {0, 0, 0}, {b, m, k},
+  nullptr, nullptr, lhs_data.data(), 0, nullptr, nullptr)
+clEnqueueExportToTensor(cmd_q, rhs_tensor, false, {0, 0, 0}, {0, 0, 0}, {b, k, n},
+  nullptr, nullptr, rhs_data.data(), 0, nullptr, nullptr)
 clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL);
+clEnqueueImportFromTensor(
+  cmd_q, res_tensor, false,  {0, 0, 0}, {0, 0, 0}, {b, m, n},
+  nullptr, nullptr, res_data.data(), 0, nullptr, nullptr);
 ----
 
 === Open questions

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -26,6 +26,7 @@ definitions and updating of previously defined ones.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
+| TODO       | TODO      | TODO
 |====
 
 ==== Dependencies
@@ -33,6 +34,8 @@ definitions and updating of previously defined ones.
 This extension is written against the OpenCL Specification version 3.0.12.
 
 This extension requires OpenCL 1.2 or later.
+
+This extension requires cl_khr_tensor (Note: unpublished draft, work in progress)
 
 ==== Contributors
 
@@ -43,24 +46,25 @@ Ben Ashbaugh, Intel. +
 
 === Overview
 
-OpenCL 1.2 specifies a built-in kernel (BiK) as a kernel that is executed on
+OpenCL 1.2 specifies a built-in kernel as a kernel that is executed on
 an OpenCL device or custom device by fixed-function hardware or in firmware.
 Applications can query the built-in kernels supported by a device or custom
 device.
 
-BiKs are referred to by a name (a C string) without any semantics attached
-to the functionality. The semantics behind the name is completely device
-specific, typically documented in vendor-specific extension specifications.
+Built-in kernels are referred to by a name (a C string) without any
+semantics attached to the functionality. The semantics behind the name
+is completely device specific, typically documented in vendor-specific
+extension specifications.
 
 The goal for this extension is to lower the bar for utilizing hardware
 accelerated functions in drivers by providing a library of
-well-defined BiKs with good coverage for common acceleration needs
+well-defined built-in kernel with good coverage for common acceleration needs
 and which is designed to easily evolve over time.
 
 The device drivers that implement this extension can freely choose which
-subset of defined BiKs they implement and advertise to the clients. The
-clients can use the BiKs to accelerate their applications by manually
-executing invoking the BiKs. The extension is designed to also support using
+subset of DBKs they implement and advertise to the clients. The
+clients can use the DBKs to accelerate their applications by manually
+executing invoking the DBKs. The extension is designed to also support using
 automated task graph lowering tooling later.
 
 ==== Background
@@ -99,222 +103,414 @@ accelerators while being able to synchronize and optimize data transfers at
 the lowest levels of the driver stack can provide significant latency benefits,
 especially when combined with the command-buffering mechanism.
 
-However, the BiK abstraction works well only when it is widely adopted by
+However, the built-in kernel abstraction works well only when it is widely adopted by
 vendors, and when multiple vendors implement the same definitions. Otherwise
-each vendor specifies and implements their own BiKs closely matching their
+each vendor specifies and implements their own built-in kernels closely matching their
 own hardware accelerator properties, resulting in lack of cross-vendor
 portability in the API abstraction presented to the upper layers of
 heterogeneous computing software stacks.
 
-This extension standardizes a set of well-defined BiKs the clients can
+This extension standardizes a set of well-defined built-in kernels the clients can
 call from higher level programming stacks built with different languages
 and multiple libraries, possibly mix accelerator calls with calls to software kernel
 commands, and rely on the driver stack to optimize the execution (especially
 the synchronization and communication) as a low level heterogeneous task graph.
-It aims to promote the use of BiKs as a programming model for hardware accelerated
+It aims to promote the use of built-in kernels as a programming model for hardware accelerated
 functionality, to improve cross-vendor portability of hardware accelerated computing.
 
-=== Modifications to section 4.2 of the OpenCL API Specification
 
-Modify *Table 5*, _Device Queries_, of section 4.2, by adding the following
-sentences to the description cell of `CL_DEVICE_BUILT_IN_KERNELS`:
+=== Add new section X.Y.Z Querying Defined Built-in Kernels
 
-[quote]
-The semantics of the returned built-in kernels are undefined or defined in
-vendor-specific documentation, unless the name starts with prefix `khr_',
-which means it's a built-in kernel with semantics defined in Appendix I.
+To request a defined built-in kernel to be executed in the given
+devices use:
+
+[source,c]
+----
+cl_dbk_descriptor clCreateDefinedBuiltInKernelDescriptor(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    cl_dbk_name kernel_name,
+    const void *kernel_attributes,
+    const cl_dbk_mode_properties* kernel_config,
+    cl_int *errcode_ret);
+----
+
+* _context_ must be a valid OpenCL context.
+
+* _num_devices_ is the number of devices listed in
+  device_list. _num_devices_ must be non-zero.
+
+* _device_list_ is a pointer to a list of devices that are in
+  context. _device_list_ must be a non-NULL value. The defined built-in kernels
+  are loaded for devices specified in this list.
+
+* _kernel_name_ is the name of the defined built-in kernel listed in Appendix I.
+
+* _kernel_attributes_ is a pointer to the structure declared in
+  description of the kernel in Appendix I. The structure holds
+  kernel's attributes.
+
+* _cl_dbk_mode_properties_ is a pointer to a list of defined built-in
+  kernel mode properties. The supported mode properties are listed in
+  DBK's entry with default settings in Appendix I. It is valid to set
+  this argument to NULL in which case default properties apply (if
+  any).
+
+*clCreateDefinedBuiltInKernelDescriptor* returns a valid kernel
+descriptor on success indicated by _errcode_ret_ which is set to
+CL_SUCCESS. Otherwise, the returned object is NULL and the
+_errcode_ret_ is set to one of following code:
+
+* CL_DBK_INVALID_ATTRIBUTE if one or more kernel attributes violates
+  conditions descried in defined built-in kernel entry in Appendix I.
+
+* CL_DBK_UNAVAILABLE if kernel attributes are valid but the
+  kernel is not supported one of the devices.
+
+* CL_DBK_UNSUPPORTED_MODE_PROPERTY if _cl_dbk_mode_properties_ includes
+  at least one property not listed in DBK's entry.
+
+* CL_DBK_UNMET_MAX_RELATIVE_ERROR if the DBK is available but does not
+  meet the requested constraint set by
+  CL_DBK_PROPERTY_MAX_RELATIVE_ERROR property.
+
+* TODO: other error cases.
+
+
+[cols="2,1,2",stripes=odd]
+|===
+| *DBK Mode Property* | *Property Value* | *Description*
+
+| CL_DBK_PROPERTY_MAX_RELATIVE_ERROR | float
+
+a| Request a DBK whose maximum relative error is bounded by the given
+value measured in ULPs.
+
+| CL_DBK_PROPERTY_NON_DETERMINISTIC | cl_bool
+
+a| Allow results of the kernel to be non-reproducible. This allows
+implementation to switch algorithm of the kernel on each launch for
+possibly better performance.
+// Idea from https://pytorch.org/docs/stable/notes/randomness.html#cuda-convolution-benchmarking
+
+| ... | -
+a|
+Ideas:
+
+* accumulation with saturation.
+* Finite math only.
+* Flush denormals to zero.
+* data layout preferences (NHWC for convolution).
+|===
+
+=== Add new function to 5.8.1 Creating Program Objects
+
+To create a program with a set of defined built-in kernel use:
+
+[source,c]
+----
+cl_program clCreateProgramWithDefinedKernels(
+    cl_context context,
+    size_t num_kernel_desc,
+    const void* kernel_desc_list,
+    cl_int* errcode_ret);
+----
+
+* _context_ must be a valid OpenCL context.
+
+* _num_kernel_desc_ is the number of kernel descriptors.
+
+* _kernel_desc_list_ is the array of valid
+  cl_dbk_descriptor objects. The array length must be at
+  least _num_kernel_desc_. The kernel descriptors must be created on
+  the same context.
+
+*clCreateProgramWithDefinedKernels* returns a valid program on success
+indicated by _errcode_ret_ which is set to CL_SUCCESS. Otherwise, the
+returned object is NULL and the _errcode_ret_ is set to one of
+following code:
+
+* TODO.
+
+=== Add new function to 5.9.1 Creating Kernel Objects
+
+To get a kernel handle for a defined built-in kernel in a program use:
+
+[source,c]
+----
+cl_kernel clCreateDefinedBuiltInKernel(
+    cl_program program,
+    cl_dbk_descriptor kernel_desc,
+    cl_int* errcode_ret);
+----
+
+* _program_ is a program object with a successfully built executable.
+
+* _kernel_desc_ is a defined built-in kernel descriptor in the program.
+
+* _errcode_ret_ will return an appropriate error code. If errcode_ret is
+  NULL, no error code is returned.
+
+*clCreateDefinedBuiltInKernel* returns a valid non-zero kernel object
+ and errcode_ret is set to CL_SUCCESS if the kernel object is created
+ successfully. Otherwise, it returns a NULL value with one of the
+ following error values returned in _errcode_ret_:
+
+* TODO.
+
 
 === Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification
 
-This chapter describes standard built-in kernels (BiK) with well-defined
-semantics. A conformant device can report to support zero or more of the built-in
-kernels via `CL_DEVICE_BUILT_IN_KERNELS` or `CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION` device queries.
+This chapter describes standard defined built-in kernels (DBK) with
+well-defined semantics. A conformant devices can report to
+availability of the built-in kernels listed in this section with
+`clCreateDefinedBuiltInKernelDescriptor` call. The availability of a
+DBK is determined from the arguments passed to the
+`clCreateDefinedBuiltInKernelDescriptor` and unavailability of a DBK
+is indicated by CL_DBK_UNAVAILABLE error code.
 
-The general client-side abstraction of the defined built-in kernels is similar to a call
-to a C function of which implementation is hidden. The device driver can invoke one or
-more physical hardware accelerators combined with firmware to implement the semantics
-as efficiently as possible.
+The general client-side abstraction of the DBKs is similar to a call
+to a C function of which implementation is hidden. The device driver
+can invoke one or more physical hardware accelerators combined with
+firmware to implement the semantics as efficiently as possible.
 
 It is the driver's responsibility to handle efficient synchronization and communication
 to the hardware accelerator, the internal accelerator state management and resource sharing
 across multiple OpenCL contexts.
 
-==== Standard Built-in Kernels ====
+Identical DBKs with identical inputs, are not guaranteed to produce
+identical results:
 
-The following list of recognized built-ins is organized according to their application
-domain and handled data types. It is expected to grow and update while preserving backwards
-compatibility.
+* across vendors,
+
+* across driver versions and
+
+* across devices.
+
+Otherwise, identical results are produced unless:
+
+* otherwise stated in DBK's description or
+
+* the DBK has CL_DBK_PROPERTY_NON_DETERMINISTIC property set to true.
+
+Two DKBs are considered identical if their descriptors are created
+using identical kernel name, kernel attribute and kernel mode property
+arguments.
+
+==== Standard Defined Built-in Kernels ====
+
+The following list of recognized defined built-in kernels. It is
+expected to grow and update while preserving backwards compatibility.
+
+Each defined built-in kernel entry is organized as followed:
+
+* *Name*: Name of the defined built-in kernel (an enumeration).
+
+* *Kernel attributes*: The kernel attributes required for creating the
+  defined built-in kernel via
+  clCreateDefinedBuiltInKernelDescriptor. Attribute values are
+  immutable.
+
+* *Kernel arguments*: The kernel arguments.
+
+* *Description*: The description of the kernel in detail.
+
+* *Attribute validation rules*: Conditions of the kernel attribute for
+  the kernel. Implementation must return CL_DBK_INVALID_ATTRIBUTE on
+  clCreateDefinedBuiltInKernelDescriptor call if any of the conditions
+  are violated.
+
+* *Kernel mode properties*: List of kernel mode
+   properties (cl_dbk_mode_properties) the kernel recognizes. The
+   properties can be used to tweak certain implementation details and
+   behaviors in the kernel execution. If a property not listed in the
+   DBK entry is fed to clCreateDefinedBuiltInKernelDescriptor call,
+   then implementation must return CL_DKB_UNSUPPORTED_MODE_PROPERTY.
 
 [caption="Table A.I.1. "]
 .Standard Built-in Kernels and Their Semantics. *The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.*
-[cols="1,3,2,2"]
 |===
-4+| *General linear algebra*
-// https://netlib.org/blas/blasqr.pdf
-| Name | Description | NDRange Dimensions | Arguments
-| *khr_blas_gemm_float*
-| xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.
+| Name: *khr_matmul_v1*
+| *Kernel Attributes*
 a|
-[start=1]
-. The height.
-. The width.
+
+Fields of the `cl_dkb_attributes_matmul_v1` structure:
+
+. cl_tensor_desc_t A: Tensor description for input matrix A.
+. cl_tensor_desc_t B: Tensor description for input matrix B.
+. cl_tensor_desc_t R: Tensor description for output matrix C.
+. cl_int transposeA: Non-zero transposes A matrix.
+. cl_int transposeB: Non-zero transposes B matrix.
+| *Kernel Arguments*
 a|
-[start=0]
-. int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)
-. int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)
-. float: scalar (alpha) to multiply the matrix multiplication result elements with
-. float* (input): matrix A
-. int: leading dimension of A (0 = row-major, 1 = column-major)
-. float* (input): matrix B
-. int: leading dimension of B (0 = row-major, 1 = column-major)
-. float: scalar (beta) to multiply the C matrix elements with before adding it to the result
-. float* (input&output): matrix C which is added to the matrix multiplication result, and stores the output
-. int: leading dimension of C (0 = row-major, 1 = column-major)
-4+| OpenCL C Semantics
-4+a|
-[source,c]
-----
-__kernel void __khr_blas_gemm_float(
-   int transA, int transB, float alpha, const global float *A, int ldA,
-   const global float *B, int ldB,
-   float beta, global float *C, int ldC) {
-   // TBD: An example implementation that can be used for verification
-   // and as a fallback SW implementation.
-}
-----
-
-4+| *OpenVX Neural Network Extension Compatible Kernels*
-// Copied from https://registry.khronos.org/OpenVX/extensions/vx_khr_nn/1.2/html/d6/d9a/group__group__cnn.html#ga69764625f436c14d739fc467515c1584
-| Name | Description | NDRange Dimensions | Arguments
-| *khr_openvx_nn_extension_convolution_uchar*
-| Convolution for 8bit unsigned integer inputs and weights.
+. cl_tensor_t A: Matrix A (read only).
+. cl_tensor_t B: Matrix B (read only).
+. cl_tensor_t R: Output matrix. (write only).
+| *Description*
 a|
-[start=1]
-. Batch size.
-. Width.
-. Height.
+Performs (batched) matrix multiplication: `R = trans(A) * trans(B)`,
+where `A`, `B` and `R` are tensors with at least rank two. The
+`trans()` is a configurable transpose operation.
+
+Last two dimensions of the tensors are treated as operands to the
+matric multiplication and rest of the dimensions are treated as batch
+dimensions.
+
+Operations of the matrix muliplication are performed in the precision
+of the `elementof\(R)`.
+
+If an overflow occurs in the accumulation of the products, then `R`
+tensor's result will be undefined.
+
+| *Attribute validation rules*
 a|
-[start=0]
-. uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].
-. uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].
-. uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2) 
-. size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.
-. size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.
-. int: Rounding method for calculating output dimensions. 
-. int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.
-. size_t: Number of elements padded at each side in the x dimension of the input.
-. size_t: Number of elements padded at each side in the y dimension of the input.
-. int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.
-. uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)
 
-4+| OpenCL C Semantics
-4+a|
-[source,c]
-----
-__kernel void __khr_openvx_nn_extension_convolution_uchar(
-   const uchar *input, const uchar *weights, const uchar *biases,
-   size_t dilation_x, size_t dilation_y,
-   int down_scale_rounding, int overflow_policy, size_t padding_x, size_t padding_y,
-   int rounding_policy, uchar *output) {
-   // TBD.
-}
-----
-
-4+| *Direct Input/Output Operations*
-4+| Kernels for accessing data sources and destinations directly without host involvement.
-| Name | Description | NDRange Dimensions | Arguments
-| *khr_io_stream_in_uchar*
-| Non-blocking read of data from a sensor/stream associated with the device.
-a| -
+* `rankof(A) == rankof(B) >= 2`.
+* Let `shapeof(A~t~) == (b..., m, k)` and `shapeof(B~t~) = (b..., k,
+  n)` of tensors `A` and `B`, respectively, after possible tranposing.
+  `shapeof\(R)` must be `(b..., m, n)`.
+* `elementof(A) == elementof(B)`
+* `elemkindof\(R) == elemkindof(A)`
+* `elementof\(R) == elementof(A)` or `elementof(A)` is promotable to
+  `elementof\(R)` without loss of meaning.
+// E.g. cl_int -> cl_uint: loses negative values
+| *Kernel mode properties*
 a|
-[start=0]
-. uchar* [out]: The data.
-. size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the `cl_pocl_content_size` extension to optimize data transfers with.)
+This DBK accepts the following properties:
 
-4+| OpenCL C Semantics
-4+a|
-[source,c]
-----
-__kernel void __khr_io_stream_in_uchar(
-   uchar *output, size_t *num) {
-   // It is not feasible to describe this kernel in OpenCL C as I/O devices
-   // are not representable with it.
-}
-----
-
-| *khr_io_stream_out_uchar*
-| Non-blocking write of data to an output/sink associated with the device.
-| -
+* CL_DBK_PROPERTY_MAX_RELATIVE_ERROR: Unset property defaults to positive infinity.
+|
+| Name: *khr_leaky_relu_v1*
+| *Kernel Attributes*
 a|
-[start=0]
-. uchar* [in]: The data to write.
-. size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).
-4+| OpenCL C Semantics
-4+a|
-[source,c]
-----
-__kernel void __khr_io_stream_out_uchar(
-   uchar *input, size_t *num) {
-   // It is not feasible to describe this kernel in OpenCL C as I/O devices
-   // are not representable with it.
-}
-----
-
-| *khr_io_stream_in_blocking_uchar*
-| Blocking read of data from a sensor/stream associated with the device.
-a| -
+Fields of the `cl_dbk_leaky_relu_v1` structure:
+. cl_tensor_desc_t in: Input tensor description.
+. cl_tensor_desc_t out: Output tensor description.
+. cl_float alpha: Coefficient of leakage.
+| *Kernel arguments*
 a|
-[start=0]
-. uchar* [out]: The data.
-* size_t* [in]: How many bytes to read before returning.
+. cl_tensor_t in: The input tensor.
+. cl_tensor_t out: The output tensor.
+| *Description*
+a|
+Applies operation `alpha * x if x < 0 else x` on all
+elements of the `in` tensor.
 
-4+| OpenCL C Semantics
-4+a|
-[source,c]
-----
-__kernel void __khr_io_stream_in_blocking_uchar(uchar *output, size_t *num) {
-   while (*num) {
-       size_t num_read = *num;
-       __khr_io_stream_in_uchar(output, &num_read);
-       num -= num_read;
-       output += num_read;
-   }
-}
-----
+If target device does not support denormals, then `alpha` is flushed
+to zero before the operation is applied.
 
+| *Kernel mode properties*
+| N/A
+| *Attribute validation rules*
+a|
+* `shapeof(in) == shapeof(out)`
+* `elementof(in) == elementof(out)`
+* `alpha` must be a finite value.
 |===
 
-==== Launching BiKs from the Device Side ====
+==== Launching DBKs from the Device Side ====
 
-BiKs are primarily meant to be launched as kernel commands via host-side command queues.
-Optionally, they can be callable from device-side via
-`enqueue_kernel`: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: `cl_khr_bik_BUILTIN_KERNEL_NAME`. In case a BiK macro is defined, a kernel with a naming convention `__khr_BUILTIN_KERNEL_NAME()` can be enqueued by the program at device side as software-defined kernels.
+DBKs are primarily meant to be launched as kernel commands via
+host-side command queues.  Optionally, they can be callable from
+device-side via `enqueue_kernel`:
 
+TBC. This probably needs device-side function corresponding to
+clCreateDefinedBuiltInKernelDescriptor.
+
+==== Sample Code ====
+
+[source,c]
+----
+// TBD. Similarly in cl_qcom_ml_ops, tensors have type
+// (cl_channel_type) and a number of dimensions (rank) and dimension
+// sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
+// "unlimited".
+cl_tensor_desc_t lhs_tensor_desc = TBD;
+cl_tensor_desc_t rhs_tensor_desc = TBD;
+cl_tensor_desc_t res_tensor_desc = TBD;
+
+cl_dkb_attributes_matmul_v1 matmul_attrs = {
+  lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
+  1, 0 // = Transpose lhs tensor
+}
+
+cl_dbk_mode_properties matmul_props = {
+  // Request a matmul implementation that meets this precision.
+  CL_DBK_PROPERTY_MAX_RELATIVE_ERROR, 100, // in ULPs.
+}
+
+cl_uint err;
+std::vector<cl_dbk_descriptor> kernel_descriptions;
+cl_dbk_descriptor matmul_desc =
+  clCreateDefinedBuiltInKernelDescriptor(
+  context, num_devices, device_list,
+  CL_DBK_MATMUL_V1, &matmul_attrs, &matmul_props, &err);
+
+} else if (err == CL_DBK_UNAVAILABLE) {
+  // Kernel attributes are valid but the kernel is not supported in at least
+  // one of the devices.
+} else if (err == CL_DBK_UNMET_MAX_RELATIVE_ERROR) {
+  // E.g. Kernel is supported but is not precise enough.
+} else if (err == CL_DBK_UNSUPPORTED_MODE_PROPERTY) {
+  // cl_dbk_mode_properties has a property not listed in the description of the
+  // defined built-in kernel.
+} else
+  kernel_descriptions.push_back(matmul_desc);
+
+...
+
+cl_program dbk_lib = clCreateProgramWithDefinedBuiltInKernels(
+  context, kernel_descriptions.size(), kernel_descriptors.data(), err);
+
+...
+
+cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
+  dkb_lib, matmul_desc, err);
+
+// TBD: allocate space for tensors. Perhaps like cl_qcom_ml_ops: query
+// tensor sizes after the final program has been created or after
+// command buffer (with DBKs within) is finalized. Implementation
+// determines the optimal data layout (opaque to the application) for
+// the tensors based on their usage.  Application uses the tensor
+// sizes to create cl_mem buffers which are bound to the tensors.
+cl_tensor_t lhs_tensor = TBD;
+cl_tensor_t rhs_tensor = TBD;
+cl_tensor_t res_tensor = TBD;
+
+// Transfer data to input tensors
+
+clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &lhs_tensor);
+clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &rhs_tensor);
+clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &res_tensor);
+
+clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL);
+----
 
 === Open questions
 
-. Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.
+. Should we enable launching DBKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.
 +
 --
 *UNRESOLVED*
 
 --
 
-. Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
+. Should the NDRange be used at all in DBKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
 +
 --
 *UNRESOLVED*
 
 --
 
-. Different accelerators prefer different channel orders (NHWC vs. NCHW...) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM's row/column order) or is it better to have different BiK variations for each?
+. Different accelerators prefer different channel orders (NHWC vs. NCHW...) for the processed data. Should the channel order be passed as a DBK argument (like in the example GEMM's row/column order) or is it better to have different DBK variations for each?
 +
 --
 *UNRESOLVED*
 
 --
 
-. How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.
+. How to denote preference? Some of the DBKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.
 +
 --
 *UNRESOLVED*
@@ -327,4 +523,3 @@ Optionally, they can be callable from device-side via
 *UNRESOLVED*
 
 --
-

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -26,7 +26,7 @@ definitions and updating of previously defined ones.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
-| 2023-11-21 | 0.2.0     |
+| 2023-11-22 | 0.2.0     |
 Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.
 |====
@@ -38,11 +38,6 @@ This extension is written against the OpenCL Specification version 3.0.12.
 This extension requires OpenCL 1.2 or later.
 
 This extension requires cl_exp_tensor.
-
-[NOTE]
-cl_exp_tensor is unpublished, work-in-progress
-extension. Briefly, It will bring concept of tensor, N-dimensional
-data structure whose data layout is opaque to applications.
 
 ==== Contributors
 

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -26,7 +26,7 @@ definitions and updating of previously defined ones.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
-| 2023-11-22 | 0.2.0     |
+| 2023-11-23 | 0.2.0     |
 Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.
 |====
@@ -339,12 +339,11 @@ Each defined built-in kernel entry is organized as follows:
 | Name: *khr_matmul*
 | *Kernel Attributes*
 a|
-
 Fields of the `cl_dkb_attributes_matmul` structure:
 
-. cl_tensor_desc A: Tensor description for input matrix A.
-. cl_tensor_desc B: Tensor description for input matrix B.
-. cl_tensor_desc R: Tensor description for output matrix C.
+. cl_tensor A: Tensor description for input matrix A.
+. cl_tensor B: Tensor description for input matrix B.
+. cl_tensor R: Tensor description for output matrix C.
 . cl_int transposeA: Non-zero transposes A matrix.
 . cl_int transposeB: Non-zero transposes B matrix.
 | *Kernel Arguments*
@@ -390,8 +389,9 @@ This DBK accepts the following properties:
 | *Kernel Attributes*
 a|
 Fields of the `cl_dbk_leaky_relu` structure:
-. cl_tensor_desc in: Input tensor description.
-. cl_tensor_desc out: Output tensor description.
+
+. cl_tensor in: Input tensor description.
+. cl_tensor out: Output tensor description.
 . cl_float alpha: Coefficient of leakage.
 | *Kernel arguments*
 a|
@@ -475,7 +475,7 @@ cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
 // Set tensor kernel arguments before binding storage to the tensors. This
 // gives clCreateBufferWithProperties() opportunity to reason about tensors'
 // uses for determining the optimal memory layout (opaque to application) and
-// the space neededfor the tensors.
+// the space needed for the tensors.
 clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &lhs_tensor);
 clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &rhs_tensor);
 clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &res_tensor);

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -26,7 +26,9 @@ definitions and updating of previously defined ones.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-12-13 | 0.1.0     | First formulation as an extension specification like proposed by Ben Ashbaugh.
-| TODO       | TODO      | TODO
+| 2022-10-23 | 0.2.0     |
+Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
+tensor type. Add sample code.
 |====
 
 ==== Dependencies
@@ -35,7 +37,12 @@ This extension is written against the OpenCL Specification version 3.0.12.
 
 This extension requires OpenCL 1.2 or later.
 
-This extension requires cl_khr_tensor (Note: unpublished draft, work in progress)
+This extension requires cl_khr_tensor.
+
+[NOTE]
+cl_khr_tensor is unpublished, work-in-progress
+extension. Briefly, It will bring concept of tensor, N-dimensional
+data structure whose data layout is opaque to applications.
 
 ==== Contributors
 
@@ -43,6 +50,7 @@ Pekka Jääskeläinen, Intel and Tampere University. +
 Topi Leppänen, Tampere University. +
 Jan Solanti, Tampere University. +
 Ben Ashbaugh, Intel. +
+Henry Linjamäki, Intel. +
 
 === Overview
 
@@ -62,7 +70,7 @@ well-defined built-in kernel with good coverage for common acceleration needs
 and which is designed to easily evolve over time.
 
 The device drivers that implement this extension can freely choose which
-subset of DBKs they implement and advertise to the clients. The
+subset of defined built-in-kernels (DBKs) they implement and advertise to the clients. The
 clients can use the DBKs to accelerate their applications by manually
 executing invoking the DBKs. The extension is designed to also support using
 automated task graph lowering tooling later.
@@ -110,13 +118,18 @@ own hardware accelerator properties, resulting in lack of cross-vendor
 portability in the API abstraction presented to the upper layers of
 heterogeneous computing software stacks.
 
-This extension standardizes a set of well-defined built-in kernels the clients can
-call from higher level programming stacks built with different languages
-and multiple libraries, possibly mix accelerator calls with calls to software kernel
-commands, and rely on the driver stack to optimize the execution (especially
-the synchronization and communication) as a low level heterogeneous task graph.
-It aims to promote the use of built-in kernels as a programming model for hardware accelerated
-functionality, to improve cross-vendor portability of hardware accelerated computing.
+This extension standardizes a set of well-defined built-in kernels the
+clients can call from higher level programming stacks built with
+different languages and multiple libraries, possibly mix accelerator
+calls with calls to software kernel commands, and rely on the driver
+stack to optimize the execution (especially the synchronization and
+communication) as a low level heterogeneous task graph.  The
+heterogeneous task graph can be described using multiple
+command-queues and optionally cached using the command buffer
+extension (cl_khr_command_buffer).  It aims to promote the use of
+built-in kernels as a programming model for hardware accelerated
+functionality, to improve cross-vendor portability of hardware
+accelerated computing.
 
 
 === Add new section X.Y.Z Querying Defined Built-in Kernels
@@ -166,7 +179,7 @@ _errcode_ret_ is set to one of following code:
   conditions descried in defined built-in kernel entry in Appendix I.
 
 * CL_DBK_UNAVAILABLE if kernel attributes are valid but the
-  kernel is not supported one of the devices.
+  kernel is not supported on one of the devices.
 
 * CL_DBK_UNSUPPORTED_MODE_PROPERTY if _cl_dbk_mode_properties_ includes
   at least one property not listed in DBK's entry.
@@ -175,17 +188,15 @@ _errcode_ret_ is set to one of following code:
   meet the requested constraint set by
   CL_DBK_PROPERTY_MAX_RELATIVE_ERROR property.
 
-* TODO: other error cases.
-
-
 [cols="2,1,2",stripes=odd]
 |===
 | *DBK Mode Property* | *Property Value* | *Description*
 
 | CL_DBK_PROPERTY_MAX_RELATIVE_ERROR | float
 
-a| Request a DBK whose maximum relative error is bounded by the given
-value measured in ULPs.
+a| Require that the DBK produces the results which do not deviate more
+than the given amount value of ULPs (units in the last place) respect
+to infnitely precise result.
 
 | CL_DBK_PROPERTY_NON_DETERMINISTIC | cl_bool
 
@@ -194,14 +205,6 @@ implementation to switch algorithm of the kernel on each launch for
 possibly better performance.
 // Idea from https://pytorch.org/docs/stable/notes/randomness.html#cuda-convolution-benchmarking
 
-| ... | -
-a|
-Ideas:
-
-* accumulation with saturation.
-* Finite math only.
-* Flush denormals to zero.
-* data layout preferences (NHWC for convolution).
 |===
 
 === Add new function to 5.8.1 Creating Program Objects
@@ -263,7 +266,7 @@ cl_kernel clCreateDefinedBuiltInKernel(
 === Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification
 
 This chapter describes standard defined built-in kernels (DBK) with
-well-defined semantics. A conformant devices can report to
+well-defined semantics. Devices can report
 availability of the built-in kernels listed in this section with
 `clCreateDefinedBuiltInKernelDescriptor` call. The availability of a
 DBK is determined from the arguments passed to the
@@ -272,38 +275,45 @@ is indicated by CL_DBK_UNAVAILABLE error code.
 
 The general client-side abstraction of the DBKs is similar to a call
 to a C function of which implementation is hidden. The device driver
-can invoke one or more physical hardware accelerators combined with
+are free to implement a DBK by invoking one or more coarse and fine grained hardware accelerators combined with
 firmware to implement the semantics as efficiently as possible.
 
 It is the driver's responsibility to handle efficient synchronization and communication
 to the hardware accelerator, the internal accelerator state management and resource sharing
 across multiple OpenCL contexts.
 
-Identical DBKs with identical inputs, are not guaranteed to produce
-identical results:
+==== Reproducibility ====
 
-* across vendors,
+Identical DBKs or same DBKs executed repeatedly with identical inputs are
+guaranteed to produce identical results, unless otherwise stated in
+the DBK's description, when:
 
-* across driver versions and
+* enqueued to the same device,
 
-* across devices.
+* on the same platform,
 
-Otherwise, identical results are produced unless:
+* on the same vendor with the same driver version and
 
-* otherwise stated in DBK's description or
+* CL_DBK_PROPERTY_NON_DETERMINISTIC property is not set on.
 
-* the DBK has CL_DBK_PROPERTY_NON_DETERMINISTIC property set to true.
-
-Two DKBs are considered identical if their descriptors are created
+Two DBK descriptors for a device are considered identical if they are created
 using identical kernel name, kernel attribute and kernel mode property
-arguments.
+arguments. In other cases, identical and inputs may produce different
+results. The result difference may occur because, for example,
+different algorithms being used across devices.
 
-==== Standard Defined Built-in Kernels ====
+DBKs may produce approximated results and the error, respect to
+infinitely precise result, can be optionally controlled by
+CL_DBK_PROPERTY_MAX_RELATIVE_ERROR when the property name is listed in
+the DBK's description. DBKs without CL_DBK_PROPERTY_MAX_RELATIVE_ERROR
+property produces exact result.
 
-The following list of recognized defined built-in kernels. It is
-expected to grow and update while preserving backwards compatibility.
+==== The Defined Built-in Kernels ====
 
-Each defined built-in kernel entry is organized as followed:
+The following is list of recognized defined built-in kernels. It is
+expected to be expanded and updated over the versions of this extensions, while preserving backwards compatibility.
+
+Each defined built-in kernel entry is organized as follows:
 
 * *Name*: Name of the defined built-in kernel (an enumeration).
 
@@ -331,11 +341,11 @@ Each defined built-in kernel entry is organized as followed:
 [caption="Table A.I.1. "]
 .Standard Built-in Kernels and Their Semantics. *The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.*
 |===
-| Name: *khr_matmul_v1*
+| Name: *khr_matmul*
 | *Kernel Attributes*
 a|
 
-Fields of the `cl_dkb_attributes_matmul_v1` structure:
+Fields of the `cl_dkb_attributes_matmul` structure:
 
 . cl_tensor_desc_t A: Tensor description for input matrix A.
 . cl_tensor_desc_t B: Tensor description for input matrix B.
@@ -381,10 +391,10 @@ This DBK accepts the following properties:
 
 * CL_DBK_PROPERTY_MAX_RELATIVE_ERROR: Unset property defaults to positive infinity.
 |
-| Name: *khr_leaky_relu_v1*
+| Name: *khr_leaky_relu*
 | *Kernel Attributes*
 a|
-Fields of the `cl_dbk_leaky_relu_v1` structure:
+Fields of the `cl_dbk_leaky_relu` structure:
 . cl_tensor_desc_t in: Input tensor description.
 . cl_tensor_desc_t out: Output tensor description.
 . cl_float alpha: Coefficient of leakage.
@@ -430,13 +440,13 @@ cl_tensor_desc_t lhs_tensor_desc = TBD;
 cl_tensor_desc_t rhs_tensor_desc = TBD;
 cl_tensor_desc_t res_tensor_desc = TBD;
 
-cl_dkb_attributes_matmul_v1 matmul_attrs = {
+cl_dkb_attributes_matmul matmul_attrs = {
   lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
   1, 0 // = Transpose lhs tensor
 }
 
 cl_dbk_mode_properties matmul_props = {
-  // Request a matmul implementation that meets this precision.
+  // Request a matmul instance that meets this precision.
   CL_DBK_PROPERTY_MAX_RELATIVE_ERROR, 100, // in ULPs.
 }
 
@@ -445,7 +455,7 @@ std::vector<cl_dbk_descriptor> kernel_descriptions;
 cl_dbk_descriptor matmul_desc =
   clCreateDefinedBuiltInKernelDescriptor(
   context, num_devices, device_list,
-  CL_DBK_MATMUL_V1, &matmul_attrs, &matmul_props, &err);
+  CL_DBK_MATMUL, &matmul_attrs, &matmul_props, &err);
 
 } else if (err == CL_DBK_UNAVAILABLE) {
   // Kernel attributes are valid but the kernel is not supported in at least
@@ -496,7 +506,7 @@ clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL)
 
 --
 
-. Should the NDRange be used at all in DBKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
+. Should the NDRange be used at all in DBKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelization strategy to implement the function. On the other hand, similar applies to software kernel launches as the NDRange-launched work-items can be executed serially if adhering to barrier semantics.
 +
 --
 *UNRESOLVED*
@@ -522,4 +532,13 @@ clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL)
 --
 *UNRESOLVED*
 
+--
+
+. What other DBK mode properties we should have? Here are some ideas:
+** Perform accumulation with saturation.
+** Finite math only
+** Flush denormals to zero.
+** data layout preferences (NHWC for convolution).
+--
+*UNRESOLVED*
 --

--- a/ext/cl_khr_defined_builtin_kernels.asciidoc
+++ b/ext/cl_khr_defined_builtin_kernels.asciidoc
@@ -347,16 +347,16 @@ a|
 
 Fields of the `cl_dkb_attributes_matmul` structure:
 
-. cl_tensor_desc_t A: Tensor description for input matrix A.
-. cl_tensor_desc_t B: Tensor description for input matrix B.
-. cl_tensor_desc_t R: Tensor description for output matrix C.
+. cl_tensor_desc A: Tensor description for input matrix A.
+. cl_tensor_desc B: Tensor description for input matrix B.
+. cl_tensor_desc R: Tensor description for output matrix C.
 . cl_int transposeA: Non-zero transposes A matrix.
 . cl_int transposeB: Non-zero transposes B matrix.
 | *Kernel Arguments*
 a|
-. cl_tensor_t A: Matrix A (read only).
-. cl_tensor_t B: Matrix B (read only).
-. cl_tensor_t R: Output matrix. (write only).
+. cl_tensor A: Matrix A (read only).
+. cl_tensor B: Matrix B (read only).
+. cl_tensor R: Output matrix. (write only).
 | *Description*
 a|
 Performs (batched) matrix multiplication: `R = trans(A) * trans(B)`,
@@ -395,13 +395,13 @@ This DBK accepts the following properties:
 | *Kernel Attributes*
 a|
 Fields of the `cl_dbk_leaky_relu` structure:
-. cl_tensor_desc_t in: Input tensor description.
-. cl_tensor_desc_t out: Output tensor description.
+. cl_tensor_desc in: Input tensor description.
+. cl_tensor_desc out: Output tensor description.
 . cl_float alpha: Coefficient of leakage.
 | *Kernel arguments*
 a|
-. cl_tensor_t in: The input tensor.
-. cl_tensor_t out: The output tensor.
+. cl_tensor in: The input tensor.
+. cl_tensor out: The output tensor.
 | *Description*
 a|
 Applies operation `alpha * x if x < 0 else x` on all
@@ -436,9 +436,9 @@ clCreateDefinedBuiltInKernelDescriptor.
 // (cl_channel_type) and a number of dimensions (rank) and dimension
 // sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
 // "unlimited".
-cl_tensor_desc_t lhs_tensor_desc = TBD;
-cl_tensor_desc_t rhs_tensor_desc = TBD;
-cl_tensor_desc_t res_tensor_desc = TBD;
+cl_tensor_desc lhs_tensor_desc = TBD;
+cl_tensor_desc rhs_tensor_desc = TBD;
+cl_tensor_desc res_tensor_desc = TBD;
 
 cl_dkb_attributes_matmul matmul_attrs = {
   lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
@@ -484,9 +484,9 @@ cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
 // determines the optimal data layout (opaque to the application) for
 // the tensors based on their usage.  Application uses the tensor
 // sizes to create cl_mem buffers which are bound to the tensors.
-cl_tensor_t lhs_tensor = TBD;
-cl_tensor_t rhs_tensor = TBD;
-cl_tensor_t res_tensor = TBD;
+cl_tensor lhs_tensor = TBD;
+cl_tensor rhs_tensor = TBD;
+cl_tensor res_tensor = TBD;
 
 // Transfer data to input tensors
 

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -482,9 +482,10 @@ definitions and updating of previously defined ones.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">TODO</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">TODO</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reference new concept as "defined built-in kernel".</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-10-23</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0.2.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
+tensor type. Add sample code.</p></td>
 </tr>
 </tbody>
 </table>
@@ -497,6 +498,23 @@ definitions and updating of previously defined ones.</p>
 <div class="paragraph">
 <p>This extension requires OpenCL 1.2 or later.</p>
 </div>
+<div class="paragraph">
+<p>This extension requires cl_khr_tensor.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+cl_khr_tensor is unpublished, work-in-progress
+extension. Briefly, It will bring concept of tensor, N-dimensional
+data structure whose data layout is opaque to applications.
+</td>
+</tr>
+</table>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_contributors">Contributors</h4>
@@ -504,7 +522,8 @@ definitions and updating of previously defined ones.</p>
 <p>Pekka Jääskeläinen, Intel and Tampere University.<br>
 Topi Leppänen, Tampere University.<br>
 Jan Solanti, Tampere University.<br>
-Ben Ashbaugh, Intel.<br></p>
+Ben Ashbaugh, Intel.<br>
+Henry Linjamäki, Intel.<br></p>
 </div>
 </div>
 </div>
@@ -530,9 +549,9 @@ and which is designed to easily evolve over time.</p>
 </div>
 <div class="paragraph">
 <p>The device drivers that implement this extension can freely choose which
-subset of defined BiKs they implement and advertise to the clients. The
-clients can use the BiKs to accelerate their applications by manually
-executing invoking the BiKs. The extension is designed to also support using
+subset of defined built-in-kernels (DBKs) they implement and advertise to the clients. The
+clients can use the DBKs to accelerate their applications by manually
+executing invoking the DBKs. The extension is designed to also support using
 automated task graph lowering tooling later.</p>
 </div>
 <div class="sect3">
@@ -585,41 +604,232 @@ portability in the API abstraction presented to the upper layers of
 heterogeneous computing software stacks.</p>
 </div>
 <div class="paragraph">
-<p>This extension standardizes a set of well-defined built-in kernels the clients can
-call from higher level programming stacks built with different languages
-and multiple libraries, possibly mix accelerator calls with calls to software kernel
-commands, and rely on the driver stack to optimize the execution (especially
-the synchronization and communication) as a low level heterogeneous task graph.
-It aims to promote the use of built-in kernels as a programming model for hardware accelerated
-functionality, to improve cross-vendor portability of hardware accelerated computing.</p>
+<p>This extension standardizes a set of well-defined built-in kernels the
+clients can call from higher level programming stacks built with
+different languages and multiple libraries, possibly mix accelerator
+calls with calls to software kernel commands, and rely on the driver
+stack to optimize the execution (especially the synchronization and
+communication) as a low level heterogeneous task graph.  The
+heterogeneous task graph can be described using multiple
+command-queues and optionally cached using the command buffer
+extension (cl_khr_command_buffer).  It aims to promote the use of
+built-in kernels as a programming model for hardware accelerated
+functionality, to improve cross-vendor portability of hardware
+accelerated computing.</p>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_modifications_to_section_4_2_of_the_opencl_api_specification">Modifications to section 4.2 of the OpenCL API Specification</h3>
+<h3 id="_add_new_section_x_y_z_querying_defined_built_in_kernels">Add new section X.Y.Z Querying Defined Built-in Kernels</h3>
 <div class="paragraph">
-<p>Modify <strong>Table 5</strong>, <em>Device Queries</em>, of section 4.2, by adding the following
-sentences to the description cell of <code>CL_DEVICE_BUILT_IN_KERNELS</code>:</p>
+<p>To request a defined built-in kernel to be executed in the given
+devices use:</p>
 </div>
-<div class="quoteblock">
-<blockquote>
-The semantics of the returned built-in kernels are undefined or defined in
-vendor-specific documentation, unless the name starts with prefix `khr_',
-which means it&#8217;s a defined built-in kernel with semantics defined in Appendix I.
-</blockquote>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">cl_dbk_descriptor clCreateDefinedBuiltInKernelDescriptor(
+    cl_context context,
+    cl_uint num_devices,
+    const cl_device_id* device_list,
+    cl_dbk_name kernel_name,
+    const void *kernel_attributes,
+    const cl_dbk_mode_properties* kernel_config,
+    cl_int *errcode_ret);</code></pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em>context</em> must be a valid OpenCL context.</p>
+</li>
+<li>
+<p><em>num_devices</em> is the number of devices listed in
+device_list. <em>num_devices</em> must be non-zero.</p>
+</li>
+<li>
+<p><em>device_list</em> is a pointer to a list of devices that are in
+context. <em>device_list</em> must be a non-NULL value. The defined built-in kernels
+are loaded for devices specified in this list.</p>
+</li>
+<li>
+<p><em>kernel_name</em> is the name of the defined built-in kernel listed in Appendix I.</p>
+</li>
+<li>
+<p><em>kernel_attributes</em> is a pointer to the structure declared in
+description of the kernel in Appendix I. The structure holds
+kernel&#8217;s attributes.</p>
+</li>
+<li>
+<p><em>cl_dbk_mode_properties</em> is a pointer to a list of defined built-in
+kernel mode properties. The supported mode properties are listed in
+DBK&#8217;s entry with default settings in Appendix I. It is valid to set
+this argument to NULL in which case default properties apply (if
+any).</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>clCreateDefinedBuiltInKernelDescriptor</strong> returns a valid kernel
+descriptor on success indicated by <em>errcode_ret</em> which is set to
+CL_SUCCESS. Otherwise, the returned object is NULL and the
+<em>errcode_ret</em> is set to one of following code:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>CL_DBK_INVALID_ATTRIBUTE if one or more kernel attributes violates
+conditions descried in defined built-in kernel entry in Appendix I.</p>
+</li>
+<li>
+<p>CL_DBK_UNAVAILABLE if kernel attributes are valid but the
+kernel is not supported on one of the devices.</p>
+</li>
+<li>
+<p>CL_DBK_UNSUPPORTED_MODE_PROPERTY if <em>cl_dbk_mode_properties</em> includes
+at least one property not listed in DBK&#8217;s entry.</p>
+</li>
+<li>
+<p>CL_DBK_UNMET_MAX_RELATIVE_ERROR if the DBK is available but does not
+meet the requested constraint set by
+CL_DBK_PROPERTY_MAX_RELATIVE_ERROR property.</p>
+</li>
+</ul>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 40%;">
+<col style="width: 20%;">
+<col style="width: 40%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top"><strong>DBK Mode Property</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Property Value</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">CL_DBK_PROPERTY_MAX_RELATIVE_ERROR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">float</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Require that the DBK produces the results which do not deviate more
+than the given amount value of ULPs (units in the last place) respect
+to infnitely precise result.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">CL_DBK_PROPERTY_NON_DETERMINISTIC</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">cl_bool</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Allow results of the kernel to be non-reproducible. This allows
+implementation to switch algorithm of the kernel on each launch for
+possibly better performance.</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_add_new_function_to_5_8_1_creating_program_objects">Add new function to 5.8.1 Creating Program Objects</h3>
+<div class="paragraph">
+<p>To create a program with a set of defined built-in kernel use:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">cl_program clCreateProgramWithDefinedKernels(
+    cl_context context,
+    size_t num_kernel_desc,
+    const void* kernel_desc_list,
+    cl_int* errcode_ret);</code></pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em>context</em> must be a valid OpenCL context.</p>
+</li>
+<li>
+<p><em>num_kernel_desc</em> is the number of kernel descriptors.</p>
+</li>
+<li>
+<p><em>kernel_desc_list</em> is the array of valid
+cl_dbk_descriptor objects. The array length must be at
+least <em>num_kernel_desc</em>. The kernel descriptors must be created on
+the same context.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>clCreateProgramWithDefinedKernels</strong> returns a valid program on success
+indicated by <em>errcode_ret</em> which is set to CL_SUCCESS. Otherwise, the
+returned object is NULL and the <em>errcode_ret</em> is set to one of
+following code:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>TODO.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_add_new_function_to_5_9_1_creating_kernel_objects">Add new function to 5.9.1 Creating Kernel Objects</h3>
+<div class="paragraph">
+<p>To get a kernel handle for a defined built-in kernel in a program use:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">cl_kernel clCreateDefinedBuiltInKernel(
+    cl_program program,
+    cl_dbk_descriptor kernel_desc,
+    cl_int* errcode_ret);</code></pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em>program</em> is a program object with a successfully built executable.</p>
+</li>
+<li>
+<p><em>kernel_desc</em> is a defined built-in kernel descriptor in the program.</p>
+</li>
+<li>
+<p><em>errcode_ret</em> will return an appropriate error code. If errcode_ret is
+NULL, no error code is returned.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>clCreateDefinedBuiltInKernel</strong> returns a valid non-zero kernel object
+ and errcode_ret is set to CL_SUCCESS if the kernel object is created
+ successfully. Otherwise, it returns a NULL value with one of the
+ following error values returned in <em>errcode_ret</em>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>TODO.</p>
+</li>
+</ul>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_add_new_appendix_appendix_i_defined_built_in_kernels_to_opencl_api_specification">Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification</h3>
 <div class="paragraph">
-<p>This chapter describes standard defined built-in kernels (DBK) with well-defined
-semantics. A conformant device can report to support zero or more of the built-in
-kernels via <code>CL_DEVICE_BUILT_IN_KERNELS</code> or <code>CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION</code> device queries.</p>
+<p>This chapter describes standard defined built-in kernels (DBK) with
+well-defined semantics. Devices can report
+availability of the built-in kernels listed in this section with
+<code>clCreateDefinedBuiltInKernelDescriptor</code> call. The availability of a
+DBK is determined from the arguments passed to the
+<code>clCreateDefinedBuiltInKernelDescriptor</code> and unavailability of a DBK
+is indicated by CL_DBK_UNAVAILABLE error code.</p>
 </div>
 <div class="paragraph">
 <p>The general client-side abstraction of the DBKs is similar to a call
 to a C function of which implementation is hidden. The device driver
-can invoke one or more physical hardware accelerators combined with
+are free to implement a DBK by invoking one or more coarse and fine grained hardware accelerators combined with
 firmware to implement the semantics as efficiently as possible.</p>
 </div>
 <div class="paragraph">
@@ -628,292 +838,356 @@ to the hardware accelerator, the internal accelerator state management and resou
 across multiple OpenCL contexts.</p>
 </div>
 <div class="sect3">
-<h4 id="_standard_defined_built_in_kernels">Standard Defined Built-in Kernels</h4>
+<h4 id="_reproducibility">Reproducibility</h4>
 <div class="paragraph">
-<p>The following list of recognized defined built-ins is organized
-according to their application domain and handled data types. It is
-expected to grow and update while preserving backwards compatibility.</p>
+<p>Identical DBKs or same DBKs executed repeatedly with identical inputs are
+guaranteed to produce identical results, unless otherwise stated in
+the DBK&#8217;s description, when:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>enqueued to the same device,</p>
+</li>
+<li>
+<p>on the same platform,</p>
+</li>
+<li>
+<p>on the same vendor with the same driver version and</p>
+</li>
+<li>
+<p>CL_DBK_PROPERTY_NON_DETERMINISTIC property is not set on.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Two DBK descriptors for a device are considered identical if they are created
+using identical kernel name, kernel attribute and kernel mode property
+arguments. In other cases, identical and inputs may produce different
+results. The result difference may occur because, for example,
+different algorithms being used across devices.</p>
+</div>
+<div class="paragraph">
+<p>DBKs may produce approximated results and the error, respect to
+infinitely precise result, can be optionally controlled by
+CL_DBK_PROPERTY_MAX_RELATIVE_ERROR when the property name is listed in
+the DBK&#8217;s description. DBKs without CL_DBK_PROPERTY_MAX_RELATIVE_ERROR
+property produces exact result.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_the_defined_built_in_kernels">The Defined Built-in Kernels</h4>
+<div class="paragraph">
+<p>The following is list of recognized defined built-in kernels. It is
+expected to be expanded and updated over the versions of this extensions, while preserving backwards compatibility.</p>
+</div>
+<div class="paragraph">
+<p>Each defined built-in kernel entry is organized as follows:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>Name</strong>: Name of the defined built-in kernel (an enumeration).</p>
+</li>
+<li>
+<p><strong>Kernel attributes</strong>: The kernel attributes required for creating the
+defined built-in kernel via
+clCreateDefinedBuiltInKernelDescriptor. Attribute values are
+immutable.</p>
+</li>
+<li>
+<p><strong>Kernel arguments</strong>: The kernel arguments.</p>
+</li>
+<li>
+<p><strong>Description</strong>: The description of the kernel in detail.</p>
+</li>
+<li>
+<p><strong>Attribute validation rules</strong>: Conditions of the kernel attribute for
+the kernel. Implementation must return CL_DBK_INVALID_ATTRIBUTE on
+clCreateDefinedBuiltInKernelDescriptor call if any of the conditions
+are violated.</p>
+</li>
+<li>
+<p><strong>Kernel mode properties</strong>: List of kernel mode
+properties (cl_dbk_mode_properties) the kernel recognizes. The
+properties can be used to tweak certain implementation details and
+behaviors in the kernel execution. If a property not listed in the
+DBK entry is fed to clCreateDefinedBuiltInKernelDescriptor call,
+then implementation must return CL_DKB_UNSUPPORTED_MODE_PROPERTY.</p>
+</li>
+</ul>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table A.I.1. Standard Built-in Kernels and Their Semantics. <strong>The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.</strong></caption>
 <colgroup>
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
+<col style="width: 100%;">
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>General linear algebra</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name: <strong>khr_matmul</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel Attributes</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_blas_gemm_float</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="1">
-<li>
-<p>The height.</p>
-</li>
-<li>
-<p>The width.</p>
-</li>
-</ol>
-</div></div></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="0">
-<li>
-<p>int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)</p>
-</li>
-<li>
-<p>int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)</p>
-</li>
-<li>
-<p>float: scalar (alpha) to multiply the matrix multiplication result elements with</p>
-</li>
-<li>
-<p>float* (input): matrix A</p>
-</li>
-<li>
-<p>int: leading dimension of A (0 = row-major, 1 = column-major)</p>
-</li>
-<li>
-<p>float* (input): matrix B</p>
-</li>
-<li>
-<p>int: leading dimension of B (0 = row-major, 1 = column-major)</p>
-</li>
-<li>
-<p>float: scalar (beta) to multiply the C matrix elements with before adding it to the result</p>
-</li>
-<li>
-<p>float* (input&amp;output): matrix C which is added to the matrix multiplication result, and stores the output</p>
-</li>
-<li>
-<p>int: leading dimension of C (0 = row-major, 1 = column-major)</p>
-</li>
-</ol>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_blas_gemm_float(
-   int transA, int transB, float alpha, const global float *A, int ldA,
-   const global float *B, int ldB,
-   float beta, global float *C, int ldC) {
-   // TBD: An example implementation that can be used for verification
-   // and as a fallback SW implementation.
-}</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpenVX Neural Network Extension Compatible Kernels</strong></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_openvx_nn_extension_convolution_uchar</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Convolution for 8bit unsigned integer inputs and weights.</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="1">
-<li>
-<p>Batch size.</p>
-</li>
-<li>
-<p>Width.</p>
-</li>
-<li>
-<p>Height.</p>
-</li>
-</ol>
-</div></div></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="0">
-<li>
-<p>uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].</p>
-</li>
-<li>
-<p>uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].</p>
-</li>
-<li>
-<p>uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2)</p>
-</li>
-<li>
-<p>size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.</p>
-</li>
-<li>
-<p>size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.</p>
-</li>
-<li>
-<p>int: Rounding method for calculating output dimensions.</p>
-</li>
-<li>
-<p>int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.</p>
-</li>
-<li>
-<p>size_t: Number of elements padded at each side in the x dimension of the input.</p>
-</li>
-<li>
-<p>size_t: Number of elements padded at each side in the y dimension of the input.</p>
-</li>
-<li>
-<p>int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.</p>
-</li>
-<li>
-<p>uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)</p>
-</li>
-</ol>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_openvx_nn_extension_convolution_uchar(
-   const uchar *input, const uchar *weights, const uchar *biases,
-   size_t dilation_x, size_t dilation_y,
-   int down_scale_rounding, int overflow_policy, size_t padding_x, size_t padding_y,
-   int rounding_policy, uchar *output) {
-   // TBD.
-}</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>Direct Input/Output Operations</strong></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">Kernels for accessing data sources and destinations directly without host involvement.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_in_uchar</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Non-blocking read of data from a sensor/stream associated with the device.</p></td>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>-</p>
-</div></div></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="0">
+<p>Fields of the <code>cl_dkb_attributes_matmul</code> structure:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>uchar* [out]: The data.</p>
+<p>cl_tensor_desc_t A: Tensor description for input matrix A.</p>
 </li>
 <li>
-<p>size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the <code>cl_pocl_content_size</code> extension to optimize data transfers with.)</p>
+<p>cl_tensor_desc_t B: Tensor description for input matrix B.</p>
+</li>
+<li>
+<p>cl_tensor_desc_t R: Tensor description for output matrix C.</p>
+</li>
+<li>
+<p>cl_int transposeA: Non-zero transposes A matrix.</p>
+</li>
+<li>
+<p>cl_int transposeB: Non-zero transposes B matrix.</p>
 </li>
 </ol>
 </div></div></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel Arguments</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_in_uchar(
-   uchar *output, size_t *num) {
-   // It is not feasible to describe this kernel in OpenCL C as I/O devices
-   // are not representable with it.
-}</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_out_uchar</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Non-blocking write of data to an output/sink associated with the device.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="0">
+<ol class="arabic">
 <li>
-<p>uchar* [in]: The data to write.</p>
+<p>cl_tensor_t A: Matrix A (read only).</p>
 </li>
 <li>
-<p>size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).</p>
+<p>cl_tensor_t B: Matrix B (read only).</p>
+</li>
+<li>
+<p>cl_tensor_t R: Output matrix. (write only).</p>
 </li>
 </ol>
 </div></div></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Description</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_out_uchar(
-   uchar *input, size_t *num) {
-   // It is not feasible to describe this kernel in OpenCL C as I/O devices
-   // are not representable with it.
-}</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_in_blocking_uchar</strong></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Blocking read of data from a sensor/stream associated with the device.</p></td>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>-</p>
+<p>Performs (batched) matrix multiplication: <code>R = trans(A) * trans(B)</code>,
+where <code>A</code>, <code>B</code> and <code>R</code> are tensors with at least rank two. The
+<code>trans()</code> is a configurable transpose operation.</p>
+</div>
+<div class="paragraph">
+<p>Last two dimensions of the tensors are treated as operands to the
+matric multiplication and rest of the dimensions are treated as batch
+dimensions.</p>
+</div>
+<div class="paragraph">
+<p>Operations of the matrix muliplication are performed in the precision
+of the <code>elementof(R)</code>.</p>
+</div>
+<div class="paragraph">
+<p>If an overflow occurs in the accumulation of the products, then <code>R</code>
+tensor&#8217;s result will be undefined.</p>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
-<ol class="arabic" start="0">
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Attribute validation rules</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
 <li>
-<p>uchar* [out]: The data.</p>
+<p><code>rankof(A) == rankof(B) &gt;= 2</code>.</p>
+</li>
+<li>
+<p>Let <code>shapeof(A<sub>t</sub>) == (b&#8230;&#8203;, m, k)</code> and <code>shapeof(B<sub>t</sub>) = (b&#8230;&#8203;, k,
+n)</code> of tensors <code>A</code> and <code>B</code>, respectively, after possible tranposing.
+<code>shapeof(R)</code> must be <code>(b&#8230;&#8203;, m, n)</code>.</p>
+</li>
+<li>
+<p><code>elementof(A) == elementof(B)</code></p>
+</li>
+<li>
+<p><code>elemkindof(R) == elemkindof(A)</code></p>
+</li>
+<li>
+<p><code>elementof(R) == elementof(A)</code> or <code>elementof(A)</code> is promotable to
+<code>elementof(R)</code> without loss of meaning.</p>
+</li>
+</ul>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel mode properties</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>This DBK accepts the following properties:</p>
+</div>
 <div class="ulist">
 <ul>
 <li>
-<p>size_t* [in]: How many bytes to read before returning.</p>
+<p>CL_DBK_PROPERTY_MAX_RELATIVE_ERROR: Unset property defaults to positive infinity.</p>
 </li>
 </ul>
-</div>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name: <strong>khr_leaky_relu</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel Attributes</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Fields of the <code>cl_dbk_leaky_relu</code> structure:
+. cl_tensor_desc_t in: Input tensor description.
+. cl_tensor_desc_t out: Output tensor description.
+. cl_float alpha: Coefficient of leakage.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel arguments</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>cl_tensor_t in: The input tensor.</p>
+</li>
+<li>
+<p>cl_tensor_t out: The output tensor.</p>
 </li>
 </ol>
 </div></div></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Description</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_in_blocking_uchar(uchar *output, size_t *num) {
-   while (*num) {
-       size_t num_read = *num;
-       __khr_io_stream_in_uchar(output, &amp;num_read);
-       num -= num_read;
-       output += num_read;
-   }
-}</code></pre>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Applies operation <code>alpha * x if x &lt; 0 else x</code> on all
+elements of the <code>in</code> tensor.</p>
 </div>
+<div class="paragraph">
+<p>If target device does not support denormals, then <code>alpha</code> is flushed
+to zero before the operation is applied.</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Kernel mode properties</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">N/A</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Attribute validation rules</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
+<li>
+<p><code>shapeof(in) == shapeof(out)</code></p>
+</li>
+<li>
+<p><code>elementof(in) == elementof(out)</code></p>
+</li>
+<li>
+<p><code>alpha</code> must be a finite value.</p>
+</li>
+</ul>
 </div></div></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_launching_biks_from_the_device_side">Launching BiKs from the Device Side</h4>
+<h4 id="_launching_dbks_from_the_device_side">Launching DBKs from the Device Side</h4>
 <div class="paragraph">
-<p>BiKs are primarily meant to be launched as kernel commands via host-side command queues.
-Optionally, they can be callable from device-side via
-<code>enqueue_kernel</code>: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: <code>cl_khr_bik_BUILTIN_KERNEL_NAME</code>. In case a BiK macro is defined, a kernel with a naming convention <code>__khr_BUILTIN_KERNEL_NAME()</code> can be enqueued by the program at device side as software-defined kernels.</p>
+<p>DBKs are primarily meant to be launched as kernel commands via
+host-side command queues.  Optionally, they can be callable from
+device-side via <code>enqueue_kernel</code>:</p>
+</div>
+<div class="paragraph">
+<p>TBC. This probably needs device-side function corresponding to
+clCreateDefinedBuiltInKernelDescriptor.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_sample_code">Sample Code</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">// TBD. Similarly in cl_qcom_ml_ops, tensors have type
+// (cl_channel_type) and a number of dimensions (rank) and dimension
+// sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
+// "unlimited".
+cl_tensor_desc_t lhs_tensor_desc = TBD;
+cl_tensor_desc_t rhs_tensor_desc = TBD;
+cl_tensor_desc_t res_tensor_desc = TBD;
+
+cl_dkb_attributes_matmul matmul_attrs = {
+  lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
+  1, 0 // = Transpose lhs tensor
+}
+
+cl_dbk_mode_properties matmul_props = {
+  // Request a matmul instance that meets this precision.
+  CL_DBK_PROPERTY_MAX_RELATIVE_ERROR, 100, // in ULPs.
+}
+
+cl_uint err;
+std::vector&lt;cl_dbk_descriptor&gt; kernel_descriptions;
+cl_dbk_descriptor matmul_desc =
+  clCreateDefinedBuiltInKernelDescriptor(
+  context, num_devices, device_list,
+  CL_DBK_MATMUL, &amp;matmul_attrs, &amp;matmul_props, &amp;err);
+
+} else if (err == CL_DBK_UNAVAILABLE) {
+  // Kernel attributes are valid but the kernel is not supported in at least
+  // one of the devices.
+} else if (err == CL_DBK_UNMET_MAX_RELATIVE_ERROR) {
+  // E.g. Kernel is supported but is not precise enough.
+} else if (err == CL_DBK_UNSUPPORTED_MODE_PROPERTY) {
+  // cl_dbk_mode_properties has a property not listed in the description of the
+  // defined built-in kernel.
+} else
+  kernel_descriptions.push_back(matmul_desc);
+
+...
+
+cl_program dbk_lib = clCreateProgramWithDefinedBuiltInKernels(
+  context, kernel_descriptions.size(), kernel_descriptors.data(), err);
+
+...
+
+cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
+  dkb_lib, matmul_desc, err);
+
+// TBD: allocate space for tensors. Perhaps like cl_qcom_ml_ops: query
+// tensor sizes after the final program has been created or after
+// command buffer (with DBKs within) is finalized. Implementation
+// determines the optimal data layout (opaque to the application) for
+// the tensors based on their usage.  Application uses the tensor
+// sizes to create cl_mem buffers which are bound to the tensors.
+cl_tensor_t lhs_tensor = TBD;
+cl_tensor_t rhs_tensor = TBD;
+cl_tensor_t res_tensor = TBD;
+
+// Transfer data to input tensors
+
+clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &amp;lhs_tensor);
+clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &amp;rhs_tensor);
+clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &amp;res_tensor);
+
+clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL);</code></pre>
+</div>
 </div>
 </div>
 </div>
@@ -922,7 +1196,7 @@ Optionally, they can be callable from device-side via
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.</p>
+<p>Should we enable launching DBKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
@@ -932,7 +1206,7 @@ Optionally, they can be callable from device-side via
 </div>
 </li>
 <li>
-<p>Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.</p>
+<p>Should the NDRange be used at all in DBKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelization strategy to implement the function. On the other hand, similar applies to software kernel launches as the NDRange-launched work-items can be executed serially if adhering to barrier semantics.</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
@@ -942,7 +1216,7 @@ Optionally, they can be callable from device-side via
 </div>
 </li>
 <li>
-<p>Different accelerators prefer different channel orders (NHWC vs. NCHW&#8230;&#8203;) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM&#8217;s row/column order) or is it better to have different BiK variations for each?</p>
+<p>Different accelerators prefer different channel orders (NHWC vs. NCHW&#8230;&#8203;) for the processed data. Should the channel order be passed as a DBK argument (like in the example GEMM&#8217;s row/column order) or is it better to have different DBK variations for each?</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
@@ -952,7 +1226,7 @@ Optionally, they can be callable from device-side via
 </div>
 </li>
 <li>
-<p>How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.</p>
+<p>How to denote preference? Some of the DBKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
@@ -971,7 +1245,33 @@ Optionally, they can be callable from device-side via
 </div>
 </div>
 </li>
+<li>
+<p>What other DBK mode properties we should have? Here are some ideas:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Perform accumulation with saturation.</p>
+</li>
+<li>
+<p>Finite math only</p>
+</li>
+<li>
+<p>Flush denormals to zero.</p>
+</li>
+<li>
+<p>data layout preferences (NHWC for convolution).</p>
+</li>
+</ul>
+</div>
+</li>
 </ol>
+</div>
+<div class="openblock">
+<div class="content">
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
 </div>
 </div>
 </div>
@@ -979,7 +1279,7 @@ Optionally, they can be callable from device-side via
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-10-11 14:38:56 +0300
+Last updated 2023-10-23 15:08:14 +0300
 </div>
 </div>
 </body>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -482,7 +482,7 @@ definitions and updating of previously defined ones.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2022-10-23</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-21</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0.2.0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.</p></td>
@@ -499,7 +499,7 @@ tensor type. Add sample code.</p></td>
 <p>This extension requires OpenCL 1.2 or later.</p>
 </div>
 <div class="paragraph">
-<p>This extension requires cl_khr_tensor.</p>
+<p>This extension requires cl_exp_tensor.</p>
 </div>
 <div class="admonitionblock note">
 <table>
@@ -508,7 +508,7 @@ tensor type. Add sample code.</p></td>
 <div class="title">Note</div>
 </td>
 <td class="content">
-cl_khr_tensor is unpublished, work-in-progress
+cl_exp_tensor is unpublished, work-in-progress
 extension. Briefly, It will bring concept of tensor, N-dimensional
 data structure whose data layout is opaque to applications.
 </td>
@@ -1124,25 +1124,21 @@ clCreateDefinedBuiltInKernelDescriptor.</p>
 <h4 id="_sample_code">Sample Code</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">// TBD. Similarly in cl_qcom_ml_ops, tensors have type
-// (cl_channel_type) and a number of dimensions (rank) and dimension
-// sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
-// "unlimited".
-cl_tensor_desc lhs_tensor_desc = TBD;
-cl_tensor_desc rhs_tensor_desc = TBD;
-cl_tensor_desc res_tensor_desc = TBD;
+<pre class="highlight"><code class="language-c" data-lang="c">constexpr size_t b = 64, m = 100, n = 200, k = 50;
+cl_int err;
+cl_tensor lhs_tensor = clCreateTensor(context, nullptr, 3, {b, m, k}, CL_TENSOR_FLOAT, err);
+cl_tensor rhs_tensor = clCreateTensor(context, nullptr, 3, {b, k, n}, CL_TENSOR_FLOAT, err);
+cl_tensor res_tensor = clCreateTensor(context, nullptr, 3, {b, m, n}, CL_TENSOR_FLOAT, err);
 
 cl_dkb_attributes_matmul matmul_attrs = {
-  lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
-  1, 0 // = Transpose lhs tensor
-}
+  lhs_tensor, rhs_tensor, res_tensor, 1, 0 // = Transpose lhs tensor
+};
 
 cl_dbk_mode_properties matmul_props = {
   // Request a matmul instance that meets this precision.
   CL_DBK_PROPERTY_MAX_RELATIVE_ERROR, 100, // in ULPs.
-}
+};
 
-cl_uint err;
 std::vector&lt;cl_dbk_descriptor&gt; kernel_descriptions;
 cl_dbk_descriptor matmul_desc =
   clCreateDefinedBuiltInKernelDescriptor(
@@ -1152,11 +1148,14 @@ cl_dbk_descriptor matmul_desc =
 } else if (err == CL_DBK_UNAVAILABLE) {
   // Kernel attributes are valid but the kernel is not supported in at least
   // one of the devices.
+  ...
 } else if (err == CL_DBK_UNMET_MAX_RELATIVE_ERROR) {
   // E.g. Kernel is supported but is not precise enough.
+  ...
 } else if (err == CL_DBK_UNSUPPORTED_MODE_PROPERTY) {
   // cl_dbk_mode_properties has a property not listed in the description of the
   // defined built-in kernel.
+  ...
 } else
   kernel_descriptions.push_back(matmul_desc);
 
@@ -1168,25 +1167,39 @@ cl_program dbk_lib = clCreateProgramWithDefinedBuiltInKernels(
 ...
 
 cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
-  dkb_lib, matmul_desc, err);
+  dkb_lib, matmul_desc, &amp;err);
 
-// TBD: allocate space for tensors. Perhaps like cl_qcom_ml_ops: query
-// tensor sizes after the final program has been created or after
-// command buffer (with DBKs within) is finalized. Implementation
-// determines the optimal data layout (opaque to the application) for
-// the tensors based on their usage.  Application uses the tensor
-// sizes to create cl_mem buffers which are bound to the tensors.
-cl_tensor lhs_tensor = TBD;
-cl_tensor rhs_tensor = TBD;
-cl_tensor res_tensor = TBD;
-
-// Transfer data to input tensors
-
+// Set tensor kernel arguments before binding storage to the tensors. This
+// gives clCreateBufferWithProperties() opportunity to reason about tensors'
+// uses for determining the optimal memory layout (opaque to application) and
+// the space neededfor the tensors.
 clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &amp;lhs_tensor);
 clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &amp;rhs_tensor);
 clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &amp;res_tensor);
 
-clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL);</code></pre>
+// Allocate storage for tensors.
+cl_mem lhs_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, lhs_tensor, 0}, CL_MEM_READ_ONLY, 0, nullptr, &amp;err);
+cl_mem rhs_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, rhs_tensor, 0}, CL_MEM_READ_ONLY, 0, nullptr, &amp;err);
+cl_mem res_mem = clCreateBufferWithProperties(
+  context, {CL_MEM_BIND_TO_TENSOR, res_tensor, 0}, CL_MEM_WRITE_ONLY, 0, nullptr, &amp;err);
+
+// Transfer data to input tensors, execute DBK, and import results
+// from the output tensor.
+
+std::vector&lt;float&gt; lhs_data = ...;
+std::vector&lt;float&gt; rhs_data = ...;
+std::vector&lt;float&gt; res_data(b * m * n);
+
+clEnqueueExportToTensor(cmd_q, lhs_tensor, false, {0, 0, 0}, {0, 0, 0}, {b, m, k},
+  nullptr, nullptr, lhs_data.data(), 0, nullptr, nullptr)
+clEnqueueExportToTensor(cmd_q, rhs_tensor, false, {0, 0, 0}, {0, 0, 0}, {b, k, n},
+  nullptr, nullptr, rhs_data.data(), 0, nullptr, nullptr)
+clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL);
+clEnqueueImportFromTensor(
+  cmd_q, res_tensor, false,  {0, 0, 0}, {0, 0, 0}, {b, m, n},
+  nullptr, nullptr, res_data.data(), 0, nullptr, nullptr);</code></pre>
 </div>
 </div>
 </div>
@@ -1279,7 +1292,7 @@ clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL)
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-10-25 10:24:30 +0300
+Last updated 2023-11-21 13:16:24 +0200
 </div>
 </div>
 </body>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -482,7 +482,7 @@ definitions and updating of previously defined ones.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-23</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0.2.0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.</p></td>
@@ -922,13 +922,13 @@ then implementation must return CL_DKB_UNSUPPORTED_MODE_PROPERTY.</p>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>cl_tensor_desc A: Tensor description for input matrix A.</p>
+<p>cl_tensor A: Tensor description for input matrix A.</p>
 </li>
 <li>
-<p>cl_tensor_desc B: Tensor description for input matrix B.</p>
+<p>cl_tensor B: Tensor description for input matrix B.</p>
 </li>
 <li>
-<p>cl_tensor_desc R: Tensor description for output matrix C.</p>
+<p>cl_tensor R: Tensor description for output matrix C.</p>
 </li>
 <li>
 <p>cl_int transposeA: Non-zero transposes A matrix.</p>
@@ -1033,10 +1033,20 @@ n)</code> of tensors <code>A</code> and <code>B</code>, respectively, after poss
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Fields of the <code>cl_dbk_leaky_relu</code> structure:
-. cl_tensor_desc in: Input tensor description.
-. cl_tensor_desc out: Output tensor description.
-. cl_float alpha: Coefficient of leakage.</p>
+<p>Fields of the <code>cl_dbk_leaky_relu</code> structure:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>cl_tensor in: Input tensor description.</p>
+</li>
+<li>
+<p>cl_tensor out: Output tensor description.</p>
+</li>
+<li>
+<p>cl_float alpha: Coefficient of leakage.</p>
+</li>
+</ol>
 </div></div></td>
 </tr>
 <tr>
@@ -1158,7 +1168,7 @@ cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
 // Set tensor kernel arguments before binding storage to the tensors. This
 // gives clCreateBufferWithProperties() opportunity to reason about tensors'
 // uses for determining the optimal memory layout (opaque to application) and
-// the space neededfor the tensors.
+// the space needed for the tensors.
 clSetKernelArg(matmul_kernel, 0, sizeof(cl_tensor_t), &amp;lhs_tensor);
 clSetKernelArg(matmul_kernel, 1, sizeof(cl_tensor_t), &amp;rhs_tensor);
 clSetKernelArg(matmul_kernel, 2, sizeof(cl_tensor_t), &amp;res_tensor);
@@ -1278,7 +1288,7 @@ clEnqueueImportFromTensor(
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-11-22 12:21:47 +0200
+Last updated 2023-11-23 10:19:45 +0200
 </div>
 </div>
 </body>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -482,7 +482,7 @@ definitions and updating of previously defined ones.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-22</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0.2.0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Add APIs for defined built-in kernel (DBK) creation. Model DBKs on
 tensor type. Add sample code.</p></td>
@@ -500,20 +500,6 @@ tensor type. Add sample code.</p></td>
 </div>
 <div class="paragraph">
 <p>This extension requires cl_exp_tensor.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-cl_exp_tensor is unpublished, work-in-progress
-extension. Briefly, It will bring concept of tensor, N-dimensional
-data structure whose data layout is opaque to applications.
-</td>
-</tr>
-</table>
 </div>
 </div>
 <div class="sect3">
@@ -1292,7 +1278,7 @@ clEnqueueImportFromTensor(
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-11-21 13:16:24 +0200
+Last updated 2023-11-22 12:21:47 +0200
 </div>
 </div>
 </body>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -1,0 +1,1288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+<meta name="generator" content="AsciiDoc 10.1.2" />
+<title>cl_khr_defined_builtin_kernels</title>
+<style type="text/css">
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overridden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}
+
+
+</style>
+<script type="text/javascript">
+/*<![CDATA[*/
+var asciidoc = {  // Namespace.
+
+/////////////////////////////////////////////////////////////////////
+// Table Of Contents generator
+/////////////////////////////////////////////////////////////////////
+
+/* Author: Mihai Bazon, September 2002
+ * http://students.infoiasi.ro/~mishoo
+ *
+ * Table Of Content generator
+ * Version: 0.4
+ *
+ * Feel free to use this script under the terms of the GNU General Public
+ * License, as long as you do not remove or alter this notice.
+ */
+
+ /* modified by Troy D. Hanson, September 2006. License: GPL */
+ /* modified by Stuart Rackham, 2006, 2009. License: GPL */
+
+// toclevels = 1..4.
+toc: function (toclevels) {
+
+  function getText(el) {
+    var text = "";
+    for (var i = el.firstChild; i != null; i = i.nextSibling) {
+      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
+        text += i.data;
+      else if (i.firstChild != null)
+        text += getText(i);
+    }
+    return text;
+  }
+
+  function TocEntry(el, text, toclevel) {
+    this.element = el;
+    this.text = text;
+    this.toclevel = toclevel;
+  }
+
+  function tocEntries(el, toclevels) {
+    var result = new Array;
+    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
+    // Function that scans the DOM tree for header elements (the DOM2
+    // nodeIterator API would be a better technique but not supported by all
+    // browsers).
+    var iterate = function (el) {
+      for (var i = el.firstChild; i != null; i = i.nextSibling) {
+        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
+          var mo = re.exec(i.tagName);
+          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
+            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
+          }
+          iterate(i);
+        }
+      }
+    }
+    iterate(el);
+    return result;
+  }
+
+  var toc = document.getElementById("toc");
+  if (!toc) {
+    return;
+  }
+
+  // Delete existing TOC entries in case we're reloading the TOC.
+  var tocEntriesToRemove = [];
+  var i;
+  for (i = 0; i < toc.childNodes.length; i++) {
+    var entry = toc.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div'
+     && entry.getAttribute("class")
+     && entry.getAttribute("class").match(/^toclevel/))
+      tocEntriesToRemove.push(entry);
+  }
+  for (i = 0; i < tocEntriesToRemove.length; i++) {
+    toc.removeChild(tocEntriesToRemove[i]);
+  }
+
+  // Rebuild TOC entries.
+  var entries = tocEntries(document.getElementById("content"), toclevels);
+  for (var i = 0; i < entries.length; ++i) {
+    var entry = entries[i];
+    if (entry.element.id == "")
+      entry.element.id = "_toc_" + i;
+    var a = document.createElement("a");
+    a.href = "#" + entry.element.id;
+    a.appendChild(document.createTextNode(entry.text));
+    var div = document.createElement("div");
+    div.appendChild(a);
+    div.className = "toclevel" + entry.toclevel;
+    toc.appendChild(div);
+  }
+  if (entries.length == 0)
+    toc.parentNode.removeChild(toc);
+},
+
+
+/////////////////////////////////////////////////////////////////////
+// Footnotes generator
+/////////////////////////////////////////////////////////////////////
+
+/* Based on footnote generation code from:
+ * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
+ */
+
+footnotes: function () {
+  // Delete existing footnote entries in case we're reloading the footnodes.
+  var i;
+  var noteholder = document.getElementById("footnotes");
+  if (!noteholder) {
+    return;
+  }
+  var entriesToRemove = [];
+  for (i = 0; i < noteholder.childNodes.length; i++) {
+    var entry = noteholder.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
+      entriesToRemove.push(entry);
+  }
+  for (i = 0; i < entriesToRemove.length; i++) {
+    noteholder.removeChild(entriesToRemove[i]);
+  }
+
+  // Rebuild footnote entries.
+  var cont = document.getElementById("content");
+  var spans = cont.getElementsByTagName("span");
+  var refs = {};
+  var n = 0;
+  for (i=0; i<spans.length; i++) {
+    if (spans[i].className == "footnote") {
+      n++;
+      var note = spans[i].getAttribute("data-note");
+      if (!note) {
+        // Use [\s\S] in place of . so multi-line matches work.
+        // Because JavaScript has no s (dotall) regex flag.
+        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
+        spans[i].innerHTML =
+          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+        spans[i].setAttribute("data-note", note);
+      }
+      noteholder.innerHTML +=
+        "<div class='footnote' id='_footnote_" + n + "'>" +
+        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
+        n + "</a>. " + note + "</div>";
+      var id =spans[i].getAttribute("id");
+      if (id != null) refs["#"+id] = n;
+    }
+  }
+  if (n == 0)
+    noteholder.parentNode.removeChild(noteholder);
+  else {
+    // Process footnoterefs.
+    for (i=0; i<spans.length; i++) {
+      if (spans[i].className == "footnoteref") {
+        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
+        href = href.match(/#.*/)[0];  // Because IE return full URL.
+        n = refs[href];
+        spans[i].innerHTML =
+          "[<a href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+      }
+    }
+  }
+},
+
+install: function(toclevels) {
+  var timerId;
+
+  function reinstall() {
+    asciidoc.footnotes();
+    if (toclevels) {
+      asciidoc.toc(toclevels);
+    }
+  }
+
+  function reinstallAndRemoveTimer() {
+    clearInterval(timerId);
+    reinstall();
+  }
+
+  timerId = setInterval(reinstall, 500);
+  if (document.addEventListener)
+    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
+  else
+    window.onload = reinstallAndRemoveTimer;
+}
+
+}
+asciidoc.install();
+/*]]>*/
+</script>
+</head>
+<body class="article">
+<div id="header">
+<h1>cl_khr_defined_builtin_kernels</h1>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="cl_khr_defined_builtin_kernels">Khronos-Defined Built-in Kernels (Early Draft)</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>The purpose of this extension is to provide a standardized set of built-in
+kernels with well-defined semantics useful for accelerating applications
+from various domains.  The extension specification is designed to rapidly
+expand and "live" via addition of new well-defined built-in kernel
+definitions and updating of previously defined ones.</p></div>
+<div class="sect2">
+<h3 id="_general_information">General Information</h3>
+<div class="sect3">
+<h4 id="_name_strings">Name Strings</h4>
+<div class="paragraph"><p><code>cl_khr_defined_builtin_kernels</code></p></div>
+</div>
+<div class="sect3">
+<h4 id="_version_history">Version History</h4>
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="20%" />
+<col width="20%" />
+<col width="60%" />
+<thead>
+<tr>
+<th align="left" valign="top"> <strong>Date</strong>     </th>
+<th align="left" valign="top"> <strong>Version</strong> </th>
+<th align="left" valign="top"> <strong>Description</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left" valign="top"><p class="table">2022-12-13</p></td>
+<td align="left" valign="top"><p class="table">0.1.0</p></td>
+<td align="left" valign="top"><p class="table">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_dependencies">Dependencies</h4>
+<div class="paragraph"><p>This extension is written against the OpenCL Specification version 3.0.12.</p></div>
+<div class="paragraph"><p>This extension requires OpenCL 1.2 or later.</p></div>
+</div>
+<div class="sect3">
+<h4 id="_contributors">Contributors</h4>
+<div class="paragraph"><p>Pekka Jääskeläinen, Intel and Tampere University.<br />
+Topi Leppänen, Tampere University.<br />
+Jan Solanti, Tampere University.<br />
+Ben Ashbaugh, Intel.<br /></p></div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_overview">Overview</h3>
+<div class="paragraph"><p>OpenCL 1.2 specifies a built-in kernel (BiK) as a kernel that is executed on
+an OpenCL device or custom device by fixed-function hardware or in firmware.
+Applications can query the built-in kernels supported by a device or custom
+device.</p></div>
+<div class="paragraph"><p>BiKs are referred to by a name (a C string) without any semantics attached
+to the functionality. The semantics behind the name is completely device
+specific, typically documented in vendor-specific extension specifications.</p></div>
+<div class="paragraph"><p>The goal for this extension is to lower the bar for utilizing hardware
+accelerated functions in drivers by providing a library of
+well-defined BiKs with good coverage for common acceleration needs
+and which is designed to easily evolve over time.</p></div>
+<div class="paragraph"><p>The device drivers that implement this extension can freely choose which
+subset of defined BiKs they implement and advertise to the clients. The
+clients can use the BiKs to accelerate their applications by manually
+executing invoking the BiKs. The extension is designed to also support using
+automated task graph lowering tooling later.</p></div>
+<div class="sect3">
+<h4 id="_background">Background</h4>
+<div class="paragraph"><p>ASIC-based coarse-grained hardware accelerators are specialized logic meant to
+speed up execution of workloads of interest, or to provide improvements in
+energy-efficiency. Examples of contemporary workloads that are beneficially hardware
+accelerated over software-based implementations include video coding, deep learning,
+cryptography, software-defined radio and graphics rendering.</p></div>
+<div class="paragraph"><p>FPGAs form a special case somewhere between instruction-set architectures and fixed
+function hardware accelerators. While advances in high-level synthesis tools
+have attempted to bridge the programmability gap between GPU and FPGA programming,
+FPGAs are still considered as devices which are challenging to achieve efficient
+implementations with. Due to extensive manual optimization work required for efficient
+implementations of the accelerated functionality, defining FPGA designs as
+a system of "hardware accelerator IPs" is still a widely used "application abstraction".
+FPGAs can be thus seen as a platform that can realize and integrate any
+hardware accelerator implementable with the programmable fabric.</p></div>
+<div class="paragraph"><p>The means to utilize hardware accelerators have typically been
+vendor-specific and abstracted behind domain-specific libraries.
+The overhead with the "bunch of libraries"-approach is seen in the lowest level
+of integration: The libraries utilize a low level library (typically
+vendor-specific) to interface with the actual hardware, and thus does not
+integrate efficiently with other libraries or software-programmable processors
+that might be available on the same chip.</p></div>
+</div>
+<div class="sect3">
+<h4 id="_rationale">Rationale</h4>
+<div class="paragraph"><p>OpenCL&#8217;s built-in kernel abstraction allows pushing both hardware
+accelerated and software defined kernels to the same command-queues,
+providing a powerful means for asynchronous execution of heterogeneous
+task graphs on diverse heterogeneous platforms. The ability to invoke hardware
+accelerators while being able to synchronize and optimize data transfers at
+the lowest levels of the driver stack can provide significant latency benefits,
+especially when combined with the command-buffering mechanism.</p></div>
+<div class="paragraph"><p>However, the BiK abstraction works well only when it is widely adopted by
+vendors, and when multiple vendors implement the same definitions. Otherwise
+each vendor specifies and implements their own BiKs closely matching their
+own hardware accelerator properties, resulting in lack of cross-vendor
+portability in the API abstraction presented to the upper layers of
+heterogeneous computing software stacks.</p></div>
+<div class="paragraph"><p>This extension standardizes a set of well-defined BiKs the clients can
+call from higher level programming stacks built with different languages
+and multiple libraries, possibly mix accelerator calls with calls to software kernel
+commands, and rely on the driver stack to optimize the execution (especially
+the synchronization and communication) as a low level heterogeneous task graph.
+It aims to promote the use of BiKs as a programming model for hardware accelerated
+functionality, to improve cross-vendor portability of hardware accelerated computing.</p></div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_modifications_to_section_4_2_of_the_opencl_api_specification">Modifications to section 4.2 of the OpenCL API Specification</h3>
+<div class="paragraph"><p>Modify <strong>Table 5</strong>, <em>Device Queries</em>, of section 4.2, by adding the following
+sentences to the description cell of <code>CL_DEVICE_BUILT_IN_KERNELS</code>:</p></div>
+<div class="quoteblock">
+<div class="content">The semantics of the returned built-in kernels are undefined or defined in
+vendor-specific documentation, unless the name starts with prefix &#8216;khr_&#8217;,
+which means it&#8217;s a built-in kernel with semantics defined in Appendix I.</div>
+<div class="attribution">
+</div></div>
+</div>
+<div class="sect2">
+<h3 id="_add_new_appendix_appendix_i_defined_built_in_kernels_to_opencl_api_specification">Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification</h3>
+<div class="paragraph"><p>This chapter describes standard built-in kernels (BiK) with well-defined
+semantics. A conformant device can report to support zero or more of the built-in
+kernels via <code>CL_DEVICE_BUILT_IN_KERNELS</code> or <code>CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION</code> device queries.</p></div>
+<div class="paragraph"><p>The general client-side abstraction of the defined built-in kernels is similar to a call
+to a C function of which implementation is hidden. The device driver can invoke one or
+more physical hardware accelerators combined with firmware to implement the semantics
+as efficiently as possible.</p></div>
+<div class="paragraph"><p>It is the driver&#8217;s responsibility to handle efficient synchronization and communication
+to the hardware accelerator, the internal accelerator state management and resource sharing
+across multiple OpenCL contexts.</p></div>
+<div class="sect3">
+<h4 id="_standard_built_in_kernels">Standard Built-in Kernels</h4>
+<div class="paragraph"><p>The following list of recognized built-ins is organized according to their application
+domain and handled data types. It is expected to grow and update while preserving backwards
+compatibility.</p></div>
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<caption class="title">Table A.I.1. Standard Built-in Kernels and Their Semantics. <strong>The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.</strong></caption>
+<col width="12%" />
+<col width="37%" />
+<col width="25%" />
+<col width="25%" />
+<tbody>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table"><strong>General linear algebra</strong></p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table">Name</p></td>
+<td align="left" valign="top"><p class="table">Description</p></td>
+<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
+<td align="left" valign="top"><p class="table">Arguments</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table"><strong>khr_blas_gemm_float</strong></p></td>
+<td align="left" valign="top"><p class="table">xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.</p></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="1">
+<li>
+<p>
+The height.
+</p>
+</li>
+<li>
+<p>
+The width.
+</p>
+</li>
+</ol></div></div></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<li>
+<p>
+int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)
+</p>
+</li>
+<li>
+<p>
+int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)
+</p>
+</li>
+<li>
+<p>
+float: scalar (alpha) to multiply the matrix multiplication result elements with
+</p>
+</li>
+<li>
+<p>
+float* (input): matrix A
+</p>
+</li>
+<li>
+<p>
+int: leading dimension of A (0 = row-major, 1 = column-major)
+</p>
+</li>
+<li>
+<p>
+float* (input): matrix B
+</p>
+</li>
+<li>
+<p>
+int: leading dimension of B (0 = row-major, 1 = column-major)
+</p>
+</li>
+<li>
+<p>
+float: scalar (beta) to multiply the C matrix elements with before adding it to the result
+</p>
+</li>
+<li>
+<p>
+float* (input&amp;output): matrix C which is added to the matrix multiplication result, and stores the output
+</p>
+</li>
+<li>
+<p>
+int: leading dimension of C (0 = row-major, 1 = column-major)
+</p>
+</li>
+</ol></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><div><div class="listingblock">
+<div class="content"><!-- Generator: GNU source-highlight
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite -->
+<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_blas_gemm_float</span></span><span style="color: #990000">(</span>
+   <span style="color: #009900">int</span> transA<span style="color: #990000">,</span> <span style="color: #009900">int</span> transB<span style="color: #990000">,</span> <span style="color: #009900">float</span> alpha<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>A<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldA<span style="color: #990000">,</span>
+   <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>B<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldB<span style="color: #990000">,</span>
+   <span style="color: #009900">float</span> beta<span style="color: #990000">,</span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>C<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldC<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+   <span style="font-style: italic"><span style="color: #9A1900">// TBD: An example implementation that can be used for verification</span></span>
+   <span style="font-style: italic"><span style="color: #9A1900">// and as a fallback SW implementation.</span></span>
+<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table"><strong>OpenVX Neural Network Extension Compatible Kernels</strong></p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table">Name</p></td>
+<td align="left" valign="top"><p class="table">Description</p></td>
+<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
+<td align="left" valign="top"><p class="table">Arguments</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table"><strong>khr_openvx_nn_extension_convolution_uchar</strong></p></td>
+<td align="left" valign="top"><p class="table">Convolution for 8bit unsigned integer inputs and weights.</p></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="1">
+<li>
+<p>
+Batch size.
+</p>
+</li>
+<li>
+<p>
+Width.
+</p>
+</li>
+<li>
+<p>
+Height.
+</p>
+</li>
+</ol></div></div></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<li>
+<p>
+uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].
+</p>
+</li>
+<li>
+<p>
+uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].
+</p>
+</li>
+<li>
+<p>
+uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2)
+</p>
+</li>
+<li>
+<p>
+size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.
+</p>
+</li>
+<li>
+<p>
+size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.
+</p>
+</li>
+<li>
+<p>
+int: Rounding method for calculating output dimensions.
+</p>
+</li>
+<li>
+<p>
+int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.
+</p>
+</li>
+<li>
+<p>
+size_t: Number of elements padded at each side in the x dimension of the input.
+</p>
+</li>
+<li>
+<p>
+size_t: Number of elements padded at each side in the y dimension of the input.
+</p>
+</li>
+<li>
+<p>
+int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.
+</p>
+</li>
+<li>
+<p>
+uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)
+</p>
+</li>
+</ol></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><div><div class="listingblock">
+<div class="content"><!-- Generator: GNU source-highlight
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite -->
+<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_openvx_nn_extension_convolution_uchar</span></span><span style="color: #990000">(</span>
+   <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>input<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>weights<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>biases<span style="color: #990000">,</span>
+   <span style="color: #008080">size_t</span> dilation_x<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> dilation_y<span style="color: #990000">,</span>
+   <span style="color: #009900">int</span> down_scale_rounding<span style="color: #990000">,</span> <span style="color: #009900">int</span> overflow_policy<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> padding_x<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> padding_y<span style="color: #990000">,</span>
+   <span style="color: #009900">int</span> rounding_policy<span style="color: #990000">,</span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+   <span style="font-style: italic"><span style="color: #9A1900">// TBD.</span></span>
+<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table"><strong>Direct Input/Output Operations</strong></p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">Kernels for accessing data sources and destinations directly without host involvement.</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table">Name</p></td>
+<td align="left" valign="top"><p class="table">Description</p></td>
+<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
+<td align="left" valign="top"><p class="table">Arguments</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table"><strong>khr_io_stream_in_uchar</strong></p></td>
+<td align="left" valign="top"><p class="table">Non-blocking read of data from a sensor/stream associated with the device.</p></td>
+<td align="left" valign="top"><div><div class="literalblock">
+<div class="content">
+<pre><code>-</code></pre>
+</div></div></div></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<li>
+<p>
+uchar* [out]: The data.
+</p>
+</li>
+<li>
+<p>
+size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the <code>cl_pocl_content_size</code> extension to optimize data transfers with.)
+</p>
+</li>
+</ol></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><div><div class="listingblock">
+<div class="content"><!-- Generator: GNU source-highlight
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite -->
+<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_uchar</span></span><span style="color: #990000">(</span>
+   <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+   <span style="font-style: italic"><span style="color: #9A1900">// It is not feasible to describe this kernel in OpenCL C as I/O devices</span></span>
+   <span style="font-style: italic"><span style="color: #9A1900">// are not representable with it.</span></span>
+<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table"><strong>khr_io_stream_out_uchar</strong></p></td>
+<td align="left" valign="top"><p class="table">Non-blocking write of data to an output/sink associated with the device.</p></td>
+<td align="left" valign="top"><p class="table">-</p></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<li>
+<p>
+uchar* [in]: The data to write.
+</p>
+</li>
+<li>
+<p>
+size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).
+</p>
+</li>
+</ol></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><div><div class="listingblock">
+<div class="content"><!-- Generator: GNU source-highlight
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite -->
+<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_out_uchar</span></span><span style="color: #990000">(</span>
+   <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>input<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+   <span style="font-style: italic"><span style="color: #9A1900">// It is not feasible to describe this kernel in OpenCL C as I/O devices</span></span>
+   <span style="font-style: italic"><span style="color: #9A1900">// are not representable with it.</span></span>
+<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table"><strong>khr_io_stream_in_blocking_uchar</strong></p></td>
+<td align="left" valign="top"><p class="table">Blocking read of data from a sensor/stream associated with the device.</p></td>
+<td align="left" valign="top"><div><div class="literalblock">
+<div class="content">
+<pre><code>-</code></pre>
+</div></div></div></td>
+<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<li>
+<p>
+uchar* [out]: The data.
+</p>
+<div class="ulist"><ul>
+<li>
+<p>
+size_t* [in]: How many bytes to read before returning.
+</p>
+</li>
+</ul></div>
+</li>
+</ol></div></div></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td colspan="4" align="left" valign="top"><div><div class="listingblock">
+<div class="content"><!-- Generator: GNU source-highlight
+by Lorenzo Bettini
+http://www.lorenzobettini.it
+http://www.gnu.org/software/src-highlite -->
+<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_blocking_uchar</span></span><span style="color: #990000">(</span><span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+   <span style="font-weight: bold"><span style="color: #0000FF">while</span></span> <span style="color: #990000">(*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
+       <span style="color: #008080">size_t</span> num_read <span style="color: #990000">=</span> <span style="color: #990000">*</span>num<span style="color: #990000">;</span>
+       <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_uchar</span></span><span style="color: #990000">(</span>output<span style="color: #990000">,</span> <span style="color: #990000">&amp;</span>num_read<span style="color: #990000">);</span>
+       num <span style="color: #990000">-=</span> num_read<span style="color: #990000">;</span>
+       output <span style="color: #990000">+=</span> num_read<span style="color: #990000">;</span>
+   <span style="color: #FF0000">}</span>
+<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_launching_biks_from_the_device_side">Launching BiKs from the Device Side</h4>
+<div class="paragraph"><p>BiKs are primarily meant to be launched as kernel commands via host-side command queues.
+Optionally, they can be callable from device-side via
+<code>enqueue_kernel</code>: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: <code>cl_khr_bik_BUILTIN_KERNEL_NAME</code>. In case a BiK macro is defined, a kernel with a naming convention <code>__khr_BUILTIN_KERNEL_NAME()</code> can be enqueued by the program at device side as software-defined kernels.</p></div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_open_questions">Open questions</h3>
+<div class="olist arabic"><ol class="arabic">
+<li>
+<p>
+Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
+</div></div>
+</li>
+<li>
+<p>
+Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
+</div></div>
+</li>
+<li>
+<p>
+Different accelerators prefer different channel orders (NHWC vs. NCHW&#8230;) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM&#8217;s row/column order) or is it better to have different BiK variations for each?
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
+</div></div>
+</li>
+<li>
+<p>
+How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
+</div></div>
+</li>
+<li>
+<p>
+Since the defined built-in kernel concept is basically just a C-like API inside another API, should it be made more generic and thus directly usable for SYCL and Vulkan as well?
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
+</div></div>
+</li>
+</ol></div>
+</div>
+</div>
+</div>
+</div>
+<div id="footnotes"><hr /></div>
+<div id="footer">
+<div id="footer-text">
+Last updated
+ 2022-12-13 15:52:00 EET
+</div>
+</div>
+</body>
+</html>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -1,736 +1,441 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 10.1.2" />
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.16">
 <title>cl_khr_defined_builtin_kernels</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
-
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
-
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;-webkit-tap-highlight-color:transparent}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install();
-/*]]>*/
-</script>
 </head>
 <body class="article">
 <div id="header">
@@ -740,83 +445,107 @@ asciidoc.install();
 <div class="sect1">
 <h2 id="cl_khr_defined_builtin_kernels">Khronos-Defined Built-in Kernels (Early Draft)</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The purpose of this extension is to provide a standardized set of built-in
+<div class="paragraph">
+<p>The purpose of this extension is to provide a standardized set of built-in
 kernels with well-defined semantics useful for accelerating applications
 from various domains.  The extension specification is designed to rapidly
 expand and "live" via addition of new well-defined built-in kernel
-definitions and updating of previously defined ones.</p></div>
+definitions and updating of previously defined ones.</p>
+</div>
 <div class="sect2">
 <h3 id="_general_information">General Information</h3>
 <div class="sect3">
 <h4 id="_name_strings">Name Strings</h4>
-<div class="paragraph"><p><code>cl_khr_defined_builtin_kernels</code></p></div>
+<div class="paragraph">
+<p><code>cl_khr_defined_builtin_kernels</code></p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_version_history">Version History</h4>
-<div class="tableblock">
-<table rules="all"
-width="100%"
-frame="border"
-cellspacing="0" cellpadding="4">
-<col width="20%" />
-<col width="20%" />
-<col width="60%" />
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 60%;">
+</colgroup>
 <thead>
 <tr>
-<th align="left" valign="top"> <strong>Date</strong>     </th>
-<th align="left" valign="top"> <strong>Version</strong> </th>
-<th align="left" valign="top"> <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Date</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Version</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="left" valign="top"><p class="table">2022-12-13</p></td>
-<td align="left" valign="top"><p class="table">0.1.0</p></td>
-<td align="left" valign="top"><p class="table">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-12-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">First formulation as an extension specification like proposed by Ben Ashbaugh.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TODO</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TODO</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reference new concept as "defined built-in kernel".</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
 <div class="sect3">
 <h4 id="_dependencies">Dependencies</h4>
-<div class="paragraph"><p>This extension is written against the OpenCL Specification version 3.0.12.</p></div>
-<div class="paragraph"><p>This extension requires OpenCL 1.2 or later.</p></div>
+<div class="paragraph">
+<p>This extension is written against the OpenCL Specification version 3.0.12.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires OpenCL 1.2 or later.</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_contributors">Contributors</h4>
-<div class="paragraph"><p>Pekka Jääskeläinen, Intel and Tampere University.<br />
-Topi Leppänen, Tampere University.<br />
-Jan Solanti, Tampere University.<br />
-Ben Ashbaugh, Intel.<br /></p></div>
+<div class="paragraph">
+<p>Pekka Jääskeläinen, Intel and Tampere University.<br>
+Topi Leppänen, Tampere University.<br>
+Jan Solanti, Tampere University.<br>
+Ben Ashbaugh, Intel.<br></p>
+</div>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_overview">Overview</h3>
-<div class="paragraph"><p>OpenCL 1.2 specifies a built-in kernel (BiK) as a kernel that is executed on
+<div class="paragraph">
+<p>OpenCL 1.2 specifies a built-in kernel as a kernel that is executed on
 an OpenCL device or custom device by fixed-function hardware or in firmware.
 Applications can query the built-in kernels supported by a device or custom
-device.</p></div>
-<div class="paragraph"><p>BiKs are referred to by a name (a C string) without any semantics attached
-to the functionality. The semantics behind the name is completely device
-specific, typically documented in vendor-specific extension specifications.</p></div>
-<div class="paragraph"><p>The goal for this extension is to lower the bar for utilizing hardware
+device.</p>
+</div>
+<div class="paragraph">
+<p>Built-in kernels are referred to by a name (a C string) without any
+semantics attached to the functionality. The semantics behind the name
+is completely device specific, typically documented in vendor-specific
+extension specifications.</p>
+</div>
+<div class="paragraph">
+<p>The goal for this extension is to lower the bar for utilizing hardware
 accelerated functions in drivers by providing a library of
-well-defined BiKs with good coverage for common acceleration needs
-and which is designed to easily evolve over time.</p></div>
-<div class="paragraph"><p>The device drivers that implement this extension can freely choose which
+well-defined built-in kernel with good coverage for common acceleration needs
+and which is designed to easily evolve over time.</p>
+</div>
+<div class="paragraph">
+<p>The device drivers that implement this extension can freely choose which
 subset of defined BiKs they implement and advertise to the clients. The
 clients can use the BiKs to accelerate their applications by manually
 executing invoking the BiKs. The extension is designed to also support using
-automated task graph lowering tooling later.</p></div>
+automated task graph lowering tooling later.</p>
+</div>
 <div class="sect3">
 <h4 id="_background">Background</h4>
-<div class="paragraph"><p>ASIC-based coarse-grained hardware accelerators are specialized logic meant to
+<div class="paragraph">
+<p>ASIC-based coarse-grained hardware accelerators are specialized logic meant to
 speed up execution of workloads of interest, or to provide improvements in
 energy-efficiency. Examples of contemporary workloads that are beneficially hardware
 accelerated over software-based implementations include video coding, deep learning,
-cryptography, software-defined radio and graphics rendering.</p></div>
-<div class="paragraph"><p>FPGAs form a special case somewhere between instruction-set architectures and fixed
+cryptography, software-defined radio and graphics rendering.</p>
+</div>
+<div class="paragraph">
+<p>FPGAs form a special case somewhere between instruction-set architectures and fixed
 function hardware accelerators. While advances in high-level synthesis tools
 have attempted to bridge the programmability gap between GPU and FPGA programming,
 FPGAs are still considered as devices which are challenging to achieve efficient
@@ -824,464 +553,433 @@ implementations with. Due to extensive manual optimization work required for eff
 implementations of the accelerated functionality, defining FPGA designs as
 a system of "hardware accelerator IPs" is still a widely used "application abstraction".
 FPGAs can be thus seen as a platform that can realize and integrate any
-hardware accelerator implementable with the programmable fabric.</p></div>
-<div class="paragraph"><p>The means to utilize hardware accelerators have typically been
+hardware accelerator implementable with the programmable fabric.</p>
+</div>
+<div class="paragraph">
+<p>The means to utilize hardware accelerators have typically been
 vendor-specific and abstracted behind domain-specific libraries.
 The overhead with the "bunch of libraries"-approach is seen in the lowest level
 of integration: The libraries utilize a low level library (typically
 vendor-specific) to interface with the actual hardware, and thus does not
 integrate efficiently with other libraries or software-programmable processors
-that might be available on the same chip.</p></div>
+that might be available on the same chip.</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_rationale">Rationale</h4>
-<div class="paragraph"><p>OpenCL&#8217;s built-in kernel abstraction allows pushing both hardware
+<div class="paragraph">
+<p>OpenCL&#8217;s built-in kernel abstraction allows pushing both hardware
 accelerated and software defined kernels to the same command-queues,
 providing a powerful means for asynchronous execution of heterogeneous
 task graphs on diverse heterogeneous platforms. The ability to invoke hardware
 accelerators while being able to synchronize and optimize data transfers at
 the lowest levels of the driver stack can provide significant latency benefits,
-especially when combined with the command-buffering mechanism.</p></div>
-<div class="paragraph"><p>However, the BiK abstraction works well only when it is widely adopted by
+especially when combined with the command-buffering mechanism.</p>
+</div>
+<div class="paragraph">
+<p>However, the built-in kernel abstraction works well only when it is widely adopted by
 vendors, and when multiple vendors implement the same definitions. Otherwise
-each vendor specifies and implements their own BiKs closely matching their
+each vendor specifies and implements their own built-in kernels closely matching their
 own hardware accelerator properties, resulting in lack of cross-vendor
 portability in the API abstraction presented to the upper layers of
-heterogeneous computing software stacks.</p></div>
-<div class="paragraph"><p>This extension standardizes a set of well-defined BiKs the clients can
+heterogeneous computing software stacks.</p>
+</div>
+<div class="paragraph">
+<p>This extension standardizes a set of well-defined built-in kernels the clients can
 call from higher level programming stacks built with different languages
 and multiple libraries, possibly mix accelerator calls with calls to software kernel
 commands, and rely on the driver stack to optimize the execution (especially
 the synchronization and communication) as a low level heterogeneous task graph.
-It aims to promote the use of BiKs as a programming model for hardware accelerated
-functionality, to improve cross-vendor portability of hardware accelerated computing.</p></div>
+It aims to promote the use of built-in kernels as a programming model for hardware accelerated
+functionality, to improve cross-vendor portability of hardware accelerated computing.</p>
+</div>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_modifications_to_section_4_2_of_the_opencl_api_specification">Modifications to section 4.2 of the OpenCL API Specification</h3>
-<div class="paragraph"><p>Modify <strong>Table 5</strong>, <em>Device Queries</em>, of section 4.2, by adding the following
-sentences to the description cell of <code>CL_DEVICE_BUILT_IN_KERNELS</code>:</p></div>
+<div class="paragraph">
+<p>Modify <strong>Table 5</strong>, <em>Device Queries</em>, of section 4.2, by adding the following
+sentences to the description cell of <code>CL_DEVICE_BUILT_IN_KERNELS</code>:</p>
+</div>
 <div class="quoteblock">
-<div class="content">The semantics of the returned built-in kernels are undefined or defined in
-vendor-specific documentation, unless the name starts with prefix &#8216;khr_&#8217;,
-which means it&#8217;s a built-in kernel with semantics defined in Appendix I.</div>
-<div class="attribution">
-</div></div>
+<blockquote>
+The semantics of the returned built-in kernels are undefined or defined in
+vendor-specific documentation, unless the name starts with prefix `khr_',
+which means it&#8217;s a defined built-in kernel with semantics defined in Appendix I.
+</blockquote>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_new_appendix_appendix_i_defined_built_in_kernels_to_opencl_api_specification">Add new appendix "Appendix I - Defined Built-in Kernels" to OpenCL API Specification</h3>
-<div class="paragraph"><p>This chapter describes standard built-in kernels (BiK) with well-defined
+<div class="paragraph">
+<p>This chapter describes standard defined built-in kernels (DBK) with well-defined
 semantics. A conformant device can report to support zero or more of the built-in
-kernels via <code>CL_DEVICE_BUILT_IN_KERNELS</code> or <code>CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION</code> device queries.</p></div>
-<div class="paragraph"><p>The general client-side abstraction of the defined built-in kernels is similar to a call
-to a C function of which implementation is hidden. The device driver can invoke one or
-more physical hardware accelerators combined with firmware to implement the semantics
-as efficiently as possible.</p></div>
-<div class="paragraph"><p>It is the driver&#8217;s responsibility to handle efficient synchronization and communication
+kernels via <code>CL_DEVICE_BUILT_IN_KERNELS</code> or <code>CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION</code> device queries.</p>
+</div>
+<div class="paragraph">
+<p>The general client-side abstraction of the DBKs is similar to a call
+to a C function of which implementation is hidden. The device driver
+can invoke one or more physical hardware accelerators combined with
+firmware to implement the semantics as efficiently as possible.</p>
+</div>
+<div class="paragraph">
+<p>It is the driver&#8217;s responsibility to handle efficient synchronization and communication
 to the hardware accelerator, the internal accelerator state management and resource sharing
-across multiple OpenCL contexts.</p></div>
+across multiple OpenCL contexts.</p>
+</div>
 <div class="sect3">
-<h4 id="_standard_built_in_kernels">Standard Built-in Kernels</h4>
-<div class="paragraph"><p>The following list of recognized built-ins is organized according to their application
-domain and handled data types. It is expected to grow and update while preserving backwards
-compatibility.</p></div>
-<div class="tableblock">
-<table rules="all"
-width="100%"
-frame="border"
-cellspacing="0" cellpadding="4">
+<h4 id="_standard_defined_built_in_kernels">Standard Defined Built-in Kernels</h4>
+<div class="paragraph">
+<p>The following list of recognized defined built-ins is organized
+according to their application domain and handled data types. It is
+expected to grow and update while preserving backwards compatibility.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table A.I.1. Standard Built-in Kernels and Their Semantics. <strong>The table has been populated with a small set of non-trivial example entries which are subject to change and the list to expand during drafting.</strong></caption>
-<col width="12%" />
-<col width="37%" />
-<col width="25%" />
-<col width="25%" />
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td colspan="4" align="left" valign="top"><p class="table"><strong>General linear algebra</strong></p></td>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>General linear algebra</strong></p></td>
 </tr>
 <tr>
-<td align="left" valign="top"><p class="table">Name</p></td>
-<td align="left" valign="top"><p class="table">Description</p></td>
-<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
-<td align="left" valign="top"><p class="table">Arguments</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
 </tr>
 <tr>
-<td align="left" valign="top"><p class="table"><strong>khr_blas_gemm_float</strong></p></td>
-<td align="left" valign="top"><p class="table">xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.</p></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="1">
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_blas_gemm_float</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">xGEMM: General matrix multiplication with real single precision floating point numbers as described in Basic Linear Algebra Subprograms. Performs C = alpha * trans(A) * trans(B) + beta*C, where A, B and C are matrices, and alpha and beta scalars. trans() is a configurable transpose operation.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="1">
 <li>
-<p>
-The height.
-</p>
+<p>The height.</p>
 </li>
 <li>
-<p>
-The width.
-</p>
+<p>The width.</p>
 </li>
-</ol></div></div></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+</ol>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="0">
 <li>
-<p>
-int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)
-</p>
+<p>int: transpose operation (trans) type for matrix A (0 = none, 1 = transpose, 2 = conjugate transpose)</p>
 </li>
 <li>
-<p>
-int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)
-</p>
+<p>int: transpose type for matrix B (0 = none, 1 = transpose, 2 = conjugate transpose)</p>
 </li>
 <li>
-<p>
-float: scalar (alpha) to multiply the matrix multiplication result elements with
-</p>
+<p>float: scalar (alpha) to multiply the matrix multiplication result elements with</p>
 </li>
 <li>
-<p>
-float* (input): matrix A
-</p>
+<p>float* (input): matrix A</p>
 </li>
 <li>
-<p>
-int: leading dimension of A (0 = row-major, 1 = column-major)
-</p>
+<p>int: leading dimension of A (0 = row-major, 1 = column-major)</p>
 </li>
 <li>
-<p>
-float* (input): matrix B
-</p>
+<p>float* (input): matrix B</p>
 </li>
 <li>
-<p>
-int: leading dimension of B (0 = row-major, 1 = column-major)
-</p>
+<p>int: leading dimension of B (0 = row-major, 1 = column-major)</p>
 </li>
 <li>
-<p>
-float: scalar (beta) to multiply the C matrix elements with before adding it to the result
-</p>
+<p>float: scalar (beta) to multiply the C matrix elements with before adding it to the result</p>
 </li>
 <li>
-<p>
-float* (input&amp;output): matrix C which is added to the matrix multiplication result, and stores the output
-</p>
+<p>float* (input&amp;output): matrix C which is added to the matrix multiplication result, and stores the output</p>
 </li>
 <li>
-<p>
-int: leading dimension of C (0 = row-major, 1 = column-major)
-</p>
+<p>int: leading dimension of C (0 = row-major, 1 = column-major)</p>
 </li>
-</ol></div></div></td>
+</ol>
+</div></div></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_blas_gemm_float</span></span><span style="color: #990000">(</span>
-   <span style="color: #009900">int</span> transA<span style="color: #990000">,</span> <span style="color: #009900">int</span> transB<span style="color: #990000">,</span> <span style="color: #009900">float</span> alpha<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>A<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldA<span style="color: #990000">,</span>
-   <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>B<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldB<span style="color: #990000">,</span>
-   <span style="color: #009900">float</span> beta<span style="color: #990000">,</span> <span style="color: #008080">global</span> <span style="color: #009900">float</span> <span style="color: #990000">*</span>C<span style="color: #990000">,</span> <span style="color: #009900">int</span> ldC<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-   <span style="font-style: italic"><span style="color: #9A1900">// TBD: An example implementation that can be used for verification</span></span>
-   <span style="font-style: italic"><span style="color: #9A1900">// and as a fallback SW implementation.</span></span>
-<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><p class="table"><strong>OpenVX Neural Network Extension Compatible Kernels</strong></p></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table">Name</p></td>
-<td align="left" valign="top"><p class="table">Description</p></td>
-<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
-<td align="left" valign="top"><p class="table">Arguments</p></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table"><strong>khr_openvx_nn_extension_convolution_uchar</strong></p></td>
-<td align="left" valign="top"><p class="table">Convolution for 8bit unsigned integer inputs and weights.</p></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="1">
-<li>
-<p>
-Batch size.
-</p>
-</li>
-<li>
-<p>
-Width.
-</p>
-</li>
-<li>
-<p>
-Height.
-</p>
-</li>
-</ol></div></div></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
-<li>
-<p>
-uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].
-</p>
-</li>
-<li>
-<p>
-uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].
-</p>
-</li>
-<li>
-<p>
-uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2)
-</p>
-</li>
-<li>
-<p>
-size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.
-</p>
-</li>
-<li>
-<p>
-size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.
-</p>
-</li>
-<li>
-<p>
-int: Rounding method for calculating output dimensions.
-</p>
-</li>
-<li>
-<p>
-int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.
-</p>
-</li>
-<li>
-<p>
-size_t: Number of elements padded at each side in the x dimension of the input.
-</p>
-</li>
-<li>
-<p>
-size_t: Number of elements padded at each side in the y dimension of the input.
-</p>
-</li>
-<li>
-<p>
-int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.
-</p>
-</li>
-<li>
-<p>
-uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)
-</p>
-</li>
-</ol></div></div></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_openvx_nn_extension_convolution_uchar</span></span><span style="color: #990000">(</span>
-   <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>input<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>weights<span style="color: #990000">,</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>biases<span style="color: #990000">,</span>
-   <span style="color: #008080">size_t</span> dilation_x<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> dilation_y<span style="color: #990000">,</span>
-   <span style="color: #009900">int</span> down_scale_rounding<span style="color: #990000">,</span> <span style="color: #009900">int</span> overflow_policy<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> padding_x<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> padding_y<span style="color: #990000">,</span>
-   <span style="color: #009900">int</span> rounding_policy<span style="color: #990000">,</span> <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-   <span style="font-style: italic"><span style="color: #9A1900">// TBD.</span></span>
-<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><p class="table"><strong>Direct Input/Output Operations</strong></p></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><p class="table">Kernels for accessing data sources and destinations directly without host involvement.</p></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table">Name</p></td>
-<td align="left" valign="top"><p class="table">Description</p></td>
-<td align="left" valign="top"><p class="table">NDRange Dimensions</p></td>
-<td align="left" valign="top"><p class="table">Arguments</p></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table"><strong>khr_io_stream_in_uchar</strong></p></td>
-<td align="left" valign="top"><p class="table">Non-blocking read of data from a sensor/stream associated with the device.</p></td>
-<td align="left" valign="top"><div><div class="literalblock">
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
 <div class="content">
-<pre><code>-</code></pre>
-</div></div></div></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
+<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_blas_gemm_float(
+   int transA, int transB, float alpha, const global float *A, int ldA,
+   const global float *B, int ldB,
+   float beta, global float *C, int ldC) {
+   // TBD: An example implementation that can be used for verification
+   // and as a fallback SW implementation.
+}</code></pre>
+</div>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpenVX Neural Network Extension Compatible Kernels</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_openvx_nn_extension_convolution_uchar</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Convolution for 8bit unsigned integer inputs and weights.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="1">
 <li>
-<p>
-uchar* [out]: The data.
-</p>
+<p>Batch size.</p>
 </li>
 <li>
-<p>
-size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the <code>cl_pocl_content_size</code> extension to optimize data transfers with.)
-</p>
-</li>
-</ol></div></div></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
-</tr>
-<tr>
-<td colspan="4" align="left" valign="top"><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_uchar</span></span><span style="color: #990000">(</span>
-   <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-   <span style="font-style: italic"><span style="color: #9A1900">// It is not feasible to describe this kernel in OpenCL C as I/O devices</span></span>
-   <span style="font-style: italic"><span style="color: #9A1900">// are not representable with it.</span></span>
-<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table"><strong>khr_io_stream_out_uchar</strong></p></td>
-<td align="left" valign="top"><p class="table">Non-blocking write of data to an output/sink associated with the device.</p></td>
-<td align="left" valign="top"><p class="table">-</p></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
-<li>
-<p>
-uchar* [in]: The data to write.
-</p>
+<p>Width.</p>
 </li>
 <li>
-<p>
-size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).
-</p>
+<p>Height.</p>
 </li>
-</ol></div></div></td>
+</ol>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="0">
+<li>
+<p>uchar* [in]: The input tensor data. 3 lower dimensions represent a single input, all following dimensions represent number of batches, possibly nested. The dimension order is [width, height, #IFM, #batches].</p>
+</li>
+<li>
+<p>uchar* [in]: Weights, as a 4d tensor with dimensions [kernel_x, kernel_y, #IFM, #OFM].</p>
+</li>
+<li>
+<p>uchar* [in]: Biases (optional, ignored if NULL). The biases, which may be shared (one per ofm) or unshared (one per ofm * output location). The possible layouts are either [#OFM] or [width, height, #OFM]. Biases data type must match the data type of the inputs. (Kernel parameter #2)</p>
+</li>
+<li>
+<p>size_t: (dilation_x) “inflate” the kernel by inserting zeros between the kernel elements in the x direction. The value is the number of zeros to insert.</p>
+</li>
+<li>
+<p>size_t: (dilation_y) “inflate” the kernel by inserting zeros between the kernel elements in the y direction. The value is the number of zeros to insert.</p>
+</li>
+<li>
+<p>int: Rounding method for calculating output dimensions.</p>
+</li>
+<li>
+<p>int: A VX_TYPE_ENUM of the vx_convert_policy_e enumeration.</p>
+</li>
+<li>
+<p>size_t: Number of elements padded at each side in the x dimension of the input.</p>
+</li>
+<li>
+<p>size_t: Number of elements padded at each side in the y dimension of the input.</p>
+</li>
+<li>
+<p>int:  A VX_TYPE_ENUM of the vx_round_policy_e enumeration.</p>
+</li>
+<li>
+<p>uchar* [out]: The output tensor data. Output will have the same number and structure of dimensions as input. Output tensor data type must be same as the inputs. (Kernel parameter #4)</p>
+</li>
+</ol>
+</div></div></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_out_uchar</span></span><span style="color: #990000">(</span>
-   <span style="color: #008080">uchar</span> <span style="color: #990000">*</span>input<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-   <span style="font-style: italic"><span style="color: #9A1900">// It is not feasible to describe this kernel in OpenCL C as I/O devices</span></span>
-   <span style="font-style: italic"><span style="color: #9A1900">// are not representable with it.</span></span>
-<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
-</tr>
-<tr>
-<td align="left" valign="top"><p class="table"><strong>khr_io_stream_in_blocking_uchar</strong></p></td>
-<td align="left" valign="top"><p class="table">Blocking read of data from a sensor/stream associated with the device.</p></td>
-<td align="left" valign="top"><div><div class="literalblock">
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
 <div class="content">
-<pre><code>-</code></pre>
-</div></div></div></td>
-<td align="left" valign="top"><div><div class="olist arabic"><ol class="arabic" start="0">
-<li>
-<p>
-uchar* [out]: The data.
-</p>
-<div class="ulist"><ul>
-<li>
-<p>
-size_t* [in]: How many bytes to read before returning.
-</p>
-</li>
-</ul></div>
-</li>
-</ol></div></div></td>
+<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_openvx_nn_extension_convolution_uchar(
+   const uchar *input, const uchar *weights, const uchar *biases,
+   size_t dilation_x, size_t dilation_y,
+   int down_scale_rounding, int overflow_policy, size_t padding_x, size_t padding_y,
+   int rounding_policy, uchar *output) {
+   // TBD.
+}</code></pre>
+</div>
+</div></div></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><p class="table">OpenCL C Semantics</p></td>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>Direct Input/Output Operations</strong></p></td>
 </tr>
 <tr>
-<td colspan="4" align="left" valign="top"><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">__kernel</span> <span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_blocking_uchar</span></span><span style="color: #990000">(</span><span style="color: #008080">uchar</span> <span style="color: #990000">*</span>output<span style="color: #990000">,</span> <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-   <span style="font-weight: bold"><span style="color: #0000FF">while</span></span> <span style="color: #990000">(*</span>num<span style="color: #990000">)</span> <span style="color: #FF0000">{</span>
-       <span style="color: #008080">size_t</span> num_read <span style="color: #990000">=</span> <span style="color: #990000">*</span>num<span style="color: #990000">;</span>
-       <span style="font-weight: bold"><span style="color: #000000">__khr_io_stream_in_uchar</span></span><span style="color: #990000">(</span>output<span style="color: #990000">,</span> <span style="color: #990000">&amp;</span>num_read<span style="color: #990000">);</span>
-       num <span style="color: #990000">-=</span> num_read<span style="color: #990000">;</span>
-       output <span style="color: #990000">+=</span> num_read<span style="color: #990000">;</span>
-   <span style="color: #FF0000">}</span>
-<span style="color: #FF0000">}</span></tt></pre></div></div></div></td>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">Kernels for accessing data sources and destinations directly without host involvement.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Description</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NDRange Dimensions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_in_uchar</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Non-blocking read of data from a sensor/stream associated with the device.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="0">
+<li>
+<p>uchar* [out]: The data.</p>
+</li>
+<li>
+<p>size_t* [in+out]: In: number of bytes to read. Out: Number of bytes that could be read (can be 0). (Compatible with the <code>cl_pocl_content_size</code> extension to optimize data transfers with.)</p>
+</li>
+</ol>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_in_uchar(
+   uchar *output, size_t *num) {
+   // It is not feasible to describe this kernel in OpenCL C as I/O devices
+   // are not representable with it.
+}</code></pre>
+</div>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_out_uchar</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Non-blocking write of data to an output/sink associated with the device.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="0">
+<li>
+<p>uchar* [in]: The data to write.</p>
+</li>
+<li>
+<p>size_t* [in+out]: In: Number of bytes to write. Out: Number of bytes that could be written (can be 0).</p>
+</li>
+</ol>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_out_uchar(
+   uchar *input, size_t *num) {
+   // It is not feasible to describe this kernel in OpenCL C as I/O devices
+   // are not representable with it.
+}</code></pre>
+</div>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>khr_io_stream_in_blocking_uchar</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Blocking read of data from a sensor/stream associated with the device.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>-</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
+<ol class="arabic" start="0">
+<li>
+<p>uchar* [out]: The data.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>size_t* [in]: How many bytes to read before returning.</p>
+</li>
+</ul>
+</div>
+</li>
+</ol>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock">OpenCL C Semantics</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">__kernel void __khr_io_stream_in_blocking_uchar(uchar *output, size_t *num) {
+   while (*num) {
+       size_t num_read = *num;
+       __khr_io_stream_in_uchar(output, &amp;num_read);
+       num -= num_read;
+       output += num_read;
+   }
+}</code></pre>
+</div>
+</div></div></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
 <div class="sect3">
 <h4 id="_launching_biks_from_the_device_side">Launching BiKs from the Device Side</h4>
-<div class="paragraph"><p>BiKs are primarily meant to be launched as kernel commands via host-side command queues.
+<div class="paragraph">
+<p>BiKs are primarily meant to be launched as kernel commands via host-side command queues.
 Optionally, they can be callable from device-side via
-<code>enqueue_kernel</code>: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: <code>cl_khr_bik_BUILTIN_KERNEL_NAME</code>. In case a BiK macro is defined, a kernel with a naming convention <code>__khr_BUILTIN_KERNEL_NAME()</code> can be enqueued by the program at device side as software-defined kernels.</p></div>
+<code>enqueue_kernel</code>: This capability can be queried on per BiK basis at compile-time in OpenCL C by checking for macro definitions which has the following naming convention: <code>cl_khr_bik_BUILTIN_KERNEL_NAME</code>. In case a BiK macro is defined, a kernel with a naming convention <code>__khr_BUILTIN_KERNEL_NAME()</code> can be enqueued by the program at device side as software-defined kernels.</p>
+</div>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_open_questions">Open questions</h3>
-<div class="olist arabic"><ol class="arabic">
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.
-</p>
+<p>Should we enable launching BiKs from the device side without requiring device-side enqueue? The main problem is those with NDRange as they are not simple single-WI helper functions.</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.
-</p>
+<p>Should the NDRange be used at all in BiKs? It feels sort of unnatural as typically the NDRange is used to imply SPMD parallelism while the hardware/firmware is free to choose whatever parallelism degree to implement the function. On the other hand, similar applies to software kernel launches as the work-items can be executed serially if adhering to barrier semantics.</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-Different accelerators prefer different channel orders (NHWC vs. NCHW&#8230;) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM&#8217;s row/column order) or is it better to have different BiK variations for each?
-</p>
+<p>Different accelerators prefer different channel orders (NHWC vs. NCHW&#8230;&#8203;) for the processed data. Should the channel order be passed as a BiK argument (like in the example GEMM&#8217;s row/column order) or is it better to have different BiK variations for each?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.
-</p>
+<p>How to denote preference? Some of the BiKs are more efficient on a given device as they map more naturally to the underlying HW accelerator, but the slower variations (for example, with unoptimal channel order in NN accelerators) might be still beneficially accelerated.</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-Since the defined built-in kernel concept is basically just a C-like API inside another API, should it be made more generic and thus directly usable for SYCL and Vulkan as well?
-</p>
+<p>Since the defined built-in kernel concept is basically just a C-like API inside another API, should it be made more generic and thus directly usable for SYCL and Vulkan as well?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>UNRESOLVED</strong></p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong></p>
+</div>
+</div>
+</div>
 </li>
-</ol></div>
+</ol>
 </div>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr /></div>
+</div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2022-12-13 15:52:00 EET
+Last updated 2023-10-11 14:38:56 +0300
 </div>
 </div>
 </body>

--- a/ext/cl_khr_defined_builtin_kernels.html
+++ b/ext/cl_khr_defined_builtin_kernels.html
@@ -936,13 +936,13 @@ then implementation must return CL_DKB_UNSUPPORTED_MODE_PROPERTY.</p>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>cl_tensor_desc_t A: Tensor description for input matrix A.</p>
+<p>cl_tensor_desc A: Tensor description for input matrix A.</p>
 </li>
 <li>
-<p>cl_tensor_desc_t B: Tensor description for input matrix B.</p>
+<p>cl_tensor_desc B: Tensor description for input matrix B.</p>
 </li>
 <li>
-<p>cl_tensor_desc_t R: Tensor description for output matrix C.</p>
+<p>cl_tensor_desc R: Tensor description for output matrix C.</p>
 </li>
 <li>
 <p>cl_int transposeA: Non-zero transposes A matrix.</p>
@@ -960,13 +960,13 @@ then implementation must return CL_DKB_UNSUPPORTED_MODE_PROPERTY.</p>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>cl_tensor_t A: Matrix A (read only).</p>
+<p>cl_tensor A: Matrix A (read only).</p>
 </li>
 <li>
-<p>cl_tensor_t B: Matrix B (read only).</p>
+<p>cl_tensor B: Matrix B (read only).</p>
 </li>
 <li>
-<p>cl_tensor_t R: Output matrix. (write only).</p>
+<p>cl_tensor R: Output matrix. (write only).</p>
 </li>
 </ol>
 </div></div></td>
@@ -1048,8 +1048,8 @@ n)</code> of tensors <code>A</code> and <code>B</code>, respectively, after poss
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
 <p>Fields of the <code>cl_dbk_leaky_relu</code> structure:
-. cl_tensor_desc_t in: Input tensor description.
-. cl_tensor_desc_t out: Output tensor description.
+. cl_tensor_desc in: Input tensor description.
+. cl_tensor_desc out: Output tensor description.
 . cl_float alpha: Coefficient of leakage.</p>
 </div></div></td>
 </tr>
@@ -1060,10 +1060,10 @@ n)</code> of tensors <code>A</code> and <code>B</code>, respectively, after poss
 <td class="tableblock halign-left valign-top"><div class="content"><div class="olist arabic">
 <ol class="arabic">
 <li>
-<p>cl_tensor_t in: The input tensor.</p>
+<p>cl_tensor in: The input tensor.</p>
 </li>
 <li>
-<p>cl_tensor_t out: The output tensor.</p>
+<p>cl_tensor out: The output tensor.</p>
 </li>
 </ol>
 </div></div></td>
@@ -1128,9 +1128,9 @@ clCreateDefinedBuiltInKernelDescriptor.</p>
 // (cl_channel_type) and a number of dimensions (rank) and dimension
 // sizes (shape). Difference over the cl_qcom_ml_ops is that the rank is
 // "unlimited".
-cl_tensor_desc_t lhs_tensor_desc = TBD;
-cl_tensor_desc_t rhs_tensor_desc = TBD;
-cl_tensor_desc_t res_tensor_desc = TBD;
+cl_tensor_desc lhs_tensor_desc = TBD;
+cl_tensor_desc rhs_tensor_desc = TBD;
+cl_tensor_desc res_tensor_desc = TBD;
 
 cl_dkb_attributes_matmul matmul_attrs = {
   lhs_tensor_desc, rhs_tensor_desc, res_tensor_desc,
@@ -1176,9 +1176,9 @@ cl_kernel matmul_kernel = clCreateDefinedBuiltinKernel(
 // determines the optimal data layout (opaque to the application) for
 // the tensors based on their usage.  Application uses the tensor
 // sizes to create cl_mem buffers which are bound to the tensors.
-cl_tensor_t lhs_tensor = TBD;
-cl_tensor_t rhs_tensor = TBD;
-cl_tensor_t res_tensor = TBD;
+cl_tensor lhs_tensor = TBD;
+cl_tensor rhs_tensor = TBD;
+cl_tensor res_tensor = TBD;
 
 // Transfer data to input tensors
 
@@ -1279,7 +1279,7 @@ clEnqueueNDRangeKernel(cmd_q, matmul_kernel, 0, NULL, NULL, NULL, 0, NULL, NULL)
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2023-10-23 15:08:14 +0300
+Last updated 2023-10-25 10:24:30 +0300
 </div>
 </div>
 </body>


### PR DESCRIPTION
This draft is an updated version of https://github.com/KhronosGroup/OpenCL-Docs/pull/867. 

Notable changes:

* Changed defined built-in kernel to use the new `cl_tensor` data type for data arguments. The data type is drafted [here](https://github.com/KhronosGroup/OpenCL-Docs/pull/1006).
* Added API functions for creating defined built-in kernels.
* Added sample code for utilizing defined built-in kernels.

HTML is rendered [here](https://htmlpreview.github.io/?https://github.com/linehill/OpenCL-Docs/blob/defined-built-in-kernels/ext/cl_khr_defined_builtin_kernels.html).

For previous discussion about the topic, follow this [link](https://github.com/KhronosGroup/OpenCL-Registry/issues/131).
