### PR TITLE
remove an extra character in an OpenCL C example

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1534,7 +1534,7 @@ For example:
 ----------
 float8 vf;
 
-float *f = &vf.x; m         // is illegal
+float *f = &vf.x;           // is illegal
 float2 *f2 = &vf.s07;       // is illegal
 
 float4 *odd = &vf.odd;      // is illegal


### PR DESCRIPTION
Fixes #1155, by removing an extra character in one of the OpenCL C examples.