### PR TITLE
Add CL_CANCELLED_IMG error code for cl_img_cancel_command extension.

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -669,11 +669,8 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums start="-1122" end="-1137" name="ErrorCodes.1122" vendor="IMG" comment="Reserved for Imagination extensions">
-        <enum value="-1122"         name="CL_ERROR_RESERVED0_IMG"/>
-        <enum value="-1123"         name="CL_ERROR_RESERVED1_IMG"/>
-        <enum value="-1124"         name="CL_ERROR_RESERVED2_IMG"/>
-        <enum value="-1125"         name="CL_ERROR_RESERVED3_IMG"/>
-            <unused start="-1126" end="-1137"/>
+        <enum value="-1122"         name="CL_CANCELLED_IMG"/>
+            <unused start="-1123" end="-1137"/>
     </enums>
 
     <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="For cl_khr_command_buffer related extensions">

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -669,8 +669,12 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <enums start="-1122" end="-1137" name="ErrorCodes.1122" vendor="IMG" comment="Reserved for Imagination extensions">
-        <enum value="-1122"         name="CL_CANCELLED_IMG"/>
-            <unused start="-1123" end="-1137"/>
+        <enum value="-1122"         name="CL_ERROR_RESERVED0_IMG"/>
+        <enum value="-1123"         name="CL_ERROR_RESERVED1_IMG"/>
+        <enum value="-1124"         name="CL_ERROR_RESERVED2_IMG"/>
+        <enum value="-1125"         name="CL_ERROR_RESERVED3_IMG"/>
+        <enum value="-1126"         name="CL_CANCELLED_IMG"/>
+            <unused start="-1127" end="-1137"/>
     </enums>
 
     <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="For cl_khr_command_buffer related extensions">


### PR DESCRIPTION
Added a new error code CL_CANCELLED_IMG, which will be used by future cl_img_cancel_commands extension.