### PR TITLE
clarify the user function for clEnqueueNativeKernel must be thread safe

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8303,6 +8303,8 @@ include::{generated}/api/version-notes/clEnqueueNativeKernel.asciidoc[]
     {CL_DEVICE_EXECUTION_CAPABILITIES} as specified in the
     <<device-queries-table,Device Queries>> table.
   * _user_func_ is a pointer to a host-callable user function.
+    It is the application's responsibility to ensure that the host-callable user
+    function is thread-safe.
   * _args_ is a pointer to the args list that _user_func_ should be called with.
   * _cb_args_ is the size in bytes of the args list that _args_ points to.
   * _num_mem_objects_ is the number of buffer objects that are passed in _args_.


### PR DESCRIPTION
see #977 

Clarifies that the application must ensure that the host-callable user function enqueued via clEnqueueNativeKernel is thread-safe.