### PR TITLE
Fix markups of parameter names ``obj`` and ``value``

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6629,7 +6629,7 @@ operation, constitutes a data-race.
 --
 
 The `atomic_init` function non-atomically initializes the atomic object
-pointed to by obj to the value value.
+pointed to by _obj_ to the value _value_.
 
 [source,opencl_c]
 ----------


### PR DESCRIPTION
In other part of the document, parameter names are enclosed in ``_``, so these parameters also should be marked up the same way.