### PR TITLE
Clarify that images cannot be created from AHB with AHARDWAREBUFFER_FORMAT_BLOB

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -2331,7 +2331,7 @@ endif::cl_khr_external_memory[]
     ** if there are no devices in _context_ that support _image_format_
 ifdef::cl_khr_external_memory_android_hardware_buffer[]
     ** if _properties_ includes an AHardwareBuffer external memory handle and
-    the AHardwareBuffer format is not supported
+    the AHardwareBuffer format is `AHARDWAREBUFFER_FORMAT_BLOB` or not supported
 endif::cl_khr_external_memory_android_hardware_buffer[]
   * {CL_MEM_OBJECT_ALLOCATION_FAILURE}
     ** if there is a failure to allocate memory for the image object


### PR DESCRIPTION
See https://github.com/KhronosGroup/OpenCL-CTS/pull/2539#discussion_r2417394991 for background.

Agreed in 2025/10/14 memory TSG teleconference.