### PR TITLE
cl_intel_subgroups out-of-range shuffle index behavior

### DIFF
--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -50,8 +50,8 @@ Final Draft
 
 == Version
 
-Built On: {docdate} +
-Revision: 8
+Built On: 2025-06-03 +
+Revision: 9
 
 == Dependencies
 
@@ -701,7 +701,7 @@ gentype intel_sub_group_shuffle(
 The data that is returned for this work item is the value of _data_ for the work item identified by _sub_group_local_id_.
 
 _sub_group_local_id_ need not be the same value for all work items in the sub-group.
-There is no defined behavior for out-of-range _sub_group_local_ids_.
+The return value is undefined for out-of-range _sub_group_local_ids_.
 
 |[source,c]
 ----
@@ -721,7 +721,7 @@ If the shuffle index is less than the max_sub_group_size, the result of this bui
 If the shuffle index is greater than or equal to the max_sub_group_size but less than twice the max_sub_group_size, the result of this built-in function is the value of the _next_ data source for the work item with sub_group_local_id equal to the shuffle index minus the max_sub_group_size.
 
 All other values of the shuffle index are considered to be out-of-range.
-There is no defined behavior for out-of-range indices.
+The return value is undefined for out-of-range indices.
 
 _delta_ need not be the same value for all work items in the sub-group.
 
@@ -743,7 +743,7 @@ If the shuffle index is greater than or equal to zero and less than the max_sub_
 If the shuffle index is less than zero but greater than or equal to the negative max_sub_group_size, the result of this built-in function is the value of the previous data source for the work item with sub_group_local_id equal to the shuffle index plus the max_sub_group_size.
 
 All other values of the shuffle index are considered to be out-of-range.
-There is no defined behavior for out-of-range indices.
+The return value is undefined for out-of-range indices.
 
 _delta_ need not be the same value for all work items in the sub-group.
 
@@ -759,7 +759,7 @@ The data that is returned for this work item is the value of _data_ for the work
 If the result of the XOR is greater than max_sub_group_size then it is considered out-of-range.
 
 _value_ need not be the same for all work items in the sub-group.
-There is no defined behavior for out-of-range indices.
+The return value is undefined for out-of-range indices.
 
 |====
 --
@@ -951,6 +951,7 @@ None.
 |6|2018-12-02|Ben Ashbaugh|Added back a section that was inadvertently removed during conversion to asciidoc.
 |7|2019-01-15|Ben Ashbaugh|Fixed a typo in the summary section of new built-in functions.
 |8|2019-09-17|Ben Ashbaugh|Added vec3 types for shuffles, restriction for block reads and writes and partial sub-groups, and asciidoctor formatting fixes.
+|9|2025-06-03|Ben Ashbaugh|Clarified that the return value is undefined for out-of-range shuffle indices, not that behavior is undefined.
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
Clarified that the return value is undefined for out-of-range shuffle indices, not that behavior is undefined.