### PR TITLE
XML `<extension>`: Replace remaining `condition` with `depends`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6071,7 +6071,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetKernelExecInfoARM"/>
             </require>
         </extension>
-        <extension name="cl_arm_get_core_id" condition="defined(CL_VERSION_1_2)" supported="opencl">
+        <extension name="cl_arm_get_core_id" depends="CL_VERSION_1_2" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7278,7 +7278,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueWriteHostPipeINTEL"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_requirements_info" condition="defined(CL_VERSION_3_0)" supported="opencl">
+        <extension name="cl_ext_image_requirements_info" depends="CL_VERSION_3_0" supported="opencl">
             <require comment="Types">
                 <type name="cl_image_requirements_info_ext"/>
             </require>
@@ -7371,7 +7371,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetMutableCommandInfoKHR"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_from_buffer" condition="defined(CL_VERSION_3_0)" supported="opencl">
+        <extension name="cl_ext_image_from_buffer" depends="CL_VERSION_3_0" supported="opencl">
             <require comment="cl_image_requirements_info_ext">
                 <enum name="CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT"/>
             </require>

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -453,7 +453,6 @@ Extensions = element extensions {
 #   author - name of the author (usually a company or project name)
 #   contact - contact responsible for the tag (name and contact information)
 #   type - 'device' or 'instance', if present
-#   condition - C preprocessor expression (**TBD**)
 #   depends - boolean expression of API and/or extension names
 #       upon which this extension depends.
 #   supported - comma-separated list of API name(s) supporting this extension,
@@ -487,7 +486,6 @@ Extension = element extension {
     attribute author { text } ? ,
     attribute contact { text } ? ,
     attribute type { text } ? ,
-    attribute condition { text } ? ,
     attribute depends { text } ?,
     attribute supported { StringGroup } ? ,
     attribute ratified { text } ? ,


### PR DESCRIPTION
Asked at the end of #950. This in particular wasn't answered yet, but after getting a bit more comfortable with new XML - I'm pretty sure this does need to be fixed.

Note: There are also a bunch of `<require>` tags with `condition` instead of the `depends` attribute.
The `depends` attribute is being used for these too, but only in one place:
```
            <require depends="CL_VERSION_2_0" comment="From version 0.9.4 of the extension">
```
But half of the `condition` attributes here use negation:
```
            <require condition="!defined(CL_VERSION_1_2)" comment="cl_device_info - defined in CL.h for OpenCL 1.2 and newer">
```
And there is also one like this:
```
            <require condition="defined(_WIN32)">
```
Which is neither a version nor an extension name, so I guess this one cannot be converted to `depends`?