### PR TITLE
Fix image conversion rules for signed and unsigned image channel data types

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -17387,12 +17387,14 @@ channel data type of {CL_FLOAT}.
 === Conversion Rules for Signed and Unsigned 8-Bit, 16-Bit and 32-Bit Integer Channel Data Types
 
 Calls to *read_imagei* with channel data type values of {CL_SIGNED_INT8},
-{CL_SIGNED_INT16} and {CL_SIGNED_INT32} return the unmodified integer values
-stored in the image at specified location.
+{CL_SIGNED_INT16} and {CL_SIGNED_INT32} return the integer values
+stored in the image at specified location, after sign extension to 32 bits for
+integer values smaller than 32 bits.
 
 Calls to *read_imageui* with channel data type values of {CL_UNSIGNED_INT8},
-{CL_UNSIGNED_INT16} and {CL_UNSIGNED_INT32} return the unmodified integer
-values stored in the image at specified location.
+{CL_UNSIGNED_INT16} and {CL_UNSIGNED_INT32} return the integer values stored in
+the image at specified location, after zero extension to 32 bits for integer
+values smaller than 32 bits.
 
 Calls to *write_imagei* will perform one of the following conversions:
 

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -651,7 +651,7 @@ For images created with image channel data type of {CL_SNORM_INT8} and {CL_SNORM
 OpenCL implementations may choose to approximate the rounding mode used in the conversions described below.
 When approximate rounding is used instead of the preferred rounding, the result of the conversion must satisfy the bound given below.
 
-The conversions from half precision floating-point values to normalized integer values are performed is as follows:
+The conversions from single precision floating-point values to normalized integer values are performed is as follows:
 
   * `float` -> {CL_UNORM_INT8} (8-bit unsigned integer)
 +
@@ -784,9 +784,15 @@ The following rules apply for reading and writing images created with channel da
 [[conversion-rules-for-signed-and-unsigned-8-bit-16-bit-and-32-bit-integer-channel-data-types]]
 ==== Conversion Rules for Signed and Unsigned 8-bit, 16-bit and 32-bit Integer Channel Data Types
 
-For images created with image channel data type of {CL_SIGNED_INT8}, {CL_SIGNED_INT16} and {CL_SIGNED_INT32}, image read instructions will return the unmodified integer values stored in the image at specified location.
+For images created with image channel data type of {CL_SIGNED_INT8},
+{CL_SIGNED_INT16} and {CL_SIGNED_INT32}, image read instructions will
+return the integer values stored in the image at specified location, after
+sign extension to 32 bits for integer values smaller than 32 bits.
 
-Likewise, for images created with image channel data type of {CL_UNSIGNED_INT8}, {CL_UNSIGNED_INT16} and {CL_UNSIGNED_INT32}, image read instructions will return the unmodified unsigned integer values stored in the image at specified location.
+Likewise, for images created with image channel data type of {CL_UNSIGNED_INT8},
+{CL_UNSIGNED_INT16} and {CL_UNSIGNED_INT32}, image read instructions will return
+the integer values stored in the image at specified location, after
+zero extension to 32 bits for integer values smaller than 32 bits.
 
 Image write instructions will perform one of the following conversions:
 


### PR DESCRIPTION
The returned values are always 32-bit integers. Pixel values are sign- or zero-extended to 32 bits when the data type is smaller than 32-bit.

Also fix a typo in the description of single precision FP values to normalized integer values (the description erroneously referred to half precision floating point).


Change-Id: Idaa61a77949530e18442df680175de04347af9fa