### PR TITLE
fix wording inconsistency for device and host timer synchronization

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -256,7 +256,7 @@ include::{generated}/api/version-notes/CL_PLATFORM_HOST_TIMER_RESOLUTION.asciido
 
         Support for device and host timer synchronization is required for
         platforms supporting OpenCL 2.1 or 2.2.
-        This value must be 0 for devices that do not support device and
+        This value must be 0 for platforms that do not support device and
         host timer synchronization.
 
 ifdef::cl_khr_command_buffer_multi_device[]


### PR DESCRIPTION
The query for CL_PLATFORM_HOST_TIMER_RESOLUTION is a platform query, not a device query, so the description should refer to platforms that do or do not support the query, not devices.

fixes #1363