### PR TITLE
update the spec source copyright dates to 2024

### DIFF
--- a/CXX_for_OpenCL.txt
+++ b/CXX_for_OpenCL.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2023 The Khronos Group Inc.
+# Copyright (c) 2013-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/OpenCL_API.txt
+++ b/OpenCL_API.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_Cxx.txt
+++ b/OpenCL_Cxx.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_Ext.txt
+++ b/OpenCL_Ext.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_ICD_Installation.txt
+++ b/OpenCL_ICD_Installation.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/OpenCL_LangExt.txt
+++ b/OpenCL_LangExt.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/acknowledgements.asciidoc
+++ b/api/acknowledgements.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 The Khronos Group. This work is licensed under a
+// Copyright 2016-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_a.asciidoc
+++ b/api/appendix_a.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_b.asciidoc
+++ b/api/appendix_b.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 The Khronos Group. This work is licensed under a
+// Copyright 2016-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_c.asciidoc
+++ b/api/appendix_c.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 The Khronos Group. This work is licensed under a
+// Copyright 2016-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_d.asciidoc
+++ b/api/appendix_d.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_f.asciidoc
+++ b/api/appendix_f.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_g.asciidoc
+++ b/api/appendix_g.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The Khronos Group. This work is licensed under a
+// Copyright 2020-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/dictionary.asciidoc
+++ b/api/dictionary.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/glossary.asciidoc
+++ b/api/glossary.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/introduction.asciidoc
+++ b/api/introduction.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/opencl_assoc_spec.asciidoc
+++ b/api/opencl_assoc_spec.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/c/appendix_a.asciidoc
+++ b/c/appendix_a.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/c/feature-dictionary.asciidoc
+++ b/c/feature-dictionary.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/config/copyright-ccby.txt
+++ b/config/copyright-ccby.txt
@@ -1,3 +1,3 @@
-Copyright 2014-2023 The Khronos Group Inc.
+Copyright 2014-2024 The Khronos Group Inc.
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/config/katex_replace.rb
+++ b/config/katex_replace.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2023 The Khronos Group Inc.
+# Copyright (c) 2016-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/katex_replace/extension.rb
+++ b/config/katex_replace/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2023 The Khronos Group Inc.
+# Copyright (c) 2016-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/opencl.asciidoc
+++ b/config/opencl.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/config/rouge_opencl.rb
+++ b/config/rouge_opencl.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
-# Copyright (c) 2011-2023 The Khronos Group, Inc.
+# Copyright (c) 2011-2024 The Khronos Group, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #puts "Loading rouge_opencl extensions for source code highlighting..."

--- a/config/spec-macros.rb
+++ b/config/spec-macros.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2023 The Khronos Group Inc.
+# Copyright (c) 2016-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/spec-macros/extension.rb
+++ b/config/spec-macros/extension.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2023 The Khronos Group Inc.
+# Copyright (c) 2016-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/version-full-links.asciidoc
+++ b/config/version-full-links.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2023 The Khronos Group. This work is licensed under a
+// Copyright 2023-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/config/version-local-links.asciidoc
+++ b/config/version-local-links.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2023 The Khronos Group. This work is licensed under a
+// Copyright 2023-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/copyrights-ccby.txt
+++ b/copyrights-ccby.txt
@@ -1,4 +1,4 @@
-Copyright 2019-2023 The Khronos Group.
+Copyright 2019-2024 The Khronos Group.
 
 Khronos licenses this file to you under the Creative Commons Attribution 4.0 
 International (CC BY 4.0) License (the "License"); you may not use this file 

--- a/copyrights.txt
+++ b/copyrights.txt
@@ -1,4 +1,4 @@
-Copyright 2008-2023 The Khronos Group Inc.
+Copyright 2008-2024 The Khronos Group Inc.
 
 This Specification is protected by copyright laws and contains material proprietary to Khronos.
 Except as described by these terms, it or any components may not be reproduced, republished,

