### PR TITLE
error code consistency for contexts

### DIFF
--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -3195,7 +3195,7 @@ returned in _errcode_ret_:
   * {CL_INVALID_PROPERTY}
     ** if a context property name in _properties_ is not a supported property name
     ** if the value specified for a supported property name is not valid
-    ** if the same property name is specified more than once.
+    ** if the same property name is specified more than once
   * {CL_INVALID_VALUE}
     ** if _devices_ is `NULL`
     ** if _num_devices_ is equal to zero
@@ -3286,7 +3286,7 @@ extension is supported:
     *** Any of the devices specified in the _devices_ argument cannot support
       OpenCL objects which share the data store of an OpenGL object.
   * {CL_INVALID_PROPERTY}
-    * if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of the properties defined
+    ** if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of the properties defined
     by the {cl_khr_gl_sharing_EXT} extension are defined in _properties_
 endif::cl_khr_gl_sharing[]
 
@@ -3353,7 +3353,7 @@ returned in _errcode_ret_:
 
   * {CL_INVALID_PLATFORM}
     ** if no platform is specified in _properties_ and no platform could be
-    selected,
+    selected
     ** if the platform specified in _properties_ is not a valid platform
   * {CL_INVALID_PROPERTY}
     ** if a context property name in _properties_ is not a supported property name
@@ -3396,7 +3396,7 @@ extension is supported:
     ** if the value of the property {CL_CONTEXT_D3D10_DEVICE_KHR} is non-`NULL`
     and does not specify a valid Direct3D 10 device with which the
     _cl_device_ids_ against which this context is to be created may
-    interoperate.
+    interoperate
   * {CL_INVALID_OPERATION}
     ** if Direct3D 10 interoperability is specified by setting
     {CL_INVALID_D3D10_DEVICE_KHR} to a non-`NULL` value and interoperability
@@ -3411,7 +3411,7 @@ extension is supported:
     ** if the value of the property {CL_CONTEXT_D3D11_DEVICE_KHR} is non-`NULL`
     and does not specify a valid Direct3D 11 device with which the
     _cl_device_ids_ against which this context is to be created may
-    interoperate.
+    interoperate
   * {CL_INVALID_OPERATION}
     ** if Direct3D 11 interoperability is specified by setting
     {CL_INVALID_D3D11_DEVICE_KHR} to a non-`NULL` value and interoperability
@@ -3701,7 +3701,7 @@ Otherwise, it returns one of the following errors:
     ** if _param_name_ is not one of the supported values
     ** if the size in bytes specified by _param_value_size_ is less than size of
     the return type specified in the <<context-info-table, Context Queries>>
-    table and _param_value_ is not `NULL`.
+    table and _param_value_ is not `NULL`
   * {CL_OUT_OF_RESOURCES}
     ** if there is a failure to allocate resources required by the OpenCL
     implementation on the device

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -3188,110 +3188,118 @@ to {CL_SUCCESS} if the context is created successfully.
 Otherwise, it returns a `NULL` value with the following error values
 returned in _errcode_ret_:
 
-  * {CL_INVALID_PLATFORM} if no platform is specified in _properties_ and no
-    platform could be selected, or if the platform specified in _properties_ is
-    not a valid platform.
-  * {CL_INVALID_PROPERTY} if a context property name in _properties_ is not a
-    supported property name, if the value specified for a supported property
-    name is not valid, or if the same property name is specified more than
-    once.
-    This error code is <<unified-spec, missing before>> version 1.1.
-  * {CL_INVALID_VALUE} if _devices_ is `NULL`.
-  * {CL_INVALID_VALUE} if _num_devices_ is equal to zero.
-  * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
-    `NULL`.
-  * {CL_INVALID_DEVICE} if any device in _devices_ is not a valid device.
-  * {CL_DEVICE_NOT_AVAILABLE} if a device in _devices_ is currently not
-    available even though the device was returned by {clGetDeviceIDs}.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_PLATFORM}
+    ** if no platform is specified in _properties_ and no platform could be
+    selected
+    ** if the platform specified in _properties_ is not a valid platform
+  * {CL_INVALID_PROPERTY}
+    ** if a context property name in _properties_ is not a supported property name
+    ** if the value specified for a supported property name is not valid
+    ** if the same property name is specified more than once.
+  * {CL_INVALID_VALUE}
+    ** if _devices_ is `NULL`
+    ** if _num_devices_ is equal to zero
+    ** if _pfn_notify_ is `NULL` and _user_data_ is not `NULL`
+  * {CL_INVALID_DEVICE}
+    ** if any device in _devices_ is not a valid device
+  * {CL_DEVICE_NOT_AVAILABLE}
+    ** if a device in _devices_ is currently not available
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 ifdef::cl_khr_dx9_media_sharing[]
 The following errors may be returned if the {cl_khr_dx9_media_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_DX9_MEDIA_ADAPTER_KHR} if any of the values of the
