### PR TITLE
clarify unsafe math accuracy requirements for the embedded profile

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -15950,11 +15950,13 @@ requires>> support for OpenCL C 2.0 or newer.
 
 | 1.0 / _x_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
-      profile, and {leq} 3 ulp for the embedded profile.
+      profile, and {leq} 3 ulp for _x_ in the domain of 2^-126^ to 2^126^ for
+      the embedded profile.
 
 | _x_ / _y_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-62^ to 2^62^ and _y_ in the
-      domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for
+      domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for _x_ in
+      the domain of 2^-62^ to 2^62^ and _y_ in the domain of 2^-62^ to 2^62^ for
       the embedded profile.
 
 | *acos*(_x_)
@@ -16022,11 +16024,11 @@ requires>> support for OpenCL C 2.0 or newer.
 
 | *exp*(_x_)
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
-      4 ulp for the embedded profile.
+      4 + *floor*(*fabs*(2 * _x_)) ulp for the embedded profile.
 
 | *exp2*(_x_)
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
-      4 ulp for the embedded profile.
+      4 + *floor*(*fabs*(2 * _x_)) ulp for the embedded profile.
 
 | *exp10*(_x_)
     | Derived implementations may implement as *exp2*(_x_ * *log2*(10)).

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -1407,11 +1407,13 @@ profile.
 
 | *OpFDiv* for 1.0 / _x_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-126^ to 2^126^ for the full
-      profile, and {leq} 3 ulp for the embedded profile.
+      profile, and {leq} 3 ulp for _x_ in the domain of 2^-126^ to 2^126^ for
+      the embedded profile.
 
 | *OpFDiv* for _x_ / _y_
     | {leq} 2.5 ulp for _x_ in the domain of 2^-62^ to 2^62^ and _y_ in the
-      domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for
+      domain of 2^-62^ to 2^62^ for the full profile, and {leq} 3 ulp for _x_ in
+      the domain of 2^-62^ to 2^62^ and _y_ in the domain of 2^-62^ to 2^62^ for
       the embedded profile.
 
 | *OpExtInst* *acos*
@@ -1479,11 +1481,11 @@ profile.
 
 | *OpExtInst* *exp*
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
-      4 ulp for the embedded profile.
+      4  + *floor*(*fabs*(2 * _x_)) ulp for the embedded profile.
 
 | *OpExtInst* *exp2*
     | {leq} 3 + *floor*(*fabs*(2 * _x_)) ulp for the full profile, and {leq}
-      4 ulp for the embedded profile.
+      4 + *floor*(*fabs*(2 * _x_)) ulp for the embedded profile.
 
 | *OpExtInst* *exp10*
     | Derived implementations may implement as *exp2*(_x_ * *log2*(10)).


### PR DESCRIPTION
Fixes #288 

Clarifies the unsafe math accuracy requirements for divide, reciprocal, exp, and exp2 for the embedded profile.  The previous wording was ambiguous, and could have been interpreted to mean that the embedded profile had stricter accuracy requirements than the full profile.