### PR TITLE
Group or shorten the names of some API specification sections

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -1704,10 +1704,11 @@ include::{generated}/api/version-notes/CL_MAP_WRITE_INVALIDATE_REGION.asciidoc[]
 |====
 --
 
+ifdef::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
+=== Creating Buffer Objects From Direct3D Buffer Resources
+endif::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
 
 ifdef::cl_khr_d3d10_sharing[]
-=== Creating OpenCL Buffer Objects From Direct3D 10 Buffer Resources
-
 [open,refpage='clCreateFromD3D10BufferKHR',desc='Create OpenCL buffer object from a Direct3D 10 buffer',type='protos']
 --
 To create an OpenCL buffer object from a Direct3D 10 buffer, call the
@@ -1763,8 +1764,6 @@ endif::cl_khr_d3d10_sharing[]
 
 
 ifdef::cl_khr_d3d11_sharing[]
-=== Creating OpenCL Buffer Objects From Direct3D 11 Buffer Resources
-
 [open,refpage='clCreateFromD3D11BufferKHR',desc='Create OpenCL buffer object from a Direct3D 11 buffer',type='protos']
 --
 To create an OpenCL buffer object from a Direct3D 11 buffer, call the
@@ -1820,7 +1819,7 @@ endif::cl_khr_d3d11_sharing[]
 
 
 ifdef::cl_khr_gl_sharing[]
-=== Creating OpenCL Buffer Objects From OpenGL Buffer Objects
+=== Creating Buffer Objects From OpenGL Buffer Objects
 
 [open,refpage='clCreateFromGLBuffer',desc='Create OpenCL buffer object from an OpenGL buffer object',type='protos']
 --
@@ -4364,7 +4363,7 @@ endif::cl_khr_d3d11_sharing[]
 
 
 ifdef::cl_khr_dx9_media_sharing[]
-=== Creating OpenCL Image Objects From DirectX 9 Media Resources
+=== Creating Image Objects From DirectX 9 Media Resources
 
 [open,refpage='clCreateFromDX9MediaSurfaceKHR',desc='Create OpenCL image object from a media surface',type='protos']
 --
@@ -4464,9 +4463,11 @@ performance.
 endif::cl_khr_dx9_media_sharing[]
 
 
-ifdef::cl_khr_d3d10_sharing[]
-=== Creating OpenCL Image Objects From Direct3D 10 Textures and Resources
+ifdef::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
+=== Creating Image Objects From Direct3D Textures and Resources
+endif::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
 
+ifdef::cl_khr_d3d10_sharing[]
 [open,refpage='clCreateFromD3D10Texture2DKHR',desc='Create OpenCL 2D image object from a Direct3D 10 2D texture',type='protos']
 --
 To create an OpenCL 2D image object from a subresource of a Direct3D 10 2D
@@ -4599,8 +4600,6 @@ endif::cl_khr_d3d10_sharing[]
 
 
 ifdef::cl_khr_d3d11_sharing[]
-=== Creating OpenCL Image Objects From Direct3D 11 Textures and Resources
-
 [open,refpage='clCreateFromD3D11Texture2DKHR',desc='Create OpenCL 2D image object from a Direct3D 11 2D texture',type='protos']
 --
 To create an OpenCL 2D image object from a subresource of a Direct3D 11 2D
@@ -4733,7 +4732,7 @@ endif::cl_khr_d3d11_sharing[]
 
 
 ifdef::cl_khr_egl_image[]
-=== Creating OpenCL Image Objects From EGL Images
+=== Creating Image Objects From EGL Images
 
 [open,refpage='clCreateFromEGLImageKHR',desc='Create cl_mem target from EGLImage source',type='protos']
 --
@@ -4812,7 +4811,7 @@ endif::cl_khr_egl_image[]
 
 
 ifdef::cl_khr_gl_sharing[]
-=== Creating OpenCL Image Objects From OpenGL Textures and Renderbuffers
+=== Creating Image Objects From OpenGL Textures and Renderbuffers
 
 [open,refpage='clCreateFromGLTexture',desc='Create OpenCL image object from an OpenGL texture object',type='protos']
 --
@@ -5240,10 +5239,7 @@ include::{generated}/api/version-notes/CL_PIPE_PROPERTIES.asciidoc[]
 --
 
 
-== Querying, Unmapping, Migrating, Retaining and Releasing Memory Objects
-
-// === Handling Memory Objects
-
+== Memory Objects
 
 === Retaining and Releasing Memory Objects
 
@@ -6210,9 +6206,11 @@ and {clGetImageInfo} with _param_name_ {CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR},
 endif::cl_khr_dx9_media_sharing[]
 
 
-ifdef::cl_khr_d3d10_sharing[]
-=== Querying Direct3D Properties of Memory Objects Created From Direct3D 10 Resources
+ifdef::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
+=== Querying Direct3D Properties of Memory Objects Created From Direct3D Resources
+endif::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
 
+ifdef::cl_khr_d3d10_sharing[]
 Properties of Direct3D 10 objects may be queried using {clGetMemObjectInfo}
 and {clGetImageInfo} with _param_name_ {CL_MEM_D3D10_RESOURCE_KHR} and
 {CL_IMAGE_D3D10_SUBRESOURCE_KHR} respectively.
@@ -6220,8 +6218,6 @@ endif::cl_khr_d3d10_sharing[]
 
 
 ifdef::cl_khr_d3d11_sharing[]
-=== Querying Direct3D Properties of Memory Objects Created From Direct3D 11 Resources
-
 Properties of Direct3D 11 objects may be queried using {clGetMemObjectInfo}
 and {clGetImageInfo} with _param_name_ {CL_MEM_D3D11_RESOURCE_KHR} and
 {CL_IMAGE_D3D11_SUBRESOURCE_KHR} respectively.
@@ -6508,9 +6504,11 @@ Otherwise it returns one of the following errors:
 endif::cl_khr_dx9_media_sharing[]
 
 
-ifdef::cl_khr_d3d10_sharing[]
-=== Sharing Memory Objects Created From Direct3D 10 Resources Between Direct3D 10 and OpenCL Contexts
+ifdef::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
+=== Sharing Memory Objects Created From Direct3D Resources Between Direct3D and OpenCL Contexts
+endif::cl_khr_d3d10_sharing,cl_khr_d3d11_sharing[]
 
+ifdef::cl_khr_d3d10_sharing[]
 [open,refpage='clEnqueueAcquireD3D10ObjectsKHR',desc='Acquire OpenCL memory objects created from Direct3D 10 resources',type='protos']
 --
 To acquire OpenCL memory objects that have been created from Direct3D 10
@@ -6681,8 +6679,6 @@ endif::cl_khr_d3d10_sharing[]
 
 
 ifdef::cl_khr_d3d11_sharing[]
-=== Sharing Memory Objects Created From Direct3D 11 Resources Between Direct3D 11 and OpenCL Contexts
-
 [open,refpage='clEnqueueAcquireD3D11ObjectsKHR',desc='Acquire OpenCL memory objects created from Direct3D 11 resources',type='protos']
 --
 To acquire OpenCL memory objects that have been created from Direct3D 11


### PR DESCRIPTION
As discussed in teleconferences, the unification of the API specification has led to some long-winded and/or redundant section headers. Here are a few proposed changes that I find make the unified specification easier to navigate.


Change-Id: I326f4195e5585a821d38f128bbc9d300f490631f