### PR TITLE
remove TODO and TBD placeholders

### DIFF
--- a/api/cl_khr_3d_image_writes.asciidoc
+++ b/api/cl_khr_3d_image_writes.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_3d_image_writes.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_async_work_group_copy_fence.asciidoc
+++ b/api/cl_khr_async_work_group_copy_fence.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_async_work_group_copy_fence.txt[]
     2021-11-10
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_byte_addressable_store.asciidoc
+++ b/api/cl_khr_byte_addressable_store.asciidoc
@@ -11,8 +11,6 @@ include::{generated}/meta/{refprefix}cl_khr_byte_addressable_store.txt[]
   - Promoted to OpenCL 1.1 core
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_create_command_queue.asciidoc
+++ b/api/cl_khr_create_command_queue.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_create_command_queue.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_d3d10_sharing.asciidoc
+++ b/api/cl_khr_d3d10_sharing.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_d3d10_sharing.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_d3d11_sharing.asciidoc
+++ b/api/cl_khr_d3d11_sharing.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_d3d11_sharing.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_depth_images.asciidoc
+++ b/api/cl_khr_depth_images.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_depth_images.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_device_enqueue_local_arg_types.asciidoc
+++ b/api/cl_khr_device_enqueue_local_arg_types.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_device_enqueue_local_arg_types.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_device_uuid.asciidoc
+++ b/api/cl_khr_device_uuid.asciidoc
@@ -6,11 +6,9 @@ include::{generated}/meta/{refprefix}cl_khr_device_uuid.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    DateTBD
+    2020-08-27
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_dx9_media_sharing.asciidoc
+++ b/api/cl_khr_dx9_media_sharing.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_dx9_media_sharing.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_egl_event.asciidoc
+++ b/api/cl_khr_egl_event.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_egl_event.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_egl_image.asciidoc
+++ b/api/cl_khr_egl_image.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_egl_image.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_expect_assume.asciidoc
+++ b/api/cl_khr_expect_assume.asciidoc
@@ -14,8 +14,6 @@ include::{generated}/meta/{refprefix}cl_khr_expect_assume.txt[]
     describes how this extension modifies the OpenCL SPIR-V environment.
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_extended_async_copies.asciidoc
+++ b/api/cl_khr_extended_async_copies.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_extended_async_copies.txt[]
     2021-11-10
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_extended_bit_ops.asciidoc
+++ b/api/cl_khr_extended_bit_ops.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_extended_bit_ops.txt[]
     2021-04-22
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_external_memory.asciidoc
+++ b/api/cl_khr_external_memory.asciidoc
@@ -46,21 +46,6 @@ image objects between OpenCL and many other APIs, including:
 Other related extensions define specific external memory types that may be
 imported into OpenCL.
 
-
-==== Background
-
-TODO
-
-==== Rationale
-
-TODO
-
-=== Interactions With Other Extensions
-
-TODO
-
-// The 'New ...' section can be auto-generated
-
 === New Commands
 
   * {clEnqueueAcquireExternalMemObjectsKHR}

--- a/api/cl_khr_external_memory_dma_buf.asciidoc
+++ b/api/cl_khr_external_memory_dma_buf.asciidoc
@@ -41,20 +41,6 @@ include::{generated}/meta/{refprefix}cl_khr_external_memory_dma_buf.txt[]
 external memory handle type that may be specified when creating a buffer or
 image memory object.
 
-==== Background
-
-TODO
-
-==== Rationale
-
-TODO
-
-=== Interactions With Other Extensions
-
-TODO
-
-// The 'New ...' section can be auto-generated
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_dx.asciidoc
+++ b/api/cl_khr_external_memory_dx.asciidoc
@@ -41,20 +41,6 @@ include::{generated}/meta/{refprefix}cl_khr_external_memory_dx.txt[]
 referring to Direct 3D resources as external memory handle types that may be
 specified when creating a buffer or image memory object.
 
