### PR TITLE
use title case for more chapter headings

### DIFF
--- a/ext/cl_khr_3d_image_writes.asciidoc
+++ b/ext/cl_khr_3d_image_writes.asciidoc
@@ -11,9 +11,9 @@ This extension adds built-in functions that allow a kernel to write to 3D image 
 
 This extension became a core feature in OpenCL 2.0.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -8,9 +8,9 @@
 This section describes the *cl_khr_async_work_group_copy_fence* extension.
 The extension adds a new built-in function to OpenCL C to establish a memory synchronization ordering of asynchronous copies.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_byte_addressable_store.asciidoc
+++ b/ext/cl_khr_byte_addressable_store.asciidoc
@@ -11,9 +11,9 @@ With this extension, applications are able to read from and write to pointers to
 
 This extension became a core feature in OpenCL 1.1.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_create_command_queue.asciidoc
+++ b/ext/cl_khr_create_command_queue.asciidoc
@@ -27,9 +27,9 @@ Applications that only target OpenCL 2.x devices should use the core
 OpenCL 2.x {clCreateCommandQueueWithProperties} API instead of this
 extension API.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -12,9 +12,9 @@ This section describes the *cl_khr_d3d10_sharing* extension.
 The goal of this extension is to provide interoperability between OpenCL and
 Direct3D 10.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_d3d11_sharing.asciidoc
+++ b/ext/cl_khr_d3d11_sharing.asciidoc
@@ -12,9 +12,9 @@ This section describes the *cl_khr_d3d11_sharing* extension.
 The goal of this extension is to provide interoperability between OpenCL and
 Direct3D 11.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_depth_images.asciidoc
+++ b/ext/cl_khr_depth_images.asciidoc
@@ -11,9 +11,9 @@ This extension adds support for depth images.
 
 This extension became a core feature in OpenCL 2.0.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
+++ b/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
@@ -11,9 +11,9 @@ requiring arguments to blocks to be pointers to void in local memory.
 
 The name of this extension is *cl_khr_device_enqueue_local_arg_types*.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_device_uuid.asciidoc
+++ b/ext/cl_khr_device_uuid.asciidoc
@@ -12,9 +12,9 @@ This extension adds the ability to query a universally unique identifier
 The UUIDs returned by the query may be used to identify drivers and devices
 across processes or APIs.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -20,9 +20,9 @@ Note that OpenCL memory objects may be created from the adapter media
 surface if and only if the OpenCL context has been created from that
 adapter.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_egl_event.asciidoc
+++ b/ext/cl_khr_egl_event.asciidoc
@@ -15,9 +15,9 @@ between the two APIs.
 The companion *EGL_KHR_cl_event* extension provides the complementary
 functionality of creating an EGL sync object from an OpenCL event object.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -12,9 +12,9 @@ This section describes the *cl_khr_egl_image* extension.
 This extension provides a mechanism to creating OpenCL memory objects from
 from EGLImages.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_expect_assume.asciidoc
+++ b/ext/cl_khr_expect_assume.asciidoc
@@ -16,7 +16,7 @@ These functions are not required for functional correctness.
 The initial version of this extension extends the OpenCL SPIR-V environment to support new instructions for offline compilation tool chains.
 Similar functionality may be provided by some OpenCL C online compilation tool chains, but formal support in OpenCL C is not required by the initial version of the extension.
 
-=== General information
+=== General Information
 
 ==== Name Strings
 

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -12,9 +12,9 @@ to support more patterns:
 1. for async copy between 2D source and 2D destination.
 2. for async copy between 3D source and 3D destination.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_extended_versioning.asciidoc
+++ b/ext/cl_khr_extended_versioning.asciidoc
@@ -17,7 +17,7 @@ Extended versioning was promoted to a core feature in OpenCL 3.0, however note
 that the query for {CL_DEVICE_OPENCL_C_NUMERIC_VERSION_KHR} was replaced by the
 query for {CL_DEVICE_OPENCL_C_ALL_VERSIONS}.
 