--- a/cxx/acknowledgements.txt
+++ b/cxx/acknowledgements.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/annotation.txt
+++ b/cxx/annotation.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/compiler_options.txt
+++ b/cxx/compiler_options.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/generic_type_name_notation.txt
+++ b/cxx/generic_type_name_notation.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/image_addressing_and_filtering.txt
+++ b/cxx/image_addressing_and_filtering.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/address_spaces.txt
+++ b/cxx/lang/address_spaces.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/attribute_qualifiers.txt
+++ b/cxx/lang/attribute_qualifiers.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/builtin_data_types.txt
+++ b/cxx/lang/builtin_data_types.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/expressions.txt
+++ b/cxx/lang/expressions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/implicit_type_conversions.txt
+++ b/cxx/lang/implicit_type_conversions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/kernel_functions.txt
+++ b/cxx/lang/kernel_functions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/keywords.txt
+++ b/cxx/lang/keywords.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/lang.txt
+++ b/cxx/lang/lang.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/preprocessor.txt
+++ b/cxx/lang/preprocessor.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/lang/restrictions.txt
+++ b/cxx/lang/restrictions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/edge_case_behavior.txt
+++ b/cxx/numerical_compliance/edge_case_behavior.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/floating_point_exceptions.txt
+++ b/cxx/numerical_compliance/floating_point_exceptions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/inf_nan_and_denormalized_numbers.txt
+++ b/cxx/numerical_compliance/inf_nan_and_denormalized_numbers.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/numerical_compliance.txt
+++ b/cxx/numerical_compliance/numerical_compliance.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/relative_error_as_ulps.txt
+++ b/cxx/numerical_compliance/relative_error_as_ulps.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/numerical_compliance/rounding_modes.txt
+++ b/cxx/numerical_compliance/rounding_modes.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/address_spaces.txt
+++ b/cxx/stdlib/address_spaces.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/array.txt
+++ b/cxx/stdlib/array.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/atomic_operations.txt
+++ b/cxx/stdlib/atomic_operations.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/common.txt
+++ b/cxx/stdlib/common.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/conversions.txt
+++ b/cxx/stdlib/conversions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/definitions.txt
+++ b/cxx/stdlib/definitions.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/device_enqueue.txt
+++ b/cxx/stdlib/device_enqueue.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/general_utilities.txt
+++ b/cxx/stdlib/general_utilities.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/geometric.txt
+++ b/cxx/stdlib/geometric.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/half_wrapper.txt
+++ b/cxx/stdlib/half_wrapper.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/images_and_samplers.txt
+++ b/cxx/stdlib/images_and_samplers.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/integer.txt
+++ b/cxx/stdlib/integer.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/iterator.txt
+++ b/cxx/stdlib/iterator.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/limits.txt
+++ b/cxx/stdlib/limits.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/marker_types.txt
+++ b/cxx/stdlib/marker_types.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/math.txt
+++ b/cxx/stdlib/math.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/math_constants.txt
+++ b/cxx/stdlib/math_constants.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/pipes.txt
+++ b/cxx/stdlib/pipes.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/printf.txt
+++ b/cxx/stdlib/printf.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/range.txt
+++ b/cxx/stdlib/range.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/reinterpreting_data.txt
+++ b/cxx/stdlib/reinterpreting_data.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/relational.txt
+++ b/cxx/stdlib/relational.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/specialization_constants.txt
+++ b/cxx/stdlib/specialization_constants.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/stdlib.txt
+++ b/cxx/stdlib/stdlib.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/synchronization.txt
+++ b/cxx/stdlib/synchronization.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/tuple.txt
+++ b/cxx/stdlib/tuple.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/type_traits.txt
+++ b/cxx/stdlib/type_traits.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/vector_data_load_and_store.txt
+++ b/cxx/stdlib/vector_data_load_and_store.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/vector_iterator.txt
+++ b/cxx/stdlib/vector_iterator.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/vector_utilities.txt
+++ b/cxx/stdlib/vector_utilities.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/vector_wrapper.txt
+++ b/cxx/stdlib/vector_wrapper.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/work_group.txt
+++ b/cxx/stdlib/work_group.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx/stdlib/work_item.txt
+++ b/cxx/stdlib/work_item.txt
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/acknowledgements.txt
+++ b/cxx4opencl/acknowledgements.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/address_spaces.txt
+++ b/cxx4opencl/address_spaces.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/cxxcasts.txt
+++ b/cxx4opencl/cxxcasts.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/diff2cxx.txt
+++ b/cxx4opencl/diff2cxx.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/diff2openclc.txt
+++ b/cxx4opencl/diff2openclc.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/intro.txt
+++ b/cxx4opencl/intro.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/kernel.txt
+++ b/cxx4opencl/kernel.txt
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group. This work is licensed under a
+// Copyright 2021-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/cxx4opencl/references.txt
+++ b/cxx4opencl/references.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/appendix_a.asciidoc
+++ b/env/appendix_a.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/dictionary.asciidoc
+++ b/env/dictionary.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/introduction.asciidoc
+++ b/env/introduction.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/references.asciidoc
+++ b/env/references.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_3d_image_writes.asciidoc
+++ b/ext/cl_khr_3d_image_writes.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/ext/cl_khr_async_work_group_copy_fence.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_byte_addressable_store.asciidoc
+++ b/ext/cl_khr_byte_addressable_store.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_command_buffer.asciidoc
+++ b/ext/cl_khr_command_buffer.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_command_buffer_multi_device.asciidoc
+++ b/ext/cl_khr_command_buffer_multi_device.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_create_command_queue.asciidoc
+++ b/ext/cl_khr_create_command_queue.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_d3d10_sharing.asciidoc
+++ b/ext/cl_khr_d3d10_sharing.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_d3d11_sharing.asciidoc
+++ b/ext/cl_khr_d3d11_sharing.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_depth_images.asciidoc
+++ b/ext/cl_khr_depth_images.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
+++ b/ext/cl_khr_device_enqueue_local_arg_types.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_device_uuid.asciidoc
+++ b/ext/cl_khr_device_uuid.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_dx9_media_sharing.asciidoc
+++ b/ext/cl_khr_dx9_media_sharing.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_egl_event.asciidoc
+++ b/ext/cl_khr_egl_event.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_egl_image.asciidoc
+++ b/ext/cl_khr_egl_image.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_expect_assume.asciidoc
+++ b/ext/cl_khr_expect_assume.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_extended_async_copies.asciidoc
+++ b/ext/cl_khr_extended_async_copies.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_extended_bit_ops.asciidoc
+++ b/ext/cl_khr_extended_bit_ops.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_extended_versioning.asciidoc
+++ b/ext/cl_khr_extended_versioning.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group. This work is licensed under a
+// Copyright 2021-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_external_semaphore.asciidoc
+++ b/ext/cl_khr_external_semaphore.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group. This work is licensed under a
+// Copyright 2021-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_fp16.asciidoc
+++ b/ext/cl_khr_fp16.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_fp64.asciidoc
+++ b/ext/cl_khr_fp64.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_gl_depth_images.asciidoc
+++ b/ext/cl_khr_gl_depth_images.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_gl_event.asciidoc
+++ b/ext/cl_khr_gl_event.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_gl_msaa_sharing.asciidoc
+++ b/ext/cl_khr_gl_msaa_sharing.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_gl_sharing__context.asciidoc
+++ b/ext/cl_khr_gl_sharing__context.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_gl_sharing__memobjs.asciidoc
+++ b/ext/cl_khr_gl_sharing__memobjs.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_icd.asciidoc
+++ b/ext/cl_khr_icd.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_il_program.asciidoc
+++ b/ext/cl_khr_il_program.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_image2d_from_buffer.asciidoc
+++ b/ext/cl_khr_image2d_from_buffer.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_initialize_memory.asciidoc
+++ b/ext/cl_khr_initialize_memory.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_int32_atomics.asciidoc
+++ b/ext/cl_khr_int32_atomics.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_int64_atomics.asciidoc
+++ b/ext/cl_khr_int64_atomics.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_integer_dot_product.asciidoc
+++ b/ext/cl_khr_integer_dot_product.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 The Khronos Group. This work is licensed under a
+// Copyright 2020-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_mipmap_image.asciidoc
+++ b/ext/cl_khr_mipmap_image.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_pci_bus_info.asciidoc
+++ b/ext/cl_khr_pci_bus_info.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_priority_hints.asciidoc
+++ b/ext/cl_khr_priority_hints.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_select_fprounding_mode.asciidoc
+++ b/ext/cl_khr_select_fprounding_mode.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_semaphore.asciidoc
+++ b/ext/cl_khr_semaphore.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group. This work is licensed under a
+// Copyright 2021-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_spir.asciidoc
+++ b/ext/cl_khr_spir.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_srgb_image_writes.asciidoc
+++ b/ext/cl_khr_srgb_image_writes.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_subgroup_named_barrier.asciidoc
+++ b/ext/cl_khr_subgroup_named_barrier.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_subgroup_rotate.asciidoc
+++ b/ext/cl_khr_subgroup_rotate.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Khronos Group. This work is licensed under a
+// Copyright 2022-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_subgroups.asciidoc
+++ b/ext/cl_khr_subgroups.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_suggested_local_work_size.asciidoc
+++ b/ext/cl_khr_suggested_local_work_size.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_terminate_context.asciidoc
+++ b/ext/cl_khr_terminate_context.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_throttle_hints.asciidoc
+++ b/ext/cl_khr_throttle_hints.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
+++ b/ext/cl_khr_work_group_uniform_arithmetic.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The Khronos Group. This work is licensed under a
+// Copyright 2022-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/deprecated_extensions.asciidoc
+++ b/ext/deprecated_extensions.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/dictionary.asciidoc
+++ b/ext/dictionary.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/index.asciidoc
+++ b/ext/index.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/introduction.asciidoc
+++ b/ext/introduction.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/provisional_notice.asciidoc
+++ b/ext/provisional_notice.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2023 The Khronos Group. This work is licensed under a
+// Copyright 2023-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/spirv_extensions.asciidoc
+++ b/ext/spirv_extensions.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/ext/to_core_features.asciidoc
+++ b/ext/to_core_features.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/extensions/cl_arm_controlled_kernel_termination.asciidoc
+++ b/extensions/cl_arm_controlled_kernel_termination.asciidoc
@@ -21,7 +21,7 @@ Anastasia Stulova, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2021-2023 Arm Ltd.
+Copyright (c) 2021-2024 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_printf.asciidoc
+++ b/extensions/cl_arm_printf.asciidoc
@@ -24,7 +24,7 @@ Kevin Petit, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2014-2023 Arm Ltd.
+Copyright (c) 2014-2024 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_protected_memory_allocation.asciidoc
+++ b/extensions/cl_arm_protected_memory_allocation.asciidoc
@@ -19,7 +19,7 @@ Kevin Petit, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2021-2023 Arm Ltd.
+Copyright (c) 2021-2024 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_arm_scheduling_controls.asciidoc
+++ b/extensions/cl_arm_scheduling_controls.asciidoc
@@ -22,7 +22,7 @@ Radek Szymanski, Arm Ltd. +
 
 == Notice
 
