### PR TITLE
Use "associated with" for external memory and semaphroes

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -599,7 +599,7 @@ endif::cl_khr_external_memory[]
 ifdef::cl_khr_external_memory[]
 If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_,
 the memory object created by {clCreateBufferWithProperties} or
-{clCreateImageWithProperties} is by default accessible to all devices in the
+{clCreateImageWithProperties} is by default associated with all devices in the
 _context_.
 
 The properties used to create a buffer from an external memory handle are
@@ -2027,7 +2027,7 @@ endif::cl_khr_external_memory[]
 ifdef::cl_khr_external_memory[]
 If {CL_MEM_DEVICE_HANDLE_LIST_KHR} is not specified as part of _properties_,
 the memory object created by {clCreateBufferWithProperties} or
-{clCreateImageWithProperties} is by default accessible to all devices in the
+{clCreateImageWithProperties} is by default associated with all devices in the
 _context_.
 
 The properties used to create an image from an external memory handle are
@@ -12876,7 +12876,7 @@ endif::cl_khr_external_semaphore[]
 
 If {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} is not specified as part of
 _sema_props_, the semaphore object created by
-{clCreateSemaphoreWithPropertiesKHR} is by default accessible to all devices
+{clCreateSemaphoreWithPropertiesKHR} is by default associated with all devices
 in the _context_.
 For a multi-device context {CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR} must be
 specified in _sema_props_.


### PR DESCRIPTION
Replace "accessible to" with "associated with" for describing the devices the external memory and semaphore are valid for.

Fixes #1240