### PR TITLE
Fix fast_distance parameter type

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -6624,7 +6624,7 @@ ifdef::cl_khr_fp16[half *length*(gentypeh _p_)]
 ifdef::cl_khr_fp16[gentypeh *normalize*(gentypeh _p_)]
     | Returns a vector in the same direction as _p_ but with a length of 1.
 | |
-| float *fast_distance*(float _p0_, float__n__ _p1_)
+| float *fast_distance*(float__n__ _p0_, float__n__ _p1_)
     | Returns *fast_length*(_p0_ - _p1_).
 | float *fast_length*(float__n__ _p_)
     | Returns the length of vector _p_ computed as:


### PR DESCRIPTION
This builtin was incorrectly described as `fast_distance(float, floatn)`.