### PR TITLE
add cl_khr_unified_svm to the main OpenCL specification and XML file

### DIFF
--- a/api/cl_khr_unified_svm.asciidoc
+++ b/api/cl_khr_unified_svm.asciidoc
@@ -1,0 +1,101 @@
+// Copyright 2025 The Khronos Group Inc.
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}cl_khr_unified_svm.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2025-08-30
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Brice Videau, Argonne National Laboratory
+  - Kévin Petit, Arm Ltd.
+  - Ewan Crawford, Codeplay Software Ltd.
+  - Paul Fradgley, Imagination Technologies
+  - Ben Ashbaugh, Intel
+  - Pekka Jääskeläinen, Intel
+  - Nikhil Joshi, NVIDIA
+  - Balaji Calidas, Qualcomm Technologies Inc.
+
+=== Description
+
+This extension adds additional types of Shared Virtual Memory (SVM) to OpenCL.
+
+The extension is still under development.
+To learn more about the APIs proposed for this extension, or to provide feedback, please visit:
+
+https://github.com/KhronosGroup/OpenCL-Docs/pull/1282
+
+=== New Commands
+
+  * {clSVMAllocWithPropertiesKHR}[[clSVMAllocWithPropertiesKHR]]
+  * {clSVMFreeWithPropertiesKHR}[[clSVMFreeWithPropertiesKHR]]
+  * {clGetSVMPointerInfoKHR}[[clGetSVMPointerInfoKHR]]
+  * {clGetSVMSuggestedTypeIndexKHR}[[clGetSVMSuggestedTypeIndexKHR]]
+
+=== New Types
+
+  * {cl_svm_capabilities_khr_TYPE}
+  * {cl_svm_alloc_properties_khr_TYPE}
+  * {cl_svm_alloc_access_flags_khr_TYPE}
+  * {cl_svm_free_properties_khr_TYPE}
+  * {cl_svm_free_flags_khr_TYPE}
+  * {cl_svm_pointer_info_khr_TYPE}
+
+=== New Enums
+
+  * {cl_platform_info_TYPE}
+  ** {CL_PLATFORM_SVM_TYPE_CAPABILITIES_KHR_ANCHOR}
+  * {cl_device_info_TYPE}
+  ** {CL_DEVICE_SVM_TYPE_CAPABILITIES_KHR_ANCHOR}
+  * {cl_svm_capabilities_khr_TYPE}
+  ** {CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_SYSTEM_ALLOCATED_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_DEVICE_OWNED_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_HOST_OWNED_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_HOST_READ_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_HOST_WRITE_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_HOST_MAP_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_DEVICE_READ_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_DEVICE_WRITE_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_CONCURRENT_ACCESS_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_CONCURRENT_ATOMIC_ACCESS_KHR_ANCHOR}
+  ** {CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR_ANCHOR}
+  * {cl_svm_alloc_properties_khr_TYPE}
+  ** {CL_SVM_ALLOC_ASSOCIATED_DEVICE_HANDLE_KHR_ANCHOR}
+  ** {CL_SVM_ALLOC_ACCESS_FLAGS_KHR_ANCHOR}
+  ** {CL_SVM_ALLOC_ALIGNMENT_KHR_ANCHOR}
+  * {cl_svm_alloc_access_flags_khr_TYPE}
+  ** {CL_SVM_ALLOC_ACCESS_HOST_NOREAD_KHR_ANCHOR}
+  ** {CL_SVM_ALLOC_ACCESS_HOST_NOWRITE_KHR_ANCHOR}
+  ** {CL_SVM_ALLOC_ACCESS_DEVICE_NOREAD_KHR_ANCHOR}
+  ** {CL_SVM_ALLOC_ACCESS_DEVICE_NOWRITE_KHR_ANCHOR}
+  * {cl_svm_pointer_info_khr_TYPE}
+  ** {CL_SVM_INFO_TYPE_INDEX_KHR_ANCHOR}
+  ** {CL_SVM_INFO_CAPABILITIES_KHR_ANCHOR}
+  ** {CL_SVM_INFO_PROPERTIES_KHR_ANCHOR}
+  ** {CL_SVM_INFO_ACCESS_FLAGS_KHR_ANCHOR}
+  ** {CL_SVM_INFO_BASE_PTR_KHR_ANCHOR}
+  ** {CL_SVM_INFO_SIZE_KHR_ANCHOR}
+  ** {CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR_ANCHOR}
+  * {cl_kernel_exec_info_TYPE}
+  ** {CL_KERNEL_EXEC_INFO_SVM_INDIRECT_ACCESS_KHR_ANCHOR}
+
+=== SVM Type Convenience Macros
+
+  * {CL_SVM_TYPE_MACRO_COARSE_GRAIN_BUFFER_KHR_ANCHOR}
+  * {CL_SVM_TYPE_MACRO_FINE_GRAIN_BUFFER_KHR_ANCHOR}
+  * {CL_SVM_TYPE_MACRO_DEVICE_KHR_ANCHOR}
+  * {CL_SVM_TYPE_MACRO_HOST_KHR_ANCHOR}
+  * {CL_SVM_TYPE_MACRO_SINGLE_DEVICE_SHARED_KHR_ANCHOR}
+  * {CL_SVM_TYPE_MACRO_SYSTEM_KHR_ANCHOR}
+
+=== Version History
+
+  * Revision 0.9.0, 2025-08-30
+  ** Initial revision incorporated into the main specification (experimental).

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -258,6 +258,12 @@ server's OpenCL/api-docs repository.
         <type category="define">typedef <type>cl_bitfield</type>      <name>cl_device_kernel_clock_capabilities_khr</name>;</type>
         <type category="define">typedef <type>cl_ulong</type>         <name>cl_mem_device_address_ext</name>;</type>
         <type category="define">typedef <type>cl_uint</type>          <name>cl_perf_hint_qcom</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_svm_capabilities_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>    <name>cl_svm_alloc_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_svm_alloc_access_flags_khr</name>;</type>
