### PR TITLE
Add error when memory objects or semaphores are created with more than one external handle

### DIFF
--- a/api/cl_khr_external_memory.asciidoc
+++ b/api/cl_khr_external_memory.asciidoc
@@ -6,7 +6,7 @@ include::{generated}/meta/{refprefix}cl_khr_external_memory.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2024-03-15
+    2024-09-03
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -290,3 +290,6 @@ while (true) {
      (provisional).
   * Revision 1.0.0, 2024-03-15
   ** First non-provisional version.
+  * Revision 1.0.1, 2024-09-03
+  ** Return {CL_INVALID_PROPERTY} when multiple external handles are provided
+     when creating a memory object.

--- a/api/cl_khr_external_semaphore.asciidoc
+++ b/api/cl_khr_external_semaphore.asciidoc
@@ -6,7 +6,7 @@ include::{generated}/meta/{refprefix}cl_khr_external_semaphore.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2024-03-15
+    2024-09-03
 *Interactions and External Dependencies*::
   * This extension requires OpenCL 1.2.
   * The {cl_khr_semaphore_EXT} extension is required as it defines semaphore
@@ -287,3 +287,6 @@ while (true) {
   ** Added re-import function call to {cl_khr_external_semaphore_sync_fd_EXT}
   * Revision 1.0.0, 2024-03-15
   ** First non-provisional version.
+  * Revision 1.0.1, 2024-09-03
+  ** Return {CL_INVALID_PROPERTY} when multiple external handles are provided
+     when creating a semaphore.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -659,6 +659,7 @@ ifdef::cl_khr_external_memory[]
   * {CL_INVALID_PROPERTY}
   ** if _properties_ does not include a supported external memory handle and
      {CL_MEM_DEVICE_HANDLE_LIST_KHR} is specified as part of _properties_.
+  ** if _properties_ includes more than one external memory handle.
 endif::cl_khr_external_memory[]
 
 [[memory-flags-table]]
@@ -2117,6 +2118,7 @@ ifdef::cl_khr_external_memory[]
   * {CL_INVALID_PROPERTY}
   ** if _properties_ does not include a supported external memory handle and
      {CL_MEM_DEVICE_HANDLE_LIST_KHR} is specified as part of _properties_.
+  ** if _properties_ includes more than one external memory handle.
 endif::cl_khr_external_memory[]
 
 [[host-ptr-buffer-size-table]]
@@ -12879,6 +12881,12 @@ in the _context_.
 For a multi-device context {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} must be
 specified in _sema_props_.
 
+ifdef::cl_khr_external_semaphore[]
+The properties used to create a semaphore from an external semaphore handle are
+<<external-semaphore-handle-types, described for the corresponding
+extensions>>.
+endif::cl_khr_external_semaphore[]
+
 // refError
 
 _errcode_ret_ returns an appropriate error code.
@@ -12924,6 +12932,8 @@ ifdef::cl_khr_external_semaphore[]
     well as {CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR}. Exporting a semaphore
     handle from a semaphore that was created by importing an external
     semaphore handle is not permitted.
+  * {CL_INVALID_PROPERTY} if _sema_props_ includes more than one external
+    semaphore handle.
 endif::cl_khr_external_semaphore[]
 --
 
@@ -13006,6 +13016,7 @@ Please refer to handle specific documentation for more details on transference r
 handle type.
 
 
+[[external-semaphore-handle-types]]
 === Descriptions of External Semaphore Handle Types
 
 This section describes the external semaphore handle types that are added by

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7039,7 +7039,7 @@ server's OpenCL/api-docs repository.
                 <command name="clRetainSemaphoreKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_semaphore" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl">
+        <extension name="cl_khr_external_semaphore" revision="1.0.1" supported="opencl" depends="CL_VERSION_1_2+cl_khr_semaphore" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7098,7 +7098,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_external_memory" revision="1.0.0" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl">
+        <extension name="cl_khr_external_memory" revision="1.0.1" supported="opencl" depends="CL_VERSION_3_0" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
Also link the description of external semaphore handles to the spec for clCreateSemaphoreWithPropertiesKHR.

Fixes #1246


Change-Id: Ifb4c02795c6d4db8aee9b5f14b10fecd26992fd5