### PR TITLE
Clear clReImportSemaphoreSyncKhr semantics for use after signal/wait

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -13842,6 +13842,10 @@ _sema_object_ and re-creating it with the original _sema_props_ from
 be imported.
 The semaphore _sema_object_ must have originally imported an external handle
 of type {CL_SEMAPHORE_HANDLE_SYNC_FD_KHR}.
+Calling {clReImportSemaphoreSyncFdKHR} after signaling the _sema_object_ or
+calling {clReImportSemaphoreSyncFdKHR} after creating the _sema_object_
+with {clCreateSemaphoreWithPropertiesKHR} without an interleaving wait may
+lead to undefined behavior.
 
 // refError
 


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/OpenCL-Docs/issues/1407

Currently the spec doesn't specify what would be the behavior if you call clReImportSemaphoreSyncKhr after signaling or importing that semaphore. 
As it is stated that "Calling clReImportSemaphoreSyncFdKHR is equivalent to destroying sema_object and re-creating it with the original sema_props from clCreateSemaphoreWithPropertiesKHR", this PR requires an interleaving wait, so no semaphore payload is left behind.