### PR TITLE
Add `cl_img_cancel_command` extension to XML

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7403,6 +7403,9 @@ server's OpenCL/api-docs repository.
             <require comment="Error codes">
                 <enum name="CL_CANCELLED_IMG"/>
             </require>
+            <require>
+                <command name="clCancelCommandsIMG"/>
+            </require>
         </extension>
     </extensions>
 </registry>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4299,6 +4299,11 @@ server's OpenCL/api-docs repository.
             <param><type>void</type>*                                   <name>param_value</name></param>
             <param><type>size_t</type>*                                 <name>param_value_size_ret</name></param>
         </command>
+        <command>
+            <proto><type>cl_int</type>                                  <name>clCancelCommandsIMG</name></proto>
+            <param>const <type>cl_event</type>*                         <name>event_list</name></param>
+            <param><type>size_t</type>                                  <name>num_events_in_list</name></param>
+        </command>
     </commands>
 
     <!-- SECTION: OpenCL API interface definitions -->
@@ -7392,6 +7397,11 @@ server's OpenCL/api-docs repository.
             <require comment="cl_channel_type">
                 <enum name="CL_UNSIGNED_INT_RAW10_EXT"/>
                 <enum name="CL_UNSIGNED_INT_RAW12_EXT"/>
+            </require>
+        </extension>
+        <extension name="cl_img_cancel_command" supported="opencl">
+            <require comment="Error codes">
+                <enum name="CL_CANCELLED_IMG"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
`CL_CANCELLED_IMG` being defined but not used was bothering me when pulling upstream changes...

@paulfradgley is this all right?

For context:
1. `CL_CANCELLED_IMG` was added to XML separately in #1042
2. Specification was added in #1046, but it didn't add the rest of the definitions to XML