### PR TITLE
Add cl_img_scheduling_controls to cl.xml

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1373,6 +1373,18 @@ server's OpenCL/api-docs repository.
         <enum bitpos="0"            name="CL_CONTEXT_WORKGROUP_PROTECTION_IMG"/>
         <enum bitpos="1"            name="CL_CONTEXT_ENHANCED_EVENT_EXECUTION_STATUS_IMG"/>
     </enums>
+    
+    <enums name="cl_device_scheduling_controls_capabilities_img" vendor="IMG" type="bitmask">
+        <enum bitpos="0"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"/>
+        <enum bitpos="1"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"/>
+        <enum bitpos="2"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"/>
+        <enum bitpos="3"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_THREED_MORTON_ORDER_IMG"/>
+            <unused start="4" end="7" comment="reserved for additional scheduling algorithm flags"/>
+        <enum bitpos="8"            name="CL_DEVICE_WORK_GROUP_ARBITRATION_ALGORITHM_TASK_DEMAND_IMG"/>
+        <enum bitpos="9"            name="CL_DEVICE_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_IMG"/>
+        <enum bitpos="10"           name="CL_DEVICE_WORK_GROUP_EXECUTE_COUNT_IMG"/>
+            <unused start="11" end="63"/>
+    </enums>
 
     <enums name="cl_device_scheduling_controls_capabilities_arm" vendor="Arm" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM"/>
@@ -2414,7 +2426,17 @@ server's OpenCL/api-docs repository.
     <enums start="0x4220" end="0x422F" name="enums.4220" vendor="IMG">
         <enum value="0x4220"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_VIRTUAL_ADDRESS_IMG"/>
         <enum value="0x4221"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_IMG"/>
-            <unused start="0x4222" end="0x422F"/>
+        <enum value="0x4222"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_IMG"/>
+        <enum value="0x4223"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"/>
+        <enum value="0x4224"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG"/>
+        <enum value="0x4225"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"/>
+        <enum value="0x4226"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"/>
+        <enum value="0x4227"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"/>
+        <enum value="0x4228"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_THREED_MORTON_ORDER_IMG"/>
+        <enum value="0x4229"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_TASK_DEMAND_IMG"/>
+        <enum value="0x422A"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_IMG"/>
+        <enum value="0x422B"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_EXECUTE_COUNT_IMG"/>
+            <unused start="0x422C" end="0x422F"/>
     </enums>
 
     <enums start="0x4230" end="0x423F" name="enums.4230" comment="Reserved for EXT extensions">
@@ -7956,6 +7978,28 @@ server's OpenCL/api-docs repository.
                 <command name="clSVMFreeWithPropertiesKHR"/>
                 <command name="clGetSVMPointerInfoKHR"/>
                 <command name="clGetSVMSuggestedTypeIndexKHR"/>
+            </require>
+        </extension>
+        <extension name="cl_img_scheduling_controls" revision="0.0.0" supported="opencl">
+            <require comment="Types">
+                <type name="cl_device_scheduling_controls_capabilities_img"/>
+            </require>
+            <require comment="cl_device_scheduling_controls_capabilities_img">
+                <enum name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_THREED_MORTON_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_ARBITRATION_ALGORITHM_TASK_DEMAND_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_ORDER_IMG"/>
+                <enum name="CL_DEVICE_WORK_GROUP_EXECUTE_COUNT_IMG"/>
+            </require>
+            <require comment="cl_device_info">
+                <enum name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_IMG"/>
+            </require>
+            <require comment="cl_queue_properties">
+                <enum name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"/>
+                <enum name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG"/>
+                <enum name="CL_COMMAND_QUEUE_WORK_GROUP_EXECUTE_COUNT_IMG"/>
             </require>
         </extension>
     </extensions>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7980,7 +7980,7 @@ server's OpenCL/api-docs repository.
                 <command name="clGetSVMSuggestedTypeIndexKHR"/>
             </require>
         </extension>
-        <extension name="cl_img_scheduling_controls" revision="0.0.0" supported="opencl">
+        <extension name="cl_img_scheduling_controls" revision="0.3.0" supported="opencl">
             <require comment="Types">
                 <type name="cl_device_scheduling_controls_capabilities_img"/>
             </require>
@@ -7999,7 +7999,7 @@ server's OpenCL/api-docs repository.
             <require comment="cl_queue_properties">
                 <enum name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"/>
                 <enum name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG"/>
-                <enum name="CL_COMMAND_QUEUE_WORK_GROUP_EXECUTE_COUNT_IMG"/>
+                <enum name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_EXECUTE_COUNT_IMG"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Adds controls for work-item execution order (linear/morton).
Adds controls for work-group arbitration to compute-units (task-demand/round-robin).
Adds controls for batching work-groups prior to arbitration.