### PR TITLE
Add properties parameter to all command-buffer commands

### DIFF
--- a/api/cl_khr_command_buffer.asciidoc
+++ b/api/cl_khr_command_buffer.asciidoc
@@ -142,7 +142,7 @@ support their intended use cases.
 The command recording entry-points allow a `properties` parameter of
 new type {cl_command_properties_khr_TYPE} to be passed. No properties are
 defined in {cl_khr_command_buffer_EXT}, but the parameter enables layered
-extensions to define characterisitcs of the individual commands.
+extensions to define characteristics of the individual commands.
 
 For example, {cl_khr_command_buffer_mutable_dispatch_EXT} defines properties
 that can be set when appending a kernel command with {clCommandNDRangeKernelKHR}.

--- a/api/cl_khr_command_buffer.asciidoc
+++ b/api/cl_khr_command_buffer.asciidoc
@@ -4,7 +4,7 @@
 include::{generated}/meta/{refprefix}cl_khr_command_buffer.txt[]
 
 // *Revision*::
-//    0.9.4
+//    0.9.5
 // *Extension and Version Dependencies*::
 //     This extension requires OpenCL 1.2 or later.
 //     Buffering of SVM commands requires OpenCL 2.0 or later.
@@ -12,7 +12,7 @@ include::{generated}/meta/{refprefix}cl_khr_command_buffer.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2023-03-31
+    2024-07-24
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -137,13 +137,15 @@ retain its provisional extension status until other layered extensions are
 released, as these may reveal modifications needed to the base specification to
 support their intended use cases.
 
-==== ND-range Kernel Command Properties
+==== Command Properties
 
-The {clCommandNDRangeKernelKHR} entry-point defines a `properties` parameter of
-new type {cl_ndrange_kernel_command_properties_khr_TYPE}. No properties are defined
-in {cl_khr_command_buffer_EXT}, but the parameter enables layered extensions like
-{cl_khr_command_buffer_mutable_dispatch_EXT} to define properties that inform
-the characteristics of the kernel command.
+The command recording entry-points allow a `properties` parameter of
+new type {cl_command_properties_khr_TYPE} to be passed. No properties are
+defined in {cl_khr_command_buffer_EXT}, but the parameter enables layered
+extensions to define characterisitcs of the individual commands.
+
+For example, {cl_khr_command_buffer_mutable_dispatch_EXT} defines properties
+that can be set when appending a kernel command with {clCommandNDRangeKernelKHR}.
 
 ==== Command Handles
 
@@ -214,7 +216,7 @@ features:
   * {cl_command_buffer_state_khr_TYPE}
   * {cl_command_buffer_properties_khr_TYPE}
   * {cl_command_buffer_flags_khr_TYPE}
-  * {cl_ndrange_kernel_command_properties_khr_TYPE}
+  * {cl_command_properties_khr_TYPE}
   * {cl_mutable_command_khr_TYPE}
 
 === New Enums
@@ -432,5 +434,8 @@ features:
   ** Remove Invalid command-buffer state (provisional).
   * 0.9.4, 2023-05-11
   ** Add clCommandSVMMemcpyKHR and clCommandSVMMemFillKHR command entries
+     (provisional).
+  * 0.9.5, 2024-07-24
+  ** Add a properties parameter to all command recording entry-points
      (provisional).
 

--- a/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -72,7 +72,7 @@ void pointer using {cl_command_buffer_update_type_khr_TYPE}.
 
   * {cl_device_info_TYPE}
   ** {CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR}
-  * {cl_ndrange_kernel_command_properties_khr_TYPE}
+  * {cl_command_properties_khr_TYPE}
   ** {CL_MUTABLE_DISPATCH_ASSERTS_KHR}
   ** {CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR}
   * {cl_mutable_dispatch_asserts_khr_TYPE}