-==== Background
-
-TODO
-
-==== Rationale
-
-TODO
-
-=== Interactions With Other Extensions
-
-TODO
-
-// The 'New ...' section can be auto-generated
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_opaque_fd.asciidoc
+++ b/api/cl_khr_external_memory_opaque_fd.asciidoc
@@ -41,20 +41,6 @@ include::{generated}/meta/{refprefix}cl_khr_external_memory_opaque_fd.txt[]
 handle as an external memory handle type that may be specified when creating
 a buffer or image memory object.
 
-==== Background
-
-TODO
-
-==== Rationale
-
-TODO
-
-=== Interactions With Other Extensions
-
-TODO
-
-// The 'New ...' section can be auto-generated
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_external_memory_win32.asciidoc
+++ b/api/cl_khr_external_memory_win32.asciidoc
@@ -41,20 +41,6 @@ include::{generated}/meta/{refprefix}cl_khr_external_memory_win32.txt[]
 external memory handle types that may be specified when creating a buffer or
 image memory object.
 
-==== Background
-
-TODO
-
-==== Rationale
-
-TODO
-
-=== Interactions With Other Extensions
-
-TODO
-
-// The 'New ...' section can be auto-generated
-
 === New Enums
 
   * {cl_external_memory_handle_type_khr_TYPE}

--- a/api/cl_khr_fp16.asciidoc
+++ b/api/cl_khr_fp16.asciidoc
@@ -12,8 +12,6 @@ include::{generated}/meta/{refprefix}cl_khr_fp16.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_fp64.asciidoc
+++ b/api/cl_khr_fp64.asciidoc
@@ -12,8 +12,6 @@ include::{generated}/meta/{refprefix}cl_khr_fp64.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_gl_depth_images.asciidoc
+++ b/api/cl_khr_gl_depth_images.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_gl_depth_images.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_gl_event.asciidoc
+++ b/api/cl_khr_gl_event.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_gl_event.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_gl_msaa_sharing.asciidoc
+++ b/api/cl_khr_gl_msaa_sharing.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_gl_msaa_sharing.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_gl_sharing.asciidoc
+++ b/api/cl_khr_gl_sharing.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_gl_sharing.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_global_int32_base_atomics.asciidoc
+++ b/api/cl_khr_global_int32_base_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_global_int32_base_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_global_int32_extended_atomics.asciidoc
+++ b/api/cl_khr_global_int32_extended_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_global_int32_extended_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_icd.asciidoc
+++ b/api/cl_khr_icd.asciidoc
@@ -12,8 +12,6 @@ include::{generated}/meta/{refprefix}cl_khr_icd.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 
@@ -260,11 +258,6 @@ Loader.
   . How are OpenCL extension to be handled?
 +
 --
-// TODO: This seems out-of-date and incorrect.
-//RESOLVED: OpenCL extension functions may be added to the ICD Loader as soon as they
-//are implemented by any vendor.
-//The suffix mechanism provides access for vendor extensions which are not yet
-//added to the ICD Loader.
 *RESOLVED*: Extension APIs must be queried using
 {clGetExtensionFunctionAddressForPlatform}.
 --
@@ -274,11 +267,6 @@ Loader.
 --
 *RESOLVED*: The ICD will by default choose the first enumerated platform as
 the `NULL` platform.
-// TODO: This seems out-of-date and incorrect.
-//The user can override this default by setting an environment variable
-//OPENCL_ICD_DEFAULT_PLATFORM to the desired platform index.
-//The API calls that deal with platforms will return {CL_INVALID_PLATFORM} if
-//the index is not between zero and (number of platforms - 1), both inclusive.
 --
 
   . There exists no mechanism to unload the ICD Loader, should there be one?