-    properties {CL_CONTEXT_ADAPTER_D3D9_KHR},
+  * {CL_INVALID_DX9_MEDIA_ADAPTER_KHR}
+    ** if any of the values of the properties {CL_CONTEXT_ADAPTER_D3D9_KHR},
     {CL_CONTEXT_ADAPTER_D3D9EX_KHR} or {CL_CONTEXT_ADAPTER_DXVA_KHR} is
     non-`NULL` and does not specify a valid media adapter with which the
     _cl_device_ids_ against which this context is to be created may
-    interoperate.
+    interoperate
 endif::cl_khr_dx9_media_sharing[]
 
 ifdef::cl_khr_d3d10_sharing[]
 The following errors may be returned if the {cl_khr_d3d10_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_D3D10_DEVICE_KHR} if the value of the property
-    {CL_CONTEXT_D3D10_DEVICE_KHR} is non-`NULL` and does not specify a valid
-    Direct3D 10 device with which the _cl_device_ids_ against which this
-    context is to be created may interoperate.
-  * {CL_INVALID_OPERATION} if Direct3D 10 interoperability is specified by
-    setting {CL_INVALID_D3D10_DEVICE_KHR} to a non-`NULL` value, and
-    interoperability with another graphics API is also specified.
+  * {CL_INVALID_D3D10_DEVICE_KHR}
+    ** if the value of the property {CL_CONTEXT_D3D10_DEVICE_KHR} is non-`NULL`
+    and does not specify a valid Direct3D 10 device with which the
+    _cl_device_ids_ against which this context is to be created may
+    interoperate
+  * {CL_INVALID_OPERATION}
+    ** if Direct3D 10 interoperability is specified by setting
+    {CL_INVALID_D3D10_DEVICE_KHR} to a non-`NULL` value and interoperability
+    with another graphics API is also specified
 endif::cl_khr_d3d10_sharing[]
 
 ifdef::cl_khr_d3d11_sharing[]
 The following errors may be returned if the {cl_khr_d3d11_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_D3D11_DEVICE_KHR} if the value of the property
-    {CL_CONTEXT_D3D11_DEVICE_KHR} is non-`NULL` and does not specify a valid
-    Direct3D 11 device with which the _cl_device_ids_ against which this
-    context is to be created may interoperate.
-  * {CL_INVALID_OPERATION} if Direct3D 11 interoperability is specified by
-    setting {CL_INVALID_D3D11_DEVICE_KHR} to a non-`NULL` value, and
-    interoperability with another graphics API is also specified.
+  * {CL_INVALID_D3D11_DEVICE_KHR}
+    ** if the value of the property {CL_CONTEXT_D3D11_DEVICE_KHR} is non-`NULL`
+    and does not specify a valid Direct3D 11 device with which the
+    _cl_device_ids_ against which this context is to be created may
+    interoperate
+  * {CL_INVALID_OPERATION}
+    ** if Direct3D 11 interoperability is specified by setting
+    {CL_INVALID_D3D11_DEVICE_KHR} to a non-`NULL` value and interoperability
+    with another graphics API is also specified
 endif::cl_khr_d3d11_sharing[]
 
 ifdef::cl_khr_gl_sharing[]
 The following errors may be returned if the {cl_khr_gl_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR} if a context was specified for