-Copyright (c) 2020-2023 Arm Ltd.
+Copyright (c) 2020-2024 Arm Ltd.
 
 == Status
 

--- a/extensions/cl_ext_cxx_for_opencl.asciidoc
+++ b/extensions/cl_ext_cxx_for_opencl.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -74,7 +74,7 @@ Ruihao Zhang, Qualcomm
 
 == Notice
 
-Copyright (c) 2021-2023 The Khronos Group Inc.
+Copyright (c) 2021-2024 The Khronos Group Inc.
 
 == Status
 

--- a/extensions/cl_ext_image_from_buffer.asciidoc
+++ b/extensions/cl_ext_image_from_buffer.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/extensions/cl_ext_image_raw10_raw12.asciidoc
+++ b/extensions/cl_ext_image_raw10_raw12.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -93,7 +93,7 @@ the time of their contribution, one person per line.
 
 == Notice
 
-Copyright (c) 2023 Some Company. Copyright terms at: +
+Copyright (c) 2023-2024 Some Company. Copyright terms at: +
 http://link/copyright.html
 
 ****

--- a/extensions/cl_img_cached_allocations.asciidoc
+++ b/extensions/cl_img_cached_allocations.asciidoc
@@ -24,7 +24,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020-2023 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2024 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_generate_mipmap.asciidoc
+++ b/extensions/cl_img_generate_mipmap.asciidoc
@@ -26,7 +26,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020-2023 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2024 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_mem_properties.asciidoc
+++ b/extensions/cl_img_mem_properties.asciidoc
@@ -24,7 +24,7 @@ Jeba Samuel, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020-2023 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2024 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_use_gralloc_ptr.asciidoc
+++ b/extensions/cl_img_use_gralloc_ptr.asciidoc
@@ -25,7 +25,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020-2023 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2024 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_img_yuv_image.asciidoc
+++ b/extensions/cl_img_yuv_image.asciidoc
@@ -25,7 +25,7 @@ Jeremy Kemp, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2020-2023 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2020-2024 Imagination Technologies Ltd. All Rights Reserved.
 
 == Status
 

