### PR TITLE
allow optional image operands for image write instructions

### DIFF
--- a/env/validation_rules.asciidoc
+++ b/env/validation_rules.asciidoc
@@ -32,12 +32,9 @@ For all *OpTypeImage* type-declaration instructions:
   * _Image Format_ must be *Unknown*, indicating that the image does not
      have a specified format.
   * The optional image _Access Qualifier_ must be present.
-  
-The image write instruction *OpImageWrite* must not include any optional
-_Image Operands_.
 
-The image read instructions *OpImageRead* and *OpImageSampleExplicitLod* 
-must not include the optional _Image Operand_ *ConstOffset*.
+For all image read and write instructions, if an optional _Image Operand_ is
+present, then it must not include *ConstOffset*.
 
 For all *Atomic Instructions*:
 


### PR DESCRIPTION
fixes #854 

The OpenCL SPIR-V environment spec currently says that image write instructions must not include an optional _Image Operand_.  While this was borderline true in the past - there was no usage with core OpenCL functionality, but it was used by `cl_khr_mipmap_image_writes` to pass the **Lod** - it is definitely no longer true now for things like **Nontemporal**.  So, instead of banning an _Image Operand_ for image write instructions, we can instead apply the same restrictions to image write instructions that we apply to image read instructions.

Additional notes:

* If we chose to, we could support the **ConstOffset** _Image Operand_ also, so long as the only supported **ConstOffset** is all zeroes.  This isn't very useful, though, and we would need to add it to the SPIR-V LLVM Translator, and we would need additional testing.
* Here is a test that passes the optional _Image Operand_ **Nontemporal** to **OpImageWrite**: https://github.com/KhronosGroup/OpenCL-CTS/blob/e936977934ac450d8bb7c66635c02105a29f7ea8/test_conformance/spirv_new/spirv_asm/spv1.6/image_operand_nontemporal.spvasm64#L28
* I don't see any tests that pass the optional _Image Operand_ **SignExtend** or **ZeroExtend** to **OpImageWrite**, either in the CTS or in the SPIR-V LLVM Translator tests.  Is this something we should add, or am I just not finding it?