### PR TITLE
remove OpenCL 1.2 dependency for Intel extensions

### DIFF
--- a/extensions/cl_intel_mem_force_host_memory.asciidoc
+++ b/extensions/cl_intel_mem_force_host_memory.asciidoc
@@ -48,8 +48,6 @@ Final Draft
 
 This extension is written against the OpenCL Specification Version 3.0.1-Provisional.
 
-This extension requires OpenCL 1.2 or later.
-
 This extension interacts with the `cl_intel_unified_shared_memory` extension.
 
 == Overview

--- a/extensions/cl_intel_packed_yuv.asciidoc
+++ b/extensions/cl_intel_packed_yuv.asciidoc
@@ -43,8 +43,6 @@ Revision: 1.0.1
 
 == Dependencies
 
-OpenCL 1.2 is required.
-
 This extension is written against the OpenCL Specification Version 3.0.7.
 
 == Overview

--- a/extensions/cl_intel_planar_yuv.asciidoc
+++ b/extensions/cl_intel_planar_yuv.asciidoc
@@ -47,8 +47,6 @@ Revision: 1.0.1
 
 == Dependencies
 
-OpenCL 1.2 is required.
-
 This extension is written against the OpenCL Specification Version 3.0.7.
 
 == Overview

--- a/extensions/cl_intel_subgroup_buffer_prefetch.asciidoc
+++ b/extensions/cl_intel_subgroup_buffer_prefetch.asciidoc
@@ -44,7 +44,7 @@ Revision: 1
 
 == Dependencies
 
-OpenCL 1.2 and support for `cl_intel_subgroups` is required.
+Support for `cl_intel_subgroups` is required.
 
 This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension.
 

--- a/extensions/cl_intel_subgroup_local_block_io.asciidoc
+++ b/extensions/cl_intel_subgroup_local_block_io.asciidoc
@@ -35,8 +35,10 @@ Version: 1.0.1
 
 == Dependencies
 
-OpenCL 1.2 and support for `cl_intel_subgroups` is required.
+Support for `cl_intel_subgroups` is required.
+
 This extension is written against version 8 of the `cl_intel_subgroups` specification.
+
 This extension interacts with the `cl_intel_subgroups_char`, `cl_intel_subgroups_short`, `cl_intel_subgroups_long`, and `cl_intel_spirv_subgroups` extensions.
 
 This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or newer, or via the `cl_khr_il_program` extension.

--- a/extensions/cl_intel_subgroups.asciidoc
+++ b/extensions/cl_intel_subgroups.asciidoc
@@ -55,8 +55,7 @@ Revision: 9
 
 == Dependencies
 
-OpenCL 1.2 is required.
-Some features (`get_num_enqueued_sub_groups()` and the `sub_group_barrier()` function that accept a memory scope) require OpenCL 2.0.
+Some features (`get_num_enqueued_sub_groups()` and the `sub_group_barrier()` function that accept a memory scope) require OpenCL C 2.0.
 
 This extension is written against revision 24 of the OpenCL 2.0 API specification, against revision 24 of the OpenCL 2.0 OpenCL C specification, and against revision 24 of the OpenCL 2.0 extension specification.
 

--- a/extensions/cl_intel_subgroups_char.asciidoc
+++ b/extensions/cl_intel_subgroups_char.asciidoc
@@ -46,7 +46,8 @@ Revision: 1
 
 == Dependencies
 
-OpenCL 1.2 and support for `cl_intel_subgroups` is required.
+Support for `cl_intel_subgroups` is required.
+
 This extension is written against the OpenCL API Specification Version 2.2 (revision v2.2-7), against the OpenCL C Language Specification Version 2.0 (revision v2.2-7), and against version 4 of the `cl_intel_subgroups` specification.
 
 This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension.

--- a/extensions/cl_intel_subgroups_long.asciidoc
+++ b/extensions/cl_intel_subgroups_long.asciidoc
@@ -43,7 +43,8 @@ Revision: 1
 
 == Dependencies
 
-OpenCL 1.2 and support for `cl_intel_subgroups` is required.
+Support for `cl_intel_subgroups` is required.
+
 This extension is written against the OpenCL API Specification Version 2.2 (revision v2.2-7), against the OpenCL C Language Specification Version 2.0 (revision v2.2-7), and against version 4 of the `cl_intel_subgroups` specification.
 
 This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the `cl_khr_il_program` extension.

--- a/extensions/cl_intel_subgroups_short.asciidoc
+++ b/extensions/cl_intel_subgroups_short.asciidoc
@@ -42,7 +42,8 @@ Revision: 1.1.0
 
 == Dependencies
 
-OpenCL 1.2 and support for `cl_intel_subgroups` is required.
+Support for `cl_intel_subgroups` is required.
+
 This extension is written against the OpenCL API Specification Version 2.2 (revision v2.2-7), against the OpenCL C Language Specification Version 2.0 (revision v2.2-7), and against version 4 of the `cl_intel_subgroups` specification.
 
 == Overview


### PR DESCRIPTION
There is no OpenCL 1.2 requirement for these extensions, either for the OpenCL device or the version of OpenCL C a program is compiled for.