### PR TITLE
remove nextafter TODO

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5469,8 +5469,6 @@ endif::cl_khr_fp16[]
     | Returns a quiet NaN.
       The _nancode_ may be placed in the significand of the resulting NaN.
 | gentype *nextafter*(gentype _x_, gentype _y_)
-// TODO shouldn't this be "next representable FP value of the precision of
-// its arguments"? See the OpenCL-Docs issue.
     | Computes the next representable floating-point value
       following _x_ in the direction of _y_.
       Thus, if _y_ is less than _x_, *nextafter*() returns the largest


### PR DESCRIPTION
We already decided to keep this description general, see https://github.com/KhronosGroup/OpenCL-Docs/issues/951.

The current description is aligned with the SYCL specification and with cppreference.