### PR TITLE
Synchronize scripts with Vulkan, correct extension appendix section nesting

### DIFF
--- a/scripts/genRef.py
+++ b/scripts/genRef.py
@@ -223,7 +223,7 @@ def refPageShell(pageName, pageDesc, fp, head_content = None, sections=None, tai
     """Generate body of a reference page.
 
     - pageName - string name of the page
-    - pageDesc - string short description of the page, or empty string
+    - pageDesc - string short description of the page
     - fp - file to write to
     - head_content - text to include before the sections
     - sections - iterable returning (title,body) for each section.
@@ -245,7 +245,6 @@ def refPageShell(pageName, pageDesc, fp, head_content = None, sections=None, tai
           conventions.extra_refpage_body,
           '',
           sep='\n', file=fp)
-
     if pageDesc.strip() == '':
         pageDesc = 'NO SHORT DESCRIPTION PROVIDED'
         logWarn('refPageHead: no short description provided for', pageName)

--- a/scripts/reflib.py
+++ b/scripts/reflib.py
@@ -326,6 +326,13 @@ def fixupRefs(pageMap, specFile, file):
                 pi.param = nextPara(file, pi.include)
                 if pi.body is None:
                     pi.body = nextPara(file, pi.param)
+
+                    # Vulkan Feature struct refpages may have interstitial
+                    # text between the include block and the actual
+                    # parameter descriptions.
+                    # If so, advance the body one more paragraph.
+                    if 'This structure describes the following feature' in file[pi.param]:
+                        pi.body = nextPara(file, pi.body)
             else:
                 if pi.body is None:
                     pi.body = nextPara(file, pi.include)
@@ -336,6 +343,16 @@ def fixupRefs(pageMap, specFile, file):
         # the end of block, if, for example, there is no parameter section.
         pi.param = clampToBlock(pi.param, pi.include, pi.end)
         pi.body = clampToBlock(pi.body, pi.param, pi.end)
+
+        if pi.type in ['funcpointers', 'protos']:
+            # It is possible for the inferred parameter section to be invalid,
+            # such as for the type PFN_vkVoidFunction, which has no parameters.
+            # Since the parameter section is always a bullet-point list, we know
+            # the section is invalid if its text does not start with a list item.
+            # Note: This also deletes parameter sections that are simply empty.
+            if pi.param is not None and not file[pi.param].startswith('  * '):
+                pi.body = pi.param
+                pi.param = None
 
         # We can get to this point with .include, .param, and .validity
         # all being None, indicating those sections were not found.

--- a/scripts/spec_tools/conventions.py
+++ b/scripts/spec_tools/conventions.py
@@ -102,6 +102,17 @@ class ConventionsBase(abc.ABC):
         """Mark up an extension name as a link in the spec."""
         return '`<<{}>>`'.format(name)
 
+    def formatSPIRVlink(self, name):
+        """Mark up a SPIR-V extension name as an external link in the spec.
+           Since these are external links, the formatting probably will be
+           the same for all APIs creating such links, so long as they use
+           the asciidoctor {spirv} attribute for the base path to the SPIR-V
+           extensions."""
+
+        (vendor, _) = self.extension_name_split(name)
+
+        return f'{{spirv}}/{vendor}/{name}.html[{name}]'
+
     @property
     @abc.abstractmethod
     def null(self):
@@ -285,7 +296,7 @@ class ConventionsBase(abc.ABC):
         Typically two uppercase letters followed by an underscore.
 
         Assumed to be the same as api_prefix, but some APIs use different
-        case convntions."""
+        case conventions."""
 
         return self.api_prefix
 
@@ -442,6 +453,16 @@ class ConventionsBase(abc.ABC):
         """Return True if MAX_ENUM tokens should be generated in
            documentation includes."""
         return False
+
+    def extension_name_split(self, name):
+        """Split an extension name, returning (vendor, rest of name).
+           The API prefix of the name is ignored."""
+
+        match = EXT_NAME_DECOMPOSE_RE.match(name)
+        vendor = match.group('vendor')
+        bare_name = match.group('name')
+
+        return (vendor, bare_name)
 
     @abc.abstractmethod
     def extension_file_path(self, name):


### PR DESCRIPTION
The observable effects of this are

- Pushes the subsection titles in the extension appendices down one level, similar to #1087 but keeping the scripts in sync
- Adds an autogenerated 'API Interactions' section with currently only affects the cl_khr_command_buffer extension, since that's the only one with some APIs tagged in the XML as dependent on a particular core version

Recommend this as a replacement for #1087