### PR TITLE
bugfix: the geometric functions do not operate componentwise

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6539,13 +6539,8 @@ endif::cl_khr_fp16[]
 
 [open,refpage='geometricFunctions',desc='Geometric Functions',type='freeform',spec='clang',anchor='geometric-functions',xrefs='integerFunctions',alias='cross dot distance length normalize fast_distance fast_length fast_normalize']
 --
-// TODO It is not actually true that these functions operate -
-// TODO in general they *combine* components.
-
 The <<table-builtin-geometric, following table>> describes the list of built-in
 geometric functions.
-These all operate component-wise.
-The description is per-component.
 
 The generic type name `gentypef` indicates that the function can take any of
 


### PR DESCRIPTION
The geometric functions are vector functions to compute things like dot products and cross products, so they do not operate componentwise.