### PR TITLE
Add revision to XML extensions

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -2263,6 +2263,25 @@ typedef cl_uint cl_version;
     ((patch) & CL_VERSION_PATCH_MASK))
 ----
 
+[NOTE]
+--
+The available version of an extension is exposed to the user via a macro
+defined by the OpenCL Headers. This macro takes the format of the uppercase
+extension name followed by the `_EXTENSION_VERSION` suffix. For example,
+`CL_KHR_SEMAPHORE_EXTENSION_VERSION` is the macro defining the version of the
+{cl_khr_semaphore_EXT} extension.
+
+The value of this macro is set to the {cl_version_TYPE} of the extension using
+the semantic version of the extension. If no semantic version is defined for
+the extension, then the value of the macro is set to `0` to represent semantic
+version `0.0.0`.
+
+Applications can use these version macros along with the convience macros
+defined in this section to guard their code against breaking changes to the API
+of extensions, in particular provisional KHR extensions which have yet to
+finalize an API.
+--
+
 [[version-name-pairing]]
 ==== Version-Name Pairing
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5389,7 +5389,7 @@ server's OpenCL/api-docs repository.
 
     <!-- SECTION: OpenCL extension interface definitions -->
     <extensions>
-        <extension name="cl_khr_d3d10_sharing" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_d3d10_sharing" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="d3d10.h"/>
                 <type name="CL/cl.h"/>
@@ -5436,7 +5436,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseD3D10ObjectsKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_d3d11_sharing" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_d3d11_sharing" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="d3d11.h"/>
                 <type name="CL/cl.h"/>
@@ -5483,7 +5483,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseD3D11ObjectsKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_dx9_media_sharing" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_dx9_media_sharing" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5532,7 +5532,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseDX9MediaSurfacesKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_egl_image" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_egl_image" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5560,7 +5560,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseEGLObjectsKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_egl_event" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_egl_event" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5574,7 +5574,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateEventFromEGLSyncKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_fp64" supported="opencl" promotedto="CL_VERSION_1_2" ratified="opencl">
+        <extension name="cl_khr_fp64" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_2" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5582,7 +5582,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_DOUBLE_FP_CONFIG"/>
             </require>
         </extension>
-        <extension name="cl_khr_fp16" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_fp16" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5590,7 +5590,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_HALF_FP_CONFIG"/>
             </require>
         </extension>
-        <extension name="cl_APPLE_SetMemObjectDestructor" comment="not registered" supported="opencl">
+        <extension name="cl_APPLE_SetMemObjectDestructor" revision="0.0.0" comment="not registered" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5598,7 +5598,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetMemObjectDestructorAPPLE"/>
             </require>
         </extension>
-        <extension name="cl_APPLE_ContextLoggingFunctions" comment="not registered" supported="opencl">
+        <extension name="cl_APPLE_ContextLoggingFunctions" revision="0.0.0" comment="not registered" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5608,7 +5608,7 @@ server's OpenCL/api-docs repository.
                 <command name="clLogMessagesToStderrAPPLE"/>
             </require>
         </extension>
-        <extension name="cl_khr_icd" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_icd" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5622,7 +5622,7 @@ server's OpenCL/api-docs repository.
                 <command name="clIcdGetPlatformIDsKHR"/>
             </require>
         </extension>
-        <extension name="cl_loader_layers" supported="opencl">
+        <extension name="cl_loader_layers" revision="1.0.0" supported="opencl">
             <require>
                 <type name="CL/cl_icd.h"/>
             </require>
@@ -5642,7 +5642,7 @@ server's OpenCL/api-docs repository.
                 <command name="clInitLayer"/>
             </require>
         </extension>
-        <extension name="cl_loader_info" supported="opencl">
+        <extension name="cl_loader_info" revision="1.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5659,7 +5659,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetICDLoaderInfoOCLICD"/>
             </require>
         </extension>
