### PR TITLE
add missing curly brace for asciidoctor attribute

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -366,7 +366,7 @@ include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES_ARRAY.asciidoc[]
         additional properties.
 
         If _command_queue_ was created using {clCreateCommandQueue}, or if the
-        _properties_ argument specified in clCreateCommandQueueWithProperties}
+        _properties_ argument specified in {clCreateCommandQueueWithProperties}
         was `NULL`, the implementation must return _param_value_size_ret_
         equal to 0, indicating that there are no properties to be returned.
 


### PR DESCRIPTION
Adds a missing curly brace causing clCreateCommandQueueWithProperties to be formatted improperly.