### PR TITLE
cleans up extension metadata

### DIFF
--- a/api/cl_khr_command_buffer_multi_device.asciidoc
+++ b/api/cl_khr_command_buffer_multi_device.asciidoc
@@ -46,6 +46,10 @@ Depending on platform support the mapping of commands to the new target
 device can be done either explicitly by the user, or automatically by the
 OpenCL runtime.
 
+=== New Commands
+
+  * {clRemapCommandBufferKHR}
+
 === New Types
 
 Bitfield for querying command-buffer capabilities of an OpenCL Platform with
@@ -53,10 +57,6 @@ Bitfield for querying command-buffer capabilities of an OpenCL Platform with
 queries table>>:
 
   * {cl_platform_command_buffer_capabilities_khr_TYPE}
-
-=== New Commands
-
-  * {clRemapCommandBufferKHR}
 
 === New Enums
 

--- a/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -70,6 +70,11 @@ As all command recording entry-points return a {cl_mutable_command_khr_TYPE}
 handle, and aspects like which {cl_mem_TYPE} object a command uses could
 also be updated between enqueues of the command-buffer.
 
+=== New Commands
+
+  * {clUpdateMutableCommandsKHR}
+  * {clGetMutableCommandInfoKHR}
+
 === New Types
 
   * {cl_mutable_dispatch_fields_khr_TYPE}
@@ -80,11 +85,6 @@ also be updated between enqueues of the command-buffer.
   * {cl_mutable_dispatch_config_khr_TYPE}
   * {cl_mutable_dispatch_exec_info_khr_TYPE}
   * {cl_mutable_dispatch_arg_khr_TYPE}
-
-=== New Commands
-
-  * {clUpdateMutableCommandsKHR}
-  * {clGetMutableCommandInfoKHR}
 
 === New Enums
 

--- a/api/cl_khr_d3d10_sharing.asciidoc
+++ b/api/cl_khr_d3d10_sharing.asciidoc
@@ -16,11 +16,6 @@ include::{generated}/meta/{refprefix}cl_khr_d3d10_sharing.txt[]
 
 `cl_khr_d3d10_sharing` provides interoperability between OpenCL and Direct3D 10.
 
-=== New Types
-
-  * {cl_d3d10_device_source_khr_TYPE}
-  * {cl_d3d10_device_set_khr_TYPE}
-
 === New Commands
 
   * {clGetDeviceIDsFromD3D10KHR}
@@ -30,7 +25,12 @@ include::{generated}/meta/{refprefix}cl_khr_d3d10_sharing.txt[]
   * {clEnqueueAcquireD3D10ObjectsKHR}
   * {clEnqueueReleaseD3D10ObjectsKHR}
 
-=== New Tokens
+=== New Types
+
+  * {cl_d3d10_device_source_khr_TYPE}
+  * {cl_d3d10_device_set_khr_TYPE}
+
+=== New Enums
 
   * {cl_d3d10_device_source_khr_TYPE}
   ** {CL_D3D10_DEVICE_KHR}

--- a/api/cl_khr_d3d11_sharing.asciidoc
+++ b/api/cl_khr_d3d11_sharing.asciidoc
@@ -25,7 +25,12 @@ include::{generated}/meta/{refprefix}cl_khr_d3d11_sharing.txt[]
   * {clEnqueueAcquireD3D11ObjectsKHR}
   * {clEnqueueReleaseD3D11ObjectsKHR}
 
-=== New Tokens
+=== New Types
+
+  * {cl_d3d11_device_source_khr_TYPE}
+  * {cl_d3d11_device_set_khr_TYPE}
+
+=== New Enums
 
   * {cl_d3d11_device_source_khr_TYPE}
   ** {CL_D3D11_DEVICE_KHR}

--- a/api/cl_khr_dx9_media_sharing.asciidoc
+++ b/api/cl_khr_dx9_media_sharing.asciidoc
@@ -32,7 +32,12 @@ adapter.
   * {clEnqueueAcquireDX9MediaSurfacesKHR}
   * {clEnqueueReleaseDX9MediaSurfacesKHR}
 
