### PR TITLE
add the unbreakable attribute to generated source blocks

### DIFF
--- a/scripts/docgenerator.py
+++ b/scripts/docgenerator.py
@@ -218,7 +218,7 @@ class DocOutputGenerator(OutputGenerator):
             index_terms.append(basename)
             write('indexterm:[{}]'.format(','.join(index_terms)), file=fp)
 
-        write('[source,opencl]', file=fp)
+        write('[source%unbreakable,opencl]', file=fp)
         write('----', file=fp)
         write(contents, file=fp)
         write('----', file=fp)
@@ -233,7 +233,7 @@ class DocOutputGenerator(OutputGenerator):
             # Asciidoc anchor
             write(self.genOpts.conventions.warning_comment, file=fp)
             write('// Include this no-xref version without cross reference id for multiple includes of same file', file=fp)
-            write('[source,opencl]', file=fp)
+            write('[source,%unbreakable,opencl]', file=fp)
             write('----', file=fp)
             write(contents, file=fp)
             write('----', file=fp)


### PR DESCRIPTION
This is a nice-to-have and not a must-have.  It only affects the PDF specs.

By default most asciidoc blocks are "breakable", meaning they can span two pages.  This includes source blocks, which we use for API descriptions, which means that a function prototype can span multiple pages.  I personally find this slightly confusing, so this change switches the generated snippets to be "unbreakable" instead.

An example showing this issue in the current PDF spec can be found between PDF page 110 and 111 (document page 105 and 106) for the `clSetCommandQueueProperty` function, which currently spans two pages:

https://registry.khronos.org/OpenCL/specs/3.0-unified/pdf/OpenCL_API.pdf

For more information about asciidoc breakable and unbreakble blocks, see:

https://docs.asciidoctor.org/pdf-converter/latest/breakable-and-unbreakable/