### PR TITLE
Add types for fields from `cl_motion_estimation_desc_intel`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -255,6 +255,10 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_platform_command_buffer_capabilities_khr</name>;</type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_mutable_dispatch_asserts_khr</name></type>
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_kernel_clock_capabilities_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_mb_block_type_intel</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_subpixel_mode_intel</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_sad_adjust_mode_intel</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_search_path_type_intel</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
@@ -262,10 +266,10 @@ server's OpenCL/api-docs repository.
             <member><type>HANDLE</type>              <name>shared_handle</name></member>
         </type>
         <type category="struct" name="cl_motion_estimation_desc_intel">
-            <member><type>cl_uint</type>             <name>mb_block_type</name></member>
-            <member><type>cl_uint</type>             <name>subpixel_mode</name></member>
-            <member><type>cl_uint</type>             <name>sad_adjust_mode</name></member>
-            <member><type>cl_uint</type>             <name>search_path_type</name></member>
+            <member><type>cl_mb_block_type_intel</type>    <name>mb_block_type</name></member>
+            <member><type>cl_subpixel_mode_intel</type>    <name>subpixel_mode</name></member>
+            <member><type>cl_sad_adjust_mode_intel</type>  <name>sad_adjust_mode</name></member>
+            <member><type>cl_search_path_type_intel</type> <name>search_path_type</name></member>
         </type>
         <type category="struct" name="cl_mem_ext_host_ptr">
             <member><type>cl_uint</type>             <name>allocation_type</name></member>
@@ -6157,25 +6161,29 @@ server's OpenCL/api-docs repository.
         <extension name="cl_intel_motion_estimation" revision="0.0.0" supported="opencl">
             <require>
                 <type name="cl_motion_estimation_desc_intel"/>
+                <type name="cl_mb_block_type_intel"/>
+                <type name="cl_subpixel_mode_intel"/>
+                <type name="cl_sad_adjust_mode_intel"/>
+                <type name="cl_search_path_type_intel"/>
             </require>
             <require comment="cl_accelerator_type_intel">
                 <enum name="CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL"/>
             </require>
-            <require comment="cl_uint mb_block_type">
+            <require comment="cl_mb_block_type_intel">
                 <enum name="CL_ME_MB_TYPE_16x16_INTEL"/>
                 <enum name="CL_ME_MB_TYPE_8x8_INTEL"/>
                 <enum name="CL_ME_MB_TYPE_4x4_INTEL"/>
             </require>
-            <require comment="cl_uint subpixel_mode">
+            <require comment="cl_subpixel_mode_intel">
                 <enum name="CL_ME_SUBPIXEL_MODE_INTEGER_INTEL"/>
                 <enum name="CL_ME_SUBPIXEL_MODE_HPEL_INTEL"/>
                 <enum name="CL_ME_SUBPIXEL_MODE_QPEL_INTEL"/>
             </require>
-            <require comment="cl_uint sad_adjust_mode">
+            <require comment="cl_sad_adjust_mode_intel">
                 <enum name="CL_ME_SAD_ADJUST_MODE_NONE_INTEL"/>
                 <enum name="CL_ME_SAD_ADJUST_MODE_HAAR_INTEL"/>
             </require>
-            <require comment="cl_uint search_path_type">
+            <require comment="cl_search_path_type_intel">
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_2_2_INTEL"/>
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_4_4_INTEL"/>
                 <enum name="CL_ME_SEARCH_PATH_RADIUS_16_12_INTEL"/>


### PR DESCRIPTION
The relevant enum values are already grouped in the `<require>` tags.

I think it's better to allocate separate types for each such group, so it's possible for higher-lvl (than C) languages to enforce assigning the right values to fields of this struct.

Creating as a draft because the spec also needs to reflect this.

@bashbaug, this was a part of #926; what do you generally think about this change?
Any suggestions on how spec text should be handled?
I think it's not worth incrementing the version here since it wouldn't change the implementations in any way - it's purely an interface change.

P.S. If we agree on this, `cl_mem_ext_host_ptr` would also need a similar change. I'll hold off creating that PR for now.