-        <extension name="cl_khr_il_program" supported="opencl" promotedto="CL_VERSION_2_1" ratified="opencl">
+        <extension name="cl_khr_il_program" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_1" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5673,13 +5673,13 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateProgramWithILKHR" comment="No EXT_SUFFIX?"/>
             </require>
         </extension>
-        <extension name="cl_khr_image2d_from_buffer" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
+        <extension name="cl_khr_image2d_from_buffer" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_IMAGE_PITCH_ALIGNMENT_KHR"/>
                 <enum name="CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_initialize_memory" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_initialize_memory" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5694,7 +5694,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_terminate_context" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_terminate_context" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5717,7 +5717,7 @@ server's OpenCL/api-docs repository.
                 <command name="clTerminateContextKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_spir" supported="opencl" obsoletedby="cl_khr_il_program" ratified="opencl">
+        <extension name="cl_khr_spir" revision="1.0.0" supported="opencl" obsoletedby="cl_khr_il_program" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5728,7 +5728,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE"/>
             </require>
         </extension>
-        <extension name="cl_khr_create_command_queue" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
+        <extension name="cl_khr_create_command_queue" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5739,7 +5739,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateCommandQueueWithPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="cl_nv_device_attribute_query" supported="opencl">
+        <extension name="cl_nv_device_attribute_query" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5753,7 +5753,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_INTEGRATED_MEMORY_NV"/>
             </require>
         </extension>
-        <extension name="cl_amd_device_attribute_query" supported="opencl">
+        <extension name="cl_amd_device_attribute_query" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5781,7 +5781,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_PCIE_ID_AMD"/>
             </require>
         </extension>
-        <extension name="cl_arm_printf" supported="opencl">
+        <extension name="cl_arm_printf" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5790,7 +5790,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_PRINTF_BUFFERSIZE_ARM"/>
             </require>
         </extension>
-        <extension name="cl_ext_device_fission" supported="opencl">
+        <extension name="cl_ext_device_fission" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5834,7 +5834,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateSubDevicesEXT"/>
             </require>
         </extension>
-        <extension name="cl_ext_migrate_memobject" supported="opencl">
+        <extension name="cl_ext_migrate_memobject" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5851,7 +5851,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueMigrateMemObjectEXT"/>
             </require>
         </extension>
-        <extension name="cl_qcom_ext_host_ptr" supported="opencl">
+        <extension name="cl_qcom_ext_host_ptr" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5880,7 +5880,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetDeviceImageInfoQCOM"/>
             </require>
         </extension>
-        <extension name="cl_qcom_ext_host_ptr_iocoherent" supported="opencl">
+        <extension name="cl_qcom_ext_host_ptr_iocoherent" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5888,7 +5888,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_MEM_HOST_IOCOHERENT_QCOM"/>
             </require>
         </extension>
-        <extension name="cl_qcom_ion_host_ptr" supported="opencl">
+        <extension name="cl_qcom_ion_host_ptr" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5900,7 +5900,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_MEM_ION_HOST_PTR_QCOM"/>
             </require>
         </extension>
-        <extension name="cl_qcom_android_native_buffer_host_ptr" supported="opencl">
+        <extension name="cl_qcom_android_native_buffer_host_ptr" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5912,7 +5912,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM"/>
             </require>
         </extension>
-        <extension name="cl_img_yuv_image" supported="opencl">
+        <extension name="cl_img_yuv_image" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5921,7 +5921,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_YV12_IMG"/>
             </require>
         </extension>
-        <extension name="cl_img_cached_allocations" supported="opencl">
+        <extension name="cl_img_cached_allocations" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5930,7 +5930,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_MEM_USE_CACHED_CPU_MEMORY_IMG"/>
             </require>
         </extension>
-        <extension name="cl_khr_mipmap_image" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_mipmap_image" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5940,7 +5940,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SAMPLER_LOD_MAX_KHR"/>
             </require>
         </extension>
