### PR TITLE
update the OpenCL SPIR-V environment for SPIR-V 1.3, 1.4, 1.5, and 1.6

### DIFF
--- a/env/extensions.asciidoc
+++ b/env/extensions.asciidoc
@@ -339,6 +339,14 @@ declare the following SPIR-V capabilities:
 * *DotProductInput4x8BitKHR* if {CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR} is supported
 * *DotProductInput4x8BitPackedKHR*
 
+If the OpenCL environment supports the extension {cl_khr_integer_dot_product_EXT}
+and SPIR-V 1.6, then the environment must accept SPIR-V 1.6 modules that declare
+the following SPIR-V capabilities:
+
+* *DotProduct*
+* *DotProductInput4x8Bit* if {CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR} is supported
+* *DotProductInput4x8BitPacked*
+
 ==== {cl_khr_expect_assume_EXT}
 
 If the OpenCL environment supports the extension {cl_khr_expect_assume_EXT}, then the environment must accept modules that declare use of the extension `SPV_KHR_expect_assume` via *OpExtension*.

--- a/env/required_capabilities.asciidoc
+++ b/env/required_capabilities.asciidoc
@@ -74,3 +74,39 @@ modules that declare the capabilities required for SPIR-V 1.1 modules,
 above.
 
 SPIR-V 1.2 does not add any new required capabilities.
+
+[[required-capabilities-1.3]]
+=== SPIR-V 1.3
+
+An OpenCL environment supporting SPIR-V 1.3 must support SPIR-V 1.3
+modules that declare the capabilities required for SPIR-V 1.2 modules,
+above.
+
+SPIR-V 1.3 does not add any new required capabilities.
+
+[[required-capabilities-1.4]]
+=== SPIR-V 1.4
+
+An OpenCL environment supporting SPIR-V 1.4 must support SPIR-V 1.4
+modules that declare the capabilities required for SPIR-V 1.3 modules,
+above.
+
+SPIR-V 1.4 does not add any new required capabilities.
+
+[[required-capabilities-1.5]]
+=== SPIR-V 1.5
+
+An OpenCL environment supporting SPIR-V 1.5 must support SPIR-V 1.5
+modules that declare the capabilities required for SPIR-V 1.4 modules,
+above.
+
+SPIR-V 1.5 does not add any new required capabilities.
+
+[[required-capabilities-1.6]]
+=== SPIR-V 1.6
+
+An OpenCL environment supporting SPIR-V 1.6 must support SPIR-V 1.6
+modules that declare the capabilities required for SPIR-V 1.5 modules,
+above.
+
+SPIR-V 1.6 does not add any new required capabilities.


### PR DESCRIPTION
Updates the OpenCL SPIR-V environment for SPIR-V 1.3, 1.4, 1.5, and 1.6.

Supporting SPIR-V 1.3, 1.4, 1.5, and 1.6 does not require support for any additional SPIR-V capabilities.