### PR TITLE
Fix a typo in the category ToC for the refpages

### DIFF
--- a/man/toctail
+++ b/man/toctail
@@ -299,7 +299,7 @@
                                     <li><a href="create_user_event.html" target="pagedisplay">create_user_event</a></li>
                                     <li><a href="is_valid_event.html" target="pagedisplay">is_valid_event</a></li>
                                     <li><a href="set_user_event_status.html" target="pagedisplay">set_user_event_status</a></li>
-                                    <li><a href="capture_event_profiling_info.html" target="capture_event_profiling_info">capture_event_profiling_info</a></li>
+                                    <li><a href="capture_event_profiling_info.html" target="pagedisplay">capture_event_profiling_info</a></li>
                                 </ul>
                             </li>
 

--- a/man/toctail
+++ b/man/toctail
@@ -363,7 +363,7 @@
                                     <li><a href="mad24.html" target="pagedisplay">mad24</a></li>
                                     <li><a href="mad_hi.html" target="pagedisplay">mad_hi</a></li>
                                     <li><a href="mad_sat.html" target="pagedisplay">mad_sat</a></li>
-                                    <li><a href="integerMax.html" target="pagedisplay">ma</a></li>
+                                    <li><a href="integerMax.html" target="pagedisplay">max</a></li>
                                     <li><a href="integerMax.html" target="pagedisplay">min</a></li>
                                     <li><a href="mul24.html" target="pagedisplay">mul24</a></li>
                                     <li><a href="mul_hi.html" target="pagedisplay">mul_hi</a></li>

--- a/man/toctail
+++ b/man/toctail
@@ -412,7 +412,7 @@
                                     <li><a href="fdim.html" target="pagedisplay">fdim</a></li>
                                     <li><a href="floor.html" target="pagedisplay">floor</a></li>
                                     <li><a href="fma.html" target="pagedisplay">fma</a></li>
-                                    <li><a href="fmax.html" target="pagedisplay">fma</a></li>
+                                    <li><a href="fmax.html" target="pagedisplay">fmax</a></li>
                                     <li><a href="fmin.html" target="pagedisplay">fmin</a></li>
                                     <li><a href="fmod.html" target="pagedisplay">fmod</a></li>
                                     <li><a href="fract.html" target="pagedisplay">fract</a></li>


### PR DESCRIPTION
@bashbaug trivial typo I noticed while comparing the category index and the generated refpage sets. The fix causes this link to open inside refpage frames, like all the others.