-        <extension name="cl_img_use_gralloc_ptr" supported="opencl">
+        <extension name="cl_img_use_gralloc_ptr" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5960,7 +5960,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseGrallocObjectsIMG"/>
             </require>
         </extension>
-        <extension name="cl_khr_subgroups" supported="opencl" promotedto="CL_VERSION_2_1" ratified="opencl">
+        <extension name="cl_khr_subgroups" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_1" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5975,7 +5975,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetKernelSubGroupInfoKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_priority_hints" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_priority_hints" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -5991,7 +5991,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_PRIORITY_LOW_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_throttle_hints" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_throttle_hints" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6007,7 +6007,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_THROTTLE_LOW_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_subgroup_named_barrier" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_subgroup_named_barrier" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6015,7 +6015,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
             </require>
         </extension>
-        <extension name="cl_arm_import_memory" supported="opencl">
+        <extension name="cl_arm_import_memory" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6053,7 +6053,7 @@ server's OpenCL/api-docs repository.
                 <command name="clImportMemoryARM"/>
             </require>
         </extension>
-        <extension name="cl_arm_shared_virtual_memory" supported="opencl">
+        <extension name="cl_arm_shared_virtual_memory" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6101,7 +6101,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetKernelExecInfoARM"/>
             </require>
         </extension>
-        <extension name="cl_arm_get_core_id" condition="defined(CL_VERSION_1_2)" supported="opencl">
+        <extension name="cl_arm_get_core_id" revision="0.0.0" condition="defined(CL_VERSION_1_2)" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6109,7 +6109,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"/>
             </require>
         </extension>
-        <extension name="cl_intel_exec_by_local_thread" supported="opencl">
+        <extension name="cl_intel_exec_by_local_thread" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
                 <type name="CL/cl_platform.h"/>
@@ -6118,13 +6118,13 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_device_partition_by_names" supported="opencl">
+        <extension name="cl_intel_device_partition_by_names" revision="0.0.0" supported="opencl">
             <require>
                 <enum name="CL_DEVICE_PARTITION_BY_NAMES_INTEL"/>
                 <enum name="CL_PARTITION_BY_NAMES_LIST_END_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_accelerator" supported="opencl">
+        <extension name="cl_intel_accelerator" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_accelerator_intel"/>
                 <type name="cl_accelerator_type_intel"/>
@@ -6149,7 +6149,7 @@ server's OpenCL/api-docs repository.
                 <command name="clReleaseAcceleratorINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_motion_estimation" supported="opencl">
+        <extension name="cl_intel_motion_estimation" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_motion_estimation_desc_intel"/>
             </require>
@@ -6176,7 +6176,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_16_12_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_advanced_motion_estimation" supported="opencl">
+        <extension name="cl_intel_advanced_motion_estimation" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_ME_VERSION_INTEL"/>
             </require>
@@ -6236,18 +6236,18 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_simultaneous_sharing" supported="opencl">
+        <extension name="cl_intel_simultaneous_sharing" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"/>
                 <enum name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_egl_image_yuv" supported="opencl">
+        <extension name="cl_intel_egl_image_yuv" revision="0.0.0" supported="opencl">
             <require comment="cl_egl_image_properties_khr">
                 <enum name="CL_EGL_YUV_PLANE_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_packed_yuv" supported="opencl">
+        <extension name="cl_intel_packed_yuv" revision="0.0.0" supported="opencl">
             <require comment="cl_channel_order">
                 <enum name="CL_YUYV_INTEL"/>
                 <enum name="CL_UYVY_INTEL"/>
@@ -6255,7 +6255,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_VYUY_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_required_subgroup_size" supported="opencl">
+        <extension name="cl_intel_required_subgroup_size" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"/>
             </require>
@@ -6266,7 +6266,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_driver_diagnostics" supported="opencl">
+        <extension name="cl_intel_driver_diagnostics" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_diagnostics_verbose_level"/>
             </require>