-    an OpenGL or OpenGL ES implementation using the EGL, GLX, or WGL binding
-    APIs, as <<specifying-gl-context, described above>>; and any of the
-    following conditions hold:
-  ** The specified display and context properties do not identify a valid
-     OpenGL or OpenGL ES context.
-  ** The specified context does not support buffer and renderbuffer objects.
-  ** The specified context is not compatible with the OpenCL context being
-     created (for example, it exists in a physically distinct address space,
-     such as another hardware device; or it does not support sharing data
-     with OpenCL due to implementation restrictions).
-  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR} if a share group was specified
-    for a CGL-based OpenGL implementation by setting the property
-    {CL_CGL_SHAREGROUP_KHR}, and the specified share group does not identify
-    a valid CGL share group object.
-  * {CL_INVALID_OPERATION} if a context was specified as described above and
-    any of the following conditions hold:
-  ** A context or share group object was specified for one of CGL, EGL, GLX,
-     or WGL and the OpenGL implementation does not support that
-     window-system binding API.
-  ** More than one of the properties {CL_CGL_SHAREGROUP_KHR},
-     {CL_EGL_DISPLAY_KHR}, {CL_GLX_DISPLAY_KHR}, and {CL_WGL_HDC_KHR} is set
-     to a non-default value.
-  ** Both of the properties {CL_CGL_SHAREGROUP_KHR} and {CL_GL_CONTEXT_KHR}
-     are set to non-default values.
-  ** Any of the devices specified in the _devices_ argument cannot support
-     OpenCL objects which share the data store of an OpenGL object.
-  * {CL_INVALID_PROPERTY} if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of
-    the properties defined by the {cl_khr_gl_sharing_EXT} extension are
-    defined in _properties_.
+  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR}
+    ** if a context was specified for an OpenGL or OpenGL ES implementation
+    using the EGL, GLX, or WGL binding APIs, as <<specifying-gl-context,
+    described above>>; and any of the following conditions hold:
+    *** The specified display and context properties do not identify a valid
+      OpenGL or OpenGL ES context.
+    *** The specified context does not support buffer and renderbuffer objects.
+    *** The specified context is not compatible with the OpenCL context being
+      created (for example, it exists in a physically distinct address space,
+      such as another hardware device; or it does not support sharing data with
+      OpenCL due to implementation restrictions).
+  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR}
+    ** if a share group was specified for a CGL-based OpenGL implementation by
+    setting the property {CL_CGL_SHAREGROUP_KHR}, and the specified share group
+    does not identify a valid CGL share group object
+  * {CL_INVALID_OPERATION}
+    ** if a context was specified as described above and any of the following
+    conditions hold:
+    *** A context or share group object was specified for one of CGL, EGL, GLX,
+      or WGL and the OpenGL implementation does not support that window-system
+      binding API.
+    *** More than one of the properties {CL_CGL_SHAREGROUP_KHR},
+      {CL_EGL_DISPLAY_KHR}, {CL_GLX_DISPLAY_KHR}, and {CL_WGL_HDC_KHR} is set to
+      a non-default value.
+    *** Both of the properties {CL_CGL_SHAREGROUP_KHR} and {CL_GL_CONTEXT_KHR}
+      are set to non-default values.
+    *** Any of the devices specified in the _devices_ argument cannot support
+      OpenCL objects which share the data store of an OpenGL object.
+  * {CL_INVALID_PROPERTY}
+    * if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of the properties defined
+    by the {cl_khr_gl_sharing_EXT} extension are defined in _properties_
 endif::cl_khr_gl_sharing[]
 
 ifdef::cl_khr_terminate_context[]
 The following errors may be returned if the {cl_khr_terminate_context_EXT}
 extension is supported:
 
-  * {CL_INVALID_PROPERTY} if the {cl_khr_terminate_context_EXT} extension is
-    supported and {CL_CONTEXT_TERMINATE_KHR} is set to {CL_TRUE} in
-    _properties_, but not all of the devices associated with the context
-    support the ability to support context termination (i.e.
-    {CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR} is set for
-    {CL_DEVICE_TERMINATE_CAPABILITY_KHR}).
+  * {CL_INVALID_PROPERTY}
+    ** if the {cl_khr_terminate_context_EXT} extension is supported and
+    {CL_CONTEXT_TERMINATE_KHR} is set to {CL_TRUE} in _properties_, but not all
+    of the devices associated with the context support the ability to support
+    context termination (i.e. {CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR} is
+    set for {CL_DEVICE_TERMINATE_CAPABILITY_KHR})
 endif::cl_khr_terminate_context[]
 
 [NOTE]
