### PR TITLE
remove duplicated extensions from quick reference table

### DIFF
--- a/ext/quick_reference.asciidoc
+++ b/ext/quick_reference.asciidoc
@@ -240,18 +240,6 @@ Language Specifications.
 | Allows Use of the SPIR-V `SPV_KHR_no_integer_wrap_decoration` Extension
 | Extension
 
-| [[cl_khr_spirv_extended_debug_info]]          link:{APISpecURL}#cl_khr_spirv_extended_debug_info[{cl_khr_spirv_extended_debug_info_EXT}]
-| Allows Use of the SPIR-V `OpenCL.DebugInfo.100` Extended Instruction Set
-| Extension
-
-| [[cl_khr_spirv_linkonce_odr]]                 link:{APISpecURL}#cl_khr_spirv_linkonce_odr[{cl_khr_spirv_linkonce_odr_EXT}]
-| Allows Use of the SPIR-V `SPV_KHR_linkonce_odr` Extension
-| Extension
-
-| [[cl_khr_spirv_no_integer_wrap_decoration]]   link:{APISpecURL}#cl_khr_spirv_no_integer_wrap_decoration[{cl_khr_spirv_no_integer_wrap_decoration_EXT}]
-| Allows Use of the SPIR-V `SPV_KHR_no_integer_wrap_decoration` Extension
-| Extension
-
 | [[cl_khr_srgb_image_writes]]                  link:{APISpecURL}#cl_khr_srgb_image_writes[{cl_khr_srgb_image_writes_EXT}]
 | Write to sRGB Images
 | Extension


### PR DESCRIPTION
Fixes #1227 by removing the duplicated extensions from the quick reference table.