### PR TITLE
Define extension macros in environment specification

### DIFF
--- a/OpenCL_Env.txt
+++ b/OpenCL_Env.txt
@@ -2,6 +2,10 @@
 // Creative Commons Attribution 4.0 International License; see
 // http://creativecommons.org/licenses/by/4.0/
 
+// Extensions to enable
+// Must be included before the header and attribs.txt
+include::{generated}/specattribs.adoc[]
+
 = The OpenCL^(TM)^ SPIR-V Environment Specification
 :R: pass:q,r[^(R)^]
 Khronos{R} OpenCL Working Group


### PR DESCRIPTION
This was missed during the spec unification work.


Change-Id: I23107b104431abdac2eaf8a3b1ebedd10303fc12