### PR TITLE
remove a few references to SPIR-V from the OpenCL C spec

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -480,9 +480,8 @@ ifdef::cl_khr_integer_dot_product[]
 [[cl_khr_integer_dot_product,cl_khr_integer_dot_product]]
 ==== Integer Dot Product
 
-The {cl_khr_integer_dot_product_EXT} extension adds support for SPIR-V
-instructions and OpenCL C built-in functions to compute the dot product of
-vectors of integers.
+The {cl_khr_integer_dot_product_EXT} extension adds OpenCL C built-in functions
+to compute the dot product of vectors of integers.
 The extension provides new <<table-builtin-functions, built-in vector
 integer argument functions>> operating on these types.
 endif::cl_khr_integer_dot_product[]
@@ -491,9 +490,9 @@ ifdef::cl_khr_kernel_clock[]
 [[cl_khr_kernel_clock,cl_khr_kernel_clock]]
 ==== Kernel Clock
 
-The `cl_khr_kernel_clock` extension adds support for SPIR-V instructions and
-OpenCL C built-in functions to sample the value from one of three clocks
-provided by compute units.  The extension provides the following functions:
+The {cl_khr_kernel_clock_EXT} extension adds OpenCL C built-in functions to sample
+the value from one of three clocks provided by compute units.
+The extension provides the following functions:
 
 * <<table-kernel-clock-functions,Built-in Kernel Clock Functions>>
 endif::cl_khr_kernel_clock[]
@@ -5448,7 +5447,6 @@ endif::cl_khr_fp16[]
     | *mad* computes _a_ * _b_ + _c_.
       The function may compute _a_ * _b_ + _c_ with reduced accuracy in the
       embedded profile.
-      See the OpenCL SPIR-V Environment Specification for details.
       On some hardware the mad instruction may provide better performance
       than expanded computation of _a_ * _b_ + _c_.
       footnote:[{fn-mad-caution}]


### PR DESCRIPTION
Removes a few stray references to SPIR-V from the OpenCL C spec.

Also fixes a missing asciidoctor attribute for `cl_khr_kernel_clock`.