--- a/extensions/cl_intel_bfloat16_conversions.asciidoc
+++ b/extensions/cl_intel_bfloat16_conversions.asciidoc
@@ -23,7 +23,7 @@ Lukasz Towarek, Intel
 
 == Notice
 
-Copyright (c) 2022-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2022-2024 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_command_queue_families.asciidoc
+++ b/extensions/cl_intel_command_queue_families.asciidoc
@@ -34,7 +34,7 @@ Michal Mrozek, Intel +
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_create_buffer_with_properties.asciidoc
+++ b/extensions/cl_intel_create_buffer_with_properties.asciidoc
@@ -32,7 +32,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2020-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_device_attribute_query.asciidoc
+++ b/extensions/cl_intel_device_attribute_query.asciidoc
@@ -44,7 +44,7 @@ Rafik Saliev, Intel
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_mem_alloc_buffer_location.asciidoc
+++ b/extensions/cl_intel_mem_alloc_buffer_location.asciidoc
@@ -40,7 +40,7 @@ Contributors
 Notice
 ------
 
-Copyright (c) 2020-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation. All rights reserved.
 
 Status
 ------

--- a/extensions/cl_intel_mem_channel_property.asciidoc
+++ b/extensions/cl_intel_mem_channel_property.asciidoc
@@ -37,7 +37,7 @@ Contributors
 Notice
 ------
 
