### PR TITLE
clean up inconsistencies for clSetKernelExecInfo error conditions

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11235,20 +11235,18 @@ successfully.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_KERNEL} if _kernel_ is a not a valid kernel object.
-  * {CL_INVALID_OPERATION} for {CL_KERNEL_EXEC_INFO_SVM_PTRS} and
-     {CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM} if no devices in
-     the context associated with _kernel_ support SVM.
-ifdef::cl_ext_buffer_device_address[]
-  * {CL_INVALID_OPERATION} for {CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT} if no
-  device in the context associated with _kernel_ support the {cl_ext_buffer_device_address_EXT}
-  extension.
-endif::cl_ext_buffer_device_address[]
-  * {CL_INVALID_VALUE} if _param_name_ is not valid, if _param_value_ is
-    `NULL` or if the size specified by _param_value_size_ is not valid.
+  * {CL_INVALID_OPERATION} if _param_name is {CL_KERNEL_EXEC_INFO_SVM_PTRS} and
+    no devices in the context associated with _kernel_ support SVM.
   * {CL_INVALID_OPERATION} if _param_name_ is
     {CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM} and _param_value_ is {CL_TRUE}
     and no devices in the context associated with _kernel_ support fine-grain
     system SVM allocations.
+ifdef::cl_ext_buffer_device_address[]
+  * {CL_INVALID_OPERATION} if _param_name_ is
+    {CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT} and no devices in the context
+    associated with _kernel_ support the {cl_ext_buffer_device_address_EXT}
+    extension.
+endif::cl_ext_buffer_device_address[]
   * {CL_INVALID_VALUE} if _param_name_ is not valid, if _param_value_ is
     `NULL` and _param_value_size_ is greater than zero, or if the size specified
     by _param_value_size_ is not valid.


### PR DESCRIPTION
fixes #1413

It is only a `CL_INVALID_VALUE` error when _param_value_ is `NULL` if _param_value_size_ is greater than zero.

Also tidies up a few of the `CL_INVALID_OPERATION` error conditions.