### PR TITLE
fix a few more broken refpage links for CL_VERSION_X_Y macros

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3405,7 +3405,7 @@ supported with `{global}` address space qualifier.
 [[preprocessor-directives-and-macros]]
 == Preprocessor Directives and Macros
 
-[open,refpage='preprocessorDirectives',desc='Preprocessor Directives and Macros',type='freeform',spec='clang',anchor='preprocessor-directives-and-macros',xrefs='clBuildProgram mathConstants EXTENSION FP_CONTRACT',alias='CL_VERSION_1_0 CL_VERSION_1_1 CL_VERSION_1_2']
+[open,refpage='preprocessorDirectives',desc='Preprocessor Directives and Macros',type='freeform',spec='clang',anchor='preprocessor-directives-and-macros',xrefs='clBuildProgram mathConstants EXTENSION FP_CONTRACT',alias='CL_VERSION_1_0 CL_VERSION_1_1 CL_VERSION_1_2 CL_VERSION_2_0 CL_VERSION_2_1 CL_VERSION_2_2 CL_VERSION_3_0']
 --
 
 The preprocessing directives defined by the C99 specification are supported.


### PR DESCRIPTION
fixes #981

#983 fixed many broken refpage links for the `CL_VERSION_X_Y` macros, but not all of them.

This PR adds the remaining `CL_VERSION_X_Y` macros.

See also: https://github.com/KhronosGroup/OpenCL-Registry/issues/146