### PR TITLE
Remove specific restrictions for custom devices

### DIFF
--- a/api/embedded_profile.asciidoc
+++ b/api/embedded_profile.asciidoc
@@ -216,8 +216,7 @@ Device Queries>> table.
 | {CL_DEVICE_MAX_PARAMETER_SIZE}
   | {size_t_TYPE}
       | Max size in bytes of all arguments that can be passed to a kernel.
-        The minimum value is 256 bytes for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 256 bytes.
 
         A maximum of 255 arguments can be passed to a kernel.
 | {CL_DEVICE_SINGLE_FP_CONFIG}
@@ -248,24 +247,20 @@ Device Queries>> table.
 
         [[embedded-profile-single-fp-config-requirements]]
         The mandated minimum floating-point capability is:
-        {CL_FP_ROUND_TO_ZERO} or {CL_FP_ROUND_TO_NEAREST} for devices that are
-        not of type {CL_DEVICE_TYPE_CUSTOM}.
+        {CL_FP_ROUND_TO_ZERO} or {CL_FP_ROUND_TO_NEAREST}.
 | {CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE}
   | {cl_ulong_TYPE}
       | Max size in bytes of a constant buffer allocation.
-        The minimum value is 1 KB for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 1 KB.
 | {CL_DEVICE_MAX_CONSTANT_ARGS}
   | {cl_uint_TYPE}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
-        The minimum value is 4 for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 4.
 | {CL_DEVICE_LOCAL_MEM_SIZE}
   | {cl_ulong_TYPE}
       | Size of local memory arena in bytes.
-        The minimum value is 1 KB for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 1 KB.
 | {CL_DEVICE_COMPILER_AVAILABLE}
   | {cl_bool_TYPE}
       | Is {CL_FALSE} if the implementation does not have a compiler available

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -552,8 +552,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS.asciid
       | Maximum dimensions that specify the global and local work-item IDs
         used by the data parallel execution model. (Refer to
         {clEnqueueNDRangeKernel}).
-        The minimum value is 3 for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 3.
 | {CL_DEVICE_MAX_WORK_ITEM_SIZES_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
@@ -564,8 +563,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_ITEM_SIZES.asciidoc[]
         Returns _n_ {size_t_TYPE} entries, where _n_ is the value returned by the
         query for {CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS}.
 
-        The minimum value is (1, 1, 1) for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is (1, 1, 1).
 | {CL_DEVICE_MAX_WORK_GROUP_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_WORK_GROUP_SIZE.asciidoc[]
@@ -650,8 +648,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_MEM_ALLOC_SIZE.asciidoc[]
   | {cl_ulong_TYPE}
       | Max size of memory object allocation in bytes.
         The minimum value is max(min(1024 {times} 1024 {times} 1024, 1/4^th^
-        of {CL_DEVICE_GLOBAL_MEM_SIZE}), 32 {times} 1024 {times} 1024) for
-        devices that are not of type {CL_DEVICE_TYPE_CUSTOM}.
+        of {CL_DEVICE_GLOBAL_MEM_SIZE}), 32 {times} 1024 {times} 1024).
 | {CL_DEVICE_IMAGE_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_IMAGE_SUPPORT.asciidoc[]
@@ -916,8 +913,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MAX_PARAMETER_SIZE.asciidoc[]
   | {size_t_TYPE}
       | Max size in bytes of all arguments that can be passed to a kernel.
 
-        The minimum value is 1024 for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 1024.
         For this minimum value, only a maximum of 128 arguments can be
         passed to a kernel.
         For all other values, a maximum of 255 arguments can be passed
@@ -929,8 +925,7 @@ include::{generated}/api/version-notes/CL_DEVICE_MEM_BASE_ADDR_ALIGN.asciidoc[]
       | Alignment requirement (in bits) for sub-buffer offsets.
         The minimum value is the size (in bits) of the largest OpenCL
         built-in data type supported by the device (long16 in FULL profile,
-        long16 or int16 in EMBEDDED profile) for devices that are not of
-        type {CL_DEVICE_TYPE_CUSTOM}.
+        long16 or int16 in EMBEDDED profile).
 | {CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE.asciidoc[]
@@ -960,7 +955,7 @@ include::{generated}/api/version-notes/CL_DEVICE_SINGLE_FP_CONFIG.asciidoc[]
         addition, subtraction, multiplication) are implemented in software
 
         For the full profile, the mandated minimum floating-point capability
-        for devices that are not of type {CL_DEVICE_TYPE_CUSTOM} is:
+        is:
 
         {CL_FP_ROUND_TO_NEAREST} \| +
         {CL_FP_INF_NAN}.
@@ -1037,16 +1032,14 @@ include::{generated}/api/version-notes/CL_DEVICE_GLOBAL_MEM_SIZE.asciidoc[]
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE.asciidoc[]
   | {cl_ulong_TYPE}
       | Max size in bytes of a constant buffer allocation.
-        The minimum value is 64 KB for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 64 KB.
 | {CL_DEVICE_MAX_CONSTANT_ARGS_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_CONSTANT_ARGS.asciidoc[]
   | {cl_uint_TYPE}
       | Max number of arguments declared with the `+__constant+` qualifier
         in a kernel.
-        The minimum value is 8 for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 8.
 | {CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE.asciidoc[]
@@ -1086,8 +1079,7 @@ include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_TYPE.asciidoc[]
 include::{generated}/api/version-notes/CL_DEVICE_LOCAL_MEM_SIZE.asciidoc[]
   | {cl_ulong_TYPE}
       | Size of local memory region in bytes.
-        The minimum value is 32 KB for devices that are not of type
-        {CL_DEVICE_TYPE_CUSTOM}.
+        The minimum value is 32 KB.
 | {CL_DEVICE_ERROR_CORRECTION_SUPPORT_anchor}
 
 include::{generated}/api/version-notes/CL_DEVICE_ERROR_CORRECTION_SUPPORT.asciidoc[]


### PR DESCRIPTION
No guarantees are provided by custom devices at all. We should not call this out for specific queries.


Change-Id: I7bf1730a94b72e1575f0703f42beb016b6a63d12