+        <type category="define">typedef <type>cl_properties</type>    <name>cl_svm_free_properties_khr</name>;</type>
+        <type category="define">typedef <type>cl_bitfield</type>      <name>cl_svm_free_flags_khr</name>;</type>
+        <type category="define">typedef <type>cl_uint</type>          <name>cl_svm_pointer_info_khr</name>;</type>
 
             <comment>Structure types</comment>
         <type category="struct" name="cl_dx9_surface_info_khr">
@@ -393,6 +399,69 @@ server's OpenCL/api-docs repository.
 #define CL_ICD2_TAG_KHR ((intptr_t)0x4F50454E434C3331)
 #endif
         </type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_COARSE_GRAIN_BUFFER_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR   | \
+    CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR        | \
+    CL_SVM_CAPABILITY_HOST_MAP_KHR              | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR)</type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_FINE_GRAIN_BUFFER_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR   | \
+    CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR        | \
+    CL_SVM_CAPABILITY_HOST_READ_KHR             | \
+    CL_SVM_CAPABILITY_HOST_WRITE_KHR            | \
+    CL_SVM_CAPABILITY_HOST_MAP_KHR              | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR  | \
+    CL_SVM_CAPABILITY_CONCURRENT_ACCESS_KHR)</type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_DEVICE_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_DEVICE_OWNED_KHR          | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR  | \
+    CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR)</type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_HOST_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR   | \
+    CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR        | \
+    CL_SVM_CAPABILITY_HOST_OWNED_KHR            | \
+    CL_SVM_CAPABILITY_HOST_READ_KHR             | \
+    CL_SVM_CAPABILITY_HOST_WRITE_KHR            | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR)</type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_SINGLE_DEVICE_SHARED_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_HOST_READ_KHR             | \
+    CL_SVM_CAPABILITY_HOST_WRITE_KHR            | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR)</type>
+
+        <type category="define">#define <name>CL_SVM_TYPE_MACRO_SYSTEM_KHR</name> \
+    (CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR | \
+    CL_SVM_CAPABILITY_SYSTEM_ALLOCATED_KHR      | \
+    CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR   | \
+    CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR        | \
+    CL_SVM_CAPABILITY_HOST_READ_KHR             | \
+    CL_SVM_CAPABILITY_HOST_WRITE_KHR            | \
+    CL_SVM_CAPABILITY_HOST_MAP_KHR              | \
+    CL_SVM_CAPABILITY_DEVICE_READ_KHR           | \
+    CL_SVM_CAPABILITY_DEVICE_WRITE_KHR          | \
+    CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR  | \
+    CL_SVM_CAPABILITY_CONCURRENT_ACCESS_KHR     | \
+    CL_SVM_CAPABILITY_CONCURRENT_ATOMIC_ACCESS_KHR | \
+    CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR)</type>
 
     </types>
 
