### PR TITLE
clarify CL_DEVICE_TYPE_DEFAULT and CL_DEVICE_TYPE_ALL for custom devices

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -395,13 +395,13 @@ include::{generated}/api/version-notes/CL_DEVICE_TYPE_DEFAULT.asciidoc[]
     {clGetDeviceIDs} or to create OpenCL contexts using
     {clCreateContextFromType}, and will never be returned in {CL_DEVICE_TYPE}
     for any OpenCL device.
-    The default OpenCL device must not be a {CL_DEVICE_TYPE_CUSTOM} device.
+    The default OpenCL device must not be a {CL_DEVICE_TYPE_CUSTOM} device
+    unless it is the only device in the platform.
 
 | {CL_DEVICE_TYPE_ALL_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_TYPE_ALL.asciidoc[]
-  | All OpenCL devices available in the platform, except for
-    {CL_DEVICE_TYPE_CUSTOM} devices.
+  | All OpenCL devices in the platform.
     {CL_DEVICE_TYPE_ALL} is only used to query OpenCL devices using
     {clGetDeviceIDs} or to create OpenCL contexts using
     {clCreateContextFromType}, and will never be returned in {CL_DEVICE_TYPE}


### PR DESCRIPTION
fixes #300 

Fixes `CL_DEVICE_TYPE_ALL` - now it will return all devices in the platform, including custom devices.

Clarifies that `CL_DEVICE_TYPE_DEFAULT` may return a custom device if it is the only device in the platform.