### PR TITLE
briefly describe cl_mutable_base_config_khr structure

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -15838,8 +15838,8 @@ defined conditions:
 
 [open,refpage='cl_mutable_base_config_khr',desc='DESC',type='structs']
 --
-The {cl_mutable_base_config_khr_TYPE} structure is TODO Add fuller
-description here and is defined as:
+The {cl_mutable_base_config_khr_TYPE} structure encapsulates all aspects of
+mutation and is defined as:
 
 include::{generated}/api/structs/cl_mutable_base_config_khr.txt[]
 


### PR DESCRIPTION
Fix a TODO by adding a brief description of the `cl_mutable_base_config_khr` structure.