@@ -1251,10 +1320,38 @@ server's OpenCL/api-docs repository.
         <enum bitpos="3"            name="CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL"/>
     </enums>
 
+    <enums name="cl_svm_capabilities_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR"/>
+        <enum bitpos="1"            name="CL_SVM_CAPABILITY_SYSTEM_ALLOCATED_KHR"/>
+        <enum bitpos="2"            name="CL_SVM_CAPABILITY_DEVICE_OWNED_KHR"/>
+        <enum bitpos="3"            name="CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR"/>
+        <enum bitpos="4"            name="CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR"/>
+        <enum bitpos="5"            name="CL_SVM_CAPABILITY_HOST_OWNED_KHR"/>
+        <enum bitpos="6"            name="CL_SVM_CAPABILITY_HOST_READ_KHR"/>
+        <enum bitpos="7"            name="CL_SVM_CAPABILITY_HOST_WRITE_KHR"/>
+        <enum bitpos="8"            name="CL_SVM_CAPABILITY_HOST_MAP_KHR"/>
+        <enum bitpos="9"            name="CL_SVM_CAPABILITY_DEVICE_READ_KHR"/>
+        <enum bitpos="10"           name="CL_SVM_CAPABILITY_DEVICE_WRITE_KHR"/>
+        <enum bitpos="11"           name="CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR"/>
+        <enum bitpos="12"           name="CL_SVM_CAPABILITY_CONCURRENT_ACCESS_KHR"/>
+        <enum bitpos="13"           name="CL_SVM_CAPABILITY_CONCURRENT_ATOMIC_ACCESS_KHR"/>
+        <enum bitpos="14"           name="CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR"/>
+    </enums>
+
     <enums name="cl_mem_alloc_flags_intel" vendor="Intel" type="bitmask">
         <enum bitpos="0"            name="CL_MEM_ALLOC_WRITE_COMBINED_INTEL"/>
         <enum bitpos="1"            name="CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL"/>
         <enum bitpos="2"            name="CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL"/>
+    </enums>
+
+    <enums name="cl_svm_alloc_access_flags_khr" vendor="Khronos" type="bitmask">
+        <enum bitpos="0"            name="CL_SVM_ALLOC_ACCESS_HOST_NOREAD_KHR"/>
+        <enum bitpos="1"            name="CL_SVM_ALLOC_ACCESS_HOST_NOWRITE_KHR"/>
+            <unused start="2" end="7" comment="reserved for additional host access flags"/>
+        <enum bitpos="8"            name="CL_SVM_ALLOC_ACCESS_DEVICE_NOREAD_KHR"/>
+        <enum bitpos="9"            name="CL_SVM_ALLOC_ACCESS_DEVICE_NOWRITE_KHR"/>
+            <unused start="10" end="15" comment="reserved for additional device access flags"/>
+            <unused start="16" end="63"/>
     </enums>
 
     <enums name="cl_mipmap_filter_mode_img" vendor="IMG" comment="cl_img_generate_mipmap extension">
@@ -1407,6 +1504,10 @@ server's OpenCL/api-docs repository.
             <unused start="3" end="63"/>
     </enums>
 
+    <enums name="cl_svm_free_flags_khr" vendor="Khronos" type="bitmask">
+            <unused start="0" end="31"/>
+    </enums>
+
     <enums start="0x10000" end="0x1FFFF" name="cl_khronos_vendor_id" vendor="Khronos">
         <comment>
             In order to synchronize vendor IDs across Khronos APIs, Vulkan's vk.xml
@@ -1434,7 +1535,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x0907"        name="CL_PLATFORM_EXTENSIONS_WITH_VERSION_KHR"/>
         <enum value="0x0907"        name="CL_PLATFORM_EXTENSIONS_WITH_VERSION"/>
         <enum value="0x0908"        name="CL_PLATFORM_COMMAND_BUFFER_CAPABILITIES_KHR"/>
