### PR TITLE
Clarify Acquire/Release behavior for external memory

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5427,6 +5427,23 @@ handle is used by an OpenCL command queued to a command-queue without being
 acquired.
 This is to guarantee that the state of the memory objects is up-to-date and
 they are accessible to OpenCL.
+
+The following restrictions shall apply -
+  * Each memory object must be acquired only once. Acquiring memory object 
+    multiple times without releasing it may result in implementation defined
+    behavior.
+  * The acquire must be performed on a command-queue associated with a device
+    that was one of the devices specified via {CL_MEM_DEVICE_HANDLE_LIST_KHR}
+    when the memory object was imported using {clCreateBufferWithProperties} or
+    {clCreateImageWithProperties}. If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not
+    specified, the acquire can be performed on a command-queue associated with
+    any device in the context.
+  * The memory object will be acquired on all devices specified
+    via {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
+    using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
+    If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory objects
+    will be aquired on all devices in the context.
+ 
 See <<cl_khr_external_memory-Sample-Code, "`Example with Acquire /
 Release`">> for more details on how to use this API.
 
@@ -5503,6 +5520,23 @@ Applications must release the memory objects that are acquired using
 commands in the other API.
 This is to guarantee that the state of memory objects is up-to-date and they
 are accessible to the other API.
+
+The following restrictions shall apply -
+  * Each memory object must be released only once. Releasing memory object 
+    multiple times without acquiring it may result in implementation defined
+    behavior.
+  * The release must be performed on a command-queue associated with a device
+    that was one of the devices specified via {CL_MEM_DEVICE_HANDLE_LIST_KHR}
+    when the memory object was imported using {clCreateBufferWithProperties} or
+    {clCreateImageWithProperties}. If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not
+    specified, the acquire can be performed on a command-queue associated with
+    any device in the context.
+  * The memory object will be released on all devices specified via
+    {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
+    using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
+    If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object
+    will be released on all devices in the context.
+
 See "`Example with Acquire / Release`" provided in
 <<cl_khr_external_memory-Sample-Code>> for more details on how to use this
 API.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5442,7 +5442,7 @@ The following restrictions shall apply -
     via {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
     using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
     If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object
-    will be aquired for all devices in the context.
+    will be acquired for all devices in the context.
  
 See <<cl_khr_external_memory-Sample-Code, "`Example with Acquire /
 Release`">> for more details on how to use this API.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5429,8 +5429,8 @@ This is to guarantee that the state of the memory objects is up-to-date and
 they are accessible to OpenCL.
 
 The following restrictions shall apply -
-  * Each memory object must be acquired only once. Acquiring memory object 
-    multiple times without releasing it may result in implementation defined
+  * Each memory object must be acquired only once. Acquiring a memory object 
+    multiple times without releasing it results in implementation-defined
     behavior.
   * The acquire must be performed on a command-queue associated with a device
     that was one of the devices specified via {CL_MEM_DEVICE_HANDLE_LIST_KHR}
@@ -5441,8 +5441,8 @@ The following restrictions shall apply -
   * The memory object will be acquired on all devices specified
     via {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
     using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
-    If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory objects
-    will be aquired on all devices in the context.
+    If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object
+    will be aquired for all devices in the context.
  
 See <<cl_khr_external_memory-Sample-Code, "`Example with Acquire /
 Release`">> for more details on how to use this API.
@@ -5522,20 +5522,20 @@ This is to guarantee that the state of memory objects is up-to-date and they
 are accessible to the other API.
 
 The following restrictions shall apply -
-  * Each memory object must be released only once. Releasing memory object 
-    multiple times without acquiring it may result in implementation defined
+  * Each memory object must be released only once. Releasing a memory object 
+    multiple times without acquiring it results in implementation-defined
     behavior.
   * The release must be performed on a command-queue associated with a device
     that was one of the devices specified via {CL_MEM_DEVICE_HANDLE_LIST_KHR}
     when the memory object was imported using {clCreateBufferWithProperties} or
     {clCreateImageWithProperties}. If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not
-    specified, the acquire can be performed on a command-queue associated with
+    specified, the release can be performed on a command-queue associated with
     any device in the context.
   * The memory object will be released on all devices specified via
     {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
     using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
     If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object
-    will be released on all devices in the context.
+    will be released for all devices in the context.
 
 See "`Example with Acquire / Release`" provided in
 <<cl_khr_external_memory-Sample-Code>> for more details on how to use this

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5438,7 +5438,7 @@ The following restrictions shall apply -
     {clCreateImageWithProperties}. If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not
     specified, the acquire can be performed on a command-queue associated with
     any device in the context.
-  * The memory object will be acquired on all devices specified
+  * The memory object will be acquired for all devices specified
     via {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
     using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
     If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object
@@ -5531,7 +5531,7 @@ The following restrictions shall apply -
     {clCreateImageWithProperties}. If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not
     specified, the release can be performed on a command-queue associated with
     any device in the context.
-  * The memory object will be released on all devices specified via
+  * The memory object will be released for all devices specified via
     {CL_MEM_DEVICE_HANDLE_LIST_KHR} when the memory object was imported
     using {clCreateBufferWithProperties} or {clCreateImageWithProperties}.
     If {CL_MEM_DEVICE_HANDLE_LIST_KHR} was not specified, the memory object


### PR DESCRIPTION
Clarify Acquire/Release behavior for external memory specs to call out the scope of operations as well as
the behavior in case of multiple acquire/release calls.

Fixes #1078, #1086