### PR TITLE
relax the full profile fp16 tan accuracy requirement to 2.25 ULP

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -16440,7 +16440,7 @@ is the infinitely precise result.
 | *smoothstep*  | Implementation-defined        | Implementation-defined
 | *sqrt*        | Correctly rounded             | \<= 1 ulp
 | *step*        | 0 ulp                         | 0 ulp
-| *tan*         | \<= 2 ulp                     | \<= 3 ulp
+| *tan*         | \<= 2.25 ulp                  | \<= 3 ulp
 | *tanh*        | \<= 2 ulp                     | \<= 3 ulp
 | *tanpi*       | \<= 2 ulp                     | \<= 3 ulp
 | *tgamma*      | \<= 4 ulp                     | \<= 4 ulp

--- a/env/numerical_compliance.asciidoc
+++ b/env/numerical_compliance.asciidoc
@@ -596,7 +596,7 @@ given as ULP values for the full profile.
 | *OpExtInst* *tan*
 | \<= 5 ulp
 | \<= 5 ulp
-| \<= 2 ulp
+| \<= 2.25 ulp
 
 | *OpExtInst* *tanh*
 | \<= 5 ulp


### PR DESCRIPTION
fixes #1303

The embedded profile accuracy requirement is unchanged and remains 3 ULP.