### PR TITLE
fix asciidoctor rightarrow typo

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -17300,7 +17300,7 @@ used in the conversions described below.
 When approximate rounding is used instead of the preferred rounding, the
 result of the conversion must satisfy the bound given below.
 
-`half` {rightarrow` {CL_UNORM_INT8} (8-bit unsigned integer)
+`half` {rightarrow} {CL_UNORM_INT8} (8-bit unsigned integer)
 
 [none]
   * Let f~exact~ = *max*(`0`, *min*(`f * 255`, `255`))
@@ -17308,7 +17308,7 @@ result of the conversion must satisfy the bound given below.
   * Let f~approx~ = *convert_uchar_sat_<impl-rounding-mode>*(`f * 255.0f`)
   * *fabs*(f~exact~ - f~approx~) must be \<= 0.6
 
-`half` {rightarrow` {CL_UNORM_INT_101010} (10-bit unsigned integer)
+`half` {rightarrow} {CL_UNORM_INT_101010} (10-bit unsigned integer)
 
 [none]
   * Let f~exact~ = *max*(`0`, *min*(`f * 1023`, `1023`))
@@ -17317,7 +17317,7 @@ result of the conversion must satisfy the bound given below.
   * Let f~approx~ = *convert_ushort_sat_<impl-rounding-mode>*(`f * 1023.0f`)
   * *fabs*(f~exact~ - f~approx~) must be \<= 0.6
 
-`half` {rightarrow` {CL_UNORM_INT16} (16-bit unsigned integer)
+`half` {rightarrow} {CL_UNORM_INT16} (16-bit unsigned integer)
 
 [none]
   * Let f~exact~ = *max*(`0`, *min*(`f * 65535`, `65535`))
@@ -17326,7 +17326,7 @@ result of the conversion must satisfy the bound given below.
     65535.0f`)
   * *fabs*(f~exact~ - f~approx~) must be \<= 0.6
 
-`half` {rightarrow` {CL_SNORM_INT8} (8-bit signed integer)
+`half` {rightarrow} {CL_SNORM_INT8} (8-bit signed integer)
 
 [none]
   * Let f~exact~ = *max*(`-128`, *min*(`f * 127`, `127`))
@@ -17334,7 +17334,7 @@ result of the conversion must satisfy the bound given below.
   * Let f~approx~ = *convert_char_sat_<impl_rounding_mode>*(`f * 127.0f`)
   * *fabs*(f~exact~ - f~approx~) must be \<= 0.6
 
-`half` {rightarrow` {CL_SNORM_INT16} (16-bit signed integer)
+`half` {rightarrow} {CL_SNORM_INT16} (16-bit signed integer)
 
 [none]
   * Let f~exact~ = *max*(`-32768`, *min*(`f * 32767`, `32767`))


### PR DESCRIPTION
fixes #1232 

Fixes a typo causing the asciidoctor rightarrow attribute to not be rendered correctly.