### PR TITLE
clarify no implicit dependencies when waiting on or signaling semaphores

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -13229,6 +13229,16 @@ events in _event_wait_list_ when {clEnqueueWaitSemaphoresKHR} returns.
 Waiting on the same binary semaphore twice without an interleaving signal
 may lead to undefined behavior.
 
+[NOTE]
+====
+When _command_queue_ is an out-of-order command-queue there are no implicit
+dependencies between the semaphore wait command and commands enqueued into the
+command-queue after the semaphore wait command.
+If such dependencies are required, applications may enqueue a command-queue
+barrier after the semaphore wait command, to explicitly add dependencies between
+the semaphore wait command and subsequent commands.
+====
+
 // refError
 
 {clEnqueueWaitSemaphoresKHR} returns {CL_SUCCESS} if the function is
@@ -13317,6 +13327,16 @@ There are no implications from this behavior for the state of _event_ or the
 events in _event_wait_list_ when {clEnqueueSignalSemaphoresKHR} returns.
 Signaling the same binary semaphore twice without an interleaving wait may
 lead to undefined behavior.
+
+[NOTE]
+====
+When _command_queue_ is an out-of-order command-queue there are no implicit
+dependencies between commands enqueued into the command-queue before the
+semaphore signal command and the semaphore signal command.
+If such dependencies are required, applications may enqueue a command-queue
+barrier before the semaphore signal command, to explicitly add dependencies between
+the preceding commands and the semaphore signal command.
+====
 
 // refError
 


### PR DESCRIPTION
Fixes #1178

Clarifies the out-of-order command-queue behavior for semaphores, specifically that there are no implied dependencies between commands preceding a semaphore and a semaphore signal command, or between a semaphore wait command and subsequent commands.