### PR TITLE
rephrase table title to avoid incorrect rendering

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14716,8 +14716,8 @@ endif::cl_khr_command_buffer_mutable_dispatch[]
     If _errcode_ret_ is `NULL`, no error code is returned.
 
 ifdef::cl_khr_command_buffer_multi_device[]
-.Summary of command-buffer creation configurations, for the {cl_khr_command_buffer_multi_device_EXT} extension
-[width="100%",options="header"]
+.Summary of multi-device command-buffer creation configurations
+[width="100%",cols="1,1,3,3",options="header"]
 |====
 | All Devices Associated With `Queues` can Device-side Sync | Platform Supports Universal Sync | Condition | Result
 .3+| Yes


### PR DESCRIPTION
Fixes #1175 

The table title with the extension name link rendered incorrectly in some browsers, so rephrase it so it renders correctly everywhere. Also, adjust table column widths.