### PR TITLE
[XML] `ARM` => `Arm`

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -502,7 +502,7 @@ server's OpenCL/api-docs repository.
         <enum value="8"             name="CL_LUID_SIZE_KHR"/>
     </enums>
 
-    <enums name="Constants.cl_arm_import_memory" vendor="ARM" comment = "cl_arm_import_memory size constants, in cl_ext.h">
+    <enums name="Constants.cl_arm_import_memory" vendor="Arm" comment = "cl_arm_import_memory size constants, in cl_ext.h">
         <enum value="SIZE_MAX"      name="CL_IMPORT_MEMORY_WHOLE_ALLOCATION_ARM"/>
     </enums>
 
@@ -977,7 +977,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x8" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_arm_device_svm_capabilities.flags" vendor="ARM" type="bitmask">
+    <enums name="cl_arm_device_svm_capabilities.flags" vendor="Arm" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="1"            name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="2"            name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM"/>
@@ -985,7 +985,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x10" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_arm_svm_alloc.flags" vendor="ARM" type="bitmask">
+    <enums name="cl_arm_svm_alloc.flags" vendor="Arm" type="bitmask">
         <enum bitpos="10"           name="CL_MEM_SVM_FINE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="11"           name="CL_MEM_SVM_ATOMICS_ARM"/>
             <unused start="0x4" end="0x80000000"/>
@@ -2076,7 +2076,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x40AA" end="0x40AF"/>
     </enums>
 
-    <enums start="0x40B0" end="0x40BF" name="enums.40B0" vendor="ARM" comment="Per Bug 10337">
+    <enums start="0x40B0" end="0x40BF" name="enums.40B0" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B0"        name="CL_PRINTF_CALLBACK_ARM"/>
         <enum value="0x40B1"        name="CL_PRINTF_BUFFERSIZE_ARM"/>
         <enum value="0x40B2"        name="CL_IMPORT_TYPE_ARM"/>


### PR DESCRIPTION
In the cl.xml file, in 4 places, it was `ARM`; in 5, `Arm`.

A minor thing, but all other vendor names are consistent, and this was tripping sanity checks in my bindings, so I fixed it a while ago. And now when reviewing - I found that I've never reported this back.