### PR TITLE
XML: add cl_properties to OpenCL 1.0 requirements

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -4429,6 +4429,7 @@ server's OpenCL/api-docs repository.
             <type name="cl_sampler"/>
             <type name="cl_bool" comment="WARNING! Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels."/>
             <type name="cl_bitfield"/>
+            <type name="cl_properties"/>
             <type name="cl_device_type"/>
             <type name="cl_platform_info"/>
             <type name="cl_device_info"/>


### PR DESCRIPTION
`cl_queue_properties` is defined as `cl_properties`, so I think OpenCL 1.0 should require `cl_properties` too.