### PR TITLE
fixes derived formula for atanh

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11677,7 +11677,7 @@ requires>> support for OpenCL C 2.0 or newer.
   | Defined for _x_ in the domain (-1, 1).
     For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
     For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
-    0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
+    0.5f * *log*\((1.0f + _x_) / (1.0f - _x_)).
     For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *atanpi*(_x_)

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1443,7 +1443,7 @@ profile.
     | Defined for _x_ in the domain (-1, 1).
       For _x_ in [-2^-10^, 2^-10^], derived implementations may implement as _x_.
       For _x_ outside of [-2^-10^, 2^-10^], derived implementations may implement as
-      0.5f * *log*((1.0f + _x_) / (1.0f - _x_)).
+      0.5f * *log*\((1.0f + _x_) / (1.0f - _x_)).
       For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *atanpi*


### PR DESCRIPTION
Asciidoctor treats words surrounded by double parentheses as index terms, so we need to escape the first parenthesis so the derived formula for atanh is properly preserved.

See: #142 

I did a search through the spec and I believe all of the other uses of double parentheses (typically for OpenCL C attributes, like the reqd_work_group_size) are properly handled.

It would be nice to have a way to disable this expansion since we don't use it, or at least to detect when it occurs.