### PR TITLE
fix a few minor issues in the extensions spec

### DIFF
--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -20,7 +20,7 @@ commands between command-buffer enqueues.
 |====
 | *Date*     | *Version* | *Description*
 | 2022-08-31 | 0.9.0     | First assigned version (provisional).
-| 2023-11-07 | 0.9.1     | Add type cl_mutable_dispatch_asserts_khr and its possible values (provisional).
+| 2023-11-07 | 0.9.1     | Add type {cl_mutable_dispatch_asserts_khr_TYPE} and its possible values (provisional).
 |====
 
 include::provisional_notice.asciidoc[]
@@ -237,10 +237,13 @@ CL_INVALID_MUTABLE_COMMAND_KHR                     -1141
 // Accepted values for the param_name parameter to clGetDeviceInfo
 CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR        0x12B0
 
-/* cl_command_buffer_properties_khr */
+// Accepted command buffer property to clCreateCommandBufferKHR
 CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR	   0x12B7
 
-// Property to cl_ndrange_kernel_command_properties_khr
+// Bits for cl_command_buffer_flags_khr
+CL_COMMAND_BUFFER_MUTABLE_KHR                    (0x1 << 1)
+
+// Accepted ND-range kernel command properties to clCommandNDRangeKernelKHR
 CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR           0x12B1
 CL_MUTABLE_DISPATCH_ASSERTS_KHR                    0x12B8
 
@@ -250,6 +253,9 @@ CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR                (0x1 << 1)
 CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR                 (0x1 << 2)
 CL_MUTABLE_DISPATCH_ARGUMENTS_KHR                  (0x1 << 3)
 CL_MUTABLE_DISPATCH_EXEC_INFO_KHR                  (0x1 << 4)
+
+// Bits for cl_mutable_dispatch_asserts_khr bitfield
+CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR	(0x1 << 0)
 
 // cl_mutable_command_info_khr
 CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR               0x12A0
@@ -261,12 +267,6 @@ CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR         0x12A5
 CL_MUTABLE_DISPATCH_GLOBAL_WORK_SIZE_KHR           0x12A6
 CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR            0x12A7
 CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR                0x12AD
-
-// Bits for cl_command_buffer_flags_khr
-CL_COMMAND_BUFFER_MUTABLE_KHR                    (0x1 << 1)
-
-// Bits for cl_mutable_dispatch_asserts_khr bitfield
-CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR	(0x1 << 0)
 ----
 
 Enum values for {cl_command_buffer_structure_type_khr_TYPE} allowing the structure

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -1007,3 +1007,4 @@ non-trivial deep copying of the underlying objects contained in the
 command-buffer. As a result of this new entry-point being an additive change to
 the specification it is omitted, and if its functionality has demand later, it
 may be a introduced as a stand alone extension.
+--

--- a/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/ext/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -105,7 +105,7 @@ typedef cl_uint cl_mutable_command_info_khr;
 // Identifies the type of a structure to allow structure pointer chains
 typedef cl_uint cl_command_buffer_structure_type_khr;
 
-// Bitfield covering certain asserts by the user to the implementation, enabling possible optimizations 
+// Bitfield describing mutable-dispatch assertions, enabling possible optimizations 
 typedef cl_bitfield cl_mutable_dispatch_asserts_khr;
 ----
 
@@ -359,11 +359,6 @@ Add a {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR} property to the
 
 |====
 
-===== Additional Errors
-
-* {CL_INVALID_VALUE} if _properties_ has a {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR} property with
-  {CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR}, but _local_work_size_ is `NULL`. 
-
 ==== Modifications to clCommandNDRangeKernelKHR
 
 ===== Properties Parameter
@@ -471,8 +466,13 @@ Is replaced with
   
 The following error condition is added:
 
-* {CL_INVALID_VALUE} if _properties_ has a {CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR} property with
-  {CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR}, but _local_work_size_ is `NULL`.
+* {CL_INVALID_VALUE} if _command_buffer_ was created with the
+  {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR} property with
+  {CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR} and
+  _local_work_size_ is `NULL`, or if _properties_ includes the
+  {CL_MUTABLE_DISPATCH_ASSERTS_KHR} property with
+  {CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR} and
+  _local_work_size_ is `NULL`.
 
 [[mutable-commands]]
 ==== New Section in the OpenCL API specification 5.X.5 - Mutable Commands:

--- a/ext/cl_khr_external_memory.asciidoc
+++ b/ext/cl_khr_external_memory.asciidoc
@@ -33,7 +33,7 @@ Other related extensions define specific external memory types that may be impor
 | 2021-09-10 | 0.9.0     | Initial version (provisional).
 | 2023-05-04 | 0.9.1     | Clarified device handle list enum cannot be specified without an external memory handle (provisional).
 | 2023-08-01 | 0.9.2     | Changed device handle list enum to the memory-specific {CL_MEM_DEVICE_HANDLE_LIST_KHR} (provisional).
-| 2023-08-29 | 0.9.3     | Added query for {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_HANDLE_TYPES_KHR} (provisional).
+| 2023-08-29 | 0.9.3     | Added query for {CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR} (provisional).
 |====
 
 include::provisional_notice.asciidoc[]


### PR DESCRIPTION
* Fixes "unterminated open block" at the end of the mutable dispatch extension.
* Fixes a typo in the assume linear images enum.
* Uses the asciidoctor attribute for the mutable dispatch asserts type.
* Minor wordsmithing and ordering improvements in the mutable dispatch new enums section.