### PR TITLE
unify the CL_INVALID_COMMAND_QUEUE behavior for semaphore signals and waits

### DIFF
--- a/api/cl_khr_semaphore.asciidoc
+++ b/api/cl_khr_semaphore.asciidoc
@@ -255,3 +255,6 @@ while (true) {
      {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} (provisional).
   * Revision 1.0.0, 2024-03-15
   ** First non-provisional version.
+  * Revision 1.0.1, 2024-09-08
+  ** Unified {CL_INVALID_COMMAND_QUEUE} error behavior for
+     {clEnqueueSignalSemaphoresKHR} and {clEnqueueWaitSemaphoresKHR}.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -13284,7 +13284,9 @@ Otherwise, it returns one of the following errors:
   ** if _command_queue_ is not a valid command-queue, or
   ** if the device associated with _command_queue_ is not same as one of the
      devices specified by {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} at the time
-     of creating one or more of _sema_objects_.
+     of creating one or more of _sema_objects_, or
+  ** if one or more of _sema_objects_ belong to a context that does not
+     contain a device associated with _command_queue_.
   * {CL_INVALID_VALUE} if _num_sema_objects_ is 0.
   * {CL_INVALID_SEMAPHORE_KHR} if any of the semaphore objects specified by
     _sema_objects_ is not valid.
@@ -13397,11 +13399,11 @@ Otherwise, it returns one of the following errors:
     _sema_objects_ requires a semaphore payload and _sema_payload_list_ is
     `NULL`.
   * {CL_INVALID_EVENT_WAIT_LIST}
-      ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not
-         0, or
-      ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is
-         0, or
-      ** if event objects in _event_wait_list_ are not valid events.
+  ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not 0,
+     or
+  ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is 0,
+     or
+  ** if event objects in _event_wait_list_ are not valid events.
   * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the execution status
     of any of the events in _event_wait_list_ is a negative integer value.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
@@ -13409,7 +13411,6 @@ Otherwise, it returns one of the following errors:
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
 --
-
 
 === Retaining and Releasing Semaphores
 


### PR DESCRIPTION
Fixes #1217 

Unifies the CL_INVALID_COMMAND_QUEUE behavior for clEnqueueSignalSemaphoresKHR and clEnqueueWaitSemaphoresKHR.

Also bumps the patch revision, as described in the suggested resolution.