### PR TITLE
correct ratification status for cl_khr_icd_unloadable

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5933,7 +5933,7 @@ server's OpenCL/api-docs repository.
                 <command name="clIcdSetPlatformDispatchDataKHR"/>
             </require>
         </extension>
-        <extension name="cl_khr_icd_unloadable" revision="1.0.0" supported="opencl" ratified="opencl">
+        <extension name="cl_khr_icd_unloadable" revision="1.0.0" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
The new extension cl_khr_icd_unloadable is currently unratified.