### PR TITLE
[XML] Fix pointer placement for `clReImportSemaphoreSyncFdKHR`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2694,7 +2694,7 @@ server's OpenCL/api-docs repository.
         <command suffix="CL_API_SUFFIX__VERSION_3_0">
             <proto><type>cl_int</type>                                  <name>clReImportSemaphoreSyncFdKHR</name></proto>
             <param><type>cl_semaphore_khr</type>                        <name>sema_object</name></param>
-            <param><type>cl_semaphore_reimport_properties_khr*</type>   <name>reimport_props</name></param>
+            <param><type>cl_semaphore_reimport_properties_khr</type>*   <name>reimport_props</name></param>
             <param><type>int</type>                                     <name>fd</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_3_0">


### PR DESCRIPTION
Everywhere else pointer is placed outside of the `<type>` tag. It's easy enough to adapt my data scrappers to this, but this was probably unintended.