### PR TITLE
Remove require of cl_icd_dispatch to avoid double typedef

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5902,7 +5902,8 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl_icd.h"/>
             </require>
             <require>
-                <type name="cl_icd_dispatch"/>
+                <!-- Defined in icd.h -->
+                <!-- <type name="cl_icd_dispatch"/> -->
                 <type name="cl_layer_info"/>
                 <type name="cl_layer_api_version"/>
             </require>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5902,7 +5902,7 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl_icd.h"/>
             </require>
             <require>
-                <!-- Defined in icd.h -->
+                <!-- Defined in cl_icd.h -->
                 <!-- <type name="cl_icd_dispatch"/> -->
                 <type name="cl_layer_info"/>
                 <type name="cl_layer_api_version"/>


### PR DESCRIPTION
Removing from icd.h would break codes that only include this file.