### PR TITLE
editorial: fix a couple of additional buffer device address asciidoctor typos

### DIFF
--- a/api/cl_ext_buffer_device_address.asciidoc
+++ b/api/cl_ext_buffer_device_address.asciidoc
@@ -50,7 +50,7 @@ can allocate.
 
 === New Types
 
-  * {cl_mem_device_address_EXT}
+  * {cl_mem_device_address_ext_TYPE}
 
 === New Enums
 

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -6674,7 +6674,7 @@ ifdef::cl_ext_buffer_device_address[]
 | {CL_MEM_DEVICE_ADDRESS_EXT_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_DEVICE_ADDRESS_EXT.asciidoc[]
-  |  {cl_mem_device_address_EXT_TYPE}[]
+  |  {cl_mem_device_address_ext_TYPE}[]
     | If _memobj_ was created using {clCreateBufferWithProperties} with
       the {CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT} property set to {CL_TRUE},
       returns a list of device addresses for the buffer, one for each
@@ -11123,7 +11123,7 @@ ifdef::cl_ext_buffer_device_address[]
 | {CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT_anchor}
 
 include::{generated}/api/version-notes/CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT.asciidoc[]
-  | {cl_mem_device_address_EXT_TYPE}[]
+  | {cl_mem_device_address_ext_TYPE}[]
       | Device pointers must reference locations contained entirely within
         buffers that are passed to kernel as arguments, or that are passed
         through the execution information. Non-argument device pointers accessed


### PR DESCRIPTION
Fix a couple of typos related to the type `cl_mem_device_address_ext` added by the buffer device address extension.