### PR TITLE
fix asciidoctor refpage warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ADOCCOMMONOPTS	      = -a apispec="$(CURDIR)/api" \
 			-a cspec="$(CURDIR)/c" \
 			-a images="$(CURDIR)/images" \
 			$(ATTRIBOPTS) $(NOTEOPTS) $(VERBOSE) $(ADOCEXTS)
-ADOCOPTS	      = --failure-level WARNING -d book $(ADOCCOMMONOPTS)
+ADOCOPTS	      = --failure-level ERROR -d book $(ADOCCOMMONOPTS)
 
 # Asciidoctor options to build refpages
 #

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -13310,8 +13310,6 @@ The following behavior is undefined:
 [[enqueuing-kernels]]
 === Enqueuing Kernels
 
-[open,refpage='enqueue_kernel',desc='Enqueuing Kernels',type='freeform',spec='clang',anchor='enqueuing-kernels',xrefs='enqueue_marker']
---
 NOTE: The functionality described in this section <<unified-spec, requires>>
 support for OpenCL C 2.0, or OpenCL C 3.0 or newer and the
 {opencl_c_device_enqueue} feature.
@@ -13321,11 +13319,19 @@ enqueue additional work to the same device, without host interaction.
 A kernel may enqueue code represented by Block syntax, and control execution
 order with event dependencies including user events and markers.
 There are several advantages to using the Block syntax: it is more compact;
-it does not require a cl_kernel object; and enqueuing can be done as a
+it does not require a {cl_kernel_TYPE} object; and enqueuing can be done as a
 single semantic step.
 
+The macro `CLK_NULL_EVENT` refers to an invalid device event.
+The macro `CLK_NULL_QUEUE` refers to an invalid device queue.
+
+[[built-in-functions-enqueuing-a-kernel]]
+==== Built-in Functions - Enqueuing a Kernel
+
+[open,refpage='enqueue_kernel',desc='Built-in Functions - Enqueuing Kernels',type='freeform',spec='clang',anchor='enqueuing-kernels',xrefs='enqueue_marker']
+--
 The following table describes the list of built-in functions that can be
-used to enqueue a kernel(s).
+used to enqueue a kernel.
 
 ifdef::cl_khr_device_enqueue_local_arg_types[]
 When the {cl_khr_device_enqueue_local_arg_types_EXT} extension macro is
@@ -13342,21 +13348,6 @@ When the  {cl_khr_device_enqueue_local_arg_types_EXT} extension macro is
 not supported, the pointee type of these functions must be `void`.
 endif::cl_khr_device_enqueue_local_arg_types[]
 
-The macro `CLK_NULL_EVENT` refers to an invalid device event.
-The macro `CLK_NULL_QUEUE` refers to an invalid device queue.
---
-
-
-[[built-in-functions-enqueuing-a-kernel]]
-==== Built-in Functions - Enqueuing a Kernel
-
-ifdef::cl_khr_device_enqueue_local_arg_types[]
-:kernelEnqueueLocalArgType: gentype
-endif::cl_khr_device_enqueue_local_arg_types[]
-ifndef::cl_khr_device_enqueue_local_arg_types[]
-:kernelEnqueueLocalArgType: void
-endif::cl_khr_device_enqueue_local_arg_types[]
-
 [[table-builtin-kernel-enqueue]]
 .Built-in Kernel Enqueue Functions
 [cols=",",options="header",]
@@ -13370,12 +13361,25 @@ endif::cl_khr_device_enqueue_local_arg_types[]
     const clk_event_t *_event_wait_list_, clk_event_t *_event_ret_,
     void (^__block__)(void)) +
   int **enqueue_kernel**(queue_t _queue_, kernel_enqueue_flags_t _flags_,
-    const ndrange_t _ndrange_, void (^__block__)(local {kernelEnqueueLocalArgType} *, ...),
+    const ndrange_t _ndrange_, void (^__block__)(local void *, ...),
     uint size0, ...) +
   int **enqueue_kernel**(queue_t _queue_, kernel_enqueue_flags_t _flags_,
     const ndrange_t _ndrange_, uint _num_events_in_wait_list_,
     const clk_event_t *_event_wait_list_, clk_event_t *_event_ret_,
-    void (^__block__)(local {kernelEnqueueLocalArgType} *, ...), uint size0, ...)
+    void (^__block__)(local void *, ...), uint size0, ...)
+
+ifdef::cl_khr_device_enqueue_local_arg_types[]
+  If the {cl_khr_device_enqueue_local_arg_types_EXT} extension macro is supported:
+
+  int **enqueue_kernel**(queue_t _queue_, kernel_enqueue_flags_t _flags_,
+    const ndrange_t _ndrange_, void (^__block__)(local gentype *, ...),
+    uint size0, ...) +
+  int **enqueue_kernel**(queue_t _queue_, kernel_enqueue_flags_t _flags_,
+    const ndrange_t _ndrange_, uint _num_events_in_wait_list_,
+    const clk_event_t *_event_wait_list_, clk_event_t *_event_ret_,
+    void (^__block__)(local gentype *, ...), uint size0, ...)
+endif::cl_khr_device_enqueue_local_arg_types[]
+
     | Enqueue the block for execution to _queue_.
 
       If an event is returned, *enqueue_kernel* performs an implicit retain
