### PR TITLE
include dictionaries before footnotes for reference pages

### DIFF
--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -201,10 +201,10 @@ class OpenCLConventions(ConventionsBase):
         """Return any extra text to add to refpage headers."""
         return 'include::{config}/attribs.txt[]\n' + \
             'include::{config}/opencl.asciidoc[]\n' + \
-            'include::{apispec}/footnotes.asciidoc[]\n' + \
-            'include::{cspec}/footnotes.asciidoc[]\n' + \
+            'include::{generated}/api/api-dictionary-no-links.asciidoc[]\n' + \
             'include::{cspec}/feature-dictionary.asciidoc[]\n' + \
-            'include::{generated}/api/api-dictionary-no-links.asciidoc[]'
+            'include::{apispec}/footnotes.asciidoc[]\n' + \
+            'include::{cspec}/footnotes.asciidoc[]\n'
 
     @property
     def extension_index_prefixes(self):


### PR DESCRIPTION
The generated asciidoctor dictionaries need to be included before footnotes because some of the footnotes use the attributes defined in the dictionaries.  If the footnotes are included first then the attributes are not properly substituted.

To see the problem, notice how the current footnote for clGetDeviceIds is not properly formatted:

https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetDeviceIDs.html#_footnotedef_1