@@ -6278,7 +6278,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_NEUTRAL_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_planar_yuv" supported="opencl">
+        <extension name="cl_intel_planar_yuv" revision="0.0.0" supported="opencl">
             <require comment="cl_channel_order">
                 <enum name="CL_NV12_INTEL"/>
             </require>
@@ -6291,7 +6291,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_device_side_avc_motion_estimation" supported="opencl">
+        <extension name="cl_intel_device_side_avc_motion_estimation" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_AVC_ME_VERSION_INTEL"/>
                 <enum name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL"/>
@@ -6443,7 +6443,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_khr_gl_event" supported="opencl" depends="cl_khr_gl_sharing" ratified="opencl">
+        <extension name="cl_khr_gl_event" revision="1.0.0" supported="opencl" depends="cl_khr_gl_sharing" ratified="opencl">
             <require>
                 <type name="cl_GLsync"/>
             </require>
@@ -6454,7 +6454,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateEventFromGLsyncKHR"/>
             </require>
         </extension>
-        <extension name="cl_intel_va_api_media_sharing" supported="opencl">
+        <extension name="cl_intel_va_api_media_sharing" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6495,7 +6495,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseVA_APIMediaSurfacesINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_dx9_media_sharing" supported="opencl">
+        <extension name="cl_intel_dx9_media_sharing" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6541,7 +6541,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseDX9ObjectsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_khr_gl_depth_images" depends="cl_khr_gl_sharing" comment="no API - reuses tokens from core API" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_gl_depth_images" revision="1.0.0" depends="cl_khr_gl_sharing" comment="no API - reuses tokens from core API" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6552,7 +6552,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_UNORM_INT24"/>
             </require>
         </extension>
-        <extension name="cl_khr_gl_msaa_sharing" depends="cl_khr_gl_depth_images+cl_khr_gl_sharing" comment="no API - reuses tokens from core API" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_gl_msaa_sharing" revision="1.0.0" depends="cl_khr_gl_depth_images+cl_khr_gl_sharing" comment="no API - reuses tokens from core API" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6562,7 +6562,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_GL_NUM_SAMPLES"/>
             </require>
         </extension>
-        <extension name="cl_khr_gl_sharing" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_gl_sharing" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6623,7 +6623,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateFromGLTexture3D"/>
             </require>
         </extension>
-        <extension name="cl_intel_unified_shared_memory" comment="in sync with rev 1.0.0" supported="opencl">
+        <extension name="cl_intel_unified_shared_memory" revision="0.0.0" comment="in sync with rev 1.0.0" supported="opencl">
             <require>
                 <type name="cl_device_unified_shared_memory_capabilities_intel"/>
                 <type name="cl_mem_properties_intel"/>
@@ -6696,7 +6696,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueMemsetINTEL"/>
             </require>
         </extension>
-        <extension name="cl_khr_device_uuid" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_device_uuid" revision="1.0.0" supported="opencl" ratified="opencl">
             <require comment="Size Constants">
                 <enum name="CL_UUID_SIZE_KHR"/>
                 <enum name="CL_LUID_SIZE_KHR"/>
@@ -6709,7 +6709,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_NODE_MASK_KHR"/>
             </require>
         </extension>
-        <extension name="cl_intel_create_buffer_with_properties" supported="opencl">
+        <extension name="cl_intel_create_buffer_with_properties" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_mem_properties_intel"/>
             </require>
@@ -6717,12 +6717,12 @@ server's OpenCL/api-docs repository.
                 <command name="clCreateBufferWithPropertiesINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_mem_channel_property" supported="opencl">
+        <extension name="cl_intel_mem_channel_property" revision="0.0.0" supported="opencl">
             <require comment="cl_mem_properties_intel">
                 <enum name="CL_MEM_CHANNEL_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_mem_alloc_buffer_location" supported="opencl">
