### PR TITLE
Fix links to commands in API specification

### DIFF
--- a/scripts/gen_dictionaries.py
+++ b/scripts/gen_dictionaries.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 
             numberOfFuncs = numberOfFuncs + 1
 
-    # Add extension API functions without links:
+    # Add extension API functions with and without links:
     for extension in spec.findall('extensions/extension/require'):
         for api in extension.findall('command'):
             name = api.get('name')
@@ -110,7 +110,8 @@ if __name__ == "__main__":
             # // clGetGLObjectInfo
             # :clGetGLObjectInfo: pass:q[*clGetGLObjectInfo*]
             apiLinkFile.write('// ' + name + '\n')
-            apiLinkFile.write(':' + name + ': pass:q[*' + name + '*]\n')
+            apiLinkFile.write(':' + name + '_label: pass:q[*' + name + '*]\n')
+            apiLinkFile.write(':' + name + ': <<' + name + ',{' + name + '_label}>>\n')
             apiLinkFile.write('\n')
 
             apiNoLinkFile.write('// ' + name + '\n')


### PR DESCRIPTION
Links were not created for commands defined by extensions. With this changes all uses of e.g. {clCreateSemaphoreWithPropertiesKHR} link to the definition of the command which makes navigating the specification much easier.


Change-Id: I4a9458609f4ba3229b66e3d169a68cb4564e2538