### PR TITLE
Add multi-device wording to clCommandBarrierWithWaitListKHR

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14381,10 +14381,17 @@ include::{generated}/api/protos/clCommandBarrierWithWaitListKHR.txt[]
 include::{generated}/api/version-notes/clCommandBarrierWithWaitListKHR.asciidoc[]
 
   * _command_buffer_ refers to a valid command-buffer object.
-  * _command_queue_ specifies the command-queue the command will be recorded
-    to.
-    This parameter is unused, as only a single
-    command-queue is supported, and **must** be `NULL`.
+  * _command_queue_ specifies the command-queue the command will be recorded to.
+    {empty} +
+    If the {cl_khr_command_buffer_multi_device_EXT} extension is not supported,
+    only a single command-queue is supported, and _command_queue_ must be
+    `NULL`.
+ifdef::cl_khr_command_buffer_multi_device[]
+    {empty} +
+    If the {cl_khr_command_buffer_multi_device_EXT} extension is supported and
+    _command_queue_ is `NULL`, then only one command-queue must have been set on
+    _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
+endif::cl_khr_command_buffer_multi_device[]
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
     synchronization-points that need to complete before this particular
     command can be executed.
@@ -14432,7 +14439,14 @@ recorded after it do not execute until it completes.
 executed successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not `NULL`.
+  * {CL_INVALID_COMMAND_QUEUE} if the
+    {cl_khr_command_buffer_multi_device_EXT} extension is not supported and
+    _command_queue_ is not `NULL`.
+  * {CL_INVALID_COMMAND_QUEUE} if the
+    {cl_khr_command_buffer_multi_device_EXT} extension is supported; and
+    either _command_queue_ is `NULL` and _command_buffer_ was created with
+    more than one queue, or _command_queue_ is not `NULL` and not a
+    command-queue listed on _command_buffer_ creation.
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and


### PR DESCRIPTION
`clCommandBarrierWithWaitListKHR` does not have wording for the `command_queue` parameter regarding when
`cl_khr_command_buffer_multi_device` is enabled, and the error wording also does not take the multi-device extension into account. Taken wording from the other command recording entry-points.