### PR TITLE
[XML] Fix type defined by `cl_intel_driver_diagnostics`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -125,7 +125,7 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef struct _cl_accelerator_intel* <name>cl_accelerator_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_accelerator_type_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_accelerator_info_intel</name>;</type>
-        <type category="define">typedef <type>cl_uint</type>          <name>cl_diagnostics_verbose_level</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_diagnostic_verbose_level_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_va_api_device_source_intel</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_va_api_device_set_intel</name>;</type>
         <type category="define">typedef struct __GLsync *             <name>cl_GLsync</name>;</type>
@@ -991,7 +991,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x4" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
+    <enums name="cl_diagnostic_verbose_level_intel" comment="From cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
         <enum value="0xff"          name="CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL"/>
         <enum bitpos="0"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL"/>
         <enum bitpos="1"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL"/>
@@ -6273,10 +6273,12 @@ server's OpenCL/api-docs repository.
         </extension>
         <extension name="cl_intel_driver_diagnostics" revision="0.0.0" supported="opencl">
             <require>
-                <type name="cl_diagnostics_verbose_level"/>
+                <type name="cl_diagnostic_verbose_level_intel"/>
             </require>
             <require comment="cl_context_properties">
                 <enum name="CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL"/>
+            </require>
+            <require comment="cl_diagnostic_verbose_level_intel">
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL"/>
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL"/>
                 <enum name="CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL"/>


### PR DESCRIPTION
https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_driver_diagnostics.txt

XML says this extension defines `cl_diagnostics_verbose_level`, but the spec says it's `cl_diagnostic_verbose_level_intel` (and with base type `cl_bitfield` rather than `cl_uint` - which checks out in favour of .txt spec)