+        <extension name="cl_intel_mem_alloc_buffer_location" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6733,7 +6733,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_arm_scheduling_controls" supported="opencl">
+        <extension name="cl_arm_scheduling_controls" revision="0.0.0" supported="opencl">
             <require comment="Types">
                 <type name="cl_device_scheduling_controls_capabilities_arm"/>
             </require>
@@ -6767,17 +6767,17 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM"/>
             </require>
         </extension>
-        <extension name="cl_ext_cxx_for_opencl" supported="opencl">
+        <extension name="cl_ext_cxx_for_opencl" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
             </require>
         </extension>
-        <extension name="cl_intel_mem_force_host_memory" supported="opencl">
+        <extension name="cl_intel_mem_force_host_memory" revision="0.0.0" supported="opencl">
             <require comment="cl_mem_flags">
                 <enum name="CL_MEM_FORCE_HOST_MEMORY_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_khr_depth_images" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
+        <extension name="cl_khr_depth_images" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6785,7 +6785,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEPTH"/>
             </require>
         </extension>
-        <extension name="cl_khr_extended_versioning" supported="opencl" promotedto="CL_VERSION_3_0" ratified="opencl">
+        <extension name="cl_khr_extended_versioning" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_3_0" ratified="opencl">
             <require>
                 <enum name="CL_VERSION_MAJOR_BITS_KHR"/>
                 <enum name="CL_VERSION_MINOR_BITS_KHR"/>
@@ -6823,7 +6823,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION_KHR"/>
             </require>
         </extension>
-        <extension name="cl_img_generate_mipmap" supported="opencl">
+        <extension name="cl_img_generate_mipmap" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_mipmap_filter_mode_img"/>
             </require>
@@ -6838,7 +6838,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueGenerateMipmapIMG"/>
             </require>
         </extension>
-        <extension name="cl_img_mem_properties" supported="opencl">
+        <extension name="cl_img_mem_properties" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6857,7 +6857,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_MEMORY_CAPABILITIES_IMG"/>
             </require>
         </extension>
-        <extension name="cl_arm_controlled_kernel_termination" supported="opencl">
+        <extension name="cl_arm_controlled_kernel_termination" revision="0.0.0" supported="opencl">
             <require comment="Types">
                 <type name="cl_device_controlled_termination_capabilities_arm"/>
             </require>
@@ -6882,7 +6882,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_COMMAND_TERMINATION_ERROR_ARM"/>
             </require>
         </extension>
-        <extension name="cl_intel_command_queue_families" supported="opencl">
+        <extension name="cl_intel_command_queue_families" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6922,7 +6922,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_CAPABILITY_KERNEL_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_khr_pci_bus_info" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_pci_bus_info" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6933,7 +6933,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_PCI_BUS_INFO_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_suggested_local_work_size" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_suggested_local_work_size" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6941,7 +6941,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetKernelSuggestedLocalWorkSizeKHR"/>
             </require>
         </extension>
-        <extension name="cl_intel_device_attribute_query" supported="opencl">
+        <extension name="cl_intel_device_attribute_query" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -6980,7 +6980,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_semaphore" revision="0.9.1" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl">
+        <extension name="cl_khr_semaphore" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7027,7 +7027,7 @@ server's OpenCL/api-docs repository.
                 <command name="clRetainSemaphoreKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl">
