### PR TITLE
clarify CL_INVALID_IMAGE_SIZE error conditions

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2786,28 +2786,35 @@ include::{generated}/api/structs/cl_image_desc.txt[]
     {CL_MEM_OBJECT_IMAGE1D_ARRAY}, {CL_MEM_OBJECT_IMAGE2D},
     {CL_MEM_OBJECT_IMAGE2D_ARRAY}, or {CL_MEM_OBJECT_IMAGE3D}.
   * _image_width_ is the width of the image in pixels.
-    For a 2D image and image array, the image width must be a value {geq} 1 and
-    {leq} {CL_DEVICE_IMAGE2D_MAX_WIDTH}.
-    For a 3D image, the image width must be a value {geq} 1 and {leq}
-    {CL_DEVICE_IMAGE3D_MAX_WIDTH}.
-    For a 1D image buffer, the image width must be a value {geq} 1 and {leq}
-    {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE}.
-    For a 1D image and 1D image array, the image width must be a value {geq} 1
-    and {leq} {CL_DEVICE_IMAGE2D_MAX_WIDTH}.
+    For a 1D image, 1D image array, 2D image, or 2D image array, the image width
+    must be greater than or equal to one and less than or equal to the
+    value returned for {CL_DEVICE_IMAGE2D_MAX_WIDTH} for all devices in the
+    context.
+    For a 3D image, the image width must be greater than or equal to one and
+    less than or equal to the value returned for {CL_DEVICE_IMAGE3D_MAX_WIDTH}
+    for all devices in the context.
+    For a 1D image buffer, the image width must be greater than or equal
+    to one and less than or equal to the value returned for
+    {CL_DEVICE_IMAGE_MAX_BUFFER_SIZE} for all devices in the context.
   * _image_height_ is the height of the image in pixels.
-    This is only used if the image is a 2D or 3D image, or a 2D image array.
-    For a 2D image or image array, the image height must be a value {geq} 1 and
-    {leq} {CL_DEVICE_IMAGE2D_MAX_HEIGHT}.
-    For a 3D image, the image height must be a value {geq} 1 and {leq}
-    {CL_DEVICE_IMAGE3D_MAX_HEIGHT}.
+    It is only used if the image is a 2D image, 2D image array, or 3D image.
+    For a 2D image or 2D image array, the image height must greater than or
+    equal to one and less than or equal to the value returned for
+    {CL_DEVICE_IMAGE2D_MAX_HEIGHT} for all devices in the context.
+    For a 3D image, the image height must be greater than or equal to one and
+    less than or equal to the value returned for {CL_DEVICE_IMAGE3D_MAX_HEIGHT}
+    for all devices in the context.
   * _image_depth_ is the depth of the image in pixels.
-    This is only used if the image is a 3D image and must be a value {geq} 1 and
-    {leq} {CL_DEVICE_IMAGE3D_MAX_DEPTH}.
+    It is only used if the image is a 3D image.
+    For a 3D image, the image depth must be greater than or equal to one and
+    less than or equal to the value returned for {CL_DEVICE_IMAGE3D_MAX_DEPTH}
+    for all devices in the context.
   * _image_array_size_ footnote:[{fn-image-array-performance}] is the number of
     images in the image array.
-    This is only used if the image is a 1D or 2D image array.
-    The values for `image_array_size`, if specified, must be a value {geq} 1 and
-    {leq} {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE}.
+    It is only used if the image is a 1D image array or 2D image array.
+    For a 1D image array or 2D image array, the image array size must be
+    greater than or equal to one and less than or equal to the value returned
+    for {CL_DEVICE_IMAGE_MAX_ARRAY_SIZE} for all devices in the context.
   * _image_row_pitch_ is the scan-line pitch in bytes.
     The _image_row_pitch_ must be zero if _host_ptr_ is `NULL`,
 ifdef::cl_khr_external_memory[]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2213,8 +2213,8 @@ endif::cl_ext_image_from_buffer[]
     image object and the rules described above are not followed.
   * {CL_INVALID_IMAGE_DESCRIPTOR} if values specified in _image_desc_ are not
     valid or if _image_desc_ is `NULL`.
-  * {CL_INVALID_IMAGE_SIZE} if image dimensions specified in _image_desc_
-    exceed the maximum image dimensions described in the
+  * {CL_INVALID_IMAGE_SIZE} if the image dimensions specified in _image_desc_
+    are not valid or exceed the maximum image dimensions described in the
     <<device-queries-table,Device Queries>> table for all devices
     in _context_.
   * {CL_INVALID_HOST_PTR} if _host_ptr_ is `NULL` and {CL_MEM_USE_HOST_PTR} or


### PR DESCRIPTION
fixes #1277

For clCreateImageWithProperties, allow implementations to return CL_INVALID_IMAGE_SIZE when image dimensions are invalid, not just when image dimensions exceed the maximum image dimensions supported by al devices in the context.  This is consistent with the behavior of clCreateImage2D, where creating a 2D image with width or height equal to zero returns CL_INVALID_IMAGE_SIZE, and with clCreateImage3D, where creating a 3D image with width, height, or depth equal to zero returns CL_INVALID_IMAGE_SIZE.