-Copyright (c) 2020-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation. All rights reserved.
 
 Status
 ------

--- a/extensions/cl_intel_mem_force_host_memory.asciidoc
+++ b/extensions/cl_intel_mem_force_host_memory.asciidoc
@@ -30,7 +30,7 @@ Filip Hazubski, Intel
 
 == Notice
 
-Copyright (c) 2020-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_packed_yuv.asciidoc
+++ b/extensions/cl_intel_packed_yuv.asciidoc
@@ -30,7 +30,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_planar_yuv.asciidoc
+++ b/extensions/cl_intel_planar_yuv.asciidoc
@@ -34,7 +34,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_program_scope_host_pipe.asciidoc
+++ b/extensions/cl_intel_program_scope_host_pipe.asciidoc
@@ -31,7 +31,7 @@ Zibai Wang, Intel +
 
 == Notice
 
-Copyright (c) 2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2023-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_required_subgroup_size.asciidoc
+++ b/extensions/cl_intel_required_subgroup_size.asciidoc
@@ -39,7 +39,7 @@ Ben Ashbaugh, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_sharing_format_query.asciidoc
+++ b/extensions/cl_intel_sharing_format_query.asciidoc
@@ -26,7 +26,7 @@ Pawel Wilma, Intel
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/cl_intel_spirv_device_side_avc_motion_estimation.asciidoc
@@ -29,7 +29,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_media_block_io.asciidoc
+++ b/extensions/cl_intel_spirv_media_block_io.asciidoc
@@ -30,7 +30,7 @@ Pawel Jurek, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_spirv_subgroups.asciidoc
+++ b/extensions/cl_intel_spirv_subgroups.asciidoc
@@ -31,7 +31,7 @@ Mariusz Merecki, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_split_work_group_barrier.asciidoc
+++ b/extensions/cl_intel_split_work_group_barrier.asciidoc
@@ -24,7 +24,7 @@ John Pennycook, Intel
 
 == Notice
 
-Copyright (c) 2022-2023 Intel Corporation. All rights reserved.
+Copyright (c) 2022-2024 Intel Corporation. All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroup_matrix_multiply_accumulate.asciidoc
+++ b/extensions/cl_intel_subgroup_matrix_multiply_accumulate.asciidoc
@@ -28,7 +28,7 @@ Lukasz Towarek, Intel
 
 == Notice
 
-Copyright (c) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2022-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroup_split_matrix_multiply_accumulate.asciidoc
+++ b/extensions/cl_intel_subgroup_split_matrix_multiply_accumulate.asciidoc
@@ -25,7 +25,7 @@ Lukasz Towarek, Intel
 
 == Notice
 
