### PR TITLE
cl_khr_external_memory: Clarify offset is zero

### DIFF
--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -192,6 +192,7 @@ Following new enums are added to the list of supported _param_names_ by {clGetDe
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR} must return a non-empty list of external memory handle types for at least one of the devices in the platform.
 
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout when no other tiling information is provided.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.
+For images that are assumed to have a linear layout, implementations will also assume that the image data is at offset 0 relative to the start of the external memory allocation.
 
 External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} may have any memory layout. The layout interpretation of images imported with these handle types is implementation defined.
 

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -192,7 +192,6 @@ Following new enums are added to the list of supported _param_names_ by {clGetDe
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR} must return a non-empty list of external memory handle types for at least one of the devices in the platform.
 
 {clGetDeviceInfo} when called with param_name {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} returns a list of external memory handle types that are assumed to have a linear memory layout when no other tiling information is provided.  This list contains a subset of {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR}.  The returned list may be empty.
-For images that are assumed to have a linear layout, implementations will also assume that the image data is at offset 0 relative to the start of the external memory allocation.
 
 External memory handle types not in {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} may have any memory layout. The layout interpretation of images imported with these handle types is implementation defined.
 
@@ -213,6 +212,7 @@ If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_, the
 The properties used to create a buffer or image from an external memory handle are described by related extensions.
 When a buffer or image is created from an external memory handle, the _flags_ used to specify usage information for the buffer or image must not include {CL_MEM_USE_HOST_PTR}, {CL_MEM_ALLOC_HOST_PTR}, or {CL_MEM_COPY_HOST_PTR}, and the _host_ptr_ argument must be `NULL`.
 When images are created from an external memory handle, implementations may acquire information about image attributes such as format and layout at the time of creation. When such information is acquired at image creation time, it is used for the lifetime of the image object.
+Implementations will also assume that the image data is at offset 0 relative to the start of the external memory allocation.
 
 Add to the list of error conditions for {clCreateBufferWithProperties} and {clCreateImageWithProperties}:
 


### PR DESCRIPTION
Clarify that the offset is zero when importing memory, and the layout is not inferred, such as linear memory from a handle specified as "assume linear". This implies that when specifying an image slice_pitch, array layer 0 is assumed to start at offset 0.