### PR TITLE
fix fract for double and half arguments

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5282,9 +5282,9 @@ ifdef::cl_khr_fp16[gentypeh *fmax*(gentypeh _x_, half _y_)]
   {opencl_c_generic_address_space} feature:
 
   gentype *fract*(gentype _x_, gentype _*iptr_)
-// TODO The fp16 extension uses the constant `0x1.ffcp-1f` below - unclear
-// why, see the OpenCL-Docs issue.
-    | Returns *fmin*(_x_ - *floor*(_x_), `0x1.fffffep-1f`).
+    | Returns *fmin*(_x_ - *floor*(_x_), `C`), where `C` is the constant
+      `0x1.fffffep-1f` for `float` aguments, `0x1.fffffffffffffp-1` for `double`
+      arguments, and `0x1.ffcp-1h` for `half` arguments.
       *floor*(x) is returned in _iptr_.
       footnote:[{fn-fract-min}]
 ifdef::cl_khr_fp16[]


### PR DESCRIPTION
see #1044, item (3).

Fixes the constant used in the description of the `fract` built-in function, for `double` and `half` arguments.