### PR TITLE
Clarify setting `work_dim` to zero in command-buffer update

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -16665,7 +16665,7 @@ conditions:
    _command_buffer_.
   * {CL_INVALID_OPERATION} if the values of _local_work_size_ and/or
     _global_work_size_ result in a change to work-group uniformity.
-  * {CL_INVALID_OPERATION} if the _work_dim_ is different from the
+  * {CL_INVALID_OPERATION} if _work_dim_ is not zero and different from the
     _work_dim_ set on _command_ recording.
   * {CL_INVALID_OPERATION} if the {CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR}
     property was not set on _command_ recording and _global_work_offset_ is
@@ -16726,8 +16726,8 @@ include::{generated}/api/structs/cl_mutable_dispatch_config_khr.txt[]
   * _num_exec_infos_ is the number of kernel execution info objects to set
     for this dispatch.
   * _work_dim_ is the number of dimensions used to specify the global
-    work-items and work-items in the work-group.
-    See {clEnqueueNDRangeKernel} for valid usage.
+    work-items and work-items in the work-group. May be set to zero to signify
+    the number of dimensions is not changed. See {clEnqueueNDRangeKernel} for valid usage.
   * _arg_list_ is an array describing the new kernel arguments for this
     enqueue.
     It must contain _num_args_ array elements, each of which encapsulates


### PR DESCRIPTION
Progresses Issue https://github.com/KhronosGroup/OpenCL-Docs/issues/1390 by clarifying that `work_dim` can be set to zero to signify no change to the kernle command work dimensions. This is the behavior currently expected in the CTS tests.

Note I have a comment in that issue about further changes we may want to make https://github.com/KhronosGroup/OpenCL-Docs/issues/1390#issuecomment-2984048935