### PR TITLE
OpenCL ICD Loader Deinitialization Support

### DIFF
--- a/api/cl_khr_icd.asciidoc
+++ b/api/cl_khr_icd.asciidoc
@@ -274,10 +274,17 @@ Returned by {clGetPlatformIDs} when no platforms are found:
 
   * {CL_PLATFORM_NOT_FOUND_KHR}
 
-New in version 2.0.0, used as a value in the pointers to `clGetPlatformIDs`
-and `clUnloadCompiler` in the dispatch structure:
+New in version 2.0.0.
+
+Used as a value in the pointers to `clGetPlatformIDs` and `clUnloadCompiler`
+in the dispatch structure:
 
   * `CL_ICD2_TAG_KHR`
+
+Used as a parameter name to query if a platform can be unlaoded by the ICD
+Loader:
+
+  * {CL_PLATFORM_UNLOADABLE_KHR}
 
 === Issues
 

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -337,6 +337,11 @@ include::{generated}/api/version-notes/CL_PLATFORM_ICD_SUFFIX_KHR.asciidoc[]
   | {char_TYPE}[]
     | The function name suffix used to identify extension functions to be
       directed to this platform by the ICD Loader.
+| {CL_PLATFORM_UNLOADABLE_KHR_anchor}
+
+include::{generated}/api/version-notes/CL_PLATFORM_UNLOADABLE_KHR.asciidoc[]
+  | {cl_bool_TYPE}
+    | The platform can be unloaded by the ICD Loader.
 endif::cl_khr_icd[]
 |====
 

--- a/extensions/cl_loader_layers.asciidoc
+++ b/extensions/cl_loader_layers.asciidoc
@@ -21,6 +21,7 @@ interception layers (Layer ICDs) for OpenCL.
 |====
 | *Date*     | *Version* | *Description*
 | 2020-11-04 | 1.0.0     | First assigned version.
+| 2024-09-04 | 2.0.0     | Deinitialization support.
 |====
 
 ==== Contributors
@@ -45,6 +46,8 @@ cl_int clInitLayer(cl_uint                 num_entries,
                    const cl_icd_dispatch  *target_dispatch,
                    cl_uint                *num_entries_ret,
                    const cl_icd_dispatch **layer_dispatch_ret);
+
+cl_int clDeinitLayer(void);
 ----
 
 [[cl_loader_layers-new-api-types]]
@@ -72,12 +75,13 @@ Accepted as _param_name_ to the function *clGetLayerInfo*:
 === New API Tokens
 
 Returned by *clGetLayerInfo* when supplied *CL_LAYER_API_VERSION*
-and the corresponding layer implements version 1.0.0 of the layer
-API:
+and the corresponding layer implements version 1.0.0 or 2.0.0 of
+the layer API:
 
 [source,opencl]
 ----
 #define CL_LAYER_API_VERSION_100 100
+#define CL_LAYER_API_VERSION_200 200
 ----
 
 [[cl_loader_layers-new-environment-variables]]
@@ -172,6 +176,18 @@ Otherwise, it returns one of the following errors.
   * *CL_INVALID_VALUE* if _num_entries_ is insufficient for the layer or if
     _target_dispatch_ is a `NULL` value, or _num_entries_ret_ is a `NULL`
     value, or _layer_dispatch_ret_ is a `NULL` value.
+
+==== Layer Deinitialization
+
+[open,refpage='clDeinitLayer',desc='Deinitialize an OpenCL layer',type='protos']
+Deinitilization of a layer can be achieved with the function:
+[source,opencl]
+
+----
+cl_int clInitLayer(void);
+----
+
+*clDeinitLayer* returns *CL_SUCCESS* if the function is executed successfully.
 
 [[cl_loader_layers-source-code]]
 === Source Code

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -523,6 +523,7 @@ server's OpenCL/api-docs repository.
 
     <enums name="Constants.cl_loader_layers" vendor="Khronos" comment="Defined Layer API version, in cl_layer.h">
         <enum value="100"           name="CL_LAYER_API_VERSION_100"/>
+        <enum value="200"           name="CL_LAYER_API_VERSION_200"/>
     </enums>
 
     <enums start="0" end="-999" name="ErrorCodes.0" vendor="Khronos" comment="Error codes start at 0 and decrease">
@@ -1423,7 +1424,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x0908"        name="CL_PLATFORM_COMMAND_BUFFER_CAPABILITIES_KHR"/>
             <unused start="0x0909" end="0x091F" comment="Reserved to Khronos"/>
         <enum value="0x0920"        name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
-            <unused start="0x0921" end="0x09FF" comment="Vendor extensions"/>
+        <enum value="0x0921"        name="CL_PLATFORM_UNLOADABLE_KHR"/>
+            <unused start="0x0922" end="0x09FF" comment="Vendor extensions"/>
     </enums>
 
     <enums start="0x1000" end="0x107F" name="cl_device_info" vendor="Khronos">
@@ -4278,6 +4280,9 @@ server's OpenCL/api-docs repository.
             <param>const <type>cl_icd_dispatch</type>**                 <name>layer_dispatch_ret</name></param>
         </command>
         <command>
+            <proto><type>cl_int</type>                                  <name>clDeinitLayer</name></proto>
+        </command>
+        <command>
             <proto><type>cl_int</type>                                  <name>clGetICDLoaderInfoOCLICD</name></proto>
             <param><type>cl_icdl_info</type>                            <name>param_name</name></param>
             <param><type>size_t</type>                                  <name>param_value_size</name></param>
@@ -5656,6 +5661,7 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_platform_info">
                 <enum name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
+                <enum name="CL_PLATFORM_UNLOADABLE_KHR"/>
             </require>
             <require comment="Error codes">
                 <enum name="CL_PLATFORM_NOT_FOUND_KHR"/>
@@ -5669,7 +5675,7 @@ server's OpenCL/api-docs repository.
                 <command name="clIcdSetPlatformDispatchDataKHR"/>
             </require>
         </extension>
-        <extension name="cl_loader_layers" revision="1.0.0" supported="opencl">
+        <extension name="cl_loader_layers" revision="2.0.0" supported="opencl">
             <require>
                 <type name="CL/cl_icd.h"/>
             </require>
@@ -5683,10 +5689,12 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="Misc API enums">
                 <enum name="CL_LAYER_API_VERSION_100"/>
+                <enum name="CL_LAYER_API_VERSION_200"/>
             </require>
             <require>
                 <command name="clGetLayerInfo"/>
                 <command name="clInitLayer"/>
+                <command name="clDeinitLayer"/>
             </require>
         </extension>
         <extension name="cl_loader_info" revision="1.0.0" supported="opencl">


### PR DESCRIPTION
This is the follow up of https://github.com/KhronosGroup/OpenCL-Docs/pull/1005 and the continuation of the implementation of https://github.com/KhronosGroup/OpenCL-Docs/issues/1003

This implements exposes the required functionalities to implement OpenCL ICD Loader de-initialization.