### PR TITLE
platform: Clarify behavior for ATOMIC_SCOPE_ALL_DEVICES #1129

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1606,6 +1606,9 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
         {CL_DEVICE_ATOMIC_ORDER_RELAXED} \| +
         {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP}
 
+        A device that does not support CL_DEVICE_SVM_ATOMICS (and hence does not support CL_MEM_SVM_ATOMICS) may still support CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES. On these devices, an atomic operation with
+        memory_scope_all_svm_devices will behave the same as if the scope were memory_scope_device - refer to <<memory-consistency-model, memory consistency model>>
+
 | {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_FENCE_CAPABILITIES.asciidoc[]

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1606,8 +1606,8 @@ include::{generated}/api/version-notes/CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES.asci
         {CL_DEVICE_ATOMIC_ORDER_RELAXED} \| +
         {CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP}
 
-        A device that does not support CL_DEVICE_SVM_ATOMICS (and hence does not support CL_MEM_SVM_ATOMICS) may still support CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES. On these devices, an atomic operation with
-        memory_scope_all_svm_devices will behave the same as if the scope were memory_scope_device - refer to <<memory-consistency-model, memory consistency model>>
+        A device that does not support {CL_DEVICE_SVM_ATOMICS} (and hence does not support {CL_MEM_SVM_ATOMICS}) may still support {CL_DEVICE_ATOMIC_SCOPE_ALL_DEVICES}. On these devices, an atomic operation with
+        *memory_scope_all_svm_devices* will behave the same as if the scope were *memory_scope_device* - refer to the <<memory-consistency-model, memory consistency model>>.
 
 | {CL_DEVICE_ATOMIC_FENCE_CAPABILITIES_anchor}
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -473,7 +473,7 @@ device except for the following queries:
 
 [[device-queries-table]]
 .List of supported param_names by {clGetDeviceInfo}
-[width="100%",cols="<33%,<17%,<50%",options="header"]
+[width="100%",cols="<28%,<15%,<57%",options="header"]
 |====
 | Device Info | Return Type | Description
 | {CL_DEVICE_TYPE_anchor}


### PR DESCRIPTION
Clarify behavior of above capability value on devices that don't support fine grained SVM