### PR TITLE
switch cl_khr_kernel_clock from provisional to final

### DIFF
--- a/api/cl_khr_kernel_clock.asciidoc
+++ b/api/cl_khr_kernel_clock.asciidoc
@@ -6,7 +6,7 @@ include::{generated}/meta/{refprefix}cl_khr_kernel_clock.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2024-03-25
+    2024-05-02
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -60,3 +60,5 @@ Support for sub-groups is required for the `clock_read_sub_group` and
 
   * Revision 0.9.0, 2024-03-25
   ** First assigned version (provisional).
+  * Revision 1.0.0, 2025-05-02
+  ** First non-provisional version.

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7553,7 +7553,7 @@ server's OpenCL/api-docs repository.
                 <command name="clCancelCommandsIMG"/>
             </require>
         </extension>
-        <extension name="cl_khr_kernel_clock" revision="0.9.0" supported="opencl" ratified="opencl" provisional="true">
+        <extension name="cl_khr_kernel_clock" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
The cl_khr_kernel_clock extension is no longer provisional and is now finalized.