-Copyright (c) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2022-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -42,7 +42,7 @@ Biju George, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_char.asciidoc
+++ b/extensions/cl_intel_subgroups_char.asciidoc
@@ -33,7 +33,7 @@ Konrad Trifunovic, Intel
 
 == Notice
 
-Copyright (c) 2020-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_long.asciidoc
+++ b/extensions/cl_intel_subgroups_long.asciidoc
@@ -30,7 +30,7 @@ Konrad Trifunovic, Intel
 
 == Notice
 
-Copyright (c) 2020-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2020-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -29,7 +29,7 @@ Insoo Woo, Intel
 
 == Notice
 
-Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2018-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_intel_unified_shared_memory.asciidoc
+++ b/extensions/cl_intel_unified_shared_memory.asciidoc
@@ -43,7 +43,7 @@ Lukasz Towarek, Intel
 
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2024 Intel Corporation.  All rights reserved.
 
 == Status
 

--- a/extensions/cl_loader_info.asciidoc
+++ b/extensions/cl_loader_info.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
@@ -29,7 +29,7 @@ Brice Videau, Argonne National Laboratory
 
 == Notice
 
-Copyright (c) 2023 The Khronos Group Inc.
+Copyright (c) 2023-2024 The Khronos Group Inc.
 
 == Status
 

--- a/extensions/cl_loader_layers.asciidoc
+++ b/extensions/cl_loader_layers.asciidoc
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/extensions/cl_pocl_content_size.asciidoc
+++ b/extensions/cl_pocl_content_size.asciidoc
@@ -31,7 +31,7 @@ Jan Solanti, Tampere University
 
 == Notice
 
-Copyright (c) 2020-2023 Tampere University
+Copyright (c) 2020-2024 Tampere University
 
 == Status
 

