### PR TITLE
clarify clGetSemaphoreHandleForTypeKHR is part of cl_khr_external_semaphore

### DIFF
--- a/api/cl_khr_external_semaphore.asciidoc
+++ b/api/cl_khr_external_semaphore.asciidoc
@@ -70,6 +70,10 @@ The layered extensions {cl_khr_external_semaphore_opaque_fd_EXT},
 {cl_khr_external_semaphore_win32_EXT} define specific external semaphores
 that may be imported into or exported from OpenCL.
 
+=== New Commands
+
+  * {clGetSemaphoreHandleForTypeKHR}
+
 === New Types
 
   * {cl_external_semaphore_handle_type_khr_TYPE}

--- a/api/cl_khr_external_semaphore_sync_fd.asciidoc
+++ b/api/cl_khr_external_semaphore_sync_fd.asciidoc
@@ -37,7 +37,6 @@ external semaphore using the APIs introduced by
 
 === New Commands
 
-  * {clGetSemaphoreHandleForTypeKHR}
   * {clReImportSemaphoreSyncFdKHR}
 
 === New Types

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -12940,6 +12940,7 @@ Please refer to handle specific documentation for more details on transference r
 To export an external handle from a semaphore, call the function
 
 include::{generated}/api/protos/clGetSemaphoreHandleForTypeKHR.txt[]
+include::{generated}/api/version-notes/clGetSemaphoreHandleForTypeKHR.asciidoc[]
 
   * _sema_object_ specifies a valid semaphore object with exportable
     properties.


### PR DESCRIPTION
fixes #1191 

* Puts clGetSemaphoreHandleForTypeKHR in the summary for cl_khr_external_semaphore, not cl_khr_external_semaphore_sync_fd.
* Adds the version note for clGetSemaphoreHandleForTypeKHR.