-=== New Tokens
+=== New Types
+
+  * {cl_dx9_media_adapter_type_khr_TYPE}
+  * {cl_dx9_media_adapter_set_khr_TYPE}
+
+=== New Enums
 
   * {cl_dx9_media_adapter_type_khr_TYPE}
   ** {CL_ADAPTER_D3D9_KHR}

--- a/api/cl_khr_egl_event.asciidoc
+++ b/api/cl_khr_egl_event.asciidoc
@@ -24,7 +24,7 @@ functionality of creating an EGL sync object from an OpenCL event object.
 
   * {clCreateEventFromEGLSyncKHR}
 
-=== New Tokens
+=== New Enums
 
   * New Error Codes
   ** {CL_INVALID_EGL_OBJECT_KHR}

--- a/api/cl_khr_egl_image.asciidoc
+++ b/api/cl_khr_egl_image.asciidoc
@@ -22,6 +22,9 @@ from from EGLImages.
   * {clCreateFromEGLImageKHR}
   * {clEnqueueAcquireEGLObjectsKHR}
   * {clEnqueueReleaseEGLObjectsKHR}
+
+=== New Enums
+
   * {cl_event_info_TYPE}
   ** {CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR}
   ** {CL_COMMAND_RELEASE_EGL_OBJECTS_KHR}

--- a/api/cl_khr_external_memory.asciidoc
+++ b/api/cl_khr_external_memory.asciidoc
@@ -66,10 +66,6 @@ TODO
   * {clEnqueueAcquireExternalMemObjectsKHR}
   * {clEnqueueReleaseExternalMemObjectsKHR}
 
-=== New Structures
-
-  * None
-
 === New Types
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_dma_buf.asciidoc
+++ b/api/cl_khr_external_memory_dma_buf.asciidoc
@@ -55,18 +55,6 @@ TODO
 
 // The 'New ...' section can be auto-generated
 
-=== New Commands
-
-  None
-
-=== New Structures
-
-  * None
-
-=== New Types
-
-  * None
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_dx.asciidoc
+++ b/api/cl_khr_external_memory_dx.asciidoc
@@ -55,18 +55,6 @@ TODO
 
 // The 'New ...' section can be auto-generated
 
-=== New Commands
-
-  None
-
-=== New Structures
-
-  * None
-
-=== New Types
-
-  * None
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_opaque_fd.asciidoc
+++ b/api/cl_khr_external_memory_opaque_fd.asciidoc
@@ -55,18 +55,6 @@ TODO
 
 // The 'New ...' section can be auto-generated
 
-=== New Commands
-
-  None
-
-=== New Structures
-
-  * None
-
-=== New Types
-
-  * None
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_win32.asciidoc
+++ b/api/cl_khr_external_memory_win32.asciidoc
@@ -55,18 +55,6 @@ TODO
 
 // The 'New ...' section can be auto-generated
 
-=== New Commands
-
-  None
-
-=== New Structures
-
-  * None
-
-=== New Types
-
-  * None
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_fp16.asciidoc
+++ b/api/cl_khr_fp16.asciidoc
@@ -23,7 +23,7 @@ built-in types that can be used for arithmetic operations, conversions, etc.
 See the link:{OpenCLCSpecURL}#cl_khr_fp16[Half-Precision Floating-Point]
 section of the OpenCL C specification for more information.
 
-=== New Tokens
+=== New Enums
 
   * {cl_device_info_TYPE}
   ** {CL_DEVICE_HALF_FP_CONFIG}

--- a/api/cl_khr_fp64.asciidoc
+++ b/api/cl_khr_fp64.asciidoc
@@ -24,7 +24,7 @@ conversions, etc.
 See the link:{OpenCLCSpecURL}#cl_khr_fp64[Double-Precision Floating-Point]
 section of the OpenCL C specification for more information.
 
-=== New Tokens
+=== New Enums
 
   * {cl_device_info_TYPE}
   ** {CL_DEVICE_DOUBLE_FP_CONFIG}

--- a/api/cl_khr_gl_event.asciidoc
+++ b/api/cl_khr_gl_event.asciidoc
@@ -30,7 +30,7 @@ as the OpenCL context.
 
   * {clCreateEventFromGLsyncKHR}
 
