### PR TITLE
error code consistency for SVM

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -8327,25 +8327,30 @@ context from which _command_queue_ was created the behavior is undefined.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
-    events in _event_wait_list_ are not the same.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the copy operation is
-    blocking and the execution status of any of the events in
-    _event_wait_list_ is a negative integer value.
-  * {CL_INVALID_VALUE} if _dst_ptr_ or _src_ptr_ is `NULL`.
-  * {CL_MEM_COPY_OVERLAP} if the values specified for _dst_ptr_, _src_ptr_ and
-    _size_ result in an overlapping copy.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _dst_ptr_ is `NULL`
+    ** if _src_ptr_ is `NULL`
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST}
+    ** if the copy operations is blocking and the execution status of
+    any of the events in _event_wait_list_ is a negative integer value indicating an error
+  * {CL_MEM_COPY_OVERLAP}
+    ** if the values specified for _dst_ptr_, _src_ptr_ and _size_ result in an overlapping copy
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clEnqueueSVMMemFill',desc='Enqueues a command to fill a region in memory with a pattern of a given pattern size.',type='protos']
@@ -8409,24 +8414,30 @@ include::{generated}/api/version-notes/clEnqueueSVMMemFill.asciidoc[]
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
-    events in _event_wait_list_ are not the same.
-  * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
-  * {CL_INVALID_VALUE} if _svm_ptr_ is not aligned to _pattern_size_ bytes.
-  * {CL_INVALID_VALUE} if _pattern_ is `NULL` or if _pattern_size_ is 0 or if
-    _pattern_size_ is not one of {1, 2, 4, 8, 16, 32, 64, 128}.
-  * {CL_INVALID_VALUE} if _size_ is not a multiple of _pattern_size_.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _svm_ptr_ is `NULL`
+    ** if _svm_ptr_ is not aligned to _pattern_size_ bytes
+    ** if _pattern_ is `NULL`
+    ** if _pattern_size_ is zero
+    ** if _pattern_size_ is not a power of two
+    ** if _pattern_size_ is greater than 128
+    ** if _size_ is not a multiple of _pattern_size_
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clEnqueueSVMMap',desc='Enqueues a command that will allow the host to update a region of a SVM buffer',type='protos']
@@ -8489,25 +8500,29 @@ already mapped in the host address space.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
-    in _event_wait_list_ are not the same.
-  * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
-  * {CL_INVALID_VALUE} if _size_ is 0 or if values specified in _map_flags_
-    are not valid.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the map operation is
-    blocking and the execution status of any of the events in
-    _event_wait_list_ is a negative integer value.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _svm_ptr_ is `NULL`
+    ** if _size_ is zero
+    ** if values specified in _map_flags_ are not valid
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST}
+    ** if the map operations is blocking and the execution status of
+    any of the events in _event_wait_list_ is a negative integer value indicating an error
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clEnqueueSVMUnmap',desc='Enqueues a command to indicate that the host has completed updating the region given by an SVM pointer and which was specified in a previous call to clEnqueueSVMMap.',type='protos']
@@ -8555,20 +8570,24 @@ the region of the SVM buffer specified in these calls.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
-    in _event_wait_list_ are not the same.
-  * {CL_INVALID_VALUE} if _svm_ptr_ is `NULL`.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or if _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _svm_ptr_ is `NULL`
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 [NOTE]
 ====
@@ -8656,24 +8675,28 @@ could result in undefined results.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and events
-    in _event_wait_list_ are not the same.
-  * {CL_INVALID_VALUE} if _num_svm_pointers_ is zero or _svm_pointers_ is
-    `NULL`.
-  * {CL_INVALID_VALUE} if _sizes_[i] is non-zero range [_svm_pointers_[i],
-    _svm_pointers_[i]+_sizes_[i]) is not contained within an existing
-    {clSVMAlloc} allocation.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or if _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _num_svm_pointers_ is zero
+    ** if _svm_pointers_ is `NULL`
+    ** if _flags_ is not zero and is not a valid combination of the values
+    described in the <<migration-flags-table, Memory migration Flags>> table
+    ** if _sizes_[i] is non-zero and the memory range described by _svm_pointers_[i] and _sizes_[i] is not contained within an SVM allocation returned by {clSVMAlloc}
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 


### PR DESCRIPTION
This is another PR to partially address the way we document error conditions, see https://github.com/KhronosGroup/OpenCL-Docs/issues/1320 and in particular https://github.com/KhronosGroup/OpenCL-Docs/issues/1320#issuecomment-2745919727.

It contains a subset of the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/1399, specifically for SVM commands.