### PR TITLE
Set anchor on `CL_COMMAND_BUFFER_MUTABLE_KHR`

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14051,7 +14051,7 @@ include::{generated}/api/version-notes/CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR.as
 endif::cl_khr_command_buffer_multi_device[]
 
 ifdef::cl_khr_command_buffer_mutable_dispatch[]
-      {CL_COMMAND_BUFFER_MUTABLE_KHR} - Enables modification of the
+      {CL_COMMAND_BUFFER_MUTABLE_KHR_anchor} - Enables modification of the
       command-buffer, by default command-buffers are immutable.
       If set, commands in the command-buffer may be updated via
       {clUpdateMutableCommandsKHR}.


### PR DESCRIPTION
The link in the "New Enums" section of cl_khr_command_buffer_mutable_dispatch doesn't lead anywhere otherwise.