### PR TITLE
clarify error condition for D3D10 and D3D11 3D textures

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4878,7 +4878,7 @@ returned in _errcode_ret_:
     _subresource_ is not a valid subresource index for _resource_.
   * {CL_INVALID_D3D10_RESOURCE_KHR} if _resource_ is not a Direct3D 10
     texture resource, if _resource_ was created with the D3D10_USAGE flag
-    D3D10_USAGE_IMMUTABLE, if _resource_ is a multisampled texture, if a
+    D3D10_USAGE_IMMUTABLE, if a
     {cl_mem_TYPE} from subresource _subresource_ of _resource_ has already
     been created using {clCreateFromD3D10Texture3DKHR}, or if _context_ was
     not created against the same Direct3D 10 device from which _resource_
@@ -5010,7 +5010,7 @@ returned in _errcode_ret_:
     _subresource_ is not a valid subresource index for _resource_.
   * {CL_INVALID_D3D11_RESOURCE_KHR} if _resource_ is not a Direct3D 11
     texture resource, if _resource_ was created with the D3D11_USAGE flag
-    D3D11_USAGE_IMMUTABLE, if _resource_ is a multisampled texture, if a
+    D3D11_USAGE_IMMUTABLE, if a
     {cl_mem_TYPE} from subresource _subresource_ of _resource_ has already
     been created using {clCreateFromD3D11Texture3DKHR}, or if _context_ was
     not created against the same Direct3D 11 device from which _resource_

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -4878,11 +4878,10 @@ returned in _errcode_ret_:
     _subresource_ is not a valid subresource index for _resource_.
   * {CL_INVALID_D3D10_RESOURCE_KHR} if _resource_ is not a Direct3D 10
     texture resource, if _resource_ was created with the D3D10_USAGE flag
-    D3D10_USAGE_IMMUTABLE, if a
-    {cl_mem_TYPE} from subresource _subresource_ of _resource_ has already
-    been created using {clCreateFromD3D10Texture3DKHR}, or if _context_ was
-    not created against the same Direct3D 10 device from which _resource_
-    was created.
+    D3D10_USAGE_IMMUTABLE, if a {cl_mem_TYPE} from subresource _subresource_ of
+    _resource_ has already been created using {clCreateFromD3D10Texture3DKHR},
+    or if _context_ was not created against the same Direct3D 10 device from
+    which _resource_ was created.
   * {CL_INVALID_IMAGE_FORMAT_DESCRIPTOR} if the Direct3D 10 texture format
     of _resource_ is not listed in the <<dxgi-image-formats-table, DXGI
     Formats and Corresponding OpenCL Image Formats>> table or if the
@@ -5010,11 +5009,10 @@ returned in _errcode_ret_:
     _subresource_ is not a valid subresource index for _resource_.
   * {CL_INVALID_D3D11_RESOURCE_KHR} if _resource_ is not a Direct3D 11
     texture resource, if _resource_ was created with the D3D11_USAGE flag
-    D3D11_USAGE_IMMUTABLE, if a
-    {cl_mem_TYPE} from subresource _subresource_ of _resource_ has already
-    been created using {clCreateFromD3D11Texture3DKHR}, or if _context_ was
-    not created against the same Direct3D 11 device from which _resource_
-    was created.
+    D3D11_USAGE_IMMUTABLE, if a {cl_mem_TYPE} from subresource _subresource_ of
+    _resource_ has already been created using {clCreateFromD3D11Texture3DKHR},
+    or if _context_ was not created against the same Direct3D 11 device from
+    which _resource_ was created.
   * {CL_INVALID_IMAGE_FORMAT_DESCRIPTOR} if the Direct3D 11 texture format
     of _resource_ is not listed in the <<dxgi-image-formats-table, DXGI
     Formats and Corresponding OpenCL Image Formats>> table or if the


### PR DESCRIPTION
Fixes #1284 

Because D3D10 and D3D11 3D textures cannot be multisampled, this condition does not need to be included in the list of possible error conditions when creating an OpenCL object from a D3D10 or D3D11 3D texture.