### PR TITLE
Fix `cl_khr_command_buffer_mutable_dispatch` extension

### DIFF
--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -337,7 +337,7 @@ description of property values.
   
 |====
 
-Add a {CL_COMMAND_BUFFER_ASSERTS_KHR} property to the
+Add a {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR} property to the
 <<commandbuffer-properties, clCreateCommandBufferKHR properties>> table.
 
 [cols=",,",options="header",]
@@ -346,7 +346,7 @@ Add a {CL_COMMAND_BUFFER_ASSERTS_KHR} property to the
 | *Property Value*
 | *Description*
 
-| {CL_COMMAND_BUFFER_ASSERTS_KHR}
+| {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR}
 | {cl_mutable_dispatch_asserts_khr_TYPE}
 | This is a bitfield and can be set to a combination of the following values:
 
@@ -361,7 +361,7 @@ Add a {CL_COMMAND_BUFFER_ASSERTS_KHR} property to the
 
 ===== Additional Errors
 
-* {CL_INVALID_VALUE} if _properties_ has a {CL_COMMAND_BUFFER_ASSERTS_KHR} property with
+* {CL_INVALID_VALUE} if _properties_ has a {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR} property with
   {CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR}, but _local_work_size_ is `NULL`. 
 
 ==== Modifications to clCommandNDRangeKernelKHR

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7183,7 +7183,6 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_command_buffer_properties_khr">
                <enum name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
-               <enum name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR"/>
             </require>
             <require comment="cl_command_buffer_flags_khr - bitfield">
                <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
@@ -7352,7 +7351,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
             </require>
             <require comment="cl_command_buffer_properties_khr">
-                <enum name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>
+                <enum name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR "/>
             </require>
             <require comment="cl_ndrange_kernel_command_properties_khr">
                 <enum name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7351,7 +7351,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
             </require>
             <require comment="cl_command_buffer_properties_khr">
-                <enum name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR "/>
+                <enum name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR"/>
             </require>
             <require comment="cl_ndrange_kernel_command_properties_khr">
                 <enum name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>


### PR DESCRIPTION
Found at the end of https://github.com/KhronosGroup/OpenCL-Docs/pull/992

`CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR` enum has the wrong name in the spec and was added to the wrong extension block in XML. It was also added to the right extension block, but under the wrong name: `CL_MUTABLE_DISPATCH_ASSERTS_KHR`.