### PR TITLE
xml: require CL/GL types for cl_khr_gl_sharing

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6567,6 +6567,11 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
             </require>
             <require>
+                <type name="cl_GLint"/>
+                <type name="cl_GLenum"/>
+                <type name="cl_GLuint"/>
+            </require>
+            <require>
                 <type name="cl_gl_context_info"/>
             </require>
             <require comment="Error codes">


### PR DESCRIPTION
So the type definitions are included in the generated cl_gl.h.

Split out of #960 following the discussion on https://github.com/KhronosGroup/OpenCL-Headers/pull/257

Change-Id: I65a666dde8066958897acf13fb755ae2a3f3b52d