### PR TITLE
cl_khr_external_semaphore_dx_fence:  Modify wording to reflect intent

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -13750,7 +13750,7 @@ a semaphore from an external handle:
 
   * {CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR} specifies an NT handle returned by
     `ID3D12Device::CreateSharedHandle` referring to a Direct3D 12 fence, or
-    `ID3D11Device5::CreateFence` referring to a Direct3D 11 fence.
+    `ID3D11Fence::CreateSharedHandle` referring to a Direct3D 11 fence.
     It owns a reference to the underlying synchronization primitive
     associated with the Direct3D fence.
 
@@ -13763,8 +13763,8 @@ be provided for semaphores created from
     {CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR} and other handle types, then the
     _sema_payload_list_ should point to a list of _num_sema_objects_ payload
     values for each semaphore in _sema_objects_.
-    However, the payload values corresponding to semaphores with type
-    {CL_SEMAPHORE_TYPE_BINARY_KHR} can be set to 0 or will be ignored.
+    However, the payload values corresponding to semaphores that do not require
+    a payload will be ignored.
 
 {clEnqueueWaitSemaphoresKHR} and {clEnqueueSignalSemaphoresKHR} may return
 {CL_INVALID_VALUE} if _sema_objects_ list has one or more semaphores
@@ -13865,8 +13865,8 @@ include::{generated}/api/version-notes/clEnqueueWaitSemaphoresKHR.asciidoc[]
   * _sema_payload_list_ points to the list of values of type
     {cl_semaphore_payload_khr_TYPE} containing valid semaphore payload
     values to wait on.
-    This can be set to `NULL` or will be ignored when all semaphores in the
-    list of _sema_objects_ are of type {CL_SEMAPHORE_TYPE_BINARY_KHR}.
+    This can be set to `NULL` or will be ignored if no semaphores in the
+    list of _sema_objects_ require a payload.
   * _num_events_in_wait_list_ specifies the number of events in
     _event_wait_list_.
   * _event_wait_list_ specifies list of events that need to complete before
@@ -13962,8 +13962,8 @@ include::{generated}/api/version-notes/clEnqueueSignalSemaphoresKHR.asciidoc[]
   * _sema_payload_list_ points to the list of values of type
     {cl_semaphore_payload_khr_TYPE} containing semaphore payload values to
     signal.
-    This can be set to `NULL` or will be ignored when all semaphores in the
-    list of _sema_objects_ are of type {CL_SEMAPHORE_TYPE_BINARY_KHR}.
+    This can be set to `NULL` or will be ignored if no semaphores in the
+    list of _sema_objects_ require a payload.
   * _num_events_in_wait_list_ specifies the number of events in
   * _event_wait_list_ points to the list of events that need to complete
     before {clEnqueueSignalSemaphoresKHR} can be executed.


### PR DESCRIPTION
Modify wording to allow proper handling of timepoints in clEnqueueWaitSemaphore and clEnqueueSignalSemaphore