-            <unused start="0x0909" end="0x091F" comment="Reserved to Khronos"/>
+        <enum value="0x0909"        name="CL_PLATFORM_SVM_TYPE_CAPABILITIES_KHR"/>
+            <unused start="0x090A" end="0x091F" comment="Reserved to Khronos"/>
         <enum value="0x0920"        name="CL_PLATFORM_ICD_SUFFIX_KHR"/>
             <unused start="0x0921" end="0x09FF" comment="Vendor extensions"/>
     </enums>
@@ -1567,7 +1669,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x1074"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR"/>
         <enum value="0x1075"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
         <enum value="0x1076"        name="CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR"/>
-            <unused start="0x1077" end="0x107F" comment="Reserved for cl_device_info"/>
+        <enum value="0x1077"        name="CL_DEVICE_SVM_TYPE_CAPABILITIES_KHR"/>
+            <unused start="0x1078" end="0x107F" comment="Reserved for cl_device_info"/>
         <enum value="0x1080"        name="CL_CONTEXT_REFERENCE_COUNT"/>
         <enum value="0x1081"        name="CL_CONTEXT_DEVICES"/>
         <enum value="0x1082"        name="CL_CONTEXT_PROPERTIES"/>
@@ -1752,7 +1855,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x11B8"        name="CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT"/>
         <enum value="0x11B9"        name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
         <enum value="0x11BA"        name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
-            <unused start="0x11BB" end="0x11CF" comment="Reserved for cl_kernel_info / cl_kernel_work_group_info / cl_kernel_exec_info / cl_kernel_sub_group_info"/>
+        <enum value="0x11BB"        name="CL_KERNEL_EXEC_INFO_SVM_INDIRECT_ACCESS_KHR"/>
+            <unused start="0x11BC" end="0x11CF" comment="Reserved for cl_kernel_info / cl_kernel_work_group_info / cl_kernel_exec_info / cl_kernel_sub_group_info"/>
         <enum value="0x11D0"        name="CL_EVENT_COMMAND_QUEUE"/>
         <enum value="0x11D1"        name="CL_EVENT_COMMAND_TYPE"/>
         <enum value="0x11D2"        name="CL_EVENT_REFERENCE_COUNT"/>
@@ -1922,7 +2026,17 @@ server's OpenCL/api-docs repository.
         <enum value="0x2069"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
             <unused start="0x206A" end="0x206F" comment="Reserved to Khronos for interop"/>
         <enum value="0x2070"        name="CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR"/>
-            <unused start="0x2071" end="0x2FFF" comment="Reserved to Khronos for interop"/>
+            <unused start="0x2071" end="0x2077" comment="Reserved for cl_khr_unified_svm"/>
+        <enum value="0x2078"        name="CL_SVM_ALLOC_ASSOCIATED_DEVICE_HANDLE_KHR"/>
+        <enum value="0x2079"        name="CL_SVM_ALLOC_ACCESS_FLAGS_KHR"/>
+        <enum value="0x207A"        name="CL_SVM_ALLOC_ALIGNMENT_KHR"/>
+            <unused start="0x207B" end="0x2087" comment="Reserved for cl_khr_unified_svm cl_svm_alloc_properties_khr"/>
+        <enum value="0x2088"        name="CL_SVM_INFO_TYPE_INDEX_KHR"/>
+        <enum value="0x2089"        name="CL_SVM_INFO_CAPABILITIES_KHR"/>
+        <enum value="0x208A"        name="CL_SVM_INFO_PROPERTIES_KHR"/>
+        <enum value="0x208B"        name="CL_SVM_INFO_ACCESS_FLAGS_KHR"/>
+            <unused start="0x208C" end="0x208F" comment="Reserved for cl_khr_unified_svm cl_svm_pointer_info_khr, etc."/>
+            <unused start="0x2090" end="0x2FFF" comment="Reserved to Khronos for interop"/>
     </enums>
 
     <enums start="0x3000" end="0x3FFF" name="enums.3000" vendor="Khronos" comment="Platform IDs. Allocate individually.">