--- a/api/cl_khr_il_program.asciidoc
+++ b/api/cl_khr_il_program.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_il_program.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_image2d_from_buffer.asciidoc
+++ b/api/cl_khr_image2d_from_buffer.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_image2d_from_buffer.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_initialize_memory.asciidoc
+++ b/api/cl_khr_initialize_memory.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_initialize_memory.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_int64_base_atomics.asciidoc
+++ b/api/cl_khr_int64_base_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_int64_base_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_int64_extended_atomics.asciidoc
+++ b/api/cl_khr_int64_extended_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_int64_extended_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_local_int32_base_atomics.asciidoc
+++ b/api/cl_khr_local_int32_base_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_local_int32_base_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_local_int32_extended_atomics.asciidoc
+++ b/api/cl_khr_local_int32_extended_atomics.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_local_int32_extended_atomics.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_mipmap_image.asciidoc
+++ b/api/cl_khr_mipmap_image.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_mipmap_image.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_mipmap_image_writes.asciidoc
+++ b/api/cl_khr_mipmap_image_writes.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_mipmap_image_writes.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_pci_bus_info.asciidoc
+++ b/api/cl_khr_pci_bus_info.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_pci_bus_info.txt[]
     2021-04-19
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_priority_hints.asciidoc
+++ b/api/cl_khr_priority_hints.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_priority_hints.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_select_fprounding_mode.asciidoc
+++ b/api/cl_khr_select_fprounding_mode.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_select_fprounding_mode.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_semaphore.asciidoc
+++ b/api/cl_khr_semaphore.asciidoc
@@ -89,7 +89,6 @@ In particular, this extension defines:
   ** {CL_SEMAPHORE_TYPE_KHR}
   ** {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR}
   ** {CL_SEMAPHORE_DEVICE_HANDLE_LIST_END_KHR}
-// TODO these are not described anywhere in the extension spec document
   * {cl_command_type_TYPE}
   ** {CL_COMMAND_SEMAPHORE_WAIT_KHR}
   ** {CL_COMMAND_SEMAPHORE_SIGNAL_KHR}

--- a/api/cl_khr_spir.asciidoc
+++ b/api/cl_khr_spir.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_spir.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_spirv_extended_debug_info.asciidoc
+++ b/api/cl_khr_spirv_extended_debug_info.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_spirv_extended_debug_info.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_spirv_linkonce_odr.asciidoc
+++ b/api/cl_khr_spirv_linkonce_odr.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_spirv_linkonce_odr.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_spirv_no_integer_wrap_decoration.asciidoc
+++ b/api/cl_khr_spirv_no_integer_wrap_decoration.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_spirv_no_integer_wrap_decoration.txt
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_srgb_image_writes.asciidoc
+++ b/api/cl_khr_srgb_image_writes.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_srgb_image_writes.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_ballot.asciidoc
+++ b/api/cl_khr_subgroup_ballot.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_ballot.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_clustered_reduce.asciidoc
+++ b/api/cl_khr_subgroup_clustered_reduce.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_clustered_reduce.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_extended_types.asciidoc
+++ b/api/cl_khr_subgroup_extended_types.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_extended_types.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_named_barrier.asciidoc
+++ b/api/cl_khr_subgroup_named_barrier.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_named_barrier.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_non_uniform_arithmetic.asciidoc
+++ b/api/cl_khr_subgroup_non_uniform_arithmetic.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_non_uniform_arithmetic.txt[
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_non_uniform_vote.asciidoc
+++ b/api/cl_khr_subgroup_non_uniform_vote.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_non_uniform_vote.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_shuffle.asciidoc
+++ b/api/cl_khr_subgroup_shuffle.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_shuffle.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroup_shuffle_relative.asciidoc
+++ b/api/cl_khr_subgroup_shuffle_relative.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroup_shuffle_relative.txt[]
     2020-12-15
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_subgroups.asciidoc
+++ b/api/cl_khr_subgroups.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_subgroups.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_suggested_local_work_size.asciidoc
+++ b/api/cl_khr_suggested_local_work_size.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_suggested_local_work_size.txt[]
     2021-04-22
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_terminate_context.asciidoc
+++ b/api/cl_khr_terminate_context.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_terminate_context.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 

--- a/api/cl_khr_throttle_hints.asciidoc
+++ b/api/cl_khr_throttle_hints.asciidoc
@@ -9,8 +9,6 @@ include::{generated}/meta/{refprefix}cl_khr_throttle_hints.txt[]
     2020-04-21
 *IP Status*::
     No known IP claims.
-*Contributors*::
-    TBD
 
 === Description
 


### PR DESCRIPTION
Removes a bunch of TODO and TBD placeholders.  We can always add content for these later, if desired.