### PR TITLE
tidy up cl_khr_create_command_queue

### DIFF
--- a/api/cl_khr_create_command_queue.asciidoc
+++ b/api/cl_khr_create_command_queue.asciidoc
@@ -26,21 +26,11 @@ No new command-queue properties are required by this extension.
 Applications may use the existing {CL_DEVICE_QUEUE_PROPERTIES} query to
 determine command-queue properties that are supported by the device.
 
-OpenCL 2.x devices may support this extension for compatibility.
+Newer OpenCL devices may support this extension for compatibility.
 In this scenario, the function added by this extension will have the same
 capabilities as the core {clCreateCommandQueueWithProperties} API.
-Applications that only target OpenCL 2.x devices should use the core OpenCL
-2.x {clCreateCommandQueueWithProperties} API instead of this extension API.
-
-NOTE: The type of the property value passed as {CL_QUEUE_PROPERTIES} to
-{clCreateCommandQueueWithPropertiesKHR} is specified as
-{cl_bitfield_TYPE} while the type passed to
-{clCreateCommandQueueWithProperties} is
-{cl_command_queue_properties_TYPE}.
-While this is not a promotion in terms of the suffixing, both types
-are aliased to {cl_ulong_TYPE}, so no ABI or compiler issues should
-result if the extension and core APIs are supported.
-
+Applications that only target newer OpenCL devices should use the core
+{clCreateCommandQueueWithProperties} API instead of this extension API.
 
 === New Commands
 
@@ -49,8 +39,6 @@ result if the extension and core APIs are supported.
 === New Types
 
   * {cl_queue_properties_khr_TYPE}
-
-//@ TODO Missing bitfield values allowed for CL_QUEUE_PROPERTIES?
 
 === Version History
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -68,10 +68,6 @@ endif::cl_khr_create_command_queue[]
 
 include::{generated}/api/version-notes/CL_QUEUE_PROPERTIES.asciidoc[]
   | {cl_command_queue_properties_TYPE}
-
-ifdef::cl_khr_create_command_queue[]
-or {cl_bitfield_TYPE} if the {cl_khr_create_command_queue_EXT} extension is supported
-endif::cl_khr_create_command_queue[]
       | This is a bitfield and can be set to a combination of the following
         values:
 


### PR DESCRIPTION
Removes unneeded special-case text regarding the type accepted for CL_QUEUE_PROPERTIES.  Calling this a cl_bitfield was a bug all along, and using cl_command_queue_properties is fine because it is a bitfield anyhow.

Generalizes some text so it is not specific to OpenCL 2.x devices.

Removes a TODO - no changes required.