### PR TITLE
adjustments to fix long table cells

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -3528,18 +3528,18 @@ Examples:
 
 kernel void f()
 {
-int *ptr;
-local int *lptr;
-global int *gptr;
-local int val = 55;
+    int *ptr;
+    local int *lptr;
+    global int *gptr;
+    local int val = 55;
 
-ptr = &val;  // legal: implicit cast to generic, then assign
-lptr = ptr;  // illegal: no implicit cast from
-             // generic to local
-lptr = gptr; // illegal: no implicit cast from
-             // global to local
-ptr = gptr;  // legal: implicit cast from global to generic,
-             // then assign
+    ptr = &val;  // legal: implicit cast to generic, then assign
+    lptr = ptr;  // illegal: no implicit cast from
+                // generic to local
+    lptr = gptr; // illegal: no implicit cast from
+                // global to local
+    ptr = gptr;  // legal: implicit cast from global to generic,
+                // then assign
 }
 ----------
 
@@ -6225,8 +6225,8 @@ a|
 [source,opencl_c]
 ----
 gentype bitfield_insert(
-    gentype base, gentype insert,
-    uint offset, uint count)
+  gentype base, gentype insert,
+  uint offset, uint count)
 ----
     | Returns a copy of _base_, with a modified bitfield that comes from
       _insert_.
@@ -6252,8 +6252,8 @@ a|
 [source,opencl_c]
 ----
 igentype bitfield_extract_signed(
-    gentype base,
-    uint offset, uint count)
+  gentype base,
+  uint offset, uint count)
 ----
     | Returns an extracted bitfield from _base_ with sign extension.
       The type of the return value is always a signed type.
@@ -6277,8 +6277,8 @@ a|
 [source,opencl_c]
 ----
 ugentype bitfield_extract_unsigned(
-    gentype base,
-    uint offset, uint count)
+  gentype base,
+  uint offset, uint count)
 ----
     | Returns an extracted bitfield from _base_ with zero extension.
       The type of the return value is always an unsigned type.
@@ -6301,7 +6301,7 @@ a|
 [source,opencl_c]
 ----
 gentype bit_reverse(
-    gentype base)
+  gentype base)
 ----
     | Returns the value of _base_ with reversed bits.
       That is, the bit numbered _n_ of the result value will be taken from
@@ -7581,7 +7581,7 @@ ifdef::cl_khr_async_work_group_copy_fence[]
 |[source,opencl_c]
 ----
 void async_work_group_copy_fence(
-    cl_mem_fence_flags flags)
+  cl_mem_fence_flags flags)
 ----
     | Orders async copies produced by the work-items of a work-group
       executing a kernel.
@@ -7682,28 +7682,28 @@ a|
 [source,opencl_c]
 ----
 event_t async_work_group_copy_2D2D(
-    __local void *dst,
-    size_t dst_offset,
-    const __global void *src,
-    size_t src_offset,
-    size_t num_bytes_per_element,
-    size_t num_elements_per_line,
-    size_t num_lines,
-    size_t src_total_line_length,
-    size_t dst_total_line_length,
-    event_t event)
+  __local void *dst,
+  size_t dst_offset,
+  const __global void *src,
+  size_t src_offset,
+  size_t num_bytes_per_element,
+  size_t num_elements_per_line,
+  size_t num_lines,
+  size_t src_total_line_length,
+  size_t dst_total_line_length,
+  event_t event)
 
 event_t async_work_group_copy_2D2D(
-    __global void *dst,
-    size_t dst_offset,
-    const __local void *src,
-    size_t src_offset,
-    size_t num_bytes_per_element,
-    size_t num_elements_per_line,
-    size_t num_lines,
-    size_t src_total_line_length,
-    size_t dst_total_line_length,
-    event_t event)
+  __global void *dst,
+  size_t dst_offset,
+  const __local void *src,
+  size_t src_offset,
+  size_t num_bytes_per_element,
+  size_t num_elements_per_line,
+  size_t num_lines,
+  size_t src_total_line_length,
+  size_t dst_total_line_length,
+  event_t event)
 ----
     | Perform an async copy of (_num_elements_per_line_ * _num_lines_)
       elements of size _num_bytes_per_element_ from (_src_ + (_src_offset_ *
@@ -7730,34 +7730,34 @@ a|
 [source,opencl_c]
 ----
 event_t async_work_group_copy_3D3D(
-    __local void *dst,
-    size_t dst_offset,
-    const __global void *src,
-    size_t src_offset,
-    size_t num_bytes_per_element,
-    size_t num_elements_per_line,
-    size_t num_lines,
-    size_t num_planes,
-    size_t src_total_line_length,
-    size_t src_total_plane_area,
-    size_t dst_total_line_length,
-    size_t dst_total_plane_area,
-    event_t event)
+  __local void *dst,
+  size_t dst_offset,
+  const __global void *src,
+  size_t src_offset,
+  size_t num_bytes_per_element,
+  size_t num_elements_per_line,
+  size_t num_lines,
+  size_t num_planes,
+  size_t src_total_line_length,
+  size_t src_total_plane_area,
+  size_t dst_total_line_length,
+  size_t dst_total_plane_area,
+  event_t event)
 
 event_t async_work_group_copy_3D3D(
-    __global void *dst,
-    size_t dst_offset,
-    const __local void *src,
-    size_t src_offset,
-    size_t num_bytes_per_element,
-    size_t num_elements_per_line,
-    size_t num_lines,
-    size_t num_planes,
-    size_t src_total_line_length,
-    size_t src_total_plane_area,
-    size_t dst_total_line_length,
-    size_t dst_total_plane_area,
-    event_t event)
+  __global void *dst,
+  size_t dst_offset,
+  const __local void *src,
+  size_t src_offset,
+  size_t num_bytes_per_element,
+  size_t num_elements_per_line,
+  size_t num_lines,
+  size_t num_planes,
+  size_t src_total_line_length,
+  size_t src_total_plane_area,
+  size_t dst_total_line_length,
+  size_t dst_total_plane_area,
+  event_t event)
 ----
     | Perform an async copy of ((_num_elements_per_line_ * _num_lines_) *
       _num_planes_) elements of size _num_bytes_per_element_ from (_src_ +
@@ -10750,28 +10750,28 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 
 int4 read_imagei(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 
 uint4 read_imageui(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 
 float read_imagef(
-    read_only image2d_depth_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image2d_depth_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 ----
     | Use the coordinate _coord.xy_ to do an element lookup in the mip level
       specified by _lod_ in the 2D image object specified by _image_.
@@ -10782,32 +10782,32 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 int4 read_imagei(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 uint4 read_imageui(
-    read_only image2d_t image,
-    sampler_t sampler,
-    float2 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_t image,
+  sampler_t sampler,
+  float2 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 float read_imagef(
-    read_only image2d_depth_t image,
-    sampler_t sampler,
-    float2 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_depth_t image,
+  sampler_t sampler,
+  float2 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 ----
     | Use the gradients to compute the lod and coordinate _coord.xy_ to do
       an element lookup in the mip level specified by the computed lod in
@@ -10819,22 +10819,22 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float lod)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float lod)
 
 int4 read_imagei(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float lod)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float lod)
 
 uint4 read_imageui(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float lod)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float lod)
 ----
     | Use the coordinate _coord_ to do an element lookup in the mip level
       specified by _lod_ in the 1D image object specified by _image_.
@@ -10845,25 +10845,25 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float gradient_x,
+  float gradient_y)
 
 int4 read_imagei(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float gradient_x,
+  float gradient_y)
 
 uint4 read_imageui(
-    read_only image1d_t image,
-    sampler_t sampler,
-    float coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_t image,
+  sampler_t sampler,
+  float coord,
+  float gradient_x,
+  float gradient_y)
 ----
     | Use the gradients to compute the lod and coordinate _coord_ to do an
       element lookup in the mip level specified by the computed lod in the
@@ -10875,22 +10875,22 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 
 int4 read_imagei(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 
 uint4 read_imageui(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 ----
     | Use the coordinate _coord.xyz_ to do an element lookup in the mip
       level specified by _lod_ in the 3D image object specified by _image_.
@@ -10901,25 +10901,25 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float4 gradient_x,
-    float4 gradient_y)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float4 gradient_x,
+  float4 gradient_y)
 
 int4 read_imagei(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float4 gradient_x,
-    float4 gradient_y)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float4 gradient_x,
+  float4 gradient_y)
 
 uint4 read_imageui(
-    read_only image3d_t image,
-    sampler_t sampler,
-    float4 coord,
-    float4 gradient_x,
-    float4 gradient_y)
+  read_only image3d_t image,
+  sampler_t sampler,
+  float4 coord,
+  float4 gradient_x,
+  float4 gradient_y)
 ----
     | Use the gradients to compute the lod and coordinate _coord.xyz_ to do
       an element lookup in the mip level specified by the computed lod in
