### PR TITLE
consistently put newer versions at the bottom of version history tables

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -30,10 +30,10 @@ Other related extensions define specific external memory types that may be impor
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
-| 2023-08-29 | 0.9.3     | Added query for {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} (provisional).
-| 2023-08-01 | 0.9.2     | Changed device handle list enum to the memory-specific {CL_MEM_DEVICE_HANDLE_LIST_KHR} (provisional).
-| 2023-05-04 | 0.9.1     | Clarified device handle list enum cannot be specified without an external memory handle (provisional).
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
+| 2023-05-04 | 0.9.1     | Clarified device handle list enum cannot be specified without an external memory handle (provisional).
+| 2023-08-01 | 0.9.2     | Changed device handle list enum to the memory-specific {CL_MEM_DEVICE_HANDLE_LIST_KHR} (provisional).
+| 2023-08-29 | 0.9.3     | Added query for {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} (provisional).
 |====
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/

--- a/ext/cl_khr_integer_dot_product.asciidoc
+++ b/ext/cl_khr_integer_dot_product.asciidoc
@@ -19,8 +19,8 @@ functions to compute the dot product of vectors of integers.
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
-| 2021-06-23 | 2.0.0     | All 8-bit support is mandatory, added 8-bit acceleration properties.
 | 2021-06-17 | 1.0.0     | Initial version.
+| 2021-06-23 | 2.0.0     | All 8-bit support is mandatory, added 8-bit acceleration properties.
 |====
 
 ==== Dependencies

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -37,8 +37,8 @@ In particular, this extension defines:
 [cols="1,1,3",options="header",]
 |====
 | *Date*     | *Version* | *Description*
-| 2023-08-01 | 0.9.1     | Changed device handle list enum to the semaphore-specific {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} (provisional).
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
+| 2023-08-01 | 0.9.1     | Changed device handle list enum to the semaphore-specific {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} (provisional).
 |====
 
 NOTE: This is a preview of an OpenCL provisional extension specification that has been Ratified under the Khronos Intellectual Property Framework. It is being made publicly available prior to being uploaded to the Khronos registry to enable review and feedback from the community. If you have feedback please create an issue on https://github.com/KhronosGroup/OpenCL-Docs/


### PR DESCRIPTION
fixes #1001 

Consistently puts newer versions at the bottom of "version history" tables.

This only changes KHR extensions in the OpenCL extension spec.  I didn't modify any vendor or EXT extensions.