--- a/extensions/extensions.txt
+++ b/extensions/extensions.txt
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 The Khronos Group. This work is licensed under a
+// Copyright 2018-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/langext/acknowledgements.txt
+++ b/langext/acknowledgements.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/langext/intro.txt
+++ b/langext/intro.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/langext/variadic_macro.txt
+++ b/langext/variadic_macro.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Khronos Group. This work is licensed under a
+// Copyright 2019-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/man/static/EXTENSION.txt
+++ b/man/static/EXTENSION.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/abstractDataTypes.txt
+++ b/man/static/abstractDataTypes.txt
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group Inc.
+// Copyright 2021-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateEventFromEGLSyncKHR.txt
+++ b/man/static/clCreateEventFromEGLSyncKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateEventFromGLsyncKHR.txt
+++ b/man/static/clCreateEventFromGLsyncKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D10BufferKHR.txt
+++ b/man/static/clCreateFromD3D10BufferKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D10Texture2DKHR.txt
+++ b/man/static/clCreateFromD3D10Texture2DKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D10Texture3DKHR.txt
+++ b/man/static/clCreateFromD3D10Texture3DKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D11BufferKHR.txt
+++ b/man/static/clCreateFromD3D11BufferKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D11Texture2DKHR.txt
+++ b/man/static/clCreateFromD3D11Texture2DKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromD3D11Texture3DKHR.txt
+++ b/man/static/clCreateFromD3D11Texture3DKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromDX9MediaSurfaceKHR.txt
+++ b/man/static/clCreateFromDX9MediaSurfaceKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromEGLImageKHR.txt
+++ b/man/static/clCreateFromEGLImageKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromGLBuffer.txt
+++ b/man/static/clCreateFromGLBuffer.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromGLRenderbuffer.txt
+++ b/man/static/clCreateFromGLRenderbuffer.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clCreateFromGLTexture.txt
+++ b/man/static/clCreateFromGLTexture.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueAcquireD3D10ObjectsKHR.txt
+++ b/man/static/clEnqueueAcquireD3D10ObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueAcquireD3D11ObjectsKHR.txt
+++ b/man/static/clEnqueueAcquireD3D11ObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueAcquireDX9MediaSurfacesKHR.txt
+++ b/man/static/clEnqueueAcquireDX9MediaSurfacesKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueAcquireEGLObjectsKHR.txt
+++ b/man/static/clEnqueueAcquireEGLObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueAcquireGLObjects.txt
+++ b/man/static/clEnqueueAcquireGLObjects.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueReleaseD3D10ObjectsKHR.txt
+++ b/man/static/clEnqueueReleaseD3D10ObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueReleaseD3D11ObjectsKHR.txt
+++ b/man/static/clEnqueueReleaseD3D11ObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueReleaseDX9MediaSurfacesKHR.txt
+++ b/man/static/clEnqueueReleaseDX9MediaSurfacesKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueReleaseEGLObjectsKHR.txt
+++ b/man/static/clEnqueueReleaseEGLObjectsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clEnqueueReleaseGLObjects.txt
+++ b/man/static/clEnqueueReleaseGLObjects.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetDeviceIDsFromD3D10KHR.txt
+++ b/man/static/clGetDeviceIDsFromD3D10KHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetDeviceIDsFromD3D11KHR.txt
+++ b/man/static/clGetDeviceIDsFromD3D11KHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetDeviceIDsFromDX9MediaAdapterKHR.txt
+++ b/man/static/clGetDeviceIDsFromDX9MediaAdapterKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetExtensionFunctionAddressForPlatform.txt
+++ b/man/static/clGetExtensionFunctionAddressForPlatform.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetGLContextInfoKHR.txt
+++ b/man/static/clGetGLContextInfoKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetGLObjectInfo.txt
+++ b/man/static/clGetGLObjectInfo.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clGetGLTextureInfo.txt
+++ b/man/static/clGetGLTextureInfo.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clIcdGetPlatformIDsKHR.txt
+++ b/man/static/clIcdGetPlatformIDsKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/clTerminateContextKHR.txt
+++ b/man/static/clTerminateContextKHR.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_3d_image_writes.txt
+++ b/man/static/cl_khr_3d_image_writes.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_byte_addressable_store.txt
+++ b/man/static/cl_khr_byte_addressable_store.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_d3d10_sharing.txt
+++ b/man/static/cl_khr_d3d10_sharing.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_d3d11_sharing.txt
+++ b/man/static/cl_khr_d3d11_sharing.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_depth_images.txt
+++ b/man/static/cl_khr_depth_images.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_device_enqueue_local_arg_types.txt
+++ b/man/static/cl_khr_device_enqueue_local_arg_types.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_dx9_media_sharing.txt
+++ b/man/static/cl_khr_dx9_media_sharing.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_egl_event.txt
+++ b/man/static/cl_khr_egl_event.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_egl_image.txt
+++ b/man/static/cl_khr_egl_image.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_fp16.txt
+++ b/man/static/cl_khr_fp16.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_fp64.txt
+++ b/man/static/cl_khr_fp64.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_gl_depth_images.txt
+++ b/man/static/cl_khr_gl_depth_images.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_gl_event.txt
+++ b/man/static/cl_khr_gl_event.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_gl_msaa_sharing.txt
+++ b/man/static/cl_khr_gl_msaa_sharing.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_gl_sharing.txt
+++ b/man/static/cl_khr_gl_sharing.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_global_int32_base_atomics.txt
+++ b/man/static/cl_khr_global_int32_base_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_global_int32_extended_atomics.txt
+++ b/man/static/cl_khr_global_int32_extended_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_icd.txt
+++ b/man/static/cl_khr_icd.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_il_program.txt
+++ b/man/static/cl_khr_il_program.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_image2d_from_buffer.txt
+++ b/man/static/cl_khr_image2d_from_buffer.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_initialize_memory.txt
+++ b/man/static/cl_khr_initialize_memory.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_int64_base_atomics.txt
+++ b/man/static/cl_khr_int64_base_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_int64_extended_atomics.txt
+++ b/man/static/cl_khr_int64_extended_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_local_int32_base_atomics.txt
+++ b/man/static/cl_khr_local_int32_base_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_local_int32_extended_atomics.txt
+++ b/man/static/cl_khr_local_int32_extended_atomics.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_mipmap_image.txt
+++ b/man/static/cl_khr_mipmap_image.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_priority_hints.txt
+++ b/man/static/cl_khr_priority_hints.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_spir.txt
+++ b/man/static/cl_khr_spir.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_srgb_image_writes.txt
+++ b/man/static/cl_khr_srgb_image_writes.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_subgroups.txt
+++ b/man/static/cl_khr_subgroups.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_terminate_context.txt
+++ b/man/static/cl_khr_terminate_context.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/cl_khr_throttle_hints.txt
+++ b/man/static/cl_khr_throttle_hints.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/convert_T.txt
+++ b/man/static/convert_T.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/deadLinks.txt
+++ b/man/static/deadLinks.txt
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 The Khronos Group Inc.
+// Copyright 2021-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/enums.txt
+++ b/man/static/enums.txt
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 The Khronos Group Inc.
+// Copyright 2014-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/man/static/footer.txt
+++ b/man/static/footer.txt
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 The Khronos Group Inc.
+// Copyright 2016-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 ifdef::doctype-manpage[]

