### PR TITLE
move image kernel argument restriction to clSetKernelArg

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -3269,9 +3269,6 @@ For each access qualifier, only images whose format is in the list of
 formats returned by {clGetSupportedImageFormats} with the given flag
 arguments in the <<image-format-mapping-table,Image Format Mapping>> table
 are permitted.
-It is not valid to pass an image supporting writing as both a `read_only`
-image and a `write_only` image parameter, or to a `read_write` image
-parameter and any other image parameter.
 
 [[image-format-mapping-table]]
 .Mapping from format flags passed to {clGetSupportedImageFormats} to OpenCL kernel language image access qualifiers
@@ -10877,6 +10874,10 @@ object if argument is declared to be of type _image2d_array_t_.
 The memory object specified as argument value must be a 2D image array
 object with image channel order = {CL_DEPTH} if argument is declared to be of
 type _image2d_array_depth_t_.
+
+Behavior is undefined if the same memory object is passed as both a `read_only`
+image and a `write_only` image, or as a `read_write` image and either a
+`read_only` image or a `write_only` image.
 
 For all other kernel arguments, the _arg_value_ entry must be a pointer to
 the actual data to be used as argument value.


### PR DESCRIPTION
fixes #1306

Documents the restriction about passing the same image as a read-only and a write-only kernel argument in the description of clSetKernelArg rather than as the description of image access qualifiers.  Also, clarifies that behavior is undefined in this case, vs. invalid.