### PR TITLE
Building individual extensions depends on generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ $(PDFDIR)/$(EXTSPEC).pdf: $(EXTSPECSRC)
 # Individual extensions spec(s)
 EXTDIR = extensions
 EXTENSIONSSPEC = extensions
-EXTENSIONSSPECSRC = $(EXTDIR)/$(EXTENSIONSSPEC).txt \
+EXTENSIONSSPECSRC = $(EXTDIR)/$(EXTENSIONSSPEC).txt ${GENDEPENDS} \
     $(shell grep ^include:: $(EXTDIR)/$(EXTENSIONSSPEC).txt | sed -e 's/^include:://' -e 's/\[\]/ /' | xargs echo)
 
 # Included extension documents


### PR DESCRIPTION
Fix an occasional parallel build failure.  I don't think this is a new issue, just it rarely occurs and only on a clean build.