### PR TITLE
further clarify a clCreateBuffer with SVM pointer error condition

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -628,8 +628,9 @@ returned in _errcode_ret_:
     in the <<memory-flags-table,Memory Flags>> table.
   * {CL_INVALID_BUFFER_SIZE} if _size_ is 0, or if _size_ is greater than
     {CL_DEVICE_MAX_MEM_ALLOC_SIZE} for all devices in _context_, or if
-    {CL_MEM_USE_HOST_PTR} is set in _flags_ and _host_ptr_ is a pointer returned by
-    {clSVMAlloc} and _size_ is greater than the size passed to {clSVMAlloc}.
+    {CL_MEM_USE_HOST_PTR} or {CL_MEM_COPY_HOST_PTR} is set in _flags_ and
+    _host_ptr_ is a pointer returned by {clSVMAlloc} and _size_ is greater than
+    the size passed to {clSVMAlloc}.
   * {CL_INVALID_HOST_PTR} if _host_ptr_ is `NULL` and {CL_MEM_USE_HOST_PTR} or
     {CL_MEM_COPY_HOST_PTR} are set in _flags_ or if _host_ptr_ is not `NULL`
     but {CL_MEM_COPY_HOST_PTR} or {CL_MEM_USE_HOST_PTR} are not set in _flags_.


### PR DESCRIPTION
It should also be invalid to use SVM host_ptr smaller than `size` in the CL_MEM_COPY_HOST_PTR case