### PR TITLE
Generate extension interfaces for all EXT extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,7 @@ CFEATURES      = c/features.txt
 CFUNCTIONS     = c/functions.txt
 GENSCRIPT      = $(SCRIPTS)/gencl.py
 DICTSCRIPT     = $(SCRIPTS)/gen_dictionaries.py
+EXTIFACESSCRIPT= $(SCRIPTS)/gen_extension_interfaces.py
 VERSIONSCRIPT  = $(SCRIPTS)/gen_version_notes.py
 CFEATSCRIPT    = $(SCRIPTS)/gen_dictionary_from_file.py
 CFUNCSCRIPT    = $(SCRIPTS)/gen_dictionary_from_file.py
@@ -542,11 +543,13 @@ $(APIDEPEND): $(APIXML) $(DICTSCRIPT) $(GENSCRIPT) $(VERSIONSCRIPT)
 
 extinc: $(METADEPEND)
 
-$(METADEPEND): $(APIXML) $(GENSCRIPT)
+$(METADEPEND): $(APIXML) $(GENSCRIPT) $(CFEATSCRIPT) $(EXTIFACESSCRIPT)
 	$(QUIET)$(MKDIR) $(METAPATH)
+	$(QUIET)$(MKDIR) $(METAPATH)/interfaces
 	$(QUIET)$(PYTHON) $(GENSCRIPT) $(GENSCRIPTOPTS) -o $(METAPATH) extinc
 	$(QUIET)$(PYTHON) $(CFEATSCRIPT) -i $(CFEATURES) -o $(METAPATH)/c-feature-dictionary.asciidoc
 	$(QUIET)$(PYTHON) $(CFUNCSCRIPT) -i $(CFUNCTIONS) -o $(METAPATH)/c-function-dictionary.asciidoc
+	$(QUIET)$(PYTHON) $(EXTIFACESSCRIPT) -registry $(APIXML) -o $(METAPATH)/interfaces
 
 # This generates a single file containing asciidoc attributes for each
 # extension in the spec being built.

--- a/api/cl_ext_buffer_device_address.asciidoc
+++ b/api/cl_ext_buffer_device_address.asciidoc
@@ -44,22 +44,7 @@ This extension is targeted to complement the OpenCL SVM extension by providing
 an additional lower-end step in the spectrum of type of pointers/buffers OpenCL
 can allocate.
 
-=== New Command
-
-  * {clSetKernelArgDevicePointerEXT}
-
-=== New Types
-
-  * {cl_mem_device_address_ext_TYPE}
-
-=== New Enums
-
-  * {cl_mem_properties_TYPE}
-  ** {CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT}
-  * {cl_mem_info_TYPE}
-  ** {CL_MEM_DEVICE_ADDRESS_EXT}
-  * {cl_kernel_exec_info_TYPE}
-  ** {CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT}
+include::{generated}/meta/interfaces/cl_ext_buffer_device_address.txt[]
 
 === Version History
 

--- a/api/cl_ext_cxx_for_opencl.asciidoc
+++ b/api/cl_ext_cxx_for_opencl.asciidoc
@@ -27,10 +27,7 @@ with stable versions published in releases of the repository.
 This extension also enables applications to query the version of the language
 supported by the device compiler.
 
-=== New Enums
-
-  * {cl_device_info_TYPE}
-  ** {CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT}
+include::{generated}/meta/interfaces/cl_ext_cxx_for_opencl.txt[]
 
 === New build option
 

--- a/api/cl_ext_image_from_buffer.asciidoc
+++ b/api/cl_ext_image_from_buffer.asciidoc
@@ -20,10 +20,7 @@ include::{generated}/meta/{refprefix}cl_ext_image_from_buffer.txt[]
 This extension enables all types of images to be created from an existing buffer
 object.
 
-=== New Enums
-
-  * {cl_image_requirements_info_ext_TYPE}
-  ** {CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT}
+include::{generated}/meta/interfaces/cl_ext_image_from_buffer.txt[]
 
 === Conformance tests
 

--- a/api/cl_ext_image_raw10_raw12.asciidoc
+++ b/api/cl_ext_image_raw10_raw12.asciidoc
@@ -15,6 +15,8 @@ include::{generated}/meta/{refprefix}cl_ext_image_raw10_raw12.txt[]
 The latest published specification for this extension is available on
 the https://registry.khronos.org/OpenCL/extensions/ext/cl_ext_image_raw10_raw12.html[OpenCL registry].
 
+include::{generated}/meta/interfaces/cl_ext_image_raw10_raw12.txt[]
+
 === Version History
 
   * Revision 1.0.0, 2023-05-03

--- a/api/cl_ext_image_requirements_info.asciidoc
+++ b/api/cl_ext_image_requirements_info.asciidoc
@@ -22,24 +22,7 @@ include::{generated}/meta/{refprefix}cl_ext_image_requirements_info.txt[]
 This extension enables applications to query requirements for an image without
 having to create the image.
 
-=== New Commands
-
-  * {clGetImageRequirementsInfoEXT}
-
-=== New Types
-
-  * {cl_image_requirements_info_ext_TYPE}
-
-=== New Enums
-
-  * {cl_image_requirements_info_ext_TYPE}
-  ** {CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_BASE_ADDRESS_ALIGNMENT_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_SIZE_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_MAX_WIDTH_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_MAX_DEPTH_EXT}
-  ** {CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT}
+include::{generated}/meta/interfaces/cl_ext_image_requirements_info.txt[]
 
 === Conformance tests
 

