### PR TITLE
relax the fp16 sqrt accuracy requirement to 1.5 ULP

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -16288,7 +16288,7 @@ is the infinitely precise result.
 | *sinpi*           | {leq} 4 ulp
 | *smoothstep*      | Implementation-defined
 | *step*            | 0 ulp
-| *fsqrt*           | Correctly rounded
+| *sqrt*            | Correctly rounded
 | *tan*             | {leq} 5 ulp
 | *tanh*            | {leq} 5 ulp
 | *tanpi*           | {leq} 6 ulp
@@ -16438,7 +16438,7 @@ is the infinitely precise result.
 | *sinh*        | \<= 2 ulp                     | \<= 3 ulp
 | *sinpi*       | \<= 2 ulp                     | \<= 2 ulp
 | *smoothstep*  | Implementation-defined        | Implementation-defined
-| *sqrt*        | Correctly rounded             | \<= 1 ulp
+| *sqrt*        | \<= 1.5 ulp                   | \<= 1.5 ulp
 | *step*        | 0 ulp                         | 0 ulp
 | *tan*         | \<= 2 ulp                     | \<= 3 ulp
 | *tanh*        | \<= 2 ulp                     | \<= 3 ulp

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -196,7 +196,7 @@ given as ULP values for the full profile.
 | *OpFDiv*
 | Correctly rounded
 | \<= 2.5 ulp
-| \<= 1.0 ulp
+| \<= 1 ulp
 
 | *OpExtInst* *acos*
 | \<= 4 ulp
@@ -586,7 +586,7 @@ given as ULP values for the full profile.
 | *OpExtInst* *sqrt*
 | Correctly rounded
 | \<= 3 ulp
-| Correctly rounded
+| \<= 1.5 ulp
 
 | *OpExtInst* *step*
 | 0 ulp
@@ -1188,7 +1188,7 @@ given as ULP values for the embedded profile.
 | *OpExtInst* *sqrt*
 | \<= 4 ulp
 | \<= 4 ulp
-| \<= 1 ulp
+| \<= 1.5 ulp
 
 | *OpExtInst* *step*
 | 0 ulp


### PR DESCRIPTION
fixes #1373