### PR TITLE
fix footnotes

### DIFF
--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -68,19 +68,6 @@ This value for memory_scope can only be used with atomic_work_item_fence with fl
 Note that the performance of 64-bit integer arithmetic can vary significantly between embedded devices. \
 ]
 
-:fn-kernel-arg-type-const-addr-space: pass:n[ \
-{CL_KERNEL_ARG_TYPE_CONST} is returned for {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is declared with the `constant` address space qualifier. \
-]
-
-:fn-kernel-arg-type-qualifier: pass:n[ \
-{CL_KERNEL_ARG_TYPE_CONST} is returned if the argument is a pointer and the referenced type is declared with the const qualifier. \
-For example, a kernel argument declared as `global int const *x` returns {CL_KERNEL_ARG_TYPE_CONST} but a kernel argument declared as `global int * const x` does not. + \
-Similarly, {CL_KERNEL_ARG_TYPE_RESTRICT} will be returned if the pointer type is marked `restrict`. \
-For example, `global int * restrict x` returns {CL_KERNEL_ARG_TYPE_RESTRICT}. + \
-{CL_KERNEL_ARG_TYPE_VOLATILE} is returned for {CL_KERNEL_ARG_TYPE_QUALIFIER} if the argument is a pointer and the referenced type is declared with the volatile qualifier. \
-For example, a kernel argument declared as `global int volatile *x` returns {CL_KERNEL_ARG_TYPE_VOLATILE} but a kernel argument declared as `global int * volatile x` does not. \
-]
-
 :fn-map-count-usage: pass:n[ \
 The map count returned should be considered immediately stale. \
 It is unsuitable for general use in applications. \
@@ -120,7 +107,7 @@ Rather than attempt to share {cl_kernel_TYPE} objects among multiple host thread
 ]
 
 :fn-readimageh: pass:n[ \
-And *read_imageh*, if the `<<cl_khr_fp16>>` extension is supported. \
+And *read_imageh*, if the `cl_khr_fp16` extension is supported. \
 ]
 
 :fn-reference-count-usage: pass:n[ \

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11080,15 +11080,33 @@ include::{generated}/api/version-notes/CL_KERNEL_ARG_TYPE_QUALIFIER.asciidoc[]
         for the argument given by _arg_index_.
         The returned values can be:
 
-        {CL_KERNEL_ARG_TYPE_CONST_anchor}
-        footnote:[{fn-kernel-arg-type-qualifier}]
-        footnote:[{fn-kernel-arg-type-const-addr-space}] +
+        {CL_KERNEL_ARG_TYPE_CONST_anchor} +
         {CL_KERNEL_ARG_TYPE_RESTRICT_anchor} +
         {CL_KERNEL_ARG_TYPE_VOLATILE_anchor} +
         {CL_KERNEL_ARG_TYPE_PIPE_anchor}, or +
         {CL_KERNEL_ARG_TYPE_NONE_anchor}
 
-        {CL_KERNEL_ARG_TYPE_NONE} is returned for all parameters passed by
+        {CL_KERNEL_ARG_TYPE_CONST} is returned if the kernel argument is a
+        pointer and the referenced type is declared with the `const` qualifier.
+        For example, a kernel argument declared as `global int const*` returns
+        {CL_KERNEL_ARG_TYPE_CONST} but a kernel argument declared as `global
+        int* const` does not.
+        Additionally, {CL_KERNEL_ARG_TYPE_CONST} is returned if the kernel
+        argument is declared with the `constant` address space qualifier.
+
+        {CL_KERNEL_ARG_TYPE_RESTRICT} is returned if the pointer type is marked
+        `restrict`.
+        For example, `global int* restrict` returns
+        {CL_KERNEL_ARG_TYPE_RESTRICT}.
+
+        {CL_KERNEL_ARG_TYPE_VOLATILE} is returned for
+        {CL_KERNEL_ARG_TYPE_QUALIFIER} if the kernel argument is a pointer and
+        the referenced type is declared with the `volatile` qualifier.
+        For example, a kernel argument declared as `global int volatile*`
+        returns {CL_KERNEL_ARG_TYPE_VOLATILE} but a kernel argument declared as
+        `global int* volatile` does not.
+
+        {CL_KERNEL_ARG_TYPE_NONE} is returned for all kernel arguments passed by
         value.
 | {CL_KERNEL_ARG_NAME_anchor}
 


### PR DESCRIPTION
fixes #1094 

Moves text for CL_KERNEL_ARG_TYPE_QUALIFIER out of a footnote and into the main spec text.

Removes link to the cl_khr_fp16 extension for the footnote.  This is not ideal, but is a reasonable short-term solution, and we'll probably want to rethink extension links for #1093 anyhow.