### PR TITLE
allow abnormal termination for in-flight commands when context is deleted

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -3428,6 +3428,8 @@ include::{generated}/api/version-notes/clReleaseContext.asciidoc[]
 After the reference count becomes zero and all the objects attached to
 _context_ (such as memory objects, command-queues) are released, the
 _context_ is deleted.
+When the _context_ is deleted, any commands associated with the context that
+have not completed may be abnormally terminated.
 Using this function to release a reference that was not obtained by creating
 the object or by calling {clRetainContext} causes undefined behavior.
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6414,7 +6414,7 @@ This also permits an application to overlap the placement of memory objects
 with other unrelated operations before these memory objects are needed
 potentially hiding transfer latencies.
 Once the event, returned from {clEnqueueMigrateMemObjects}, has been marked
-CL_COMPLETE the memory objects specified in _mem_objects_ have been
+{CL_COMPLETE} the memory objects specified in _mem_objects_ have been
 successfully migrated to the device associated with _command_queue_.
 The migrated memory object shall remain resident on the device until another
 command is enqueued that either implicitly or explicitly migrates it away.


### PR DESCRIPTION
Fixes #1238

When a context is deleted, any in-flight commands (commands that have not completed) may be abnormally terminated.