### PR TITLE
clarify the minimum value for CL_DEVICE_HALF_FP_CONFIG

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1929,8 +1929,7 @@ include::{generated}/api/version-notes/CL_DEVICE_HALF_FP_CONFIG.asciidoc[]
         addition, subtraction, multiplication) are implemented in software
 
         If half-precision is supported by the device, then the minimum
-        half-precision floating-point capability for OpenCL 2.0 or newer
-        devices is:
+        half-precision floating-point capability is either:
 
         {CL_FP_ROUND_TO_ZERO}
 


### PR DESCRIPTION
fixes #1267

The minimum value for CL_DEVICE_HALF_FP_CONFIG applies to devices supporting all OpenCL versions, not just for OpenCL 2.0 or newer devices.