@@ -196,7 +196,7 @@ kernel void vector_addition(global int* tile1, global int* tile2,
   CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &output_buffers[0]));
 
   // Instruct the nd-range command to allow for mutable kernel arguments
-  cl_ndrange_kernel_command_properties_khr mutable_properties[] = {
+  cl_command_properties_khr mutable_properties[] = {
       CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR,
       CL_MUTABLE_DISPATCH_ARGUMENTS_KHR, 0};
 

--- a/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -6,7 +6,7 @@ include::{generated}/meta/{refprefix}cl_khr_command_buffer_mutable_dispatch.txt[
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2024-06-19
+    2024-09-05
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -86,7 +86,7 @@ void pointer using {cl_command_buffer_update_type_khr_TYPE}.
   * {cl_mutable_command_info_khr_TYPE}
   ** {CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR}
   ** {CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR}
-  ** {CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR}
+  ** {CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR}
   ** {CL_MUTABLE_DISPATCH_KERNEL_KHR}
   ** {CL_MUTABLE_DISPATCH_DIMENSIONS_KHR}
   ** {CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR}
@@ -360,3 +360,6 @@ may be a introduced as a stand alone extension.
   * Revision 0.9.2, 2024-06-19
   ** Change {clUpdateMutableCommandsKHR} API to pass configs as an array rather
      than linked list (provisional).
+  * Revision 0.9.3, 2024-09-05
+  ** Rename `CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR` to
+     `CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR` (provisional).

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14396,6 +14396,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
     synchronization-points that need to complete before this particular
     command can be executed.
@@ -14458,6 +14463,7 @@ ifdef::cl_khr_command_buffer_multi_device[]
     associated with _command_queue_ and _command_buffer_ is not the same.
 endif::cl_khr_command_buffer_multi_device[]
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
   * {CL_INVALID_SYNC_POINT_WAIT_LIST_KHR} if _sync_point_wait_list_ is
     `NULL` and _num_sync_points_in_wait_list_ is > 0, or
@@ -14490,6 +14496,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _src_buffer_, _dst_buffer_, _src_offset_, _dst_offset_, _size_ refer
     to {clEnqueueCopyBuffer}.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
@@ -14558,6 +14569,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -14581,6 +14593,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _src_origin_, _dst_origin_, _region_, _src_row_pitch_,
     _src_slice_pitch_, _dst_row_pitch_, _dst_slice_pitch_ refer to
     {clEnqueueCopyBufferRect}.
@@ -14667,6 +14684,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -14690,6 +14708,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _src_buffer_, _dst_image_, _src_offset_, _dst_origin_, _region_ refer to
     {clEnqueueCopyBufferToImage}
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
@@ -14759,6 +14782,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -14781,6 +14805,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _src_image_, _dst_image_, _src_origin_, _dst_origin_, _region_ refer to
     {clEnqueueCopyImage}.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
@@ -14857,6 +14886,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -14880,6 +14910,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _src_image_, _dst_buffer_, _src_origin_, _region_, _dst_offset_ refer to
     {clEnqueueCopyImageToBuffer}.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
@@ -14949,6 +14984,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -14980,6 +15016,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _buffer_, _pattern_, _pattern_size_, _offset_, _size_ refer to
     {clEnqueueFillBuffer}.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
@@ -15048,6 +15089,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -15078,6 +15120,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _image_, _fill_color_, _origin_, _region_ refer to {clEnqueueFillImage}.
   * _sync_point_wait_list_, _num_sync_points_in_wait_list_ specify
     synchronization-points that need to complete before this particular
@@ -15145,6 +15192,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -15180,7 +15228,7 @@ ifdef::cl_khr_command_buffer_mutable_dispatch[]
     The {cl_khr_command_buffer_EXT} extension does not define any
     properties, but supported properties defined by extensions are defined
     in the <<ndrange-kernel-properties-table, List of supported properties
-    by {clCommandNDRangeKernelKHR}>> table.
+    by clCommandNDRangeKernelKHR>> table.
 endif::cl_khr_command_buffer_mutable_dispatch[]
   * _kernel_ is a valid kernel object which **must** have its arguments set.
     Any changes to _kernel_ after calling {clCommandNDRangeKernelKHR}, such
@@ -15392,8 +15440,8 @@ New errors:
 
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
-  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if the {cl_khr_command_buffer_mutable_dispatch_EXT}
     extension is not supported and _mutable_handle_ is not `NULL`.
   * {CL_INVALID_OPERATION} if the device associated with _command_queue_
@@ -15442,6 +15490,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and thier
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _dst_ptr_ is the pointer to a host (if the device supports system SVM)
     or SVM memory allocation where data is copied to.
   * _src_ptr_ is the pointer to a host (if the device supports system SVM)
@@ -15516,6 +15569,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 
@@ -15539,6 +15593,11 @@ ifdef::cl_khr_command_buffer_multi_device[]
     _command_queue_ is `NULL`, then only one command-queue must have been set on
     _command_buffer_ creation; otherwise, _command_queue_ must not be `NULL`.
 endif::cl_khr_command_buffer_multi_device[]
+  * _properties_ specifies a list of properties for the command and their
+    corresponding values. Each property name is immediately followed by the
+    corresponding desired value. The list is terminated with 0. The
+    {cl_khr_command_buffer_EXT} extension does not define any properties, but
+    supported properties may be defined by layered extensions in future.
   * _svm_ptr_ is a pointer to a (if the device supports system SVM)
     or SVM memory region that will be filled with _pattern_.
     It must be aligned to _pattern_size_ bytes.
@@ -15628,6 +15687,7 @@ New errors:
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
   * {CL_INVALID_OPERATION} if _command_buffer_ has been finalized.
+  * {CL_INVALID_VALUE} if values specified in _properties_ are not valid.
   * {CL_INVALID_VALUE} if _mutable_handle_ is not `NULL`.
 --
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -16225,9 +16225,9 @@ include::{generated}/api/version-notes/CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR.ascii
 
       The list of supported event command types defined by {clGetEventInfo}
       is used with the matching command.
-| {CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR_anchor}
+| {CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR_anchor}
 
-include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR.asciidoc[]
+include::{generated}/api/version-notes/CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR.asciidoc[]
   | {cl_command_properties_khr_TYPE}[]
     | Return the properties argument specified on _command_ recording.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -16228,9 +16228,8 @@ include::{generated}/api/version-notes/CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR.ascii
 | {CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR_anchor}
 
 include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR.asciidoc[]
-  | {cl_ndrange_kernel_command_properties_khr_TYPE}[]
-    | Return the properties argument specified on _command_ recording with
-      {clCommandNDRangeKernelKHR}.
+  | {cl_command_properties_khr_TYPE}[]
+    | Return the properties argument specified on _command_ recording.
 
       If the properties argument specified on creation of _command_ was not
       `NULL`, the implementation must return the values specified in the
@@ -16238,10 +16237,8 @@ include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR.
       properties.
 
       If the properties argument specified on creation of _command_ was
-      `NULL`, or _command_ was not recorded from a
-      {clCommandNDRangeKernelKHR} command, the implementation must return
-      _param_value_size_ret_ equal to 0, indicating that there are no
-      properties to be returned.
+      `NULL`, the implementation must return _param_value_size_ret_ equal to 0,
+      indicating that there are no properties to be returned.
 | {CL_MUTABLE_DISPATCH_KERNEL_KHR_anchor}
 
 include::{generated}/api/version-notes/CL_MUTABLE_DISPATCH_KERNEL_KHR.asciidoc[]

--- a/config/rouge/lib/rouge/lexers/opencl.rb
+++ b/config/rouge/lib/rouge/lexers/opencl.rb
@@ -158,7 +158,7 @@ module Rouge
         cl_command_buffer_state_khr
         cl_command_buffer_properties_khr
         cl_command_buffer_flags_khr
-        cl_ndrange_kernel_command_properties_khr
+        cl_command_properties_khr
         cl_mutable_command_khr
         cl_mutable_dispatch_fields_khr
         cl_mutable_command_info_khr

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1783,7 +1783,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x129A" end="0x129F" comment="Available to use"/>
         <enum value="0x12A0"             name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
         <enum value="0x12A1"             name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
-        <enum value="0x12A2"             name="CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR"/>
+        <enum value="0x12A2"             name="CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR"/>
         <enum value="0x12A3"             name="CL_MUTABLE_DISPATCH_KERNEL_KHR"/>
         <enum value="0x12A4"             name="CL_MUTABLE_DISPATCH_DIMENSIONS_KHR"/>
         <enum value="0x12A5"             name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR"/>
@@ -7331,7 +7331,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_JOB_SLOT_ARM"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer_mutable_dispatch" revision="0.9.2" supported="opencl" depends="cl_khr_command_buffer" ratified="opencl" provisional="true" comment="requires cl_khr_command_buffer 0.9.0 or later">
+        <extension name="cl_khr_command_buffer_mutable_dispatch" revision="0.9.3" supported="opencl" depends="cl_khr_command_buffer" ratified="opencl" provisional="true" comment="requires cl_khr_command_buffer 0.9.5 or later">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7368,7 +7368,7 @@ server's OpenCL/api-docs repository.
                <enum name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
                <enum name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
                <enum name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
-               <enum name="CL_MUTABLE_DISPATCH_PROPERTIES_ARRAY_KHR"/>
+               <enum name="CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR"/>
                <enum name="CL_MUTABLE_DISPATCH_KERNEL_KHR"/>
                <enum name="CL_MUTABLE_DISPATCH_DIMENSIONS_KHR"/>
                <enum name="CL_MUTABLE_DISPATCH_GLOBAL_WORK_OFFSET_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -245,7 +245,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_uint</type>          <name>cl_command_buffer_state_khr</name>;</type>
         <type category="define">typedef <type>cl_properties</type>    <name>cl_command_buffer_properties_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_command_buffer_flags_khr</name>;</type>
-        <type category="define">typedef <type>cl_properties</type>    <name>cl_ndrange_kernel_command_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>    <name>cl_command_properties_khr</name>;</type>
         <type category="define">typedef struct _cl_mutable_command_khr* <name>cl_mutable_command_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>       <name>cl_mutable_dispatch_fields_khr</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_mutable_command_info_khr</name>;</type>
@@ -3118,6 +3118,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandBarrierWithWaitListKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_uint</type>                   <name>num_sync_points_in_wait_list</name></param>
             <param>const <type>cl_sync_point_khr</type>*  <name>sync_point_wait_list</name></param>
             <param><type>cl_sync_point_khr</type>*        <name>sync_point</name></param>
@@ -3127,6 +3128,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandCopyBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
             <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
             <param><type>size_t</type>                    <name>src_offset</name></param>
@@ -3141,6 +3143,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandCopyBufferRectKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
             <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
             <param>const <type>size_t</type>*             <name>src_origin</name></param>
@@ -3159,6 +3162,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandCopyBufferToImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>src_buffer</name></param>
             <param><type>cl_mem</type>                    <name>dst_image</name></param>
             <param><type>size_t</type>                    <name>src_offset</name></param>
@@ -3173,6 +3177,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandCopyImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>src_image</name></param>
             <param><type>cl_mem</type>                    <name>dst_image</name></param>
             <param>const <type>size_t</type>*             <name>src_origin</name></param>
@@ -3187,6 +3192,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandCopyImageToBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>src_image</name></param>
             <param><type>cl_mem</type>                    <name>dst_buffer</name></param>
             <param>const <type>size_t</type>*             <name>src_origin</name></param>
@@ -3201,6 +3207,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandFillBufferKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>buffer</name></param>
             <param>const <type>void</type>*               <name>pattern</name></param>
             <param><type>size_t</type>                    <name>pattern_size</name></param>
@@ -3215,6 +3222,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                    <name>clCommandFillImageKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>     <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>          <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_mem</type>                    <name>image</name></param>
             <param>const <type>void</type>*               <name>fill_color</name></param>
             <param>const <type>size_t</type>*             <name>origin</name></param>
@@ -3228,7 +3236,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                     <name>clCommandNDRangeKernelKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>                      <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>                           <name>command_queue</name></param>
-            <param>const <type>cl_ndrange_kernel_command_properties_khr</type>*  <name>properties</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>cl_kernel</type>                                  <name>kernel</name></param>
             <param><type>cl_uint</type>                                    <name>work_dim</name></param>
             <param>const <type>size_t</type>*                              <name>global_work_offset</name></param>
@@ -3243,6 +3251,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                     <name>clCommandSVMMemcpyKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>                      <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>                           <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>void</type>*                                      <name>dst_ptr</name></param>
             <param>const <type>void</type>*                                <name>src_ptr</name></param>
             <param><type>size_t</type>                                     <name>size</name></param>
@@ -3255,6 +3264,7 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                                     <name>clCommandSVMMemFillKHR</name></proto>
             <param><type>cl_command_buffer_khr</type>                      <name>command_buffer</name></param>
             <param><type>cl_command_queue</type>                           <name>command_queue</name></param>
+            <param>const <type>cl_command_properties_khr</type>*           <name>properties</name></param>
             <param><type>void</type>*                                      <name>svm_ptr</name></param>
             <param>const <type>void</type>*                                <name>pattern</name></param>
             <param><type>size_t</type>                                     <name>pattern_size</name></param>
@@ -7174,7 +7184,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetContentSizeBufferPoCL"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer" revision="0.9.4" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl" provisional="true">
+        <extension name="cl_khr_command_buffer" revision="0.9.5" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl" provisional="true">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7186,7 +7196,7 @@ server's OpenCL/api-docs repository.
                 <type name="cl_command_buffer_state_khr"/>
                 <type name="cl_command_buffer_properties_khr"/>
                 <type name="cl_command_buffer_flags_khr"/>
-                <type name="cl_ndrange_kernel_command_properties_khr"/>
+                <type name="cl_command_properties_khr"/>
                 <type name="cl_mutable_command_khr"/>
             </require>
             <require comment="cl_device_info">
@@ -7343,7 +7353,7 @@ server's OpenCL/api-docs repository.
             <require comment="cl_device_info">
                 <enum name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
             </require>
-            <require comment="cl_ndrange_kernel_command_properties_khr">
+            <require comment="cl_command_properties_khr">
                <enum name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
             </require>
 
@@ -7371,7 +7381,7 @@ server's OpenCL/api-docs repository.
             <require comment="cl_command_buffer_properties_khr">
                 <enum name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR"/>
             </require>
-            <require comment="cl_ndrange_kernel_command_properties_khr">
+            <require comment="cl_command_properties_khr">
                 <enum name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>
             </require>
             <require comment="cl_mutable_dispatch_asserts_khr - bitfield">


### PR DESCRIPTION
See Issue https://github.com/KhronosGroup/OpenCL-Docs/issues/1207 discussion how it could make the `cl_khr_command_buffer` extension more extensible if we allowed all the command-recording parameters to have a `properties` parameter that could be used.

Closes https://github.com/KhronosGroup/OpenCL-Docs/issues/1207 

Related PRs:
* https://github.com/KhronosGroup/OpenCL-CLHPP/pull/305
* https://github.com/KhronosGroup/OpenCL-Headers/pull/260
* https://github.com/KhronosGroup/OpenCL-CTS/pull/2050