### PR TITLE
add the numerical value of the image channel order and data type

### DIFF
--- a/env/common_properties.asciidoc
+++ b/env/common_properties.asciidoc
@@ -211,69 +211,98 @@ The following table describes how the results of the SPIR-V
 channel orders.
 
 .Image Channel Order mapping
-[cols="1,1",options="header"]
+[cols="1,5,5",options="header"]
 |====
-| *SPIR-V Image Channel Order*
+2+| *SPIR-V Image Channel Order*
 | *OpenCL Image Channel Order*
 
-| `R`
+| 0
+| *R*
 | `CL_R`
 
-| `A`
+| 1
+| *A*
 | `CL_A`
 
-| `RG`
+| 2
+| *RG*
 | `CL_RG`
 
-| `RA`
+| 3
+| *RA*
 | `CL_RA`
 
-| `RGB`
+| 4
+| *RGB*
 | `CL_RGB`
 
-| `RGBA`
+| 5
+| *RGBA*
 | `CL_RGBA`
 
-| `BGRA`
+| 6
+| *BGRA*
 | `CL_BGRA`
 
-| `ARGB`
+| 7
+| *ARGB*
 | `CL_ARGB`
 
-| `Intensity`
+| 8
+| *Intensity*
 | `CL_INTENSITY`
 
-| `Luminance`
+| 9
+| *Luminance*
 | `CL_LUMINANCE`
 
-| `Rx`
+| 10
+| *Rx*
 | `CL_Rx`
 
-| `RGx`
+| 11
+| *RGx*
 | `CL_RGx`
 
-| `RGBx`
+| 12
+| *RGBx*
 | `CL_RGBx`
 
-| `Depth`
+| 13
+| *Depth*
 | `CL_DEPTH`
 
-| `DepthStencil`
+| 14
+| *DepthStencil*
 | `CL_DEPTH_STENCIL`
 
-| `sRGB`
+| 15
+| *sRGB*
 | `CL_sRGB`
 
-| `sRGBA`
-| `CL_sRGBA`
-
-| `sBGRA`
-| `CL_sBGRA`
-
-| `sRGBx`
+| 16
+| *sRGBx*
 | `CL_sRGBx`
 
+| 17
+| *sRGBA*
+| `CL_sRGBA`
+
+| 18
+| *sBGRA*
+| `CL_sBGRA`
+
+| 19
+| *ABGR*
+| `CL_ABGR`
+
 |====
+
+[NOTE]
+--
+The SPIR-V Image Channel Orders are enumerated in the same order as the
+OpenCL Channel Order enums to enable simple conversion between the two.
+--
 
 === Image Channel Data Type Mapping
 
@@ -282,63 +311,86 @@ The following table describes how the results of the SPIR-V
 channel data types.
 
 .Image Channel Data Type mapping
-[cols="1,1",options="header"]
+[cols="1,5,5",options="header"]
 |====
-| *SPIR-V Image Channel Data Type*
+2+| *SPIR-V Image Channel Data Type*
 | *OpenCL Image Channel Data Type*
 
-| `SnormInt8`
+| 0
+| *SnormInt8*
 | `CL_SNORM_INT8`
 
-| `SnormInt16`
+| 1
+| *SnormInt16*
 | `CL_SNORM_INT16`
 
-| `UnormInt8`
+| 2
+| *UnormInt8*
 | `CL_UNORM_INT8`
 
-| `UnormInt16`
+| 3
+| *UnormInt16*
 | `CL_UNORM_INT16`
 
-| `UnormInt24`
-| `CL_UNORM_INT24`
-
-| `UnormShort565`
+| 4
+| *UnormShort565*
 | `CL_UNORM_SHORT_565`
 
-| `UnormShort555`
+| 5
+| *UnormShort555*
 | `CL_UNORM_SHORT_555`
 
-| `UnormInt101010`
+| 6
+| *UnormInt101010*
 | `CL_UNORM_INT_101010`
 
-| `UnormInt101010_2`
-| `CL_UNORM_INT_101010_2`
-
-| `SignedInt8`
+| 7
+| *SignedInt8*
 | `CL_SIGNED_INT8`
 
-| `SignedInt16`
+| 8
+| *SignedInt16*
 | `CL_SIGNED_INT16`
 
-| `SignedInt32`
+| 9
+| *SignedInt32*
 | `CL_SIGNED_INT32`
 
-| `UnsignedInt8`
+| 10
+| *UnsignedInt8*
 | `CL_UNSIGNED_INT8`
 
-| `UnsignedInt16`
+| 11
+| *UnsignedInt16*
 | `CL_UNSIGNED_INT16`
 
-| `UnsignedInt32`
+| 12
+| *UnsignedInt32*
 | `CL_UNSIGNED_INT32`
 
-| `HalfFloat`
+| 13
+| *HalfFloat*
 | `CL_HALF_FLOAT`
 
-| `Float`
+| 14
+| *Float*
 | `CL_FLOAT`
 
+| 15
+| *UnormInt24*
+| `CL_UNORM_INT24`
+
+| 16
+| *UnormInt101010_2*
+| `CL_UNORM_INT_101010_2`
+
 |====
+
+[NOTE]
+--
+The SPIR-V Image Channel Data Types are enumerated in the same order as the
+OpenCL Channel Data Type enums to enable simple conversion between the two.
+--
 
 === Kernels
 


### PR DESCRIPTION
This may make it easier to extend these tables or enable additional simplifications in the future.

see internal SPIR-V issue 773