@@ -10931,22 +10931,22 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 
 int4 read_imagei(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 
 uint4 read_imageui(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float lod)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float lod)
 ----
     | Use the coordinate _coord.x_ to do an element lookup in the 1D image
       identified by _coord.x_ and mip level specified by _lod_ in the 1D
@@ -10958,25 +10958,25 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float gradient_x,
+  float gradient_y)
 
 int4 read_imagei(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float gradient_x,
+  float gradient_y)
 
 uint4 read_imageui(
-    read_only image1d_array_t image,
-    sampler_t sampler,
-    float2 coord,
-    float gradient_x,
-    float gradient_y)
+  read_only image1d_array_t image,
+  sampler_t sampler,
+  float2 coord,
+  float gradient_x,
+  float gradient_y)
 ----
     | Use the gradients to compute the lod and coordinate _coord.x_ to do an
       element lookup in the mip level specified by the computed lod in the
@@ -10988,28 +10988,28 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 
 int4 read_imagei(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 
 uint4 read_imageui(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 
 float read_imagef(
-    read_only image2d_array_depth_t image,
-    sampler_t sampler,
-    float4 coord,
-    float lod)
+  read_only image2d_array_depth_t image,
+  sampler_t sampler,
+  float4 coord,
+  float lod)
 ----
     | Use the coordinate _coord.xy_ to do an element lookup in the 2D image
       identified by _coord.z_ and mip level specified by _lod_ in the 2D
@@ -11021,32 +11021,32 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 int4 read_imagei(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 uint4 read_imageui(
-    read_only image2d_array_t image,
-    sampler_t sampler,
-    float4 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_array_t image,
+  sampler_t sampler,
+  float4 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 
 float read_imagef(
-    read_only image2d_array_depth_t image,
-    sampler_t sampler,
-    float4 coord,
-    float2 gradient_x,
-    float2 gradient_y)
+  read_only image2d_array_depth_t image,
+  sampler_t sampler,
+  float4 coord,
+  float2 gradient_x,
+  float2 gradient_y)
 ----
     | Use the gradients to compute the lod coordinate and _coord.xy_ to do
       an element lookup in the 2D image identified by _coord.z_ and mip
@@ -11520,9 +11520,9 @@ a|
 [source,opencl_c]
 ----
 float4 read_imagef(
-    image2d_msaa_t image,
-    int2 coord,
-    int sample)
+  image2d_msaa_t image,
+  int2 coord,
+  int sample)
 ----
     | Use the coordinate _(coord.x, coord.y)_ and _sample_ to do an element
       lookup in the 2D image object specified by _image_.
@@ -11548,13 +11548,15 @@ float4 read_imagef(
 a|
 [source,opencl_c]
 ----
-int4 read_imagei(image2d_msaa_t image,
-                 int2 coord,
-                 int sample)
+int4 read_imagei(
+  image2d_msaa_t image,
+  int2 coord,
+  int sample)
 
-uint4 read_imageui(image2d_msaa_t image,
-                   int2 coord,
-                   int sample)
+uint4 read_imageui(
+  image2d_msaa_t image,
+  int2 coord,
+  int sample)
 ----
     | Use the coordinate _(coord.x, coord.y)_ and _sample_ to do an element
       lookup in the 2D image object specified by _image_.
@@ -11588,9 +11590,10 @@ uint4 read_imageui(image2d_msaa_t image,
 a|
 [source,opencl_c]
 ----
-float4 read_imagef(image2d_array_msaa_t image,
-                   int4 coord,
-                   int sample)
+float4 read_imagef(
+  image2d_array_msaa_t image,
+  int4 coord,
+  int sample)
 ----
     | Use _coord.xy_ and _sample_ to do an element lookup in the 2D image
       identified by _coord.z_ in the 2D image array specified by _image_.
@@ -11616,13 +11619,15 @@ float4 read_imagef(image2d_array_msaa_t image,
 a|
 [source,opencl_c]
 ----
-int4 read_imagei(image2d_array_msaa_t image,
-                 int4 coord,
-                 int sample)
+int4 read_imagei(
+  image2d_array_msaa_t image,
+  int4 coord,
+  int sample)
 
-uint4 read_imageui(image2d_array_msaa_t image,
-                   int4 coord,
-                   int sample)
+uint4 read_imageui(
+  image2d_array_msaa_t image,
+  int4 coord,
+  int sample)
 ----
     | Use _coord.xy_ and _sample_ to do an element lookup in the 2D image
       identified by _coord.z_ in the 2D image array specified by _image_.
@@ -11656,9 +11661,10 @@ uint4 read_imageui(image2d_array_msaa_t image,
 a|
 [source,opencl_c]
 ----
-float read_imagef(image2d_msaa_depth_t image,
-                  int2 coord,
-                  int sample)
+float read_imagef(
+  image2d_msaa_depth_t image,
+  int2 coord,
+  int sample)
 ----
     | Use the coordinate _(coord.x, coord.y)_ and _sample_ to do an element
       lookup in the 2D depth image object specified by _image_.
@@ -11751,15 +11757,27 @@ endif::cl_khr_srgb_image_writes[]
 
 [[table-image-write]]
 .Built-in Image Write Functions
-[cols=",",options="header",]
+[cols="3,4",options="header",]
 |====
 | Function | Description
-| void *write_imagef*(_aQual_ image2d_t _image_, int2 _coord_, float4 _color_) +
+| void *write_imagef*( +
+  _aQual_ image2d_t _image_, +
+  int2 _coord_, +
+  float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image2d_t _image_, int2 _coord_, half4 _color_) +
+  void *write_imageh*( +
+  _aQual_ image2d_t _image_, +
+  int2 _coord_, +
+  half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image2d_t _image_, int2 _coord_, int4 _color_) +
-  void *write_imageui*(_aQual_ image2d_t _image_, int2 _coord_, uint4 _color_)
+  void *write_imagei*( +
+  _aQual_ image2d_t _image_, +
+  int2 _coord_, +
+  int4 _color_) +
+  void *write_imageui*( +
+  _aQual_ image2d_t _image_, +
+  int2 _coord_, +
+  uint4 _color_)
     | Write _color_ value to location specified by _coord.xy_ in the 2D
       image object specified by _image_.
       Appropriate data format conversion to the specified image format is
@@ -11805,15 +11823,23 @@ ifdef::cl_khr_fp16[]
       `<<cl_khr_fp16>>` extension macro.
 endif::cl_khr_fp16[]
 | |
-| void *write_imagef*(_aQual_ image2d_array_t _image_, int4 _coord_,
+| void *write_imagef*( +
+  _aQual_ image2d_array_t _image_, +
+  int4 _coord_, +
   float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image2d_array_t _image_, int4 _coord_,
+  void *write_imageh*( +
+  _aQual_ image2d_array_t _image_, +
+  int4 _coord_, +
   half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image2d_array_t _image_, int4 _coord_,
+  void *write_imagei*( +
+  _aQual_ image2d_array_t _image_, +
+  int4 _coord_, +
   int4 _color_) +
-  void *write_imageui*(_aQual_ image2d_array_t _image_, int4 _coord_,
+  void *write_imageui*( +
+  _aQual_ image2d_array_t _image_, +
+  int4 _coord_, +
   uint4 _color_)
     | Write _color_ value to location specified by _coord.xy_ in the 2D
       image identified by _coord.z_ in the 2D image array specified by
@@ -11862,25 +11888,41 @@ ifdef::cl_khr_fp16[]
       `<<cl_khr_fp16>>` extension macro.
 endif::cl_khr_fp16[]
 | |
-| void *write_imagef*(_aQual_ image1d_t _image_, int _coord_,
+| void *write_imagef*( +
+  _aQual_ image1d_t _image_, +
+  int _coord_, +
   float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image1d_t _image_, int _coord_,
+  void *write_imageh*( +
+  _aQual_ image1d_t _image_, +
+  int _coord_, +
   half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image1d_t _image_, int _coord_,
+  void *write_imagei*( +
+  _aQual_ image1d_t _image_, +
+  int _coord_, +
   int4 _color_) +
-  void *write_imageui*(_aQual_ image1d_t _image_, int _coord_,
+  void *write_imageui*( +
+  _aQual_ image1d_t _image_, +
+  int _coord_, +
   uint4 _color_) +
-  void *write_imagef*(_aQual_ image1d_buffer_t _image_, int _coord_,
+  void *write_imagef*( +
+  _aQual_ image1d_buffer_t _image_, +
+  int _coord_, +
   float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image1d_buffer_t _image_, int _coord_,
+  void *write_imageh*( +
+  _aQual_ image1d_buffer_t _image_, +
+  int _coord_, +
   half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image1d_buffer_t _image_, int _coord_,
+  void *write_imagei*( +
+  _aQual_ image1d_buffer_t _image_, +
+  int _coord_, +
   int4 _color_) +
-  void *write_imageui*(_aQual_ image1d_buffer_t _image_, int _coord_,
+  void *write_imageui*( +
+  _aQual_ image1d_buffer_t _image_, +
+  int _coord_, +
   uint4 _color_)
     | Write _color_ value to location specified by _coord_ in the 1D image
       or 1D image buffer object specified by _image_.
@@ -11927,15 +11969,23 @@ ifdef::cl_khr_fp16[]
       `<<cl_khr_fp16>>` extension macro.
 endif::cl_khr_fp16[]
 | |
-| void *write_imagef*(_aQual_ image1d_array_t _image_, int2 _coord_,
+| void *write_imagef*( +
+  _aQual_ image1d_array_t _image_, +
+  int2 _coord_, +
   float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image1d_array_t _image_, int2 _coord_,
+  void *write_imageh*( +
+  _aQual_ image1d_array_t _image_, +
+  int2 _coord_, +
   half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image1d_array_t _image_, int2 _coord_,
+  void *write_imagei*( +
+  _aQual_ image1d_array_t _image_, +
+  int2 _coord_, +
   int4 _color_) +
-  void *write_imageui*(_aQual_ image1d_array_t _image_, int2 _coord_,
+  void *write_imageui*( +
+  _aQual_ image1d_array_t _image_, +
+  int2 _coord_,
   uint4 _color_)
     | Write _color_ value to location specified by _coord.x_ in the 1D image
       identified by _coord.y_ in the 1D image array specified by _image_.
@@ -11979,7 +12029,9 @@ ifdef::cl_khr_fp16[*write_imageh*,]
 
       <<unified-spec, Requires>> support for OpenCL C 1.2 or newer.
 | |
-| void *write_imagef*(_aQual_ image2d_depth_t _image_, int2 _coord_,
+| void *write_imagef*( +
+  _aQual_ image2d_depth_t _image_, +
+  int2 _coord_, +
   float _depth_)
     | Write _depth_ value to location specified by _coord.xy_ in the 2D
       depth image object specified by _image_.
@@ -12005,7 +12057,9 @@ ifdef::cl_khr_fp16[*write_imageh*,]
       <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, or for
       the `<<cl_khr_depth_images>>` extension macro.
 | |
-| void *write_imagef*(_aQual_ image2d_array_depth_t _image_, int4 _coord_,
+| void *write_imagef*( +
+  _aQual_ image2d_array_depth_t _image_, +
+  int4 _coord_, +
   float _depth_)
     | Write _depth_ value to location specified by _coord.xy_ in the 2D
       image identified by _coord.z_ in the 2D depth image array specified by
@@ -12032,15 +12086,23 @@ ifdef::cl_khr_fp16[*write_imageh*,]
       <<unified-spec, Requires>> support for OpenCL C 2.0 or newer, or for
       the `<<cl_khr_depth_images>>` extension macro.
 | |
-| void *write_imagef*(_aQual_ image3d_t _image_, int4 _coord_,
+| void *write_imagef*( +
+  _aQual_ image3d_t _image_, +
+  int4 _coord_, +
   float4 _color_) +
 ifdef::cl_khr_fp16[]
-  void *write_imageh*(_aQual_ image3d_t _image_, int4 _coord_,
+  void *write_imageh*( +
+  _aQual_ image3d_t _image_, +
+  int4 _coord_, +
   half4 _color_) +
 endif::cl_khr_fp16[]
-  void *write_imagei*(_aQual_ image3d_t _image_, int4 _coord_,
+  void *write_imagei*( +
+  _aQual_ image3d_t _image_, +
+  int4 _coord_, +
   int4 _color_) +
-  void *write_imageui*(_aQual_ image3d_t _image_, int4 _coord_,
+  void *write_imageui*( +
+  _aQual_ image3d_t _image_, +
+  int4 _coord_, +
   uint4 _color_)
     | Write _color_ value to the location specified by _coord.xyz_ in the 3D
       image object specified by _image_.
@@ -12096,28 +12158,28 @@ a|
 [source,opencl_c]
 ----
 void write_imagef(
-    write_only image2d_t image,
-    int2 coord,
-    int lod,
-    float4 color)
+  write_only image2d_t image,
+  int2 coord,
+  int lod,
+  float4 color)
 
 void write_imagei(
-    write_only image2d_t image,
-    int2 coord,
-    int lod,
-    int4 color)
+  write_only image2d_t image,
+  int2 coord,
+  int lod,
+  int4 color)
 
 void write_imageui(
-    write_only image2d_t image,
-    int2 coord,
-    int lod,
-    uint4 color)
+  write_only image2d_t image,
+  int2 coord,
+  int lod,
+  uint4 color)
 
 void write_imagef(
-    write_only image2d_depth_t image,
-    int2 coord,
-    int lod,
-    float depth)
+  write_only image2d_depth_t image,
+  int2 coord,
+  int lod,
+  float depth)
 ----
     | Write _color_ value to location specified by _coord.xy_ in the mip
       level specified by _lod_ in the 2D image object specified by _image_.
@@ -12137,22 +12199,22 @@ a|
 [source,opencl_c]
 ----
 void write_imagef(
-    write_only image1d_t image,
-    int coord,
-    int lod,
-    float4 color)
+  write_only image1d_t image,
+  int coord,
+  int lod,
+  float4 color)
 
 void write_imagei(
-    write_only image1d_t image,
-    int coord,
-    int lod,
-    int4 color)
+  write_only image1d_t image,
+  int coord,
+  int lod,
+  int4 color)
 
 void write_imageui(
-    write_only image1d_t image,
-    int coord,
-    int lod,
-    uint4 color)
+  write_only image1d_t image,
+  int coord,
+  int lod,
+  uint4 color)
 ----
     | Write _color_ value to location specified by _coord_ in the mip level
       specified by _lod_ in the 1D image object specified by _image_.
@@ -12170,22 +12232,22 @@ a|
 [source,opencl_c]
 ----
 void write_imagef(
-    write_only image1d_array_t image,
-    int2 coord,
-    int lod,
-    float4 color)
+  write_only image1d_array_t image,
+  int2 coord,
+  int lod,
+  float4 color)
 
 void write_imagei(
-    write_only image1d_array_t image,
-    int2 coord,
-    int lod,
-    int4 color)
+  write_only image1d_array_t image,
+  int2 coord,
+  int lod,
+  int4 color)
 
 void write_imageui(
-    write_only image1d_array_t image,
-    int2 coord,
-    int lod,
-    uint4 color)
+  write_only image1d_array_t image,
+  int2 coord,
+  int lod,
+  uint4 color)
 ----
     | Write _color_ value to location specified by _coord.x_ in the 1D image
       identified by _coord.y_ and mip level _lod_ in the 1D image array
@@ -12205,28 +12267,28 @@ a|
 [source,opencl_c]
 ----
 void write_imagef(
-    write_only image2d_array_t image,
-    int4 coord,
-    int lod,
-    float4 color)
+  write_only image2d_array_t image,
+  int4 coord,
+  int lod,
+  float4 color)
 
 void write_imagei(
-    write_only image2d_array_t image,
-    int4 coord,
-    int lod,
-    int4 color)
+  write_only image2d_array_t image,
+  int4 coord,
+  int lod,
+  int4 color)
 
 void write_imageui(
-    write_only image2d_array_t image,
-    int4 coord,
-    int lod,
-    uint4 color)
+  write_only image2d_array_t image,
+  int4 coord,
+  int lod,
+  uint4 color)
 
 void write_imagef(
-    write_only image2d_array_depth_t image,
-    int4 coord,
-    int lod,
-    float depth)
+  write_only image2d_array_depth_t image,
+  int4 coord,
+  int lod,
+  float depth)
 ----
     | Write _color_ value to location specified by _coord.xy_ in the 2D image
       identified by _coord.z_ and mip level _lod_ in the 2D image array
@@ -12247,22 +12309,22 @@ a|
 [source,opencl_c]
 ----
 void write_imagef(
-    write_only image3d_t image,
-    int4 coord,
-    int lod,
-    float4 color)
+  write_only image3d_t image,
+  int4 coord,
+  int lod,
+  float4 color)
 
 void write_imagei(
-    write_only image3d_t image,
-    int4 coord,
-    int lod,
-    int4 color)
+  write_only image3d_t image,
+  int4 coord,
+  int lod,
+  int4 color)
 
 void write_imageui(
-    write_only image3d_t image,
-    int4 coord,
-    int lod,
-    uint4 color)
+  write_only image3d_t image,
+  int4 coord,
+  int lod,
+  uint4 color)
 ----
     | Write _color_ value to location specified by _coord.xyz_ and mip level
       _lod_ in the 3D image object specified by _image_.
@@ -12765,22 +12827,28 @@ logically `false`.
 
 [[table-builtin-work-group-logical]]
 .Built-in Work-group Logical Arithmetic Functions
-[cols="2a,1",options="header"]
+[cols="4a,3",options="header"]
 |====
 | Function | Description
 |[source,opencl_c]
 ----
-int work_group_reduce_logical_and(int predicate);
-int work_group_reduce_logical_or(int predicate);
-int work_group_reduce_logical_xor(int predicate);
+int work_group_reduce_logical_and(
+  int predicate);
+int work_group_reduce_logical_or(
+  int predicate);
+int work_group_reduce_logical_xor(
+  int predicate);
 ----
   | Returns the logical *and*, *or*, or *xor* of _predicate_ for all work
     items in the work-group.
 |[source,opencl_c]
 ----
-int work_group_scan_inclusive_logical_and(int predicate);
-int work_group_scan_inclusive_logical_or(int predicate);
-int work_group_scan_inclusive_logical_xor(int predicate);
+int work_group_scan_inclusive_logical_and(
+  int predicate);
+int work_group_scan_inclusive_logical_or(
+  int predicate);
+int work_group_scan_inclusive_logical_xor(
+  int predicate);
 ----
   | Returns the result of an inclusive scan operation, which is the logical
     *and*, *or*, or *xor* of _predicate_ for all work items in the
@@ -12788,9 +12856,12 @@ int work_group_scan_inclusive_logical_xor(int predicate);
     work item's work-group linear local ID.
 |[source,opencl_c]
 ----
-int work_group_scan_exclusive_logical_and(int predicate);
-int work_group_scan_exclusive_logical_or(int predicate);
-int work_group_scan_exclusive_logical_xor(int predicate);
+int work_group_scan_exclusive_logical_and(
+  int predicate);
+int work_group_scan_exclusive_logical_or(
+  int predicate);
+int work_group_scan_exclusive_logical_xor(
+  int predicate);
 ----
   | Returns the result of an exclusive scan operation, which is the logical
     *and*, *or*, or *xor* of _predicate_ for all work items in the
@@ -12814,22 +12885,28 @@ supported built-in scalar data types `int`, `uint`, `long`, and `ulong`.
 
 [[table-builtin-work-group-bitwise-integer]]
 .Built-in Work-group Bitwise Integer Functions
-[cols="2a,1",options="header"]
+[cols="1a,1",options="header"]
 |====
 | Function | Description
 |[source,opencl_c]
 ----
-gentype work_group_reduce_and(gentype value);
-gentype work_group_reduce_or(gentype value);
-gentype work_group_reduce_xor(gentype value);
+gentype work_group_reduce_and(
+  gentype value);
+gentype work_group_reduce_or(
+  gentype value);
+gentype work_group_reduce_xor(
+  gentype value);
 ----
   | Returns the bitwise *and*, *or*, or *xor* of _value_ for all work items
     in the work-group.
 |[source,opencl_c]
 ----
-gentype work_group_scan_inclusive_and(gentype value);
-gentype work_group_scan_inclusive_or(gentype value);
-gentype work_group_scan_inclusive_xor(gentype value);
+gentype work_group_scan_inclusive_and(
+  gentype value);
+gentype work_group_scan_inclusive_or(
+  gentype value);
+gentype work_group_scan_inclusive_xor(
+  gentype value);
 ----
   | Returns the result of an inclusive scan operation, which is the bitwise
     *and*, *or*, or *xor* of _value_ for all work items in the work-group
@@ -12837,9 +12914,12 @@ gentype work_group_scan_inclusive_xor(gentype value);
     work-group linear local ID.
 |[source,opencl_c]
 ----
-gentype work_group_scan_exclusive_and(gentype value);
-gentype work_group_scan_exclusive_or(gentype value);
-gentype work_group_scan_exclusive_xor(gentype value);
+gentype work_group_scan_exclusive_and(
+  gentype value);
+gentype work_group_scan_exclusive_or(
+  gentype value);
+gentype work_group_scan_exclusive_xor(
+  gentype value);
 ----
   | Returns the result of an exclusive scan operation, which is the bitwise
     *and*, *or*, or *xor* of _value_ for all work items in the work-group
@@ -12865,18 +12945,20 @@ precision is supported).
 
 [[table-builtin-work-group-multiplicative]]
 .Built-in Work-group Multiplicative Functions
-[cols="2a,1",options="header"]
+[cols="1a,1",options="header"]
 |====
 | Function | Description
 |[source,opencl_c]
 ----
-gentype work_group_reduce_mul(gentype value);
+gentype work_group_reduce_mul(
+  gentype value);
 ----
   | Returns the multiplication of _value_ for all work items in the
     work-group.
 |[source,opencl_c]
 ----
-gentype work_group_scan_inclusive_mul(gentype value);
+gentype work_group_scan_inclusive_mul(
+  gentype value);
 ----
   | Returns the result of an inclusive scan operation which is the
     multiplication of _value_ for all work items in the work-group with a
@@ -12884,7 +12966,8 @@ gentype work_group_scan_inclusive_mul(gentype value);
     work-group linear local ID.
 |[source,opencl_c]
 ----
-gentype work_group_scan_exclusive_mul(gentype value);
+gentype work_group_scan_exclusive_mul(
+  gentype value);
 ----
   | Returns the result of an exclusive scan operation which is the
     multiplication of _value_ for all work items in the work-group with a
@@ -14098,8 +14181,8 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_broadcast(
-    gentype value,
-    uint index )
+  gentype value,
+  uint index )
 ----
   | Returns _value_ for the work item with sub-group local ID equal to
     _index_.
@@ -14113,14 +14196,14 @@ gentype sub_group_non_uniform_broadcast(
 |[source,opencl_c]
 ----
 gentype sub_group_broadcast_first(
-    gentype value )
+  gentype value )
 ----
     | Returns _value_ for the work item with the smallest sub-group local ID
       among active work items in the sub-group.
 |[source,opencl_c]
 ----
 uint4 sub_group_ballot(
-    int predicate )
+  int predicate )
 ----
   | Returns a bitfield combining the _predicate_ values from all work items
     in the sub-group.
@@ -14132,7 +14215,7 @@ uint4 sub_group_ballot(
 |[source,opencl_c]
 ----
 int sub_group_inverse_ballot(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the predicate value for this work item in the sub-group from the
     bitfield _value_ representing predicate values from all work items in
@@ -14148,8 +14231,8 @@ int sub_group_inverse_ballot(
 |[source,opencl_c]
 ----
 int sub_group_ballot_bit_extract(
-    uint4 value,
-    uint index )
+  uint4 value,
+  uint index )
 ----
   | Returns the predicate value for the work item with sub-group local ID
     equal to _index_ from the bitfield _value_ representing predicate values
@@ -14164,7 +14247,7 @@ int sub_group_ballot_bit_extract(
 |[source,opencl_c]
 ----
 uint sub_group_ballot_bit_count(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the number of bits that are set in the bitfield _value_, only
     considering the bits in _value_ that represent predicate values
@@ -14173,7 +14256,7 @@ uint sub_group_ballot_bit_count(
 |[source,opencl_c]
 ----
 uint sub_group_ballot_inclusive_scan(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the number of bits that are set in the bitfield _value_, only
     considering the bits in _value_ representing work items with a sub-group
@@ -14181,7 +14264,7 @@ uint sub_group_ballot_inclusive_scan(
 |[source,opencl_c]
 ----
 uint sub_group_ballot_exclusive_scan(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the number of bits that are set in the bitfield _value_, only
     considering the bits in _value_ representing work items with a sub-group
@@ -14189,7 +14272,7 @@ uint sub_group_ballot_exclusive_scan(
 |[source,opencl_c]
 ----
 uint sub_group_ballot_find_lsb(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the smallest sub-group local ID with a bit set in the bitfield
     _value_, only considering the bits in _value_ that represent predicate
@@ -14202,7 +14285,7 @@ uint sub_group_ballot_find_lsb(
 |[source,opencl_c]
 ----
 uint sub_group_ballot_find_msb(
-    uint4 value )
+  uint4 value )
 ----
   | Returns the largest sub-group local ID with a bit set in the bitfield
     _value_, only considering the bits in _value_ that represent predicate
@@ -14305,13 +14388,13 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_clustered_reduce_add(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 gentype sub_group_clustered_reduce_mul(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 gentype sub_group_clustered_reduce_min(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 gentype sub_group_clustered_reduce_max(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 ----
   | Returns the summation, multiplication, minimum, or maximum of _value_
     for all active work items in the sub-group within a cluster of the
@@ -14343,11 +14426,11 @@ the supported built-in scalar data types `char`, `uchar`, `short`, `ushort`,
 |[source,opencl_c]
 ----
 gentype sub_group_clustered_reduce_and(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 gentype sub_group_clustered_reduce_or(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 gentype sub_group_clustered_reduce_xor(
-    gentype value, uint clustersize )
+  gentype value, uint clustersize )
 ----
   | Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work
     items in the sub-group within a cluster of the specified _clustersize_.
@@ -14373,11 +14456,11 @@ logically `false`.
 |[source,opencl_c]
 ----
 int sub_group_clustered_reduce_logical_and(
-    int predicate, uint clustersize )
+  int predicate, uint clustersize )
 int sub_group_clustered_reduce_logical_or(
-    int predicate, uint clustersize )
+  int predicate, uint clustersize )
 int sub_group_clustered_reduce_logical_xor(
-    int predicate, uint clustersize )
+  int predicate, uint clustersize )
 ----
   | Returns the logical *and*, *or*, or *xor* of _predicate_ for all active
     work items in the sub-group within a cluster of the specified
@@ -14414,13 +14497,13 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_reduce_add(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_reduce_min(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_reduce_max(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_reduce_mul(
-    gentype value )
+  gentype value )
 ----
   | Returns the summation, multiplication, minimum, or maximum of _value_
     for all active work items in the sub-group.
@@ -14432,13 +14515,13 @@ gentype sub_group_non_uniform_reduce_mul(
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_inclusive_add(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_inclusive_min(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_inclusive_max(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_inclusive_mul(
-    gentype value )
+  gentype value )
 ----
   | Returns the result of an inclusive scan operation, which is the
     summation, multiplication, minimum, or maximum of _value_ for all active
@@ -14452,13 +14535,13 @@ gentype sub_group_non_uniform_scan_inclusive_mul(
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_exclusive_add(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_exclusive_min(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_exclusive_max(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_exclusive_mul(
-    gentype value )
+  gentype value )
 ----
   | Returns the result of an exclusive scan operation, which is the
     summation, multiplication, minimum, or maximum of _value_ for all active
@@ -14506,22 +14589,22 @@ supported built-in scalar data types `char`, `uchar`, `short`, `ushort`,
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_reduce_and(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_reduce_or(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_reduce_xor(
-    gentype value )
+  gentype value )
 ----
   | Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work
     items in the sub-group.
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_inclusive_and(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_inclusive_or(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_inclusive_xor(
-    gentype value )
+  gentype value )
 ----
   | Returns the result of an inclusive scan operation, which is the bitwise
     *and*, *or*, or *xor* of _value_ for all active work items in the
@@ -14530,11 +14613,11 @@ gentype sub_group_non_uniform_scan_inclusive_xor(
 |[source,opencl_c]
 ----
 gentype sub_group_non_uniform_scan_exclusive_and(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_exclusive_or(
-    gentype value )
+  gentype value )
 gentype sub_group_non_uniform_scan_exclusive_xor(
-    gentype value )
+  gentype value )
 ----
   | Returns the result of an exclusive scan operation, which is the bitwise
     *and*, *or*, or *xor* of _value_ for all active work items in the
@@ -14568,22 +14651,22 @@ logically `false`.
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_reduce_logical_and(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_reduce_logical_or(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_reduce_logical_xor(
-    int predicate )
+  int predicate )
 ----
   | Returns the logical *and*, *or*, or *xor* of _predicate_ for all active
     work items in the sub-group.
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_scan_inclusive_logical_and(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_scan_inclusive_logical_or(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_scan_inclusive_logical_xor(
-    int predicate )
+  int predicate )
 ----
   | Returns the result of an inclusive scan operation, which is the logical
     *and*, *or*, or *xor* of _predicate_ for all active work items in the
@@ -14592,11 +14675,11 @@ int sub_group_non_uniform_scan_inclusive_logical_xor(
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_scan_exclusive_logical_and(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_scan_exclusive_logical_or(
-    int predicate )
+  int predicate )
 int sub_group_non_uniform_scan_exclusive_logical_xor(
-    int predicate )
+  int predicate )
 ----
   | Returns the result of an exclusive scan operation, which is the logical
     *and*, *or*, or *xor* of _predicate_ for all active work items in the
@@ -14648,7 +14731,7 @@ int sub_group_elect()
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_all(
-    int predicate )
+  int predicate )
 ----
   | Examines _predicate_ for all active work items in the sub-group and
     returns a non-zero value if _predicate_ is non-zero for all active work
@@ -14660,7 +14743,7 @@ int sub_group_non_uniform_all(
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_any(
-    int predicate )
+  int predicate )
 ----
   | Examines _predicate_ for all active work items in the sub-group and
     returns a non-zero value if _predicate_ is non-zero for any active work
@@ -14672,7 +14755,7 @@ int sub_group_non_uniform_any(
 |[source,opencl_c]
 ----
 int sub_group_non_uniform_all_equal(
-    gentype value )
+  gentype value )
 ----
   | Examines _value_ for all active work items in the sub-group and returns
     a non-zero value if _value_ is equivalent for all active invocations in
@@ -14712,7 +14795,7 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_rotate(
-    gentype value, int delta)
+  gentype value, int delta)
 ----
   | Returns _value_ for the work item with sub-group local ID equal to the
     remainder of the division of the sum of this work item's sub-group local
@@ -14725,8 +14808,8 @@ gentype sub_group_rotate(
 |[source,opencl_c]
 ----
 gentype sub_group_clustered_rotate(
-    gentype value, int delta,
-    uint clustersize)
+  gentype value, int delta,
+  uint clustersize)
 ----
   | Returns _value_ for the work item with sub-group local ID equal to the
     sum of, the remainder of the division of the sum of this work item's ID
@@ -14772,7 +14855,7 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_shuffle(
-    gentype value, uint index )
+  gentype value, uint index )
 ----
   | Returns _value_ for the work item with sub-group local ID equal to
     _index_.
@@ -14785,7 +14868,7 @@ gentype sub_group_shuffle(
 |[source,opencl_c]
 ----
 gentype sub_group_shuffle_xor(
-    gentype value, uint mask )
+  gentype value, uint mask )
 ----
   | Returns _value_ for the work item with sub-group local ID equal to
     this work item's sub-group local ID xor'd with _mask_.
@@ -14824,7 +14907,7 @@ footnote:[{fn-double-supported}].
 |[source,opencl_c]
 ----
 gentype sub_group_shuffle_up(
-    gentype value, uint delta )
+  gentype value, uint delta )
 ----
   | Returns _value_ for the work item with sub-group local ID equal to this
     work item's sub-group local ID minus _delta_.
@@ -14840,7 +14923,7 @@ gentype sub_group_shuffle_up(
 |[source,opencl_c]
 ----
 gentype sub_group_shuffle_down(
-    gentype value, uint delta )
+  gentype value, uint delta )
 ----
   | Returns _value_ for the work item with sub-group local ID equal to this
     work item's sub-group local ID plus _delta_.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14049,7 +14049,7 @@ include::{generated}/api/version-notes/clCreateCommandBufferKHR.asciidoc[]
 +
 [[commandbuffer-properties]]
 .{clCreateCommandBufferKHR} properties
-[cols=",,",options="header",]
+[cols="2,1,3",options="header",]
 |====
 | Recording Properties | Property Value | Description
 
@@ -15187,7 +15187,7 @@ endif::cl_khr_command_buffer_mutable_dispatch[]
 
 [[ndrange-kernel-properties-table]]
 .List of supported properties by {clCommandNDRangeKernelKHR}
-[cols=",,",options="header",]
+[cols="3,2,10",options="header",]
 |====
 | Recording Properties | Property Value | Description
 
@@ -15208,7 +15208,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ASSERTS_KHR.asciidoc[
       _0_ to _work_dim - 1_ of
       _ceil(global_work_size[i]/local_work_size[i])_.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR.asciidoc[]
 
 | {CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR_anchor}
 
@@ -15226,7 +15228,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR.
       parameter.
       Otherwise, the _global_work_offset_ cannot be modified.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR.asciidoc[]
 
       {CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR_anchor} determines whether the
       _global_work_size_ of kernel execution can be modified after
@@ -15237,7 +15241,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR.asc
       parameter.
       Otherwise, the _global_work_size_ cannot be modified.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR.asciidoc[]
 
       {CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR_anchor} determines whether the
       _local_work_size_ of kernel execution can be modified after recording.
@@ -15247,7 +15253,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR.ascii
       parameter.
       Otherwise, the _local_work_size_ cannot be modified.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR.asciidoc[]
 
       {CL_MUTABLE_DISPATCH_ARGUMENTS_KHR_anchor} determines whether the
       kernel arguments set on _kernel_ can be updated between executions.
@@ -15258,7 +15266,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR.asciid
       parameter.
       Otherwise, the kernel arguments cannot be modified between executions.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ARGUMENTS_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ARGUMENTS_KHR.asciidoc[]
 
       {CL_MUTABLE_DISPATCH_EXEC_INFO_KHR_anchor} determines whether the
       information passed to _kernel_ can be updated between executions.
@@ -15268,7 +15278,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_ARGUMENTS_KHR.asciido
       parameter.
       Otherwise, the kernel execution information cannot be modified.
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_EXEC_INFO_KHR.asciidoc[]
+// Removed for now to reduce table cell size.
+// The extension dependency is captured in the property itself.
+//include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_EXEC_INFO_KHR.asciidoc[]
 
       If {CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR_anchor} is not specified
       then it defaults to the value returned by the

--- a/config/rouge/lib/rouge/lexers/opencl.rb
+++ b/config/rouge/lib/rouge/lexers/opencl.rb
@@ -120,6 +120,8 @@ module Rouge
         cl_profiling_info
         cl_sampler_properties
         cl_kernel_exec_info
+        cl_context_memory_initialize_khr
+        cl_device_terminate_capability_khr
         cl_device_unified_shared_memory_capabilities_intel
         cl_mem_properties_intel
         cl_mem_alloc_flags_intel
@@ -135,6 +137,7 @@ module Rouge
         cl_mem_alloc_flags_img
         cl_layer_info
         cl_layer_api_version
+        cl_icdl_info
         cl_icd_dispatch
         cl_device_scheduling_controls_capabilities_arm
         cl_device_controlled_termination_capabilities_arm
@@ -142,6 +145,7 @@ module Rouge
         cl_device_feature_capabilities_intel
         cl_device_integer_dot_product_capabilities_khr
         cl_semaphore_properties_khr
+        cl_semaphore_reimport_properties_khr
         cl_semaphore_info_khr
         cl_semaphore_type_khr
         cl_semaphore_payload_khr
@@ -153,7 +157,16 @@ module Rouge
         cl_command_buffer_info_khr
         cl_command_buffer_state_khr
         cl_command_buffer_properties_khr
+        cl_command_buffer_flags_khr
         cl_ndrange_kernel_command_properties_khr
+        cl_mutable_command_khr
+        cl_mutable_dispatch_fields_khr
+        cl_mutable_command_info_khr
+        cl_command_buffer_structure_type_khr
+        cl_device_fp_atomic_capabilities_ext
+        cl_image_requirements_info_ext
+        cl_platform_command_buffer_capabilities_khr
+        cl_mutable_dispatch_asserts_khr
         cl_dx9_surface_info_khr
         cl_motion_estimation_desc_intel
         cl_mem_ext_host_ptr
@@ -174,16 +187,10 @@ module Rouge
         CL_VERSION_PATCH_KHR
         CL_MAKE_VERSION_KHR
         cl_device_integer_dot_product_acceleration_properties_khr
-        cl_command_buffer_khr
-        cl_mutable_command_khr
-        cl_mutable_command_info_khr
-        cl_command_buffer_structure_type_khr
-        cl_mutable_base_config_khr
         cl_mutable_dispatch_arg_khr
-        cl_mutable_dispatch_config_khr
         cl_mutable_dispatch_exec_info_khr
-        cl_mutable_dispatch_fields_khr
-        cl_platform_command_buffer_capabilities_khr
+        cl_mutable_dispatch_config_khr
+        cl_mutable_base_config_khr
       )
 
       # Here are some interesting tokens

--- a/config/rouge/lib/rouge/lexers/opencl_c.rb
+++ b/config/rouge/lib/rouge/lexers/opencl_c.rb
@@ -31,6 +31,7 @@ module Rouge
         image2d_array_t
         image2d_depth_t
         image2d_array_depth_t
+        image2d_msaa_t
         sampler_t
         queue_t
         ndrange_t


### PR DESCRIPTION
fixes #1109

Various fixes to shrink the size of several problematic table cells so they fit on one PDF page.  We really need a better long-term solution for this...

Other fixes:
- Generally indented built-in function prototypes by two characters instead of four to conserve column width.
- Rouge syntax highlighting updates.