### PR TITLE
Fixup command-buffer enqueue error after PR-1382

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -15122,12 +15122,6 @@ include::{generated}/api/version-notes/clEnqueueCommandBufferKHR.asciidoc[]
     application to wait on this command or query it for profiling
     information.
 
-[NOTE]
-====
-To enqueue a command-buffer it must be in a <<executable, Executable>> state,
-see {clFinalizeCommandBufferKHR}.
-====
-
 // refError
 
 {clEnqueueCommandBufferKHR} returns {CL_SUCCESS} if the command-buffer
@@ -15135,7 +15129,8 @@ execution was successfully queued, or one of the errors below:
 
   * {CL_INVALID_COMMAND_BUFFER_KHR} if _command_buffer_ is not a valid
     command-buffer.
-  * {CL_INVALID_OPERATION} if _command_buffer_ has not been finalized.
+  * {CL_INVALID_OPERATION} if _command_buffer_ is not in the
+    <<executable, Executable>> state.
   * {CL_INVALID_VALUE} if _queues_ is `NULL` and _num_queues_ is > 0, or
     _queues_ is not `NULL` and _num_queues_ is 0.
   * {CL_INVALID_VALUE} if _num_queues_ is > 0 and not the same value as


### PR DESCRIPTION
https://github.com/KhronosGroup/OpenCL-Docs/pull/1382 added support for deferring setting arguments on a kernel command which is updatable. To achieve this we added an extra command-buffer state, "finalized" which is entered when a command-buffer has been finalized but doesn't yet have all it's arguments set.

However, if a user tries to enqueue a command-buffer in this state it shouldn't be valid. Therefore update our current wording about when an command-buffer can be enqueued to say the specifically the executable state, when all the arguments are set. Rather than defined as only after the finalization operation, which could result in the command-buffer being in either the finalization or executable state.

We have a NOTE a few lines above to this effect already, which I'm not really sure 