### PR TITLE
editorial: fix asciidoctor attributes for -cl-std=CLC++

### DIFF
--- a/api/cl_ext_cxx_for_opencl.asciidoc
+++ b/api/cl_ext_cxx_for_opencl.asciidoc
@@ -34,7 +34,7 @@ supported by the device compiler.
 
 === New build option
 
-This extension adds support for a new `CLC++` value to be passed to the
+This extension adds support for a new `CLC{pp}` value to be passed to the
 `-cl-std` build option accepted by {clBuildProgram} and {clCompileProgram}.
 
 === Preprocessor Macros
@@ -48,9 +48,9 @@ macros".
 
 === Conformance tests
 
-. Test that a program can successfully be compiled with `-cl-std=CLC++`.
-. Test with a program compiled with `-cl-std=CLC++` that the value of the
-  +__OPENCL_CPP_VERSION__+ macro agrees with the version returned by
+. Test that a program can successfully be compiled with `-cl-std=CLC{pp}`.
+. Test with a program compiled with `-cl-std=CLC{pp}` that the value of the
+  `+__OPENCL_CPP_VERSION__+` macro agrees with the version returned by
   `CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT`.
 
 === Version History

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -10096,8 +10096,8 @@ IMPORTANT: Debugging options are <<unified-spec, missing before>> version 2.0.
 ifdef::cl_ext_cxx_for_opencl[]
 ==== C++ for OpenCL
 
-Applications may pass `-cl-std=CLC\++` to {clCompileProgram} or {clBuildProgram}
-for programs created using {clCreateProgramFromSource} to request the program
+Applications may pass `-cl-std=CLC{pp}` to {clCompileProgram} or {clBuildProgram}
+for programs created using {clCreateProgramWithSource} to request the program
 be built as C++ for OpenCL.
 endif::cl_ext_cxx_for_opencl[]
 


### PR DESCRIPTION
Fixes several editorial issues caused by unexpected asciidoctor formatting for "-cl-std=CLC++".