--- a/api/cl_ext_image_unorm_int_2_101010.asciidoc
+++ b/api/cl_ext_image_unorm_int_2_101010.asciidoc
@@ -20,14 +20,11 @@ image format.
 OpenCL C compilers supporting this extension will define the
 {opencl_c_ext_image_unorm_int_2_101010} feature macro.
 
+include::{generated}/meta/interfaces/cl_ext_image_unorm_int_2_101010.txt[]
+
 === New feature macro
 
   * {opencl_c_ext_image_unorm_int_2_101010}
-
-=== New Enums
-
-  * {cl_channel_type_TYPE}
-  ** {CL_UNORM_INT_2_101010_EXT}
 
 === New OpenCL C channel data type
 

--- a/api/cl_ext_image_unsigned_10x6_12x4_14x2.asciidoc
+++ b/api/cl_ext_image_unsigned_10x6_12x4_14x2.asciidoc
@@ -27,19 +27,11 @@ formats:
 OpenCL C compilers supporting this extension will define the
 {opencl_c_ext_image_unsigned_10x6_12x4_14x2} feature macro.
 
+include::{generated}/meta/interfaces/cl_ext_image_unsigned_10x6_12x4_14x2.txt[]
+
 === New feature macro
 
   * {opencl_c_ext_image_unsigned_10x6_12x4_14x2}
-
-=== New Enums
-
-  * {cl_channel_type_TYPE}
-  ** {CL_UNSIGNED_INT10X6_EXT}
-  ** {CL_UNSIGNED_INT12X4_EXT}
-  ** {CL_UNSIGNED_INT14X2_EXT}
-  ** {CL_UNORM_INT10X6_EXT}
-  ** {CL_UNORM_INT12X4_EXT}
-  ** {CL_UNORM_INT14X2_EXT}
 
 === New OpenCL C channel data type
 

--- a/api/cl_ext_immutable_memory_objects.asciidoc
+++ b/api/cl_ext_immutable_memory_objects.asciidoc
@@ -23,10 +23,7 @@ objects that cannot be modified by the implementation after creation. This,
 for example, enables implementation to support image formats for which no write
 operations can be supported.
 
-=== New Enums
-
-  * {cl_mem_flags_TYPE}
-  ** {CL_MEM_IMMUTABLE_EXT}
+include::{generated}/meta/interfaces/cl_ext_immutable_memory_objects.txt[]
 
 === Issues
 

--- a/scripts/gen_extension_interfaces.py
+++ b/scripts/gen_extension_interfaces.py
@@ -16,7 +16,7 @@ def parse_xml(path):
         return tree
 
 def GetHeader():
-    return """// Copyright 2017-2025 The Khronos Group.
+    return """// Copyright 2025 The Khronos Group.
 // SPDX-License-Identifier: CC-BY-4.0
 
 """

--- a/scripts/gen_extension_interfaces.py
+++ b/scripts/gen_extension_interfaces.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2025 The Khronos Group Inc.
+# Copyright 2025 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/scripts/gen_extension_interfaces.py
+++ b/scripts/gen_extension_interfaces.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Copyright 2019-2025 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import urllib
+import xml.etree.ElementTree as etree
+import urllib.request
+
+def parse_xml(path):
+    file = urllib.request.urlopen(path) if path.startswith("http") else open(path, 'r')
+    with file:
+        tree = etree.parse(file)
+        return tree
+
+def GetHeader():
+    return """// Copyright 2017-2025 The Khronos Group.
+// SPDX-License-Identifier: CC-BY-4.0
+
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-registry', action='store',
+                        default='cl.xml',
+                        help='Use specified registry file instead of cl.xml')
+    parser.add_argument('-o', action='store', dest='directory',
+                        default='.',
+                        help='Create target and related files in specified directory')
+
+    args = parser.parse_args()
+
+    specpath = args.registry
+
+    print('Generating extension interfaces from: ' + specpath)
+
+    spec = parse_xml(specpath)
+
+    for extension in spec.findall('extensions/extension'):
+        extname = extension.get('name')
+        #print(extname)
+        iface_file = open(os.path.join(args.directory, extname + '.txt'), 'w')
+
+        iface_file.write(GetHeader())
+
+        # New commands
+        commands = extension.findall('require/command')
+        if commands:
+            iface_file.write('=== New Commands\n\n')
+            for cmd in commands:
+                iface_file.write('  * {{{}}}\n'.format(cmd.get('name')))
+            iface_file.write('\n')
+
+        # New types
+        types = extension.findall('require/type')
+        if types:
+            iface_file.write('=== New Types\n\n')
+            for ty in types:
+                iface_file.write('  * {{{}_TYPE}}\n'.format(ty.get('name')))
+
+        # New enums
+        first_enum = True
+        requires = extension.findall('require')
+        for req in requires:
+            enums = req.findall('enum')
+            first_for_require = True
+            for e in enums:
+                if first_enum:
+                    iface_file.write('=== New enums\n\n')
+                    first_enum = False
+                if first_for_require:
+                    comment = req.get('comment')
+                    if comment == 'Error codes':
+                        iface_file.write('  * New Error Codes\n')
+                    else:
+                        iface_file.write('  * {{{}_TYPE}}\n'.format(comment))
+                    first_for_require = False
+                iface_file.write('  ** {{{}}}\n'.format(e.get('name')))
+            iface_file.write('\n')
+
+        iface_file.close()


### PR DESCRIPTION
- Add script to automatically generate the list of new commands, types, enums, and error codes.
- Use generated output for all EXT extensions.
- This fixes missing new enums for cl_ext_image_raw10_raw12.


Change-Id: I5a7edd837d39a3a0c6f86876ec7faa97a01d736e