### PR TITLE
Update extension template

### DIFF
--- a/extensions/cl_extension_template.asciidoc
+++ b/extensions/cl_extension_template.asciidoc
@@ -5,6 +5,7 @@
 :data-uri:
 :icons: font
 include::../config/attribs.txt[]
+include::{generated}/api/api-dictionary.asciidoc[]
 :source-highlighter: coderay
 
 = cl_khr_extension_template
@@ -137,8 +138,7 @@ Write dates in https://en.wikipedia.org/wiki/ISO_8601[ISO 8601] date format.
 
 == Dependencies
 
-This extension is written against the OpenCL Specification
-Version 1.0, Revision 1.
+This extension is written against the OpenCL Specification version 3.X.Y.
 
 This extension requires OpenCL 1.0.
 
@@ -498,6 +498,7 @@ best not to renumber issues, either.
 | 0.6.0   | 2020-04-20 | Alastair Murray | Use naming conventions in the new type example.
 | 0.7.0   | 2021-10-05 | Ben Ashbaugh | Added recommendation for bits in bitfields.
 | 0.8.0   | 2021-12-13 | Ben Ashbaugh | Added OpenCL C feature names section
+| 0.9.0   | 2024-07-01 | Kévin Petit  | Update format for spec version and include generated definitions.
 |====
 
 ****


### PR DESCRIPTION
- Update format for specification versions. We now use MAJOR.MINOR.PATCH as opposed to MAJOR.MINOR Revision PATCH.
- Include generated dictionaries by default.


Change-Id: Ie2cd8fc08ae6ec71d340bf9f274ffb17d8ebb118