### PR TITLE
clarify cl_mem_flags to not affect copies

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1254,6 +1254,11 @@ include::{generated}/api/version-notes/clEnqueueCopyBuffer.asciidoc[]
     If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
     to an element of the _event_wait_list_ array.
 
+The usage information which indicates whether the memory object can be read
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
+argument value specified when _src_buffer_ or _dst_buffer is created is ignored by
+{clEnqueueCopyBuffer}.
+
 // refError
 
 {clEnqueueCopyBuffer} returns {CL_SUCCESS} if the function is executed
@@ -1380,6 +1385,11 @@ If _src_buffer_ and _dst_buffer_ are the same buffer object, _src_row_pitch_
 must equal _dst_row_pitch_ and _src_slice_pitch_ must equal
 _dst_slice_pitch_.
 ====
+
+The usage information which indicates whether the memory object can be read
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
+argument value specified when _src_buffer_ or _dst_buffer_ is created is ignored by
+{clEnqueueCopyBufferRect}.
 
 // refError
 
@@ -3535,6 +3545,11 @@ memory objects for {clEnqueueCopyImage} must have the exact same image
 format (i.e. the {cl_image_format_TYPE} descriptor specified when _src_image_ and
 _dst_image_ are created must match).
 
+The usage information which indicates whether the memory object can be read
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
+argument value specified when _src_image_ or _dst_image_ is created is ignored by
+{clEnqueueCopyImage}.
+
 // refError
 
 {clEnqueueCopyImage} returns {CL_SUCCESS} if the function is executed
@@ -3782,6 +3797,11 @@ endif::cl_khr_mipmap_image[]
     If _event_wait_list_ and _event_ are not `NULL`, _event_ must not refer
     to an element of the _event_wait_list_ array.
 
+The usage information which indicates whether the memory object can be read
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
+argument value specified when _src_image_ or _dst_buffer_ is created is ignored by
+{clEnqueueCopyImageToBuffer}.
+
 // refError
 
 {clEnqueueCopyImageToBuffer} returns {CL_SUCCESS} if the function is executed
@@ -3908,6 +3928,11 @@ computed as _width_ {times} _bytes/image element_ if _dst_image_ is a 1D
 image or 1D image buffer object and is computed as _width_ {times}
 _arraysize_ {times} _bytes/image element_ if _dst_image_ is a 1D image array
 object.
+
+The usage information which indicates whether the memory object can be read
+or written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE}
+argument value specified when _src_buffer_ or _dst_image_ is created is ignored by
+{clEnqueueCopyBufferToImage}.
 
 // refError
 
@@ -14464,6 +14489,14 @@ after the function returns.
   * _mutable_handle_ returns a handle to the command.
     This parameter is unused, and **must** be `NULL`.
 
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE} argument
+value specified when _src_buffer_ or _dst_buffer_ is created is ignored by
+{clCommandCopyBufferKHR}.
+====
+
 // refError
 
 {clCommandCopyBufferKHR} returns {CL_SUCCESS} if the function is executed
@@ -14572,6 +14605,14 @@ After copying each 2D rectangle, the source and destination offsets are
 incremented by their respective source and destination slice pitches.
 ====
 
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE} argument
+value specified when _src_buffer_ or _dst_buffer_ is created is ignored by
+{clCommandCopyBufferRectKHR}.
+====
+
 // refError
 
 {clCommandCopyBufferRectKHR} returns {CL_SUCCESS} if the function is
@@ -14663,6 +14704,14 @@ after the function returns.
     _sync_point_wait_list_ array.
   * _mutable_handle_ returns a handle to the command.
     This parameter is unused, and **must** be `NULL`.
+
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE} argument
+value specified when _src_buffer_ or _dst_image_ is created is ignored by
+{clCommandCopyBufferToImageKHR}.
+====
 
 // refError
 
@@ -14763,6 +14812,14 @@ format, i.e. the {cl_image_format_TYPE} descriptor specified when
 _src_image_ and _dst_image_ are created must match.
 ====
 
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE} argument
+value specified when _src_image_ or _dst_image_ is created is ignored by
+{clCommandCopyImageKHR}.
+====
+
 // refError
 
 {clCommandCopyImageKHR} returns {CL_SUCCESS} if the function is executed
@@ -14853,6 +14910,14 @@ after the function returns.
     _sync_point_wait_list_ array.
   * _mutable_handle_ returns a handle to the command.
     This parameter is unused, and **must** be `NULL`.
+
+[NOTE]
+====
+The usage information which indicates whether the memory object can be read or
+written by a kernel and/or the host and is given by the {cl_mem_flags_TYPE} argument
+value specified when _src_image_ or _dst_buffer_ is created is ignored by
+{clCommandCopyImageToBufferKHR}.
+====
 
 // refError
 


### PR DESCRIPTION
Fixes #770 

Clarifies that the cl_mem_flags for the source and destination memory objects for copies are ignored, for both commands enqueued into a command-queue and commands recorded into a command-buffer.