+        <extension name="cl_khr_external_semaphore" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7054,7 +7054,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetSemaphoreHandleForTypeKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore_opaque_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
+        <extension name="cl_khr_external_semaphore_opaque_fd" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7062,7 +7062,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore_sync_fd" revision="0.9.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
+        <extension name="cl_khr_external_semaphore_sync_fd" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore+cl_khr_external_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7085,7 +7085,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl">
+        <extension name="cl_khr_external_memory" revision="1.0.0" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7112,7 +7112,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueReleaseExternalMemObjectsKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_dma_buf" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
+        <extension name="cl_khr_external_memory_dma_buf" revision="1.0.0" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7120,7 +7120,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_opaque_fd" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
+        <extension name="cl_khr_external_memory_opaque_fd" revision="1.0.0" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7128,7 +7128,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory_win32" revision="0.9.3" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
+        <extension name="cl_khr_external_memory_win32" revision="1.0.0" supported="opencl" depends="CL_VERSION_3_0+cl_khr_external_memory" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7137,37 +7137,37 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query" supported="opencl">
+        <extension name="cl_intel_sharing_format_query" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query_gl" supported="opencl" comment="GL API for cl_intel_sharing_format_query">
+        <extension name="cl_intel_sharing_format_query_gl" revision="0.0.0" supported="opencl" comment="GL API for cl_intel_sharing_format_query">
             <require comment="when cl_khr_gl_sharing is supported">
                 <command name="clGetSupportedGLTextureFormatsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query_dx9" supported="opencl" comment="DX9 API for cl_intel_sharing_format_query">
+        <extension name="cl_intel_sharing_format_query_dx9" revision="0.0.0" supported="opencl" comment="DX9 API for cl_intel_sharing_format_query">
             <require comment="when cl_khr_dx9_media_sharing or cl_intel_dx9_media_sharing is supported">
                 <command name="clGetSupportedDX9MediaSurfaceFormatsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query_d3d10" supported="opencl" comment="D3D10 API for cl_intel_sharing_format_query">
+        <extension name="cl_intel_sharing_format_query_d3d10" revision="0.0.0" supported="opencl" comment="D3D10 API for cl_intel_sharing_format_query">
             <require comment="when cl_khr_d3d10_sharing is supported">
                 <command name="clGetSupportedD3D10TextureFormatsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query_d3d11" supported="opencl" comment="D3D11 API for cl_intel_sharing_format_query">
+        <extension name="cl_intel_sharing_format_query_d3d11" revision="0.0.0" supported="opencl" comment="D3D11 API for cl_intel_sharing_format_query">
             <require comment="when cl_khr_d3d11_sharing is supported">
                 <command name="clGetSupportedD3D11TextureFormatsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_intel_sharing_format_query_va_api" supported="opencl" comment="VA_API API for cl_intel_sharing_format_query">
+        <extension name="cl_intel_sharing_format_query_va_api" revision="0.0.0" supported="opencl" comment="VA_API API for cl_intel_sharing_format_query">
             <require comment="when cl_intel_va_api_media_sharing is supported">
                 <command name="clGetSupportedVA_APIMediaSurfaceFormatsINTEL"/>
             </require>
         </extension>
-        <extension name="cl_pocl_content_size" supported="opencl">
+        <extension name="cl_pocl_content_size" revision="0.0.0" supported="opencl">
             <require>
                 <command name="clSetContentSizeBufferPoCL"/>
             </require>
@@ -7246,12 +7246,12 @@ server's OpenCL/api-docs repository.
                 <command name="clCommandSVMMemFillKHR"/>
             </require>
         </extension>
-        <extension name="cl_arm_protected_memory_allocation" supported="opencl">
+        <extension name="cl_arm_protected_memory_allocation" revision="0.0.0" supported="opencl">
             <require>
                 <enum name="CL_MEM_PROTECTED_ALLOC_ARM"/>
             </require>
         </extension>
-        <extension name="cl_ext_float_atomics" supported="opencl">
+        <extension name="cl_ext_float_atomics" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7272,7 +7272,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
             </require>
         </extension>
-        <extension name="cl_intel_program_scope_host_pipe" supported="opencl">
+        <extension name="cl_intel_program_scope_host_pipe" revision="0.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7289,7 +7289,7 @@ server's OpenCL/api-docs repository.
                 <command name="clEnqueueWriteHostPipeINTEL"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_requirements_info" condition="defined(CL_VERSION_3_0)" supported="opencl">
+        <extension name="cl_ext_image_requirements_info" revision="0.0.0" condition="defined(CL_VERSION_3_0)" supported="opencl">
             <require comment="Types">
                 <type name="cl_image_requirements_info_ext"/>
             </require>
