### PR TITLE
Update XML to mark recently ratified extensions as non-provisional

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6950,7 +6950,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_semaphore" revision="0.9.1" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl" provisional="true">
+        <extension name="cl_khr_semaphore" revision="0.9.1" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6997,7 +6997,7 @@ server's OpenCL/api-docs repository.
                 <command name="clRetainSemaphoreKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_semaphore" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7032,7 +7032,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore_opaque_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_semaphore_opaque_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7040,7 +7040,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore_sync_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_semaphore_sync_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7063,7 +7063,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_memory" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7090,7 +7090,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseExternalMemObjectsKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_dma_buf" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_memory_dma_buf" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7109,7 +7109,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_opaque_fd" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_memory_opaque_fd" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7117,7 +7117,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_win32" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl" provisional="true">
+        <extension name="cl_khr_external_memory_win32" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
Net effect is to rearrange the extension appendices so these extensions are no longer in a 'provisional' subsection, and to remove the generated comments about their being provisional from the extension refpages.

@neiltrevett @bashbaug once #950 is merged into main, doing this sort of update will be needed whenever an extension is moved from non-ratified to ratified, or provisional ratified to fully ratified. For Vulkan, we've incorporated this into the extension release / ratification process checklists (along with many other minor, easy to overlook tasks).

I encourage merging #950 (with this included) ASAP as this is the start of generating divergences and merge conflicts that will have to be synced up with #950 every time one of the old independent khr extension docs is modified.