### PR TITLE
Fix formatting issues in builtins tables

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -5368,6 +5368,7 @@ endif::cl_khr_fp16[]
   double__n__ *ldexp*(double__n__ _x_, int__n__ _k_) +
   double__n__ *ldexp*(double__n__ _x_, int _k_) +
   double *ldexp*(double _x_, int _k_)
+
 ifdef::cl_khr_fp16[]
   half__n__ *ldexp*(half__n__ _x_, int__n__ _k_) +
   half__n__ *ldexp*(half__n__ _x_, int _k_) +
@@ -6484,11 +6485,10 @@ ifdef::cl_khr_fp16[gentypeh *min*(gentypeh _x_, half _y_)]
 ifdef::cl_khr_fp16[gentypeh *mix*(gentypeh _x_, gentypeh _y_, half _a_)]
    a| Returns the linear blend of _x_ and _y_ implemented as:
 
-      _x_ + (_y_ - _x_) * _a_
+_x_ + (_y_ - _x_) * _a_
 
-      _a_ must be a value in the range [0.0, 1.0].
-      If _a_ is not in the range [0.0, 1.0], the return values are
-      undefined.
+_a_ must be a value in the range [0.0, 1.0]. If _a_ is not in the range [0.0,
+1.0], the return values are undefined.
 
 ifdef::cl_khr_fp16[]
 NOTE: The half-precision *mix* function can be implemented using


### PR DESCRIPTION
1. Add missing newline between double and half versions of 'ldexp'
2. Fix formatting of snippets in 'mix'