### PR TITLE
Fix section titles in Appendix I - OpenCL extensions

### DIFF
--- a/scripts/clconventions.py
+++ b/scripts/clconventions.py
@@ -199,7 +199,7 @@ class OpenCLConventions(ConventionsBase):
            file.
             - name - extension name"""
 
-        return 'include::{{apispec}}/{}[]'.format(
+        return 'include::{{apispec}}/{}[leveloffset=+1]'.format(
                 self.extension_file_path(name))
 
     @property

--- a/scripts/extensionmetadocgenerator.py
+++ b/scripts/extensionmetadocgenerator.py
@@ -256,7 +256,7 @@ class Extension:
 
         if not isRefpage:
             write('[[' + self.name + ']]', file=fp)
-            write('=== ' + self.name, file=fp)
+            write('== ' + self.name, file=fp)
             write('', file=fp)
 
             self.writeTag('Name String', '`' + self.name + '`', isRefpage, fp)


### PR DESCRIPTION
The section headers for "Name String", "Ratification Status", etc should be one level below the headers for individual extensions.

Another, possibly cleaner, way to fix this would be to add one level of nesting to headers in all the extension files under api/


Change-Id: I97bc12a845ccb39c421dfed16223b3cdee5203af