### PR TITLE
clarify the image row pitch requirements

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2864,28 +2864,28 @@ include::{generated}/api/structs/cl_image_desc.txt[]
 ifdef::cl_khr_external_memory[]
     the image is not an image created from an external memory handle,
 endif::cl_khr_external_memory[]
-    and the image is not a 2D image created from a buffer,
+    and the image is not a 2D image created from a buffer. +
     If _image_row_pitch_ is zero and _host_ptr_ is not `NULL`, then the
-    image row pitch is calculated as _image_width_ {times} the size of an
-    image element in bytes.
+    image row pitch is calculated as _image_width_ times the size of an
+    image element in bytes. +
 ifdef::cl_khr_external_memory[]
     If _image_row_pitch_ is zero and the image is created from an external
-    memory handle, then the image row pitch is implementation-defined.
+    memory handle, then the image row pitch is implementation-defined. +
 endif::cl_khr_external_memory[]
-    The image row pitch must be {geq} _image_width_ {times} the size of an
-    image element in bytes, and must be a multiple of the size of an image
-    element in bytes.
+    If _image_row_pitch_ is non-zero, then it must be greater than or equal to
+    the _image_width_ times the size of an image element in bytes, and must be a
+    multiple of the size of an image element in bytes. +
 ifndef::cl_ext_image_requirements_info[]
-    For a 2D image created from a buffer the image row pitch must also be a
+    For a 2D image created from a buffer the _image_row_pitch_ must also be a
     multiple of the maximum of the {CL_DEVICE_IMAGE_PITCH_ALIGNMENT} value
     for all devices in the context that support images.
 endif::cl_ext_image_requirements_info[]
 ifdef::cl_ext_image_requirements_info[]
-    For an image created from a buffer, the image row pitch must also
-    - Be a multiple of the {CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT} value
-    for the _image_format_, _image_type_ and _flags_ used to create the image, if
+    For an image created from a buffer, the _image_row_pitch_ must also:
+    ** be a multiple of the {CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT} value
+    for the _image_format_, _image_type_, and _flags_ used to create the image, if
     the {cl_ext_image_requirements_info_EXT} extension is supported, or
-    - Be a multiple of the maximum of the {CL_DEVICE_IMAGE_PITCH_ALIGNMENT} value
+    ** be a multiple of the maximum of the {CL_DEVICE_IMAGE_PITCH_ALIGNMENT} value
     for all devices in the context that support images, otherwise.
 endif::cl_ext_image_requirements_info[]
   * _image_slice_pitch_ is the size in bytes of each 2D slice in a 3D image,


### PR DESCRIPTION
fixes #1333 

Clarifies the conditions when the image row pitch must be zero and what the requirements are when the image row pitch is nonzero.  I thought it was helpful to add line breaks to separate the different conditions, but I'm flexible and I can remove these or convert them to bullet points or similar, if desired.

Here are how these changes render in the spec:

> _image_row_pitch_ is the scan-line pitch in bytes. The _image_row_pitch_ must be zero if host_ptr is NULL, the image is not an image created from an external memory handle, and the image is not a 2D image created from a buffer.
If _image_row_pitch_ is zero and host_ptr is not NULL, then the image row pitch is calculated as image_width times the size of an image element in bytes.
If _image_row_pitch_ is zero and the image is created from an external memory handle, then the image row pitch is implementation-defined.
If _image_row_pitch_ is non-zero, then it must be greater than or equal to the image_width times the size of an image element in bytes, and must be a multiple of the size of an image element in bytes.
For an image created from a buffer, the _image_row_pitch_ must also:
> * be a multiple of the [CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT](https://github.com/KhronosGroup/OpenCL-Docs/compare/main...bashbaug:fix-image-row-pitch?expand=1#CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT) value for the image_format, image_type, and flags used to create the image, if the [cl_ext_image_requirements_info](https://github.com/KhronosGroup/OpenCL-Docs/compare/main...bashbaug:fix-image-row-pitch?expand=1#cl_ext_image_requirements_info) extension is supported, or
> * be a multiple of the maximum of the [CL_DEVICE_IMAGE_PITCH_ALIGNMENT](https://github.com/KhronosGroup/OpenCL-Docs/compare/main...bashbaug:fix-image-row-pitch?expand=1#CL_DEVICE_IMAGE_PITCH_ALIGNMENT) value for all devices in the context that support images, otherwise.