### PR TITLE
Drop NULL from named win32 handle description

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5621,7 +5621,7 @@ buffer or an image memory object from an external handle:
   * {CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR_anchor} specifies an NT handle name that
     has only limited valid usage outside of OpenCL and other compatible
     APIs.
-    NT handle name is NULL or a null-terminated UTF-16 string naming the payload to import.
+    NT handle name is a null-terminated UTF-16 string naming the payload to import.
     It must be compatible with the functions `DuplicateHandle`,
     `CloseHandle`, `CompareObjectHandles`, `GetHandleInformation`, and
     `SetHandleInformation`.
@@ -13139,7 +13139,7 @@ a semaphore from an external handle:
     when all semaphore objects associated with it are destroyed.
   * {CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR} specifies an NT handle name that has
     only limited valid usage outside of OpenCL and other compatible APIs.
-    NT handle name is NULL or a null-terminated UTF-16 string naming the payload to import.
+    NT handle name is a null-terminated UTF-16 string naming the payload to import.
     It must be compatible with the functions `DuplicateHandle`,
     `CloseHandle`, `CompareObjectHandles`, `GetHandleInformation`, and
     `SetHandleInformation`.


### PR DESCRIPTION
Address review comments to drop NULL from named win32 handle description.

Fixes #943 