@@ -13384,7 +13388,7 @@ endif::cl_khr_device_enqueue_local_arg_types[]
 
 The *enqueue_kernel* built-in function allows a work-item to enqueue a
 block.
-Work-items can enqueue multiple blocks to a device queue(s).
+Work-items can enqueue multiple blocks to device queues.
 
 The *enqueue_kernel* built-in function returns `CLK_SUCCESS` if the block is
 enqueued successfully and returns `CLK_ENQUEUE_FAILURE` otherwise.
@@ -13409,6 +13413,7 @@ block:
     could not be allocated.
   * `CLK_OUT_OF_RESOURCES` if there is a failure to queue the block in
     _queue_ because of insufficient resources needed to execute the kernel.
+--
 
 Below are some examples of how to enqueue a block.
 
@@ -13717,20 +13722,20 @@ execution.
 
 [open,refpage='kernelQueryFunctions',desc='Built-in Functions - Kernel Query Functions',type='freeform',spec='clang',anchor='built-in-functions-kernel-query-functions',xrefs='enqueue_kernel',alias='get_kernel_preferred get_kernel_work_group_size']
 --
-ifdef::cl_khr_device_enqueue_local_arg_types[]
-:kernelQueryLocalArgType: gentype
-endif::cl_khr_device_enqueue_local_arg_types[]
-ifndef::cl_khr_device_enqueue_local_arg_types[]
-:kernelQueryLocalArgType: void
-endif::cl_khr_device_enqueue_local_arg_types[]
-
 [[table-builtin-kernel-query]]
 .Built-in Kernel Query Functions
 [cols=",",options="header",]
 |====
 | Built-in Function | Description
 | uint *get_kernel_work_group_size*(void (^block)(void)) +
-  uint *get_kernel_work_group_size*(void (^block)(local {kernelQueryLocalArgType} *, ...))
+  uint *get_kernel_work_group_size*(void (^block)(local void *, ...))
+
+ifdef::cl_khr_device_enqueue_local_arg_types[]
+  If the {cl_khr_device_enqueue_local_arg_types_EXT} extension macro is supported:
+
+  uint *get_kernel_work_group_size*(void (^block)(local gentype *, ...))
+endif::cl_khr_device_enqueue_local_arg_types[]
+
     | This provides a mechanism to query the maximum work-group size that
       can be used to execute a block on a specific device given by _device_.
 
@@ -13738,7 +13743,15 @@ endif::cl_khr_device_enqueue_local_arg_types[]
 | uint *{get_kernel_preferred_work_group_size_multiple}*(
   void (^block)(void)) +
   uint *{get_kernel_preferred_work_group_size_multiple}*(
-  void (^block)(local {kernelQueryLocalArgType} *, ...))
+  void (^block)(local void *, ...))
+
+ifdef::cl_khr_device_enqueue_local_arg_types[]
+  If the {cl_khr_device_enqueue_local_arg_types_EXT} extension macro is supported:
+
+  uint *{get_kernel_preferred_work_group_size_multiple}*(
+  void (^block)(local gentype *, ...))
+endif::cl_khr_device_enqueue_local_arg_types[]
+
     | Returns the preferred multiple of work-group size for launch.
       This is a performance hint.
       Specifying a work-group size that is not a multiple of the value


### PR DESCRIPTION
Fixes several asciidoctor refpage warnings about missing attributes for the device enqueue functions.

Also fixes some of the refpage markup so the right content gets included in the online reference pages.

With these changes fixes we should be able to switch the spec toolchain to fail on asciidoctor warnings, see #1425.