### PR TITLE
clarify clEnqueueReleaseExternalMemObjectsKHR

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5875,10 +5875,10 @@ include::{generated}/api/protos/clEnqueueReleaseExternalMemObjectsKHR.txt[]
     command to complete.
 
 Applications must release the memory objects that are acquired using
-{clEnqueueReleaseExternalMemObjectsKHR} before using them through any
-commands in the other API.
-This is to guarantee that the state of memory objects is up-to-date and they
-are accessible to the other API.
+{clEnqueueReleaseExternalMemObjectsKHR} before using them through any commands
+outside of OpenCL.
+This is to guarantee that the state of memory objects is up-to-date and that
+they are accessible outside of OpenCL.
 
 The following restrictions shall apply:
 
@@ -7619,7 +7619,7 @@ in _mem_objects_ have completed prior to executing subsequent commands in the
 other API which reference these objects.
 
 This may be accomplished portably by calling {clWaitForEvents} with the
-event object returned by *clEnqueueReleaseGLObjects,* or by calling
+event object returned by {clEnqueueReleaseGLObjects}, or by calling
 {clFinish}.
 As above, some implementations may offer more efficient methods.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -5874,9 +5874,11 @@ include::{generated}/api/protos/clEnqueueReleaseExternalMemObjectsKHR.txt[]
     application to query the status of this command or queue a wait for this
     command to complete.
 
-Applications must release the memory objects that are acquired using
-{clEnqueueReleaseExternalMemObjectsKHR} before using them through any commands
-outside of OpenCL.
+Applications must release memory objects that were acquired using
+{clEnqueueReleaseExternalMemObjectsKHR} before using any external memory
+handles that were specified when the memory objects were created or accessing
+the external memory that these handles represent outside of OpenCL, otherwise
+behavior is undefined.
 This is to guarantee that the state of memory objects is up-to-date and that
 they are accessible outside of OpenCL.
 


### PR DESCRIPTION
partial fix for #1308 

This changes the text in the description of clEnqueueReleaseExternalMemObjectsKHR from "in the other API" to "outside of OpenCL".