### PR TITLE
Remove `cl_semaphore_import_properties_khr`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6992,8 +6992,6 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
                 <enum name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR"/>
             </require>
-            <require comment="cl_semaphore_import_properties_khr">
-            </require>
             <require comment="cl_semaphore_info_khr">
                 <enum name="CL_SEMAPHORE_EXPORTABLE_KHR"/>
             </require>


### PR DESCRIPTION
I cannot find the spec description, and there is no related `<type category="define">` tag.
Probably editing leftover from #939? @lakshmih 