### PR TITLE
fix dictionary generation script to generate links for extension APIs

### DIFF
--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -105,12 +105,9 @@ if __name__ == "__main__":
             name = api.get('name')
             #print('found extension api: ' +name)
 
-            # Example without link:
-            #
-            # // clGetGLObjectInfo
-            # :clGetGLObjectInfo: pass:q[*clGetGLObjectInfo*]
             apiLinkFile.write('// ' + name + '\n')
-            apiLinkFile.write(':' + name + ': pass:q[*' + name + '*]\n')
+            apiLinkFile.write(':' + name + '_label: pass:q[*' + name + '*]\n')
+            apiLinkFile.write(':' + name + ': <<' + name + ',{' + name + '_label}>>\n')
             apiLinkFile.write('\n')
 
             apiNoLinkFile.write('// ' + name + '\n')


### PR DESCRIPTION
Fixes #1170.

Updates the dictionary generation script to generate links for extension APIs in addition to core APIs, now that the extensions are merged into the core spec.