### PR TITLE
adding missing anchor for CL_MEM_DEVICE_HANDLE_LIST_END_KHR

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -595,8 +595,8 @@ ifdef::cl_khr_external_memory[]
 include::{generated}/api/version-notes/CL_MEM_DEVICE_HANDLE_LIST_KHR.asciidoc[]
   | {cl_device_id_TYPE}[]
       | Specifies the list of OpenCL devices (terminated with
-        {CL_MEM_DEVICE_HANDLE_LIST_END_KHR}) to associate with the external
-        memory handle.
+        {CL_MEM_DEVICE_HANDLE_LIST_END_KHR_anchor}) to associate with the
+        external memory handle.
 endif::cl_khr_external_memory[]
 |====
 


### PR DESCRIPTION
Adds a missing anchor for `CL_MEM_DEVICE_HANDLE_LIST_END_KHR`.

After this change my script to check for missing anchors is clean.