### PR TITLE
add unsafe math optimization error bounds for the non-derived atan2

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -11688,6 +11688,7 @@ requires>> support for OpenCL C 2.0 or newer.
     | Derived implementations may implement as *atan*(_y_ / _x_) for _x_ > 0,
       *atan*(_y_ / _x_) + `M_PI_F` for _x_ < 0 and _y_ > 0, and
       *atan*(_y_ / _x_) - `M_PI_F` for _x_ < 0 and _y_ < 0.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *atan2pi*(_y_, _x_)
     | Derived implementations may implement as *atan2*(_y_, _x_) * `M_1_PI_F`.

--- a/cxx/numerical_compliance/relative_error_as_ulps.txt
+++ b/cxx/numerical_compliance/relative_error_as_ulps.txt
@@ -630,6 +630,7 @@ The reference value used to compute the ULP value of an arithmetic operation is 
 
 | atan2(y, x)
 | Implemented as atan(y/x) for x > 0, atan(y/x) + M_PI_F for x < 0 and y > 0 and atan(y/x) - M_PI_F for x < 0 and y < 0.
+  For non-derived implementations, the error is \<= 8192 ulp.
 
 | atanpi(x)
 | Implemented as atan(x) * M_1_PI_F.

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1454,6 +1454,7 @@ profile.
     | Derived implementations may implement as *atan*(_y_ / _x_) for _x_ > 0,
       *atan*(_y_ / _x_) + `M_PI_F` for _x_ < 0 and _y_ > 0, and
       *atan*(_y_ / _x_) - `M_PI_F` for _x_ < 0 and _y_ < 0.
+      For non-derived implementations, the error is {leq} 8192 ulp.
 
 | *OpExtInst* *atan2pi*
     | Derived implementations may implement as *atan2*(_y_, _x_) * `M_1_PI_F`.


### PR DESCRIPTION
In the tables describing required accuracy for math functions with "unsafe math optimizations" enabled we describe the required accuracy for both "derived" and "non-derived" implementations for most functions, but not for `atan2`.

This PR adds the required error bounds for atan2 as <= 8192 ulp, consistent with the required error bounds for the other non-derived implementations.

In addition, for Khronos folks, note that the required error bounds in these cases were originally added by BugZilla 12379.  I believe the intent all along was to define non-derived error bounds for `atan2`, but in the original proposal document the table cell for `atan2` wraps onto the next page and it doesn't appear that the non-derived error bounds were ever incorporated into the actual spec.