### PR TITLE
clarify description of sub-group functions

### DIFF
--- a/api/opencl_architecture.asciidoc
+++ b/api/opencl_architecture.asciidoc
@@ -578,12 +578,12 @@ Consider the following three domains of synchronization in OpenCL:
     for execution
 
 
-Synchronization across all work-items within a single work-group is carried
-out using a _work-group function_.
-These functions carry out collective operations across all the work-items in
-a work-group.
-Available collective operations are: barrier, reduction, broadcast, prefix
-sum, and evaluation of a predicate.
+Synchronization across work-items within a work-group is done by using a
+_work-group function_.
+These functions perform collective operations across the work-items in a
+work-group.
+Available collective operations include barriers, reductions, broadcast, prefix
+sums, and evaluation of a predicate.
 A work-group function must occur within a converged control flow; i.e. all
 work-items in the work-group must encounter precisely the same work-group
 function.
@@ -592,27 +592,18 @@ must encounter the same work-group function in the same loop iterations.
 All the work-items of a work-group must execute the work-group function and
 complete reads and writes to memory before any are allowed to continue
 execution beyond the work-group function.
-Work-group functions that apply between work-groups are not provided in
+Work-group functions that apply across work-groups are not provided in
 OpenCL since OpenCL does not define forward-progress or ordering relations
 between work-groups, hence collective synchronization operations are not
 well defined.
 
-Synchronization across all work-items within a single sub-group is carried
-out using a _sub-group function_.
-These functions carry out collective operations across all the work-items in
-a sub-group.
-Available collective operations are: barrier, reduction, broadcast, prefix
-sum, and evaluation of a predicate.
-A sub-group function must occur within a converged control flow; i.e. all
-work-items in the sub-group must encounter precisely the same sub-group
-function.
-For example, if a work-group function occurs within a loop, the work-items
-must encounter the same sub-group function in the same loop iterations.
-All the work-items of a sub-group must execute the sub-group function and
-complete reads and writes to memory before any are allowed to continue
-execution beyond the sub-group function.
-Synchronization between sub-groups must either be performed using work-group
-functions, or through memory operations.
+Synchronization across work-items within a sub-group is done by using a
+_sub-group function_.
+These functions perform collective operations across the work-items in a
+sub-group.
+Like work-group functions, sub-group functions must also occur within a
+converged control flow; i.e. all work-items in the sub-group must encounter
+precisely the same sub-group function.
 Using memory operations for sub-group synchronization should be used
 carefully as forward progress of sub-groups relative to each other is only
 supported optionally by OpenCL implementations.


### PR DESCRIPTION
Fixes #1429

Removes a copy-paste error and rephrases to reduce duplication.