### PR TITLE
Add missing `clInitLayerWithProperties` return type

### DIFF
--- a/extensions/cl_loader_layers.asciidoc
+++ b/extensions/cl_loader_layers.asciidoc
@@ -59,6 +59,7 @@ strategies for backward and forward compatibility.
 
 [source,opencl]
 ----
+cl_int
 clInitLayerWithProperties(cl_uint                    num_entries,
                           const cl_icd_dispatch     *target_dispatch,
                           cl_uint                   *num_entries_ret,
@@ -216,6 +217,7 @@ If they require deinitialization, layers that support
 
 [source,opencl]
 ----
+cl_int
 clInitLayerWithProperties(cl_uint                    num_entries,
                           const cl_icd_dispatch     *target_dispatch,
                           cl_uint                   *num_entries_ret,


### PR DESCRIPTION
In PR https://github.com/KhronosGroup/OpenCL-Docs/pull/1350 which added the `clInitLayerWithProperties` entry-point to the cl_loader_layers extension the `cl_int` return type was missing from the entry-point declaration snippets.

cc @Kerilk 