### PR TITLE
clarify that format must be a string literal in OpenCL_C.txt

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -9571,9 +9571,7 @@ The format is composed of zero or more directives: ordinary characters (not
 specifications, each of which results in fetching zero or more subsequent
 arguments, converting them, if applicable, according to the corresponding
 conversion specifier, and then writing the result to the output stream.
-The format is in the constant address space and must be resolvable at
-compile time, i.e. cannot be dynamically created by the executing program
-itself.
+The format must be a string literal.
 
 Each conversion specification is introduced by the character *%*.
 After the *%*, the following appear in sequence:


### PR DESCRIPTION
The intent behind "resolvable at compile time" is that `format` cannot be a kernel argument (see https://github.com/KhronosGroup/OpenCL-Docs/issues/1325#issuecomment-268542016)