### PR TITLE
Fix provisional extension notes in appendices

### DIFF
--- a/api/appendix_extensions.asciidoc
+++ b/api/appendix_extensions.asciidoc
@@ -25,6 +25,22 @@ alphabetically by author ID.
 Within each group, extensions are listed in alphabetical order by their
 names.
 
+
+[[boilerplate-provisional-header]]
+== Provisional Extensions
+
+_Provisional_ OpenCL extensions described in this appendix have been
+Ratified under the Khronos Intellectual Property Framework.
+They are being made publicly available as provisional extensions to enable
+review and feedback from the community.
+While an extension is provisional, features may be added, removed, or
+changed in non-backward compatible ways.
+
+If you have feedback on a provisional extension, please create an issue on
+the link:https://github.com/KhronosGroup/OpenCL-Docs/[OpenCL-Docs
+repository].
+
+
 == Extension Dependencies
 
 Extensions which have dependencies on specific core versions or on other

--- a/api/cl_khr_command_buffer.asciidoc
+++ b/api/cl_khr_command_buffer.asciidoc
@@ -419,8 +419,6 @@ features:
 *UNRESOLVED*
 --
 
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-11-10

--- a/api/cl_khr_command_buffer_multi_device.asciidoc
+++ b/api/cl_khr_command_buffer_multi_device.asciidoc
@@ -305,8 +305,6 @@ require it.
 *RESOLVED*: Added as an optional feature.
 --
 
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2023-04-14

--- a/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -367,8 +367,6 @@ specification it is omitted, and if its functionality has demand later, it
 may be a introduced as a stand alone extension.
 --
 
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2022-08-31

--- a/api/cl_khr_external_memory.asciidoc
+++ b/api/cl_khr_external_memory.asciidoc
@@ -298,8 +298,6 @@ while (true) {
 *UNRESOLVED*
 --
 
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_memory_dma_buf.asciidoc
+++ b/api/cl_khr_external_memory_dma_buf.asciidoc
@@ -72,10 +72,6 @@ TODO
   * {cl_external_memory_handle_type_khr_TYPE}
   ** {CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_memory_dx.asciidoc
+++ b/api/cl_khr_external_memory_dx.asciidoc
@@ -75,10 +75,6 @@ TODO
   ** {CL_EXTERNAL_MEMORY_HANDLE_D3D12_HEAP_KHR}
   ** {CL_EXTERNAL_MEMORY_HANDLE_D3D12_RESOURCE_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_memory_opaque_fd.asciidoc
+++ b/api/cl_khr_external_memory_opaque_fd.asciidoc
@@ -72,10 +72,6 @@ TODO
   * {cl_external_memory_handle_type_khr_TYPE}
   ** {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_memory_win32.asciidoc
+++ b/api/cl_khr_external_memory_win32.asciidoc
@@ -73,10 +73,6 @@ TODO
   ** {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR}
   ** {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_semaphore.asciidoc
+++ b/api/cl_khr_external_semaphore.asciidoc
@@ -274,10 +274,6 @@ while (true) {
 }
 ----
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_semaphore_dx_fence.asciidoc
+++ b/api/cl_khr_external_semaphore_dx_fence.asciidoc
@@ -39,10 +39,6 @@ D3D12 fence as an external semaphore using the APIs introduced by
   * {cl_external_semaphore_handle_type_khr_TYPE}
   ** {CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_semaphore_opaque_fd.asciidoc
+++ b/api/cl_khr_external_semaphore_opaque_fd.asciidoc
@@ -39,10 +39,6 @@ introduced by `<<cl_khr_external_semaphore>>`.
   * {cl_external_semaphore_handle_type_khr_TYPE}
   ** {CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_semaphore_sync_fd.asciidoc
+++ b/api/cl_khr_external_semaphore_sync_fd.asciidoc
@@ -48,10 +48,6 @@ external semaphore using the APIs introduced by
   * {cl_external_semaphore_handle_type_khr_TYPE}
   ** {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_external_semaphore_win32.asciidoc
+++ b/api/cl_khr_external_semaphore_win32.asciidoc
@@ -40,10 +40,6 @@ introduced by `<<cl_khr_external_semaphore>>`.
   ** {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR}
   ** {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR}
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10

--- a/api/cl_khr_semaphore.asciidoc
+++ b/api/cl_khr_semaphore.asciidoc
@@ -247,10 +247,6 @@ while (true) {
 }
 ----
 
-=== Issues
-
-include::provisional_notice.asciidoc[]
-
 === Version History
 
   * Revision 0.9.0, 2021-09-10


### PR DESCRIPTION
The autogenerated metadata for provisional extensions includes a sentence linking to what was previously a dead anchor. The anchor now points to a short subsection at the start of the extensions appendix capturing substantially the same language as the explicitly included provisional_notice.asciidoc in the separate extension documents - it has been rephrased slightly and reads slightly better now, I think.

The explicit includes of provisional_notice.asciidoc have been removed (and also from some extensions that were recently ratified as non-provisional).

N.b. some older extensions that were ratified initially as provisional later had the extension version number bumped and a version commented added to the effect that they were no longer provisional. I don't know if that is really needed when they are ratified as non-provisional without any API changes, but for consistency that might be something you wish to do. It is out of scope for this PR and would require changes to both XML and the extension appendix version notes.

Closes #1106 