--- a/man/static/intro.txt
+++ b/man/static/intro.txt
@@ -1,4 +1,4 @@
-// Copyright 2007-2023 The Khronos Group Inc.
+// Copyright 2007-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: CC-BY-4.0
 
 :data-uri:

--- a/scripts/cgenerator.py
+++ b/scripts/cgenerator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/checklinks.py
+++ b/scripts/checklinks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Working-group-specific style conventions,

--- a/scripts/conventions.py
+++ b/scripts/conventions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/docgenerator.py
+++ b/scripts/docgenerator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/extensionmetadocgenerator.py
+++ b/scripts/extensionmetadocgenerator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2016-2023 The Khronos Group Inc.
+# Copyright 2016-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -51,7 +51,7 @@ def printCopyrightSourceComments(fp):
 
     Writes an asciidoc comment block, which copyrights the source
     file."""
-    print('// Copyright 2014-2023 The Khronos Group, Inc.', file=fp)
+    print('// Copyright 2014-2024 The Khronos Group, Inc.', file=fp)
     print('//', file=fp)
     # This works around constraints of the 'reuse' tool
     print('// SPDX' + '-License-Identifier: CC-BY-4.0', file=fp)

--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2019-2023 The Khronos Group Inc.
+# Copyright 2019-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
@@ -19,7 +19,7 @@ def parse_xml(path):
 
 # File Header:
 def GetHeader():
-    return """// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+    return """// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 

--- a/scripts/gen_version_notes.py
+++ b/scripts/gen_version_notes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright 2019-2023 The Khronos Group Inc.
+# Copyright 2019-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
@@ -23,7 +23,7 @@ def parse_xml(path):
 
 # File Header:
 def GetHeader():
-    return """// Copyright 2017-2023 The Khronos Group. This work is licensed under a
+    return """// Copyright 2017-2024 The Khronos Group. This work is licensed under a
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 """

--- a/scripts/gencl.py
+++ b/scripts/gencl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -109,7 +109,7 @@ def makeGenOpts(args):
     # The SPDX formatting below works around constraints of the 'reuse' tool
     prefixStrings = [
         '/*',
-        '** Copyright 2015-2023 The Khronos Group Inc.',
+        '** Copyright 2015-2024 The Khronos Group Inc.',
         '**',
         '** SPDX' + '-License-Identifier: Apache-2.0',
         '*/',

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 """Base class for source/header/doc generators, as well as some utility functions."""

--- a/scripts/pygenerator.py
+++ b/scripts/pygenerator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/realign.py
+++ b/scripts/realign.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: realign [infile] > outfile

--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2016-2023 The Khronos Group Inc.
+# Copyright 2016-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/reg.py
+++ b/scripts/reg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright 2013-2023 The Khronos Group Inc.
+# Copyright 2013-2024 The Khronos Group Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/spec_tools/util.py
+++ b/scripts/spec_tools/util.py
@@ -1,6 +1,6 @@
 """Utility functions not closely tied to other spec_tools types."""
 # Copyright (c) 2018-2019 Collabora, Ltd.
-# Copyright (c) 2013-2023 The Khronos Group Inc.
+# Copyright (c) 2013-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xml/Makefile
+++ b/xml/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2023 The Khronos Group Inc.
+# Copyright (c) 2013-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright 2013-2023 The Khronos Group Inc.
+Copyright 2013-2024 The Khronos Group Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2023 The Khronos Group Inc.
+# Copyright (c) 2013-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the spec source copyright dates to 2024, using the script from #757.

As with #881 this PR also updates the spec source copyright dates for several vendor extensions.