### PR TITLE
clarify the free function for clEnqueueSVMFree must be thread-safe

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1837,7 +1837,7 @@ include::{generated}/api/version-notes/clCreateContext.asciidoc[]
     at runtime in this context.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread-safe.
     If _pfn_notify_ is `NULL`, no callback function is registered.
   * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4531,6 +4531,10 @@ include::{generated}/api/version-notes/clEnqueueSVMFree.asciidoc[]
     function returns.
   * _pfn_free_func_ specifies the callback function to be called to free the SVM
     pointers.
+    This callback function may be called asynchronously by the OpenCL
+    implementation.
+    It is the application's responsibility to ensure that the callback function
+    is thread-safe.
     _pfn_free_func_ takes four arguments: _queue_ which is the command-queue in
     which {clEnqueueSVMFree} was enqueued, the count and list of SVM pointers to
     free and _user_data_ which is a pointer to user specified data.
@@ -5660,7 +5664,7 @@ include::{generated}/api/version-notes/clSetProgramReleaseCallback.asciidoc[]
   ** _user_data_ is a pointer to user supplied data.
   * _user_data_ will be passed as the _user_data_ argument when _pfn_notify_ is
     called.
-    user data can be `NULL`.
+    _user_data_ can be `NULL`.
 
 Each call to {clSetProgramReleaseCallback} registers the specified
 callback function on a callback stack associated with _program_.
@@ -5813,10 +5817,10 @@ include::{generated}/api/version-notes/clBuildProgram.asciidoc[]
     has completed.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread-safe.
-  ** _user_data_ will be passed as an argument when _pfn_notify_ is called.
-     _user_data_ can be `NULL`.
+  * _user_data_ will be passed as an argument when _pfn_notify_ is called.
+    _user_data_ can be `NULL`.
 
 The program executable is built from the program source or binary for all
 the devices, or a specific device(s) in the OpenCL context associated with
@@ -5951,10 +5955,10 @@ include::{generated}/api/version-notes/clCompileProgram.asciidoc[]
     compiler has completed.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread-safe.
-  ** _user_data_ will be passed as an argument when _pfn_notify_ is called.
-     _user_data_ can be `NULL`.
+  * _user_data_ will be passed as an argument when _pfn_notify_ is called.
+    _user_data_ can be `NULL`.
 
 The pre-processor runs before the program sources are compiled.
 The compiled binary is built for all devices associated with _program_ or
@@ -6094,8 +6098,8 @@ include::{generated}/api/version-notes/clLinkProgram.asciidoc[]
     The notification routine is a callback function that an application can
     register and which will be called when the program executable has been built
     (successfully or unsuccessfully).
-  ** _user_data_ will be passed as an argument when _pfn_notify_ is called.
-     _user_data_ can be `NULL`.
+  * _user_data_ will be passed as an argument when _pfn_notify_ is called.
+    _user_data_ can be `NULL`.
 
 If _pfn_notify_ is not `NULL`, {clLinkProgram} does not need to wait for the
 linker to complete, and can return immediately once the linking operation can
@@ -6106,7 +6110,7 @@ Any state changes of the program object that result from calling {clLinkProgram}
 (e.g. link status or log) will be observable from this callback function.
 This callback function may be called asynchronously by the OpenCL
 implementation.
-It is the applications responsibility to ensure that the callback function
+It is the application's responsibility to ensure that the callback function
 is thread-safe.
 
 If _pfn_notify_ is `NULL`, {clLinkProgram} does not return until the linker
@@ -8858,7 +8862,7 @@ include::{generated}/api/version-notes/clSetEventCallback.asciidoc[]
     the application.
     This callback function may be called asynchronously by the OpenCL
     implementation.
-    It is the applications responsibility to ensure that the callback function
+    It is the application's responsibility to ensure that the callback function
     is thread-safe.
     The parameters to this callback function are:
   ** _event_ is the event object for which the callback function is invoked.


### PR DESCRIPTION
Clarify that the free function pointer passed to clEnqueueSVMFree must be thread-safe.  See #977.

Also:

* Fixes a grammatical error: "applications reponsibility" -> "application's responsibility".
* Fixes a few formatting errors in the description of _user_data_.