### PR TITLE
Add simultaneous update capability

### DIFF
--- a/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
+++ b/api/cl_khr_command_buffer_mutable_dispatch.asciidoc
@@ -6,7 +6,7 @@ include::{generated}/meta/{refprefix}cl_khr_command_buffer_mutable_dispatch.txt[
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2025-08-08
+    2025-09-30
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -45,10 +45,15 @@ in a new command-buffer.
 
 The optional <<simultaneous-use, simultaneous use>> capability was added to the
 extension so that vendors could support concurrent execution of the same
-command-buffer object which has been updated between submissions. However,
-simultaneous use may result in command-buffers having a larger overhead to
-implement, so the capability is optional to enable optimizations when this
-usage isn't required by a user.
+command-buffer object. However, simultaneous use may result in command-buffers
+having a larger overhead to implement, so the capability is optional to enable
+optimizations when this usage isn't required by a user.
+
+==== Simultaneous Update
+
+The optional <<simultaneous-update, simultaneous update>> capability adds support 
+for updating the command-buffer without requiring the application to wait on the
+previous enqueues of the command-buffer to reach completed state.
 
 === Interactions With Other Extensions
 
@@ -83,6 +88,7 @@ void pointer using {cl_command_buffer_update_type_khr_TYPE}.
   ** {CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR}
   * {cl_device_command_buffer_capabilities_khr_TYPE}
   ** {CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR}
+  ** {CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR}
   * {cl_command_properties_khr_TYPE}
   ** {CL_MUTABLE_DISPATCH_ASSERTS_KHR}
   ** {CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR}
@@ -107,6 +113,7 @@ void pointer using {cl_command_buffer_update_type_khr_TYPE}.
   * {cl_command_buffer_flags_khr_TYPE}
   ** {CL_COMMAND_BUFFER_MUTABLE_KHR}
   ** {CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR}
+  ** {CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR}
   * {cl_command_buffer_properties_khr_TYPE}
   ** {CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR}
   * {cl_command_buffer_update_type_khr_TYPE}
@@ -379,3 +386,6 @@ may be a introduced as a stand alone extension.
     **  Move `CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR` and
         `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR` in this
         extension from the base extension (experimental).
+  * Revision 0.9.5, 2025-09-30
+    **  Add `CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR` and
+        `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR` (experimental).

--- a/api/opencl_platform_layer.asciidoc
+++ b/api/opencl_platform_layer.asciidoc
@@ -1819,6 +1819,12 @@ ifdef::cl_khr_command_buffer_mutable_dispatch[]
         simultaneous use>> usage pattern.
 
 include::{generated}/api/version-notes/CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR.asciidoc[]
+
+        {CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR_anchor} Device
+        supports updating command-buffers with a <<simultaneous-update,
+        simultaneous update>> usage pattern.
+
+include::{generated}/api/version-notes/CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR.asciidoc[]
 endif::cl_khr_command_buffer_mutable_dispatch[]
 
 ifdef::cl_khr_command_buffer_multi_device[]

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -14723,16 +14723,16 @@ usage>>.
 
 Simultaneous use is defined using the _prerequisite_ terminology from the
 <<_execution_model, execution model>>.
-ifndef::cl_khr_command_buffer_multi_device[]
+ifndef::cl_khr_command_buffer_mutable_dispatch[]
 A command-buffer exhibits undefined behavior if a simultaneous use
 pattern occurs.
-endif::cl_khr_command_buffer_multi_device[]
-ifdef::cl_khr_command_buffer_multi_device[]
+endif::cl_khr_command_buffer_mutable_dispatch[]
+ifdef::cl_khr_command_buffer_mutable_dispatch[]
 Simultaneous use is an optional feature for devices to support concurrent
-executions of a command-buffer which have been updated between submissions.
-A command-buffer must be created with {CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR}
-to avoid undefined behavior if a simultaneous use pattern occurs.
-endif::cl_khr_command_buffer_multi_device[]
+executions of a command-buffer. A command-buffer must be created with 
+{CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR} to avoid undefined behavior if a 
+simultaneous use pattern occurs.
+endif::cl_khr_command_buffer_mutable_dispatch[]
 
 [[simultaneous-use]]
 Simultaneous Use:: When a command-buffer is submitted for
@@ -14746,6 +14746,28 @@ command-buffer to a single out-of-order queue, without any events or barriers
 used to express a dependency between the two enqueue calls. Using a single
 in-order queue, events, or barriers to express dependencies between submissions
 of the same command-buffer would each be ways to avoid simultaneous use.
+====
+
+ifndef::cl_khr_command_buffer_mutable_dispatch[]
+A command-buffer exhibits undefined behavior if a simultaneous update
+pattern occurs.
+endif::cl_khr_command_buffer_mutable_dispatch[]
+ifdef::cl_khr_command_buffer_mutable_dispatch[]
+Simultaneous update is an optional feature for devices to support updating a 
+command-buffer while all the previous submissions of the same command-buffer
+have not finished. A command-buffer must be created with
+{CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR} to avoid undefined behavior if a
+simultaneous update pattern occurs.
+endif::cl_khr_command_buffer_mutable_dispatch[]
+
+[[simultaneous-update]]
+Simultaneous Update:: When a command-buffer is updated while any of the previous
+submissions of the same command-buffer is not in the {CL_COMPLETE} state.
+
+[NOTE]
+====
+An example of simultaneous update would be calling {clUpdateMutableCommandsKHR}
+after submitting a command-buffer without waiting on the submission event.
 ====
 
 ifdef::cl_khr_command_buffer_multi_device[]
@@ -14863,6 +14885,14 @@ ifdef::cl_khr_command_buffer_mutable_dispatch[]
         {CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR}.
 
 include::{generated}/api/version-notes/CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR.asciidoc[]
+
+        {CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR_anchor} - Allow an
+        instance of the command-buffer to be updated in a usage pattern that 
+        exhibits <<simultaneous-update, simultaneous update>>. If set,
+        devices must support {CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR}.
+
+include::{generated}/api/version-notes/CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR.asciidoc[]
+
 endif::cl_khr_command_buffer_mutable_dispatch[]
 
 ifdef::cl_khr_command_buffer_multi_device[]
@@ -16722,6 +16752,14 @@ one of the errors below is returned:
     required by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
     required by the OpenCL implementation on the host.
+
+If the implementation supports the
+{CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR} capability, and the
+command-buffer was created with the {CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR}
+flag, {clUpdateMutableCommandsKHR} can be called without waiting for previous
+submissions of the command-buffer to be completed. If this capability is not
+supported, updating the command-buffer in a <<simultaneous-update, simultaneous-
+update>> pattern will result in undefined behavior.
 
 [NOTE]
 ====

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1451,7 +1451,7 @@ server's OpenCL/api-docs repository.
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
-            <unused start="3" end="3" comment="Available for future use"/>
+        <enum bitpos="3"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR"/>
         <enum bitpos="4"            name="CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR"/>
             <unused start="5" end="6" comment="Used by future command-buffer extensions"/>
             <unused start="6" end="31"/>
@@ -1461,7 +1461,7 @@ server's OpenCL/api-docs repository.
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR"/>
-            <unused start="3" end="4" comment="Used by future command-buffer extensions"/>
+        <enum bitpos="3"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR"/>
             <unused start="4" end="31"/>
     </enums>
 
@@ -7658,7 +7658,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_QUEUE_JOB_SLOT_ARM"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer_mutable_dispatch" revision="0.9.4" supported="opencl" depends="cl_khr_command_buffer" ratified="opencl" experimental="true" comment="requires cl_khr_command_buffer 0.9.8 or later">
+        <extension name="cl_khr_command_buffer_mutable_dispatch" revision="0.9.5" supported="opencl" depends="cl_khr_command_buffer" ratified="opencl" experimental="true" comment="requires cl_khr_command_buffer 0.9.8 or later">
             <require>
                 <type name="CL/cl.h"/>
             </require>
@@ -7673,11 +7673,13 @@ server's OpenCL/api-docs repository.
             </require>
             <require comment="cl_command_buffer_flags_khr - bitfield">
                <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
+               <enum name="CL_COMMAND_BUFFER_SIMULTANEOUS_UPDATE_KHR"/>
                <enum name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
             </require>
 
             <require comment="cl_device_command_buffer_capabilities_khr - bitfield">
                 <enum name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
+                <enum name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR"/>
             </require>
 
             <require comment="Error codes">


### PR DESCRIPTION
This PR addresses https://github.com/KhronosGroup/OpenCL-Docs/issues/1465.
It follows a similar pattern to the one used for simultaneous update https://github.com/KhronosGroup/OpenCL-Docs/pull/1411.

It adds the `CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_UPDATE_KHR` capability, which allows developers to query if the implementation supports updating a command-buffer while an instance of the same is being ran.
If the capability is not supported, applications must wait for all previous submissions of the command-buffer to be finished before calling `clUpdateMutableCommandsKHR`.

It also fixes a wrong `ifdef` that was checking for `cl_khr_command_buffer_multi_device` instead of `cl_khr_command_buffer_mutable_dispatch`.