### PR TITLE
fix EPSILON typo

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5845,7 +5845,7 @@ the application.
 | `FLT_RADIX`                 | {CL_FLT_RADIX}
 | `FLT_MAX`                   | {CL_FLT_MAX}
 | `FLT_MIN`                   | {CL_FLT_MIN}
-| `FLT_EPSILSON`              | {CL_FLT_EPSILON}
+| `FLT_EPSILON`               | {CL_FLT_EPSILON}
 |====
 
 The following macros shall expand to integer constant expressions whose
@@ -5916,7 +5916,7 @@ the application.
 | `DBL_MIN_EXP`              | {CL_DBL_MIN_EXP}
 | `DBL_MAX`                  | {CL_DBL_MAX}
 | `DBL_MIN`                  | {CL_DBL_MIN}
-| `DBL_EPSILSON`             | {CL_DBL_EPSILON}
+| `DBL_EPSILON`              | {CL_DBL_EPSILON}
 |====
 
 The following constants are also available.
@@ -5986,7 +5986,7 @@ the application.
 | `HALF_RADIX`               | {CL_HALF_RADIX}
 | `HALF_MAX`                 | {CL_HALF_MAX}
 | `HALF_MIN`                 | {CL_HALF_MIN}
-| `HALF_EPSILSON`            | {CL_HALF_EPSILON}
+| `HALF_EPSILON`             | {CL_HALF_EPSILON}
 |====
 
 The following constants are also available.


### PR DESCRIPTION
Fixes #1198.

Fixes typo: EPSILSON -> EPSILON.