### PR TITLE
Mention dependency on SPV_EXT_shader_atomic_float16_add in cl_ext_float_atomics

### DIFF
--- a/extensions/cl_ext_float_atomics.asciidoc
+++ b/extensions/cl_ext_float_atomics.asciidoc
@@ -93,7 +93,7 @@ The functionality added by this extension uses the OpenCL C 2.0 atomic syntax an
 
 This extension interacts with `cl_khr_fp16` by optionally adding the ability to atomically operate on 16-bit floating-point values in memory.
 
-This extension depends on `SPV_EXT_shader_atomic_float_add` and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
+This extension depends on `SPV_EXT_shader_atomic_float_add`, `SPV_EXT_shader_atomic_float16_add`, and `SPV_EXT_shader_atomic_float_min_max` for implementations that support SPIR-V and floating-point atomic add, min, or max operations.
 
 == Overview
 


### PR DESCRIPTION
The AtomicFloat16AddEXT capability it defines is referred to.


Change-Id: Icbae5f1ad02561e11517a47e9640eea4bc6a4283