### PR TITLE
fix a markup issue regarding cl_khr_subgroup_extended_types

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -13888,8 +13888,8 @@ footnote:[{fn-half-supported}], `float`, and `double`
 footnote:[{fn-double-supported}].
 
 ifdef::cl_khr_subgroup_extended_types[]
-NOTE: If the `<<cl_khr_subgroup_extended_types>>` extension is supported,
-the supported `gentype`s also include `char`, `uchar`, `short`, and
+NOTE: If the `<<cl_khr_subgroup_extended_types>>` extension is supported, the
+generic type name `gentype` may additionally be `char`, `uchar`, `short`, and
 `ushort`.
 For the `sub_group_broadcast` function, `gentype` may additionally be one of
 the supported built-in vector data types `char__n__`, `uchar__n__`,


### PR DESCRIPTION
Looks like asciidoctor was getting confused by the "``s" at the end of "gentype", so just rephrase this sentence to avoid the confusion.