-=== New Tokens
+=== New Enums
 
   * {cl_command_type_TYPE}
   ** {CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR}

--- a/api/cl_khr_gl_sharing.asciidoc
+++ b/api/cl_khr_gl_sharing.asciidoc
@@ -61,7 +61,7 @@ and buffer object images with OpenCL is required by this extension.
   * {cl_gl_texture_info_TYPE}
   * {cl_gl_platform_info_TYPE}
 
-=== New Tokens
+=== New Enums
 
   * New Error Codes
   ** {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR}

--- a/api/cl_khr_icd.asciidoc
+++ b/api/cl_khr_icd.asciidoc
@@ -236,7 +236,7 @@ continue on to the next.
 
   * {clIcdGetPlatformIDsKHR}
 
-=== New Tokens
+=== New Enums
 
 Accepted as _param_name_ to the function {clGetPlatformInfo}:
 

--- a/api/cl_khr_il_program.asciidoc
+++ b/api/cl_khr_il_program.asciidoc
@@ -28,7 +28,7 @@ This functionality described by this extension is a core feature in OpenCL
 
   * {clCreateProgramWithILKHR}
 
-=== New Tokens
+=== New Enums
 
   * {cl_device_info_TYPE}
   ** {CL_DEVICE_IL_VERSION_KHR}

--- a/api/cl_khr_image2d_from_buffer.asciidoc
+++ b/api/cl_khr_image2d_from_buffer.asciidoc
@@ -22,7 +22,7 @@ This extension became a core feature in OpenCL 2.0.
 Refer to the discussion of 2D images created from buffers in the
 <<image-descriptor, Image Descriptor>> section for additional details.
 
-=== New Tokens
+=== New Enums
 
   * {CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR}
   * {CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR}

--- a/api/cl_khr_integer_dot_product.asciidoc
+++ b/api/cl_khr_integer_dot_product.asciidoc
@@ -52,10 +52,6 @@ Product] section of the OpenCL C specification for more information.
   ** {CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR}
   ** {CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR}
 
-=== New SPIR-V Capabilities
-
-  * TBD
-
 === Version History
 
   * Revision 1.0.0, 2021-06-17

--- a/api/cl_khr_spir.asciidoc
+++ b/api/cl_khr_spir.asciidoc
@@ -26,7 +26,7 @@ information on compiling SPIR binaries.
 which is supported by the `<<cl_khr_il_program>>` extension, and is a core
 feature in OpenCL 2.1.
 
-=== New Tokens
+=== New Enums
 
   * {cl_device_info_TYPE}
   ** {CL_DEVICE_SPIR_VERSIONS}

--- a/api/cl_khr_subgroups.asciidoc
+++ b/api/cl_khr_subgroups.asciidoc
@@ -33,13 +33,13 @@ However, note that:
 See the link:{OpenCLCSpecURL}#cl_khr_subgroups[Sub-Groups] section of the
 OpenCL C specification for more information.
 
-=== New Types
-
-  * {cl_kernel_sub_group_info_TYPE}
-
 === New Commands
 
   * {clGetKernelSubGroupInfoKHR}
+
+=== New Types
+
+  * {cl_kernel_sub_group_info_TYPE}
 
 === New Enums
 

--- a/api/cl_khr_terminate_context.asciidoc
+++ b/api/cl_khr_terminate_context.asciidoc
@@ -35,13 +35,13 @@ closure of ongoing operations when the results are no longer required in a
 much more expedient manner than waiting for all previously enqueued
 operations to finish.
 
-=== New Types
-
-  * {cl_device_terminate_capability_khr_TYPE}
-
 === New Commands
 
   * {clTerminateContextKHR}
+
+=== New Types
+
+  * {cl_device_terminate_capability_khr_TYPE}
 
 === New Enums
 


### PR DESCRIPTION
fixes #1098 
fixes #1099

* Use a consistent order for new commands, types, enums, etc.
* Add a few missing extension types
* Do not use the new SPIR-V capabilities section
* Use consistent terminology
* Do not include sections where nothing was added