@@ -3301,8 +3309,8 @@ command-queues that use this device(s) have been created and commands have
 been queued to command-queues.
 In this case the behavior of OpenCL API calls that use this context (and
 command-queues) are considered to be implementation-defined.
-The user callback function, if specified, when the context is created can be
-used to record appropriate information in the _errinfo_, _private_info_
+The user callback function, if specified when the context is created, can be
+used to record appropriate information in the _errinfo_ and _private_info_
 arguments passed to the callback function when the device becomes
 unavailable.
 ====
@@ -3343,100 +3351,109 @@ is set to {CL_SUCCESS} if the context is created successfully.
 Otherwise, it returns a `NULL` value with the following error values
 returned in _errcode_ret_:
 
-  * {CL_INVALID_PLATFORM} if no platform is specified in _properties_ and no
-    platform could be selected, or if the platform specified in _properties_ is
-    not a valid platform.
-  * {CL_INVALID_PROPERTY} if a context property name in _properties_ is not a
-    supported property name, if the value specified for a supported property
-    name is not valid, or if the same property name is specified more than
-    once.
-    This error code is <<unified-spec, missing before>> version 1.1.
-  * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL` but _user_data_ is not
-    `NULL`.
-  * {CL_INVALID_DEVICE_TYPE} if _device_type_ is not a valid value.
-  * {CL_DEVICE_NOT_AVAILABLE} if no devices that match _device_type_ and
-    property values specified in _properties_ are currently available.
-  * {CL_DEVICE_NOT_FOUND} if no devices that match _device_type_ and property
-    values specified in _properties_ were found.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_PLATFORM}
+    ** if no platform is specified in _properties_ and no platform could be
+    selected,
+    ** if the platform specified in _properties_ is not a valid platform
+  * {CL_INVALID_PROPERTY}
+    ** if a context property name in _properties_ is not a supported property name
+    ** if the value specified for a supported property name is not valid
+    ** if the same property name is specified more than once
+  * {CL_INVALID_VALUE}
+    ** if _pfn_notify_ is `NULL` and _user_data_ is not `NULL`
+  * {CL_INVALID_DEVICE_TYPE}
+    ** if _device_type_ is not a valid value
+  * {CL_DEVICE_NOT_AVAILABLE}
+    ** if no devices that match _device_type_ and property values specified in
+    _properties_ are currently available
+  * {CL_DEVICE_NOT_FOUND}
+    ** if no devices that match _device_type_ and property values specified in
+    _properties_ were found
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 ifdef::cl_khr_dx9_media_sharing[]
 The following errors may be returned if the {cl_khr_dx9_media_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_DX9_MEDIA_ADAPTER_KHR} if any of the values of the
-    properties {CL_CONTEXT_ADAPTER_D3D9_KHR},
+  * {CL_INVALID_DX9_MEDIA_ADAPTER_KHR}
+    ** if any of the values of the properties {CL_CONTEXT_ADAPTER_D3D9_KHR},
     {CL_CONTEXT_ADAPTER_D3D9EX_KHR} or {CL_CONTEXT_ADAPTER_DXVA_KHR} is
     non-`NULL` and does not specify a valid media adapter with which the
     _cl_device_ids_ against which this context is to be created may
-    interoperate.
+    interoperate
 endif::cl_khr_dx9_media_sharing[]
 
 ifdef::cl_khr_d3d10_sharing[]
 The following errors may be returned if the {cl_khr_d3d10_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_D3D10_DEVICE_KHR} if the value of the property
-    {CL_CONTEXT_D3D10_DEVICE_KHR} is non-`NULL` and does not specify a valid
-    Direct3D 10 device with which the _cl_device_ids_ against which this
-    context is to be created may interoperate.
-  * {CL_INVALID_OPERATION} if Direct3D 10 interoperability is specified by
-    setting {CL_INVALID_D3D10_DEVICE_KHR} to a non-`NULL` value, and
-    interoperability with another graphics API is also specified.
+  * {CL_INVALID_D3D10_DEVICE_KHR}
+    ** if the value of the property {CL_CONTEXT_D3D10_DEVICE_KHR} is non-`NULL`
+    and does not specify a valid Direct3D 10 device with which the
+    _cl_device_ids_ against which this context is to be created may
+    interoperate.
+  * {CL_INVALID_OPERATION}
+    ** if Direct3D 10 interoperability is specified by setting
+    {CL_INVALID_D3D10_DEVICE_KHR} to a non-`NULL` value and interoperability
+    with another graphics API is also specified
 endif::cl_khr_d3d10_sharing[]
 
 ifdef::cl_khr_d3d11_sharing[]
 The following errors may be returned if the {cl_khr_d3d11_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_D3D11_DEVICE_KHR} if the value of the property
-    {CL_CONTEXT_D3D11_DEVICE_KHR} is non-`NULL` and does not specify a valid
-    Direct3D 11 device with which the _cl_device_ids_ against which this
-    context is to be created may interoperate.
-  * {CL_INVALID_OPERATION} if Direct3D 11 interoperability is specified by
-    setting {CL_INVALID_D3D11_DEVICE_KHR} to a non-`NULL` value, and
-    interoperability with another graphics API is also specified.
+  * {CL_INVALID_D3D11_DEVICE_KHR}
+    ** if the value of the property {CL_CONTEXT_D3D11_DEVICE_KHR} is non-`NULL`
+    and does not specify a valid Direct3D 11 device with which the
+    _cl_device_ids_ against which this context is to be created may
+    interoperate.
+  * {CL_INVALID_OPERATION}
+    ** if Direct3D 11 interoperability is specified by setting
+    {CL_INVALID_D3D11_DEVICE_KHR} to a non-`NULL` value and interoperability
+    with another graphics API is also specified
 endif::cl_khr_d3d11_sharing[]
 
 ifdef::cl_khr_gl_sharing[]
 The following errors may be returned if the {cl_khr_gl_sharing_EXT}
 extension is supported:
 
-  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR} if a context was specified for
-    an OpenGL or OpenGL ES implementation using the EGL, GLX, or WGL binding
-    APIs, as <<specifying-gl-context, described for `clCreateContext`>>; and
-    any of the following conditions hold:
-  ** The specified display and context properties do not identify a valid
-     OpenGL or OpenGL ES context.
-  ** The specified context does not support buffer and renderbuffer objects.
-  ** The specified context is not compatible with the OpenCL context being
-     created (for example, it exists in a physically distinct address space,
-     such as another hardware device; or it does not support sharing data
-     with OpenCL due to implementation restrictions).
-  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR} if a share group was specified
-    for a CGL-based OpenGL implementation by setting the property
-    {CL_CGL_SHAREGROUP_KHR}, and the specified share group does not identify
-    a valid CGL share group object.
-  * {CL_INVALID_OPERATION} if a context was specified as described above and
-    any of the following conditions hold:
-  ** A context or share group object was specified for one of CGL, EGL, GLX,
-     or WGL and the OpenGL implementation does not support that
-     window-system binding API.
-  ** More than one of the properties {CL_CGL_SHAREGROUP_KHR},
-     {CL_EGL_DISPLAY_KHR}, {CL_GLX_DISPLAY_KHR}, and {CL_WGL_HDC_KHR} is set
-     to a non-default value.
-  ** Both of the properties {CL_CGL_SHAREGROUP_KHR} and {CL_GL_CONTEXT_KHR}
-     are set to non-default values.
-  ** Any of the devices specified in the _devices_ argument cannot support
-     OpenCL objects which share the data store of an OpenGL object.
-  * {CL_INVALID_PROPERTY} if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of
-    the properties defined by the {cl_khr_gl_sharing_EXT} extension are
-    defined in _properties_.
+  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR}
+    ** if a context was specified for an OpenGL or OpenGL ES implementation
+    using the EGL, GLX, or WGL binding APIs, as <<specifying-gl-context,
+    described for `clCreateContext`>>; and any of the following conditions hold:
+    *** The specified display and context properties do not identify a valid
+      OpenGL or OpenGL ES context.
+    *** The specified context does not support buffer and renderbuffer objects.
+    *** The specified context is not compatible with the OpenCL context being
+      created (for example, it exists in a physically distinct address space,
+      such as another hardware device; or it does not support sharing data with
+      OpenCL due to implementation restrictions).
+  * {CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR}
+    ** if a share group was specified for a CGL-based OpenGL implementation by
+    setting the property {CL_CGL_SHAREGROUP_KHR}, and the specified share group
+    does not identify a valid CGL share group object
+  * {CL_INVALID_OPERATION}
+    ** if a context was specified as described above and any of the following
+    conditions hold:
+    *** A context or share group object was specified for one of CGL, EGL, GLX,
+      or WGL and the OpenGL implementation does not support that window-system
+      binding API.
+    *** More than one of the properties {CL_CGL_SHAREGROUP_KHR},
+      {CL_EGL_DISPLAY_KHR}, {CL_GLX_DISPLAY_KHR}, and {CL_WGL_HDC_KHR} is set to
+      a non-default value.
+    *** Both of the properties {CL_CGL_SHAREGROUP_KHR} and {CL_GL_CONTEXT_KHR}
+      are set to non-default values.
+    *** Any of the devices specified in the _devices_ argument cannot support
+      OpenCL objects which share the data store of an OpenGL object.
+  * {CL_INVALID_PROPERTY}
+    ** if both {CL_CONTEXT_INTEROP_USER_SYNC}, and any of the properties defined
+    by the {cl_khr_gl_sharing_EXT} extension are defined in _properties_
 endif::cl_khr_gl_sharing[]
-
 --
 
 [open,refpage='clRetainContext',desc='Retain an OpenCL context',type='protos',xrefs='clCreateContext clReleaseContext']
@@ -3464,11 +3481,14 @@ the problem of a context being used by a library no longer being valid.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_CONTEXT} if _context_ is not a valid OpenCL context.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_CONTEXT}
+    ** if _context_ is not a valid OpenCL context
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clReleaseContext',desc='Release an OpenCL context',type='protos',xrefs='clCreateContext clRetainContext']
@@ -3495,11 +3515,14 @@ the object or by calling {clRetainContext} causes undefined behavior.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_CONTEXT} if _context_ is not a valid OpenCL context.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_CONTEXT}
+    ** if _context_ is not a valid OpenCL context
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 ifdef::cl_khr_terminate_context[]
@@ -3553,14 +3576,19 @@ When a context is terminated:
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_CONTEXT} if _context_ is not a valid OpenCL context.
-  * {CL_CONTEXT_TERMINATED_KHR} if _context_ has already been terminated.
-  * {CL_INVALID_OPERATION} if _context_ was not created with
-    {CL_CONTEXT_TERMINATE_KHR} set to {CL_TRUE}.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
-    required by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_CONTEXT}
+    ** if _context_ is not a valid OpenCL context
+  * {CL_CONTEXT_TERMINATED_KHR}
+    ** if _context_ has already been terminated
+  * {CL_INVALID_OPERATION}
+    ** if _context_ was not created with {CL_CONTEXT_TERMINATE_KHR} set to
+    {CL_TRUE}
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 An implementation that supports this extension must be able to terminate
 commands currently executing on devices or queued across all command-queues
@@ -3667,16 +3695,19 @@ endif::cl_khr_d3d11_sharing[]
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values, or
-    if the size in bytes specified by _param_value_size_ is less than size of
-    the return type specified in the
-    <<context-info-table, Context Queries>> table
-    and _param_value_ is not `NULL`.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_CONTEXT}
+    ** if _context_ is not a valid context
+  * {CL_INVALID_VALUE}
+    ** if _param_name_ is not one of the supported values
+    ** if the size in bytes specified by _param_value_size_ is less than size of
+    the return type specified in the <<context-info-table, Context Queries>>
+    table and _param_value_ is not `NULL`.
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clSetContextDestructorCallback',desc='Registers a destructor callback function with a context.',type='protos']
@@ -3719,11 +3750,15 @@ context callback function when _context_ was created.
 executed successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
-  * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL`.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_CONTEXT}
+    ** if _context_ is not a valid context
+  * {CL_INVALID_VALUE}
+    ** if _pfn_notify_ is `NULL`
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 


### PR DESCRIPTION
This is a PR to partially address the way we document error conditions, see https://github.com/KhronosGroup/OpenCL-Docs/issues/1320 and in particular https://github.com/KhronosGroup/OpenCL-Docs/issues/1320#issuecomment-2745919727.

It contains a subset of the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/1399, specifically for contexts.