### PR TITLE
explicitly list the data types supported for explicit conversions

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -376,10 +376,8 @@ ifdef::cl_khr_fp16[]
 [[cl_khr_fp16,cl_khr_fp16]]
 ==== Half-Precision Floating-Point
 
-The {cl_khr_fp16_EXT} extension was promoted to OpenCL C 1.2 as an optional
-feature, and to OpenCL 3.0 as the optional {cl_khr_fp16_EXT} feature.
-The extension provides 16-bit precision scalar and vector floating-point
-data types and extends many functions to accept these types.
+The {cl_khr_fp16_EXT} extension provides 16-bit half-precision scalar and vector
+floating-point data types and extends many functions to accept these types.
 endif::cl_khr_fp16[]
 
 
@@ -388,9 +386,9 @@ ifdef::cl_khr_fp64[]
 ==== Double-Precision Floating-Point
 
 The {cl_khr_fp64_EXT} extension was promoted to OpenCL C 1.2 as an optional
-feature, and to OpenCL 3.0 as the optional {cl_khr_fp64_EXT} feature.
-The extension provides double-precision scalar and vector floating-point
-data types and extends many functions to accept these types.
+feature.
+It provides double-precision scalar and vector floating-point data types and
+extends many functions to accept these types.
 endif::cl_khr_fp64[]
 
 
@@ -1688,11 +1686,16 @@ convert_destType(sourceType)
 
 suite of functions.
 These provide a full set of type conversions between supported
-<<built-in-scalar-data-types,scalar>>,
-<<built-in-vector-data-types,vector>>, and
-<<other-built-in-data-types,other>> data types except for the following
-types: `bool`, `half`, `size_t`, `ptrdiff_t`, `intptr_t`, `uintptr_t`, and
-`void`.
+<<built-in-scalar-data-types,scalar>> and
+<<built-in-vector-data-types,vector>> data types:
+
+* `char`, `char__n__`, `uchar`, `uchar__n__`
+* `short`, `short__n__`, `ushort`, `ushort__n__`
+* `int`, `int__n__`, `uint`, `uint__n__`
+* `long` footnote:[{fn-int64-supported}], `long__n__`, `ulong`, `ulong__n__`
+* `float`, `float__n__`
+* `half` footnote:[{fn-half-supported}], `half__n__`
+* `double` footnote:[{fn-double-supported}], `double__n__`
 
 The number of elements in the source and destination vectors must match.
 


### PR DESCRIPTION
Fixes #1190
Fixes #1239

Instead of listing the data types that are NOT supported for explicit conversions, list the data types that ARE supported.  This includes the `half` data type, when the `cl_khr_fp16` extension is supported and enabled.

Also, tidies up the text for the half-precision and double-precision data types.