### PR TITLE
add additional clarification for num_mip_levels

### DIFF
--- a/api/footnotes.asciidoc
+++ b/api/footnotes.asciidoc
@@ -120,6 +120,11 @@ This feature is provided for identifying memory leaks. \
 Implementations are encouraged to favor this option as it makes it more likely that errors will be managed by applications. \
 ]
 
+:fn-single-mipmap-level: pass:n[ \
+Therefore, specifying _num_mip_levels_ equal to either `0` or `1` creates an image with a single mipmap level. \
+]
+
+
 :fn-srgb-image-requirements: pass:n[ \
 Support for reading from the {CL_sRGBA} image channel order is optional for 1D image buffers. \
 Support for writing to the {CL_sRGBA} image channel order is optional for all image types. \

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2665,14 +2665,17 @@ endif::cl_khr_external_memory[]
     _image_height_ for a 2D image array or a 3D image, must be {geq} the
     image row pitch for a 1D image array, and must be a multiple of the
     image row pitch.
-  * _num_mip_levels_ must be
-ifndef::cl_khr_mipmap_image[0.]
-ifdef::cl_khr_mipmap_image[]
-    0 unless the {cl_khr_mipmap_image_EXT} extension is supported, in which
-    case it may be a nonzero value specifying the number of mipmap
-    levels in the image.
+  * _num_mip_levels_ must be `0`, indicating that the image has a single
+ifndef::cl_khr_mipmap_image[]
+    mipmap level.
 endif::cl_khr_mipmap_image[]
-  * _num_samples_ must be 0.
+ifdef::cl_khr_mipmap_image[]
+    mipmap level, unless the {cl_khr_mipmap_image_EXT} extension is supported.
+    When the {cl_khr_mipmap_image_EXT} extension is supported, _num_mip_levels_
+    may additionally specify the total number of mipmap levels in the image,
+    including the base level footnote:[{fn-single-mipmap-level}].
+endif::cl_khr_mipmap_image[]
+  * _num_samples_ must be `0`.
   * _mem_object_ may refer to a valid buffer or image memory object.
     `mem_object` can be a buffer memory object if `image_type` is
     {CL_MEM_OBJECT_IMAGE1D_BUFFER} or


### PR DESCRIPTION
Adds additional clarification for num_mip_levels.

See discussion: https://github.com/KhronosGroup/OpenCL-Docs/issues/1241#issuecomment-2384263411