@@ -2233,8 +2347,11 @@ server's OpenCL/api-docs repository.
         <enum value="0x4199"        name="CL_MEM_TYPE_SHARED_INTEL"/>
         <enum value="0x419A"        name="CL_MEM_ALLOC_TYPE_INTEL"/>
         <enum value="0x419B"        name="CL_MEM_ALLOC_BASE_PTR_INTEL"/>
+        <enum value="0x419B"        name="CL_SVM_INFO_BASE_PTR_KHR"/>
         <enum value="0x419C"        name="CL_MEM_ALLOC_SIZE_INTEL"/>
+        <enum value="0x419C"        name="CL_SVM_INFO_SIZE_KHR"/>
         <enum value="0x419D"        name="CL_MEM_ALLOC_DEVICE_INTEL"/>
+        <enum value="0x419D"        name="CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR"/>
         <enum value="0x419E"        name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
             <unused start="0x419F" end="0x419F"/>
     </enums>
@@ -3375,6 +3492,40 @@ server's OpenCL/api-docs repository.
             <proto><type>cl_int</type>                     <name>clSetContentSizeBufferPoCL</name></proto>
             <param><type>cl_mem</type>                     <name>buffer</name></param>
             <param><type>cl_mem</type>                     <name>content_size_buffer</name></param>
+        </command>
+        <command>
+            <proto><type>void</type>*                           <name>clSVMAllocWithPropertiesKHR</name></proto>
+            <param><type>cl_context</type>                      <name>context</name></param>
+            <param>const <type>cl_svm_alloc_properties_khr</type>*  <name>properties</name></param>
+            <param><type>cl_uint</type>                         <name>svm_type_index</name></param>
+            <param><type>size_t</type>                          <name>size</name></param>
+            <param><type>cl_int</type>*                         <name>errcode_ret</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                          <name>clSVMFreeWithPropertiesKHR</name></proto>
+            <param><type>cl_context</type>                      <name>context</name></param>
+            <param>const <type>cl_svm_free_properties_khr</type>* <name>properties</name></param>
+            <param><type>cl_svm_free_flags_khr</type>           <name>flags</name></param>
+            <param><type>void</type>*                           <name>ptr</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                          <name>clGetSVMPointerInfoKHR</name></proto>
+            <param><type>cl_context</type>                      <name>context</name></param>
+            <param><type>cl_device_id</type>                    <name>device</name></param>
+            <param>const <type>void</type>*                     <name>ptr</name></param>
+            <param><type>cl_svm_pointer_info_khr</type>                 <name>param_name</name></param>
+            <param><type>size_t</type>                          <name>param_value_size</name></param>
+            <param><type>void</type>*                           <name>param_value</name></param>
+            <param><type>size_t</type>*                         <name>param_value_size_ret</name></param>
+        </command>
+        <command>
+            <proto><type>cl_int</type>                          <name>clGetSVMSuggestedTypeIndexKHR</name></proto>
+            <param><type>cl_context</type>                      <name>context</name></param>
+            <param><type>cl_svm_capabilities_khr</type>         <name>required_capabilities</name></param>
+            <param><type>cl_svm_capabilities_khr</type>         <name>desired_capabilities</name></param>
+            <param>const <type>cl_svm_alloc_properties_khr</type>*  <name>properties</name></param>
+            <param><type>size_t</type>                          <name>size</name></param>
+            <param><type>cl_uint</type>*                        <name>suggested_svm_type_index</name></param>
         </command>
         <command suffix="CL_API_SUFFIX__VERSION_1_0">
             <proto><type>cl_int</type>                                  <name>clGetPlatformIDs</name></proto>
@@ -7728,6 +7879,78 @@ server's OpenCL/api-docs repository.
             <require comment="cl_svm_alloc_properties_khr">
                 <enum name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_VIRTUAL_ADDRESS_IMG"/>
                 <enum name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_IMG"/>
