### PR TITLE
add nofooter by default when building the OpenCL specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ COMMONATTRIBOPTS	= -a revdate="$(SPECDATE)" \
 			  -a stem=latexmath \
 			  -a generated=$(GENERATED) \
 			  -a sectnumlevels=5 \
+			  -a nofooter \
 			  -a refprefix
 
 ATTRIBOPTS   = -a revnumber="$(SPECREVISION)" \


### PR DESCRIPTION
fixes #1222

This will minimize diffs in the future, especially for things like the reference pages that may change infrequently.