@@ -7306,12 +7306,12 @@ server's OpenCL/api-docs repository.
                 <command name="clGetImageRequirementsInfoEXT"/>
             </require>
         </extension>
-        <extension name="cl_intel_queue_no_sync_operations" supported="opencl">
+        <extension name="cl_intel_queue_no_sync_operations" revision="0.0.0" supported="opencl">
             <require comment="cl_command_queue_properties">
                 <enum name="CL_QUEUE_NO_SYNC_OPERATIONS_INTEL"/>
             </require>
         </extension>
-        <extension name="cl_arm_job_slot_selection" supported="opencl">
+        <extension name="cl_arm_job_slot_selection" revision="0.0.0" supported="opencl">
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_JOB_SLOTS_ARM"/>
             </require>
@@ -7382,12 +7382,12 @@ server's OpenCL/api-docs repository.
                 <command name="clGetMutableCommandInfoKHR"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_from_buffer" condition="defined(CL_VERSION_3_0)" supported="opencl">
+        <extension name="cl_ext_image_from_buffer" revision="0.0.0" condition="defined(CL_VERSION_3_0)" supported="opencl">
             <require comment="cl_image_requirements_info_ext">
                 <enum name="CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT"/>
             </require>
         </extension>
-        <extension name="cl_intel_create_mem_object_properties" supported="opencl">
+        <extension name="cl_intel_create_mem_object_properties" revision="0.0.0" supported="opencl">
             <require comment="cl_mem_properties">
                 <enum name="CL_MEM_LOCALLY_UNCACHED_RESOURCE_INTEL"/>
                 <enum name="CL_MEM_DEVICE_ID_INTEL"/>
@@ -7422,41 +7422,41 @@ server's OpenCL/api-docs repository.
                 <command name="clRemapCommandBufferKHR"/>
             </require>
         </extension>
-        <extension name="cl_ext_image_raw10_raw12" supported="opencl">
+        <extension name="cl_ext_image_raw10_raw12" revision="0.0.0" supported="opencl">
             <require comment="cl_channel_type">
                 <enum name="CL_UNSIGNED_INT_RAW10_EXT"/>
                 <enum name="CL_UNSIGNED_INT_RAW12_EXT"/>
             </require>
         </extension>
