### PR TITLE
fix a few notes in the spec for consistency

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -51,11 +51,11 @@ include::copyrights.txt[]
 = The OpenCL C Programming Language
 
 [NOTE]
---
+====
 This document starts at chapter 6 to keep the section numbers historically
 consistent with previous versions of the OpenCL and OpenCL C Programming
 Language specifications.
---
+====
 
 This section describes the OpenCL C programming language.
 The OpenCL C programming language may be used to write kernels that execute

--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -81,7 +81,6 @@ Edge case behavior and accuracy rules are described in the OpenCL C
 and OpenCL SPIR-V Environment specifications.
 
 [NOTE]
-.Note
 ====
 If addition, subtraction and multiplication have default round to zero
 rounding mode, then *fract*, *fma* and *fdim* shall produce the correctly


### PR DESCRIPTION
Fixes a few minor issues with the "note" markup in the spec.

The first change doesn't seem to be a functional change, but I'm not quite sure how it is working right now, and we may as well make them all consistent.

The second change removes an extraneous ".Note" that we do not have for any of the other "notes".