### PR TITLE
Add missing error case for clSetKernelArgDevicePointerEXT

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11173,7 +11173,10 @@ successfully. Otherwise, it returns one of the following errors:
   * {CL_INVALID_KERNEL} if _kernel_ is not a valid kernel object.
   * {CL_INVALID_OPERATION} if no devices in the context associated with _kernel_ support
     the {cl_ext_buffer_device_address_EXT} extension.
-  * {CL_INVALID_ARG_INDEX} if _arg_index_ is not a valid argument index.
+  * {CL_INVALID_ARG_INDEX}
+  ** if _arg_index_ is not a valid argument index.
+  ** if _arg_index_ corresponds to an argument that is not a pointer to the `global`
+     address space.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
     by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources


### PR DESCRIPTION
It is never valid to call clSetKernelArgDevicePointerEXT for an argument that is not a pointer to the global address space. Since it is the choice of argument that is wrong in this case, CL_INVALID_ARG_INDEX looks like the most natural error code.