### PR TITLE
cl_intel_unified_shared_memory version 1.2

### DIFF
--- a/extensions/cl_intel_unified_shared_memory.asciidoc
+++ b/extensions/cl_intel_unified_shared_memory.asciidoc
@@ -953,6 +953,7 @@ _ptr_ is a pointer to the start of the shared Unified Shared Memory allocation t
 _size_ describes the size of the memory region to migrate.
 
 _flags_ is a bit-field that is used to specify memory migration options.
+The set of supported memory migration flags is described in the https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#migration-flags-table[Memory Migration Flags] table.
 
 _event_wait_list_ and _num_events_in_wait_list_ specify events that need to complete before this command can be executed.
 If _event_wait_list_ is `NULL`, then this command does not wait on any event to complete.
@@ -966,13 +967,21 @@ _event_ returns a unique event object that identifies this command.
 If _event_ is `NULL`, no event will be created and therefore it will not be possible to query or wait for this command.
 If the _event_wait_list_ and the _event_ arguments are not `NULL`, the _event_ argument must not refer to an element of the _event_wait_list_ array.
 
+[[valid-migration-flags-definition]]
+The definition of valid _flags_ was changed in extension version 1.2.0:
+
+* For extension versions prior to version 1.2.0:
+_flags_ equal to zero was considered invalid.
+* For extension versions 1.2.0 and newer:
+_flags_ equal to zero is valid and indicates that the memory should be migrated to the device associated with _command_queue_, similar to *clEnqueueMigrateMemObjects* and *clEnqueueSVMMigrateMem*.
+
 *clEnqueueMigrateMemINTEL* returns CL_SUCCESS if the command is queued successfully.
 Otherwise, it will return one of the following errors:
 
 * `CL_INVALID_COMMAND_QUEUE` if _command_queue_ is not a valid host command-queue.
 * `CL_INVALID_CONTEXT` if the context associated with _command_queue_ and events in _event_wait_list_ are not the same.
-* `CL_INVALID_VALUE` **TODO**, are any values of _ptr_ and _size_ considered invalid?
-* `CL_INVALID_VALUE` if _flags_ is zero or is not a supported combination of memory migration flags.
+//* `CL_INVALID_VALUE` **TODO**, are any values of _ptr_ and _size_ considered invalid?
+* `CL_INVALID_VALUE` if _flags_ is not a supported combination of memory migration flags.
 * `CL_INVALID_EVENT_WAIT_LIST` if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero, or if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero, or if event objects in _event_wait_list_ are not valid events.
 * `CL_OUT_OF_RESOURCES` if there is a failure to allocate resources required by the OpenCL implementation on the device.
 * `CL_OUT_OF_HOST_MEMORY` if there is a failure to allocate resources required by the OpenCL implementation on the host.
@@ -1341,6 +1350,7 @@ Note that a USM allocation against a sub-device need not be accessible by its pa
 |1.0.0|2022-11-08|Ben Ashbaugh|Added new issues regarding error behavior for clSetKernelArgMemPointerINTEL and rect copies.
 |1.0.1|2023-08-28|Ben Ashbaugh|Documented error conditions for clSetKernelExecInfo.
 |1.1.0|2024-07-30|Ben Ashbaugh|Modified error behavior for clSetKernelArgMemPointerINTEL and clSetKernelExecInfo.
+|1.2.0|2025-07-07|Ben Ashbaugh|Modified error behavior for clEnqueueMigrateMemINTEL when the migration flags are zero.
 |========================================
 
 //************************************************************************


### PR DESCRIPTION
Updates the cl_intel_unified_shared_memory spec to allow passing memory migration flags equal to zero, to migrate memory to the device associated with the command-queue.  This was the intended behavior, and is consistent with clEnqueueMigrateMemObjects and clEnqueueSVMMigrateMem, but prior versions of the specification incorrectly stated that flags equal to zero was invalid and some devices implemented this error behavior.

By updating the extension version, applications can reliably know when they may pass flags equal to zero without generating an error.