-        <extension name="cl_khr_3d_image_writes" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_async_work_group_copy_fence" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_byte_addressable_store" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_device_enqueue_local_arg_types" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_expect_assume" supported="opencl" ratified="opencl" comment="OpenCL C only - not exactly an extension, but a compiler directive?"/>
-        <extension name="cl_khr_extended_async_copies" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_extended_bit_ops" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_global_int32_base_atomics" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
-        <extension name="cl_khr_global_int32_extended_atomics" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
-        <extension name="cl_khr_local_int32_base_atomics" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
-        <extension name="cl_khr_local_int32_extended_atomics" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
-        <extension name="cl_khr_int64_base_atomics" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_int64_extended_atomics" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_mipmap_image_writes" supported="opencl" depends="cl_khr_mipmap_image" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_select_fprounding_mode" supported="opencl" obsoletedby="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_srgb_image_writes" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_extended_types" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_non_uniform_vote" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_ballot" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_non_uniform_arithmetic" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_shuffle" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_shuffle_relative" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_clustered_reduce" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_subgroup_rotate" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_work_group_uniform_arithmetic" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
-        <extension name="cl_khr_spirv_no_integer_wrap_decoration" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
-        <extension name="cl_khr_spirv_extended_debug_info" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
-        <extension name="cl_khr_spirv_linkonce_odr" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
-        <extension name="cl_img_cancel_command" supported="opencl">
+        <extension name="cl_khr_3d_image_writes" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_2_0" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_async_work_group_copy_fence" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_byte_addressable_store" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_device_enqueue_local_arg_types" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_expect_assume" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only - not exactly an extension, but a compiler directive?"/>
+        <extension name="cl_khr_extended_async_copies" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_extended_bit_ops" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_global_int32_base_atomics" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
+        <extension name="cl_khr_global_int32_extended_atomics" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
+        <extension name="cl_khr_local_int32_base_atomics" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
+        <extension name="cl_khr_local_int32_extended_atomics" revision="1.0.0" supported="opencl" promotedto="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only, promotion with name changes"/>
+        <extension name="cl_khr_int64_base_atomics" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_int64_extended_atomics" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_mipmap_image_writes" revision="1.0.0" supported="opencl" depends="cl_khr_mipmap_image" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_select_fprounding_mode" revision="1.0.0" supported="opencl" obsoletedby="CL_VERSION_1_1" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_srgb_image_writes" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_extended_types" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_non_uniform_vote" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_ballot" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_non_uniform_arithmetic" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_shuffle" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_shuffle_relative" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_clustered_reduce" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_subgroup_rotate" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_work_group_uniform_arithmetic" revision="1.0.0" supported="opencl" ratified="opencl" comment="OpenCL C only"/>
+        <extension name="cl_khr_spirv_no_integer_wrap_decoration" revision="1.0.0" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
+        <extension name="cl_khr_spirv_extended_debug_info" revision="1.0.0" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
+        <extension name="cl_khr_spirv_linkonce_odr" revision="1.0.0" supported="opencl" ratified="opencl" comment="SPIR-V only"/>
+        <extension name="cl_img_cancel_command" revision="0.0.0" supported="opencl">
             <require comment="Error codes">
                 <enum name="CL_CANCELLED_IMG"/>
             </require>
@@ -7464,7 +7464,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCancelCommandsIMG"/>
             </require>
         </extension>
-        <extension name="cl_khr_kernel_clock" supported="opencl" ratified="opencl" provisional="true">
+        <extension name="cl_khr_kernel_clock" revision="0.9.0" supported="opencl" ratified="opencl" provisional="true">
             <require>
                 <type name="CL/cl.h"/>
             </require>

--- a/xml/registry.rnc
+++ b/xml/registry.rnc
@@ -445,7 +445,7 @@ Extensions = element extensions {
 #     exactly match an API being generated (implicit ^$ surrounding).
 #   name - extension name string
 #   number - extension number (positive integer, should be unique)
-#   revision - extension spec revision (text, usually numeric major.minor.patch)
+#   revision - extension spec revision, must be numeric 'major.minor.patch'
 #   sortorder - order relative to other extensions, default 0
 #   protect - C preprocessor symbol to conditionally define the interface
 #   platform - should be one of the platform names defined in the
@@ -479,8 +479,8 @@ Extensions = element extensions {
 #       Not a regular expression.
 Extension = element extension {
     Name ,
+    attribute revision { text },
     attribute number { Integer } ? ,
-    attribute revision { text } ? ,
     attribute sortorder { xsd:integer } ?,
     attribute protect { text } ? ,
     attribute platform { text } ? ,


### PR DESCRIPTION
This PR actions https://github.com/KhronosGroup/OpenCL-Headers/issues/248 to mandate a revision field in the XML tag for extensions. This allows a version macro to be generated with headers PR https://github.com/KhronosGroup/OpenCL-Headers/pull/251

To reduce the scope of this change only KHR extensions are given a revision,  based on the semantic version defined in their respective specifications. For EXT and vendor extensions where using semantic versioning is less standardized, a placeholder `0.0.0` value is used until they can be updated by the owner as part of https://github.com/KhronosGroup/OpenCL-Docs/issues/1168

The XML schema is updated to make the revision field mandatory in the XML entry for extensions, in the future this means that the rendered extension specifications could generated the revision based on this - as tracked by https://github.com/KhronosGroup/OpenCL-Docs/issues/1169 

The existence of the macro is also advertised as a note in the versioning sectioning of the spec.