+            </require>
+        </extension>
+        <extension name="cl_khr_unified_svm" revision="0.9.0" condition="defined(CL_VERSION_2_0)" supported="opencl" experimental="true">
+            <require comment="cl_platform_info">
+                <enum name="CL_PLATFORM_SVM_TYPE_CAPABILITIES_KHR"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_SVM_TYPE_CAPABILITIES_KHR"/>
+            </require>
+            <require>
+                <type name="cl_svm_capabilities_khr"/>
+            </require>
+            <require comment="cl_svm_capabilities_khr - bitfield">
+                <enum name="CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_SYSTEM_ALLOCATED_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_DEVICE_OWNED_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_DEVICE_UNASSOCIATED_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_CONTEXT_ACCESS_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_HOST_OWNED_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_HOST_READ_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_HOST_WRITE_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_HOST_MAP_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_DEVICE_READ_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_DEVICE_WRITE_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_DEVICE_ATOMIC_ACCESS_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_CONCURRENT_ACCESS_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_CONCURRENT_ATOMIC_ACCESS_KHR"/>
+                <enum name="CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR"/>
+            </require>
+            <require>
+                <type name="cl_svm_alloc_properties_khr"/>
+                <type name="cl_svm_alloc_access_flags_khr"/>
+                <type name="cl_svm_free_properties_khr"/>
+                <type name="cl_svm_free_flags_khr"/>
+                <type name="cl_svm_pointer_info_khr"/>
+            </require>
+            <require comment="cl_svm_alloc_properties_khr">
+                <enum name="CL_SVM_ALLOC_ASSOCIATED_DEVICE_HANDLE_KHR"/>
+                <enum name="CL_SVM_ALLOC_ACCESS_FLAGS_KHR"/>
+                <enum name="CL_SVM_ALLOC_ALIGNMENT_KHR"/>
+            </require>
+            <require comment="cl_svm_alloc_access_flags_khr">
+                <enum name="CL_SVM_ALLOC_ACCESS_HOST_NOREAD_KHR"/>
+                <enum name="CL_SVM_ALLOC_ACCESS_HOST_NOWRITE_KHR"/>
+                <enum name="CL_SVM_ALLOC_ACCESS_DEVICE_NOREAD_KHR"/>
+                <enum name="CL_SVM_ALLOC_ACCESS_DEVICE_NOWRITE_KHR"/>
+            </require>
+            <require comment="cl_svm_pointer_info_khr">
+                <enum name="CL_SVM_INFO_TYPE_INDEX_KHR"/>
+                <enum name="CL_SVM_INFO_CAPABILITIES_KHR"/>
+                <enum name="CL_SVM_INFO_PROPERTIES_KHR"/>
+                <enum name="CL_SVM_INFO_ACCESS_FLAGS_KHR"/>
+                <enum name="CL_SVM_INFO_BASE_PTR_KHR"/>
+                <enum name="CL_SVM_INFO_SIZE_KHR"/>
+                <enum name="CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR"/>
+            </require>
+            <require comment="cl_kernel_exec_info">
+                <enum name="CL_KERNEL_EXEC_INFO_SVM_INDIRECT_ACCESS_KHR"/>
+            </require>
+            <require comment="SVM type convenience macros">
+                <type name="CL_SVM_TYPE_MACRO_COARSE_GRAIN_BUFFER_KHR"/>
+                <type name="CL_SVM_TYPE_MACRO_FINE_GRAIN_BUFFER_KHR"/>
+                <type name="CL_SVM_TYPE_MACRO_DEVICE_KHR"/>
+                <type name="CL_SVM_TYPE_MACRO_HOST_KHR"/>
+                <type name="CL_SVM_TYPE_MACRO_SINGLE_DEVICE_SHARED_KHR"/>
+                <type name="CL_SVM_TYPE_MACRO_SYSTEM_KHR"/>
+            </require>
+            <require>
+                <command name="clSVMAllocWithPropertiesKHR"/>
+                <command name="clSVMFreeWithPropertiesKHR"/>
+                <command name="clGetSVMPointerInfoKHR"/>
+                <command name="clGetSVMSuggestedTypeIndexKHR"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Adds a basic info page for cl_khr_unified_svm to the main OpenCL specification and adds the extension enums and APIs to the XML file.

The main extension development will stil occur in https://github.com/KhronosGroup/OpenCL-Docs/pull/1282, but this will help with  layered extension development and enable inclusion of the cl_khr_unified_svm APIs in the generated headers.