-=== General information
+=== General Information
 
 ==== Name Strings
 
@@ -30,7 +30,7 @@ Ben Ashbaugh, Intel +
 Alastair Murray, Codeplay Software Ltd. +
 Einar Hov, Arm Ltd.
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -9,9 +9,9 @@ This section describes the *cl_khr_fp16* extension.
 This extension adds support for half scalar and vector types as built-in
 types that can be used for arithmetic operations, conversions etc.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -8,9 +8,9 @@
 This section describes the *cl_khr_fp64* extension.
 This extension became an optional core feature in OpenCL 1.2.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_gl_depth_images.asciidoc
+++ b/ext/cl_khr_gl_depth_images.asciidoc
@@ -12,9 +12,9 @@ cl_khr_gl_sharing_extension) defined in
 Objects>> to allow an OpenCL image to be created from an OpenGL depth or
 depth-stencil texture.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_gl_event.asciidoc
+++ b/ext/cl_khr_gl_event.asciidoc
@@ -20,9 +20,9 @@ In addition, this extension modifies the behavior of
 guarantee synchronization with an OpenGL context bound in the same thread as
 the OpenCL context.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_gl_msaa_sharing.asciidoc
+++ b/ext/cl_khr_gl_msaa_sharing.asciidoc
@@ -15,9 +15,9 @@ MSAA) texture (color or depth).
 This extension name is *cl_khr_gl_msaa_sharing*.
 This extension requires *cl_khr_gl_depth_images*.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_gl_sharing__context.asciidoc
+++ b/ext/cl_khr_gl_sharing__context.asciidoc
@@ -18,9 +18,9 @@ may be used to share OpenGL buffer, texture, and renderbuffer objects with the O
 An OpenGL implementation supporting buffer objects and sharing of texture
 and buffer object images with OpenCL is required by this extension.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -19,9 +19,9 @@ Any supported OpenGL object defined within the associated OpenGL context
 or share group object may be shared, with the exception of the default
 OpenGL objects (i.e. objects named zero), which may not be shared.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_icd.asciidoc
+++ b/ext/cl_khr_icd.asciidoc
@@ -20,9 +20,9 @@ This is a platform extension, so if this extension is supported by an
 implementation, the string *cl_khr_icd* will be present in the
 {CL_PLATFORM_EXTENSIONS} string.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_il_program.asciidoc
+++ b/ext/cl_khr_il_program.asciidoc
@@ -14,9 +14,9 @@ the OpenCL environment may be found in the OpenCL SPIR-V Environment Specificati
 
 This functionality described by this extension is a core feature in OpenCL 2.1.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_image2d_from_buffer.asciidoc
+++ b/ext/cl_khr_image2d_from_buffer.asciidoc
@@ -11,9 +11,9 @@ This extension allows a 2D image to be created from an existing OpenCL buffer me
 
 This extension became a core feature in OpenCL 2.0.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_initialize_memory.asciidoc
+++ b/ext/cl_khr_initialize_memory.asciidoc
@@ -19,9 +19,9 @@ This extension adds support for initializing local and private memory before
 a kernel begins execution.
 This extension name is *cl_khr_initialize_memory*.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_int32_atomics.asciidoc
+++ b/ext/cl_khr_int32_atomics.asciidoc
@@ -10,9 +10,9 @@ These extensions allow atomic operations to be performed on 32-bit signed and un
 
 These extensions became core features in OpenCL 1.1, except the built-in atomic function names are changed to use the **atomic_** prefix instead of **atom_** and the volatile qualifier was added to the pointer parameter _p_.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_int64_atomics.asciidoc
+++ b/ext/cl_khr_int64_atomics.asciidoc
@@ -7,9 +7,9 @@
 
 This section describes the *cl_khr_int64_base_atomics* and *cl_khr_int64_extended_atomics* extensions. These extensions allow atomic operations to be performed on 64-bit signed and unsigned integers in global and local memory.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_mipmap_image.asciidoc
