### PR TITLE
eliminate some duplicated words found in the spec

### DIFF
--- a/api/appendix_e.asciidoc
+++ b/api/appendix_e.asciidoc
@@ -377,7 +377,7 @@ device:
     capabilities of a device.
   * {CL_DEVICE_PIPE_SUPPORT} to determine whether a device supports
     pipe memory objects.
-  * {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE} to determine the
+  * {CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE} to determine
     the preferred work-group size multiple for a device.
 
 OpenCL 3.0 adds new queries to conveniently and precisely

--- a/api/appendix_h.asciidoc
+++ b/api/appendix_h.asciidoc
@@ -334,7 +334,7 @@ When sRGB images are not supported:
 |*Behavior*
 
 | {clGetSupportedImageFormats}
-| Will not return return any image formats with `image_channel_order` equal to an sRGB image channel order if no devices in _context_ support sRGB images.
+| Will not return any image formats with `image_channel_order` equal to an sRGB image channel order if no devices in _context_ support sRGB images.
 
 |====
 

--- a/api/cl_khr_egl_image.asciidoc
+++ b/api/cl_khr_egl_image.asciidoc
@@ -13,7 +13,7 @@ include::{generated}/meta/{refprefix}cl_khr_egl_image.txt[]
 === Description
 
 {cl_khr_egl_image_EXT} provides a mechanism to creating OpenCL memory objects
-from from EGLImages.
+from EGLImages.
 
 === New Commands
 

--- a/api/cl_khr_external_memory.asciidoc
+++ b/api/cl_khr_external_memory.asciidoc
@@ -60,7 +60,7 @@ imported into OpenCL.
   * {cl_mem_properties_TYPE}
   ** {CL_MEM_DEVICE_HANDLE_LIST_KHR}
   ** {CL_MEM_DEVICE_HANDLE_LIST_END_KHR}
-  * Return values from from {clGetEventInfo} when _param_name_ is
+  * Return values from {clGetEventInfo} when _param_name_ is
     {cl_command_type_TYPE}:
   ** {CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR}
   ** {CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR}

--- a/api/cl_khr_priority_hints.asciidoc
+++ b/api/cl_khr_priority_hints.asciidoc
@@ -14,7 +14,7 @@ include::{generated}/meta/{refprefix}cl_khr_priority_hints.txt[]
 
 The {cl_khr_priority_hints_EXT} extension adds priority hints for OpenCL, but
 does not specify the scheduling behavior or minimum guarantees.
-It is expected that the the user guides associated with each implementation
+It is expected that the user guides associated with each implementation
 which supports this extension will describe the scheduling behavior
 guarantees.
 

--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -11,7 +11,7 @@ Note that this flag does not provide meaning for atomic memory operations, but o
 ]
 
 :fn-create-context-all-or-subset: pass:n[ \
-{clCreateContextfromType} may may create a context for all or a subset of the actual physical devices present in the platform that match _device_type_. \
+{clCreateContextfromType} may create a context for all or a subset of the actual physical devices present in the platform that match _device_type_. \
 ]
 
 :fn-default-device-queue: pass:n[ \

--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -679,7 +679,7 @@ The OpenCL execution model supports three types of kernels:
   * *OpenCL kernels* are managed by the OpenCL API as kernel objects
     associated with kernel functions within program objects.
     OpenCL program objects are created and built using OpenCL APIs.
-    The OpenCL API includes functions to query the kernel languages and
+    The OpenCL API includes functions to query the kernel languages
     and intermediate languages that may be used to create OpenCL program
     objects for a device.
   * *Native kernels* are accessed through a host function pointer.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1837,7 +1837,7 @@ include::{generated}/api/version-notes/clCreateFromGLBuffer.asciidoc[]
     Only the {CL_MEM_READ_ONLY}, {CL_MEM_WRITE_ONLY} and {CL_MEM_READ_WRITE}
     flags specified in that table can be used.
   * _bufobj_ is the name of an OpenGL buffer object.
-    The data store of the OpenGL buffer object must have have been
+    The data store of the OpenGL buffer object must have been
     previously created by calling `glBufferData`, although its contents need
     not be initialized.
     The size of the data store will be used to determine the size of the
@@ -2646,7 +2646,7 @@ ifdef::cl_khr_external_memory[]
     If _image_slice_pitch_ is zero and the image is created from an external
     memory handle, then the image slice pitch is implementation-defined.
 endif::cl_khr_external_memory[]
-    The image slice pitch must be {geq} the image image row pitch {times}
+    The image slice pitch must be {geq} the image row pitch {times}
     _image_height_ for a 2D image array or a 3D image, must be {geq} the
     image row pitch for a 1D image array, and must be a multiple of the
     image row pitch.
@@ -7088,7 +7088,7 @@ include::{generated}/api/version-notes/clEnqueueReleaseGLObjects.asciidoc[]
     to an element of the _event_wait_list_ array.
 
 ifdef::cl_khr_gl_event[]
-If an OpenGL context is bound to the current thread, then then any OpenGL
+If an OpenGL context is bound to the current thread, then any OpenGL
 commands which
 
   . affect or access the contents of the memory objects listed in the
@@ -12864,7 +12864,7 @@ _errcode_ret_ returns an appropriate error code.
 If _errcode_ret_ is `NULL`, no error code is returned.
 
 {clCreateSemaphoreWithPropertiesKHR} returns a valid semaphore object in an
-un-signaled state and and _errcode_ret_ is set to {CL_SUCCESS} if the
+un-signaled state and _errcode_ret_ is set to {CL_SUCCESS} if the
 function is executed successfully.
 Otherwise, it returns a `NULL` value with one of the following error values
 returned in _errcode_ret_:

--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -39,7 +39,7 @@ in a SPIR-V module using *OpExtension*.
 
 If the OpenCL environment supports the extension {cl_khr_3d_image_writes_EXT},
 then the environment must accept _Image_ operands to *OpImageWrite* that
-are declared with with dimensionality _Dim_ equal to *3D*.
+are declared with dimensionality _Dim_ equal to *3D*.
 
 ==== {cl_khr_depth_images_EXT}
 
@@ -57,7 +57,7 @@ Additionally, the following Image Channel Orders may be returned by
 ==== {cl_khr_device_enqueue_local_arg_types_EXT}
 
 If the OpenCL environment supports the extension
-{cl_khr_device_enqueue_local_arg_types_EXT}, then then environment will allow
+{cl_khr_device_enqueue_local_arg_types_EXT}, then the environment will allow
 _Invoke_ functions to be passed to *OpEnqueueKernel* with *Workgroup*
 memory pointer parameters of any type.
 

--- a/ext/introduction.asciidoc
+++ b/ext/introduction.asciidoc
@@ -189,7 +189,7 @@ that extension on different devices for a platform.
 The behavior of calling a device extension function on a device not
 supporting that extension is undefined.
 
-{clGetExtensionFunctionAddressForPlatform} may not be be used to query for core
+{clGetExtensionFunctionAddressForPlatform} may not be used to query for core
 (non-extension) functions in OpenCL.
 For extension functions that may be queried using
 {clGetExtensionFunctionAddressForPlatform}, implementations may also choose to


### PR DESCRIPTION
Fixes some duplicated words in the spec.  I'm sure there are a few more!

Found with the Visual Studio Code regular expression: ``\b(\w+)\b(?:[\s*`_}]+)\b\1\b``