### PR TITLE
Add vec16 types for short types

### DIFF
--- a/extensions/cl_intel_subgroup_local_block_io.asciidoc
+++ b/extensions/cl_intel_subgroup_local_block_io.asciidoc
@@ -115,6 +115,12 @@ void  intel_sub_group_block_write_us( __local ushort* p, ushort data )
 void  intel_sub_group_block_write_us2( __local ushort* p, ushort2 data )
 void  intel_sub_group_block_write_us4( __local ushort* p, ushort4 data )
 void  intel_sub_group_block_write_us8( __local ushort* p, ushort8 data )
+
+/* Extension version 1.1 adds the functions: */
+
+ushort16 intel_sub_group_block_read_us16( const __local ushort* p )
+
+void intel_sub_group_block_write_us16( __local ushort* p, ushort16 data )
 ----
 
 If `cl_intel_subgroups_long` is supported, add variants of the `ulong` subgroup block read and write functions that support loading from and storing to pointers to the `+__local+` address space:
@@ -318,9 +324,17 @@ ushort4 intel_sub_group_block_read_us4(
           const __local ushort* p )
 ushort8 intel_sub_group_block_read_us8(
           const __local ushort* p )
+
+/* For extension version 1.1 or newer: */
+
+ushort16 intel_sub_group_block_read_us16(
+          const __global ushort* p )
+
+ushort16 intel_sub_group_block_read_us16(
+          const __local ushort* p )
 ----
 
-| Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified pointer as a block operation...
+| Reads 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the subgroup from the specified pointer as a block operation...
 
 |[source,opencl_c]
 ----
@@ -341,9 +355,17 @@ void  intel_sub_group_block_write_us4(
         __local ushort* p, ushort4 data )
 void  intel_sub_group_block_write_us8(
         __local ushort* p, ushort8 data )
+
+/* For extension version 1.1 or newer: */
+
+void  intel_sub_group_block_write_us16(
+        __global ushort* p, ushort16 data )
+
+void  intel_sub_group_block_write_us16(
+        __local ushort* p, ushort16 data )
 ----
 
-| Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified pointer as a block operation...
+| Writes 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the subgroup to the specified pointer as a block operation...
 
 |==================================
 
@@ -468,6 +490,7 @@ For consistency with `cl_intel_subgroups` we should include both the un-suffixed
 |========================================
 |Rev|Date|Author|Changes
 |1.0.0|2023-11-29|Ben Ashbaugh|*Initial revision for publication*
+|1.1.0|2025-07-01|Gergely Meszaros|Added vec16 types for short block reads and writes
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
Match cl_intel_subgroups_short version 1.1 and add vec16 types for block reads and writes for shorts.