+++ b/ext/cl_khr_mipmap_image.asciidoc
@@ -17,9 +17,9 @@ be used to write a mip-mapped image in an OpenCL C program.
 If the *cl_khr_mipmap_image_writes* extension is supported by the OpenCL
 device, the *cl_khr_mipmap_image* extension must also be supported.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_pci_bus_info.asciidoc
+++ b/ext/cl_khr_pci_bus_info.asciidoc
@@ -18,7 +18,7 @@ extension string for each individual OpenCL device for which they intend to
 issue the new query for and should not have any assumptions about the
 availability of the extension on any given platform.
 
-=== General information
+=== General Information
 
 ==== Name Strings
 

--- a/ext/cl_khr_priority_hints.asciidoc
+++ b/ext/cl_khr_priority_hints.asciidoc
@@ -12,9 +12,9 @@ It is expected that the the user guides associated with each implementation
 which supports this extension will describe the scheduling behavior
 guarantees.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_select_fprounding_mode.asciidoc
+++ b/ext/cl_khr_select_fprounding_mode.asciidoc
@@ -10,9 +10,9 @@ It allows an application to specify the rounding mode for an instruction or grou
 
 **This extension was deprecated in OpenCL 1.1 and its use is not recommended.**
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_spir.asciidoc
+++ b/ext/cl_khr_spir.asciidoc
@@ -15,9 +15,9 @@ This extension has been superseded by the SPIR-V intermediate
 representation, which is supported by the *cl_khr_il_program* extension,
 and is a core feature in OpenCL 2.1.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_srgb_image_writes.asciidoc
+++ b/ext/cl_khr_srgb_image_writes.asciidoc
@@ -13,9 +13,9 @@ The sRGB image formats that may be written to will be returned by {clGetSupporte
 When the image is an sRGB image, the *write_imagef* built-in function will perform the linear to sRGB conversion.
 Only the R, G, and B components are converted from linear to sRGB; the A component is written as-is.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_subgroup_extensions.asciidoc
+++ b/ext/cl_khr_subgroup_extensions.asciidoc
@@ -28,9 +28,9 @@ The functionality added by these extensions includes:
 This section describes changes to the OpenCL C Language for these extensions.
 There are no new API functions or enums added by these extensions.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 For all of the extensions described in this section:
 

--- a/ext/cl_khr_subgroup_named_barrier.asciidoc
+++ b/ext/cl_khr_subgroup_named_barrier.asciidoc
@@ -14,9 +14,9 @@ sub-groups named barriers in the SPIR-V intermediate representation, and to
 the OpenCL {cpp} specification for descriptions of the sub-group named
 barrier built-in functions in the OpenCL {cpp} kernel language.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -16,9 +16,9 @@ Sub-groups were promoted to a core feature in OpenCL 2.1, however note that:
 * The sub-group OpenCL C built-in functions described by this extension must still be accessed as an OpenCL C extension in OpenCL 2.1.
 * Sub-group independent forward progress is an optional device property in OpenCL 2.1, see {CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS}.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_terminate_context.asciidoc
+++ b/ext/cl_khr_terminate_context.asciidoc
@@ -27,9 +27,9 @@ terminate an OpenCL context and adds an API to terminate a context.
 
 The extension name is *cl_khr_terminate_context*.
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====

--- a/ext/cl_khr_throttle_hints.asciidoc
+++ b/ext/cl_khr_throttle_hints.asciidoc
@@ -17,9 +17,9 @@ For example, a task may have high priority ({CL_QUEUE_PRIORITY_HIGH_KHR})
 but should at the same time be executed at an optimized throttle setting
 ({CL_QUEUE_THROTTLE_LOW_KHR}).
 
-=== General information
+=== General Information
 
-==== Version history
+==== Version History
 
 [cols="1,1,3",options="header",]
 |====


### PR DESCRIPTION
This is a purely editorial change.

We tend to use title case (all major words capitalized) for most of our chapter headings, but in a few places we only capitalized the first letter.  Switched some of the more common chapter headings to title case:

* "General information" -> "General Information"
* "Version history" -> "Version History"
