### PR TITLE
Fail spec creation if asciidoctor errors are encountered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ADOCCOMMONOPTS	      = -a apispec="$(CURDIR)/api" \
 			-a cspec="$(CURDIR)/c" \
 			-a images="$(CURDIR)/images" \
 			$(ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
-ADOCOPTS	      = -d book $(ADOCCOMMONOPTS)
+ADOCOPTS	      = --failure-level ERROR -d book $(ADOCCOMMONOPTS)
 
 # Asciidoctor options to build refpages
 #

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2524,14 +2524,14 @@ The memory layout of this image format is described below:
 
 [width="60%",cols="<10%,<10%,<10%,<10%,<60%"]
 |====
-| R | G | B | A | ... |
+| R | G | B | A | ...
 |====
 
 with the corresponding byte offsets
 
 [width="60%",cols="<10%,<10%,<10%,<10%,<60%"]
 |====
-| 0 | 1 | 2 | 3 | ... |
+| 0 | 1 | 2 | 3 | ...
 |====
 
 Similar, if `image_channel_order` = {CL_RGBA} and `image_channel_data_type` =
@@ -2539,14 +2539,14 @@ Similar, if `image_channel_order` = {CL_RGBA} and `image_channel_data_type` =
 
 [width="60%",cols="<10%,<10%,<10%,<10%,<60%"]
 |====
-| R | G | B | A | ... |
+| R | G | B | A | ...
 |====
 
 with the corresponding byte offsets
 
 [width="60%",cols="<10%,<10%,<10%,<10%,<60%"]
 |====
-| 0 | 2 | 4 | 6 | ... |
+| 0 | 2 | 4 | 6 | ...
 |====
 
 `image_channel_data_type` values of {CL_UNORM_SHORT_565}, {CL_UNORM_SHORT_555},


### PR DESCRIPTION
This would have enabled the CI to catch a markup issue introduced by #938.


Change-Id: I49de3eaf623117f7c29d1019dedf5b342766a029