### PR TITLE
Add missing error condition for clCompileProgram and clLinkProgram

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -9756,6 +9756,8 @@ successfully.
 Otherwise, it returns one of the following errors:
 
   * {CL_INVALID_PROGRAM} if _program_ is not a valid program object.
+  * {CL_INVALID_CONTEXT} if the context associated with _program_ and
+    programs in _input_headers_ are not the same.
   * {CL_INVALID_VALUE} if _device_list_ is `NULL` and _num_devices_ is greater
     than zero, or if _device_list_ is not `NULL` and _num_devices_ is zero.
   * {CL_INVALID_VALUE} if _num_input_headers_ is zero and
@@ -9895,6 +9897,8 @@ check if the link was successful or not.
 The list of errors that can be returned are:
 
   * {CL_INVALID_CONTEXT} if _context_ is not a valid context.
+  * {CL_INVALID_CONTEXT} if the context associated with programs in
+    _input_programs_ is not the same as _context_.
   * {CL_INVALID_VALUE} if _device_list_ is `NULL` and _num_devices_ is greater
     than zero, or if _device_list_ is not `NULL` and _num_devices_ is zero.
   * {CL_INVALID_VALUE} if _num_input_programs_ is zero and _input_programs_ is


### PR DESCRIPTION
These error conditions are typically specified for other OpenCL commands.


Change-Id: Ic1fa4a3012271f791148bfb51f5ef24711eef073