### PR TITLE
remove TODO comment in semaphore spec

### DIFF
--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -239,8 +239,6 @@ include::{generated}/api/protos/clCreateSemaphoreWithPropertiesKHR.txt[]
 
 _context_ identifies a valid OpenCL context that the created {cl_semaphore_khr_TYPE} will belong to.
 
-// TODO: Do we want the same "all devices in the context" behavior if CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR is not specified?
-
 _sema_props_ specifies additional semaphore properties in the form list of <property_name, property_value> pairs terminated with 0.
 {CL_SEMAPHORE_TYPE_KHR} must be part of the list of properties specified by _sema_props_.
 


### PR DESCRIPTION
related to #957

The default behavior when the device handle list is not specified is now properly described, so the TODO comment can be removed.

CC @joshqti 