### PR TITLE
Upload cl_img_cancel_command asciidoc specification

### DIFF
--- a/extensions/cl_img_cancel_command.asciidoc
+++ b/extensions/cl_img_cancel_command.asciidoc
@@ -1,0 +1,96 @@
+
+= cl_img_cancel_command
+
+== Name Strings
+
+`cl_img_cancel_command`
+
+== Version History
+
+[cols="1,1,3",options="header",]
+|====
+| *Date*     | *Version* | *Description*
+| 2023-07-05 | 1.0.0     | Initial revision.
+|====
+
+== Contacts
+
+Imagination Technologies Developer Forum: +
+https://forums.imgtec.com/
+
+Paul Fradgley, Imagination Technologies (paul.fradgley 'at' imgtec.com)
+	
+== Contributors
+
+Paul Fradgley, Imagination Technologies.
+
+== Notice
+
+Copyright (c) 2023-2027 Imagination Technologies Ltd. All Rights Reserved.
+	
+== Status
+
+Shipping.
+
+== Version
+
+Built On: {docdate} +
+Version: 1.0.0
+
+== Dependencies
+
+Requires OpenCL version 3.0 or later.
+
+This extension is written against the wording of the OpenCL 3.0 Specification.
+
+== Overview
+
+This extension adds the functionality to instruct the OpenCL implementation that an incomplete OpenCL command no longer needs to be executed.
+
+== New API Functions
+
+[source]
+----
+cl_int clCancelCommandsIMG(
+    const cl_event *event_list,
+    size_t num_events_in_list)
+----
+
+== New API Enums
+
+[source,opencl]
+----
+CL_CANCELLED_IMG -1126
+----
+
+== Modifications to the OpenCL API Specification
+
+(Add Section 5.16, *Cancelling Queued Commands*) ::
++
+
+The function
+
+[source]
+----
+cl_int clCancelCommandsIMG(
+    size_t num_events_in_list,
+    const cl_event *event_list);
+----
+is used to inform the OpenCL implementation that a list of commands that were previously enqueued are no longer required. +
+Any commands belonging to events in the _event_list_ that are in the `CL_QUEUED` state will not be executed. These events will be set to the `CL_CANCELLED_IMG` state. +
+Any commands belonging to events in the _event_list_ that are in the `CL_SUBMITTED` might not be executed. These events will be set to the `CL_CANCELLED_IMG` state. +
+Any commands belonging to events in the _event_list_ that are in the `CL_RUNNING`, `CL_COMPLETE` or an error state will not be affected. +
+Any other command in the `CL_QUEUED` state that has a `CL_CANCELLED_IMG` event in its event_wait_list will not be executed. The events belonging to these commands will also be set to the `CL_CANCELLED_IMG` state.
+
+_event_list_ and _num_events_in_list_ specify events that belong to commands that no longer need to be executed.
+If _event_list_ is `NULL`, _num_events_in_list_ must be 0.
+If _event_list_ is not `NULL`, the list of events pointed to by _event_list_ must be valid and _num_events_in_list_ must be greater than 0.
+
+*clCancelCommandsIMG* returns `CL_SUCCESS` if the function is executed successfully, otherwise it returns one of the following errors:
+
+* `CL_INVALID_VALUE` if _event_list_ is `NULL` and _num_events_in_list_ is greater than 0.
+* `CL_INVALID_VALUE` if _event_list_ is not `NULL` and _num_events_in_list_ is 0.
+* `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by the	OpenCL implementation on the device.
+* `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by the OpenCL implementation on the host.
+
+== Issues

--- a/extensions/cl_img_cancel_command.asciidoc
+++ b/extensions/cl_img_cancel_command.asciidoc
@@ -26,7 +26,7 @@ Paul Fradgley, Imagination Technologies.
 
 == Notice
 
-Copyright (c) 2023-2027 Imagination Technologies Ltd. All Rights Reserved.
+Copyright (c) 2023-2024 Imagination Technologies Ltd. All Rights Reserved.
 	
 == Status
 


### PR DESCRIPTION
This extension adds the functionality to instruct the OpenCL implementation that an incomplete OpenCL command no longer needs to be executed.