### PR TITLE
OpenCL C: Update ULP requirements for half-precision divide and reciprocal

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -16288,7 +16288,7 @@ is the infinitely precise result.
 | *_x_ + _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ - _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ * _y_*   | Correctly rounded             | Correctly rounded
-| *1.0 / _x_*   | Correctly rounded             | \<= 1 ulp
+| *1.0 / _x_*   | \<= 1 ulp                     | \<= 1 ulp
 | *_x_ / _y_*   | \<= 1 ulp                     | \<= 1 ulp
 | | |
 | *acos*        | \<= 2 ulp                     | \<= 3 ulp

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -16288,7 +16288,7 @@ is the infinitely precise result.
 | *_x_ + _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ - _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ * _y_*   | Correctly rounded             | Correctly rounded
-| *1.0 / _x_*   | \<= 1 ulp                     | \<= 1 ulp
+| *1.0 / _x_*   | Correctly rounded             | \<= 1 ulp
 | *_x_ / _y_*   | \<= 1 ulp                     | \<= 1 ulp
 | | |
 | *acos*        | \<= 2 ulp                     | \<= 3 ulp

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -16288,8 +16288,8 @@ is the infinitely precise result.
 | *_x_ + _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ - _y_*   | Correctly rounded             | Correctly rounded
 | *_x_ * _y_*   | Correctly rounded             | Correctly rounded
-| *1.0 / _x_*   | Correctly rounded             | \<= 1 ulp
-| *_x_ / _y_*   | Correctly rounded             | \<= 1 ulp
+| *1.0 / _x_*   | \<= 1 ulp                     | \<= 1 ulp
+| *_x_ / _y_*   | \<= 1 ulp                     | \<= 1 ulp
 | | |
 | *acos*        | \<= 2 ulp                     | \<= 3 ulp
 | *acosh*       | \<= 2 ulp                     | \<= 3 ulp

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -196,7 +196,7 @@ given as ULP values for the full profile.
 | *OpFDiv*
 | Correctly rounded
 | \<= 2.5 ulp
-| Correctly rounded
+| \<= 1.0 ulp
 
 | *OpExtInst* *acos*
 | \<= 4 ulp


### PR DESCRIPTION
Update ULP requirements for these builtins to 1.0 as per discussion on #1278