### PR TITLE
clarify conditions for CL_INVALID_PLATFORM

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1894,9 +1894,9 @@ to {CL_SUCCESS} if the context is created successfully.
 Otherwise, it returns a `NULL` value with the following error values
 returned in _errcode_ret_:
 
-  * {CL_INVALID_PLATFORM} if _properties_ is `NULL` and no platform could be
-    selected or if platform value specified in _properties_ is not a valid
-    platform.
+  * {CL_INVALID_PLATFORM} if no platform is specified in _properties_ and no
+    platform could be selected, or if the platform specified in _properties_ is
+    not a valid platform.
   * {CL_INVALID_PROPERTY} if context property name in _properties_ is not a
     supported property name, if the value specified for a supported property
     name is not valid, or if the same property name is specified more than
@@ -1962,9 +1962,9 @@ is set to {CL_SUCCESS} if the context is created successfully.
 Otherwise, it returns a `NULL` value with the following error values
 returned in _errcode_ret_:
 
-  * {CL_INVALID_PLATFORM} if _properties_ is `NULL` and no platform could be
-    selected or if platform value specified in _properties_ is not a valid
-    platform.
+  * {CL_INVALID_PLATFORM} if no platform is specified in _properties_ and no
+    platform could be selected, or if the platform specified in _properties_ is
+    not a valid platform.
   * {CL_INVALID_PROPERTY} if context property name in _properties_ is not a
     supported property name, if the value specified for a supported property
     name is not valid, or if the same property name is specified more than


### PR DESCRIPTION
See discussion: https://github.com/KhronosGroup/OpenCL-Docs/issues/1061#issuecomment-1949130684

Clarifies the conditions when clCreateContext and clCreateContextFromType should return CL_INVALID_PLATFORM.

CC @s-barannikov.