### PR TITLE
refactor the description for clSetKernelArg

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11039,7 +11039,6 @@ Otherwise, it returns one of the following errors:
     ** if _arg_value_ points to the data to be used as the kernel argument value
     and _arg_size_ does not match the size of the data type for the argument
   * {CL_INVALID_ARG_VALUE}
-    ** if _arg_value_ is not a valid value.
     ** if the argument is an image declared with the `read_only` qualifier and
     _arg_value_ points to an image object created with the memory flag
     {CL_MEM_WRITE_ONLY}


### PR DESCRIPTION
Refactors the description of clSetKernelArg.

Key changes:

1. Removes the example kernel.  I did not find it useful, and it breaks the description of the API in a way that I found confusing.
2. Documents the requirements for the kernel argument value more precisely, based on the what the kernel argument is.
    * Note, the descriptions do not use the OpenCL C types, since the API works both for OpenCL C kernels and kernels created from SPIR-V or other mechanisms.
3. Updates the error code descriptions to use the new layout convention. 