### PR TITLE
error code consistency for clEnqueueNDRangeKernel

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -11975,12 +11975,12 @@ Otherwise, it returns one of the following errors:
     _command_queue_.
     This error code is <<unified-spec, missing before>> version 1.1.
   * {CL_INVALID_IMAGE_SIZE}
-    ** if a kernel argument for _kernel_ is an image and the dimensions for the
+    ** if a kernel argument for _kernel_ is an image and the dimensions of the
     image, such as the image width or image height, are not supported by the
     device associated with _command_queue_
   * {CL_IMAGE_FORMAT_NOT_SUPPORTED}
-    ** if a kernel argument for _kernel_ is an image and the format the _image_,
-    such as the image channel order or image channel data type, are not
+    ** if a kernel argument for _kernel_ is an image and the format of the
+    image, such as the image channel order or image channel data type, are not
     supported by the device associated with _command_queue_
   * {CL_INVALID_OPERATION}
     ** if SVM pointers are set as arguments for _kernel_ and the device associated with _command_queue_ does not support SVM
@@ -12172,12 +12172,12 @@ Otherwise, it returns one of the following errors:
     _command_queue_.
     This error code is <<unified-spec, missing before>> version 1.1.
   * {CL_INVALID_IMAGE_SIZE}
-    ** if a kernel argument for _kernel_ is an image and the dimensions for the
+    ** if a kernel argument for _kernel_ is an image and the dimensions of the
     image, such as the image width or image height, are not supported by the
     device associated with _command_queue_
   * {CL_IMAGE_FORMAT_NOT_SUPPORTED}
-    ** if a kernel argument for _kernel_ is an image and the format the _image_,
-    such as the image channel order or image channel data type, are not
+    ** if a kernel argument for _kernel_ is an image and the format of the
+    image, such as the image channel order or image channel data type, are not
     supported by the device associated with _command_queue_
   * {CL_MEM_OBJECT_ALLOCATION_FAILURE}
     ** if there is a failure to allocate memory for the data store associated with any buffer or image object kernel arguments for _kernel_


### PR DESCRIPTION
This is another PR to partially address the way we document error conditions, see https://github.com/KhronosGroup/OpenCL-Docs/issues/1320 and in particular https://github.com/KhronosGroup/OpenCL-Docs/issues/1320#issuecomment-2745919727.

It contains a subset of the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/1399, specifically for clEnqueueNDRangeKernel.

Also, for clGetKernelSuggestedLocalWorkSizeKHR, while we're at it, since they share a lot of the same error conditions.