### PR TITLE
clarify that 16-bit and 64-bit floats can be passed as kernel arguments

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -370,7 +370,7 @@ Allowed types for OpenCL kernel arguments are:
 For *OpTypeInt* parameters, supported _Widths_ are 8, 16, 32, and 64, and
 must have no signedness semantics.
 
-For *OpTypeFloat* parameters, _Width_ must be 32.
+For *OpTypeFloat* parameters, supported _Width_ are 16, 32, and 64.
 
 For *OpTypeStruct* parameters, supported structure _Member Types_ are:
 


### PR DESCRIPTION
fixes #1037