### PR TITLE
remove unnecessary rounding mode text for geometric and common functions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5473,11 +5473,6 @@ We use the generic type name `gentyped` to indicate that the function can
 take `double`, `double2`, `double3`, `double4`, `double8` or `double16` as
 the type for the arguments.
 
-The built-in common functions are implemented using the round to nearest
-even rounding mode.
-The built-in common functions may be implemented using contractions such
-as *mad* or *fma*.
-
 [[table-builtin-common]]
 .Built-in Scalar and Vector Argument Common Functions
 [cols=",",]
@@ -5559,11 +5554,6 @@ The description is per-component.
 `float__n__` is `float`, `float2`, `float3`, or `float4` and `double__n__` is
 `double` footnote:[{fn-double-supported}], `double2`, `double3`, or
 `double4`.
-
-The built-in geometric functions are implemented using the round to nearest
-even rounding mode.
-The built-in geometric functions may be implemented using contractions such
-as *mad* or *fma*.
 
 [[table-builtin-geometric]]
 .Built-in Scalar and Vector Argument Geometric Functions


### PR DESCRIPTION
fixes #1024

Without knowing how these functions are implemented any statements about rounding modes or contractions are unnecessary and confusing. We have defined error bounds for these functions, and as long as an implementation meets these error bounds it should be considered correct.