### PR TITLE
clarify num_mip_levels

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2666,7 +2666,7 @@ endif::cl_khr_external_memory[]
 ifndef::cl_khr_mipmap_image[0.]
 ifdef::cl_khr_mipmap_image[]
     0 unless the {cl_khr_mipmap_image_EXT} extension is supported, in which
-    case it must be a value greater than 1 specifying the number of mipmap
+    case it may be a nonzero value specifying the number of mipmap
     levels in the image.
 endif::cl_khr_mipmap_image[]
   * _num_samples_ must be 0.


### PR DESCRIPTION
Fixes #1241.

Clarifies that the number of mip levels **may** be nonzero when the cl_khr_mipmap_image extension is supported, rather than that the number of mip levels **must** be greater than one.