### PR TITLE
Fix CL_INVALID_CONTEXT command-buffer error definitions

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14370,8 +14370,7 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
@@ -14458,8 +14457,7 @@ Otherwise, it returns the errors defined by {clEnqueueCopyBuffer} except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
     _src_buffer_, and _dst_buffer_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -14568,8 +14566,7 @@ except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
     _src_buffer_, and _dst_buffer_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -14661,8 +14658,7 @@ except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
     _src_buffer_, and _dst_image_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -14760,8 +14756,7 @@ Otherwise, it returns the errors defined by {clEnqueueCopyImage} except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
     _src_image_, and _dst_image_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -14853,8 +14848,7 @@ except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
     _src_image_, and _dst_buffer_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -14953,8 +14947,7 @@ Otherwise, it returns the errors defined by {clEnqueueFillBuffer} except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
     _buffer_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -15051,8 +15044,7 @@ Otherwise, it returns the errors defined by {clEnqueueFillImage} except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
     _image_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -15300,8 +15292,7 @@ Otherwise, it returns the errors defined by {clEnqueueNDRangeKernel} except:
   * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
     _kernel_ is not the same.
 ifdef::cl_khr_command_buffer_multi_device[]
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 
@@ -15419,8 +15410,7 @@ Otherwise, it returns the errors defined by {clEnqueueSVMMemcpy} except:
 ifdef::cl_khr_command_buffer_multi_device[]
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 
 endif::cl_khr_command_buffer_multi_device[]
@@ -15533,8 +15523,7 @@ successfully. Otherwise, it returns the errors defined by
 ifdef::cl_khr_command_buffer_multi_device[]
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
-    extension is enabled, and _command_queue_ is not `NULL`, and the context
+  * {CL_INVALID_CONTEXT} if _command_queue_ is not `NULL`, and the context
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14369,8 +14369,11 @@ Otherwise, it returns one of the following errors:
   * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not `NULL`.
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
-    _command_buffer_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
   * {CL_INVALID_SYNC_POINT_WAIT_LIST_KHR} if _sync_point_wait_list_ is
@@ -14452,8 +14455,13 @@ Otherwise, it returns the errors defined by {clEnqueueCopyBuffer} except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, _src_buffer_, and _dst_buffer_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
+    _src_buffer_, and _dst_buffer_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -14557,8 +14565,13 @@ except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, _src_buffer_, and _dst_buffer_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
+    _src_buffer_, and _dst_buffer_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -14645,8 +14658,13 @@ except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, _src_buffer_, and _dst_image_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
+    _src_buffer_, and _dst_image_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -14739,8 +14757,13 @@ Otherwise, it returns the errors defined by {clEnqueueCopyImage} except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, _src_image_, and _dst_image_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
+    _src_image_, and _dst_image_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -14827,8 +14850,13 @@ except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, _src_image_, and _dst_buffer_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_,
+    _src_image_, and _dst_buffer_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -14922,8 +14950,13 @@ Otherwise, it returns the errors defined by {clEnqueueFillBuffer} except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, and _buffer_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
+    _buffer_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -15015,8 +15048,13 @@ Otherwise, it returns the errors defined by {clEnqueueFillImage} except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, and _image_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
+    _image_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -15259,8 +15297,13 @@ Otherwise, it returns the errors defined by {clEnqueueNDRangeKernel} except:
 
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, and _kernel_ are not the same.
+  * {CL_INVALID_CONTEXT} if the context associated with _command_buffer_ and
+    _kernel_ is not the same.
+ifdef::cl_khr_command_buffer_multi_device[]
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -15373,10 +15416,18 @@ Otherwise, it returns the errors defined by {clEnqueueSVMMemcpy} except:
     more than one queue, or _command_queue_ is not `NULL` and not a
     command-queue listed on _command_buffer_ creation.
 
+ifdef::cl_khr_command_buffer_multi_device[]
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, and _kernel_ are not the same.
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+
+endif::cl_khr_command_buffer_multi_device[]
+
+ifndef::cl_khr_command_buffer_multi_device[]
+{CL_INVALID_CONTEXT} error case is removed.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 
@@ -15479,10 +15530,17 @@ successfully. Otherwise, it returns the errors defined by
     more than one queue, or _command_queue_ is not `NULL` and not a
     command-queue listed on _command_buffer_ creation.
 
+ifdef::cl_khr_command_buffer_multi_device[]
 {CL_INVALID_CONTEXT} is replaced with:
 
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_,
-    _command_buffer_, and _kernel_ are not the same.
+  * {CL_INVALID_CONTEXT} if the {cl_khr_command_buffer_multi_device_EXT}
+    extension is enabled, and _command_queue_ is not `NULL`, and the context
+    associated with _command_queue_ and _command_buffer_ is not the same.
+endif::cl_khr_command_buffer_multi_device[]
+
+ifndef::cl_khr_command_buffer_multi_device[]
+{CL_INVALID_CONTEXT} error case is removed.
+endif::cl_khr_command_buffer_multi_device[]
 
 {CL_INVALID_EVENT_WAIT_LIST} is replaced with:
 


### PR DESCRIPTION
See issue https://github.com/KhronosGroup/OpenCL-Docs/issues/1147 documenting that the error specification for `CL_INVALID_CONTEXT` doesn't take into account the variation when
`cl_khr_command_buffer_multi_device` is enabled.

Doing this change also picked up that the error wording for `clCommandSVMMemcpyKHR` and `clCommandSVMMemFillKHR` referenced the _kernel_ parameter which doesn't exist.

Closes https://github.com/KhronosGroup/OpenCL-Docs/issues/1147