### PR TITLE
Fix name of cl_arm_core_id extension

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -6427,7 +6427,7 @@ server's OpenCL/api-docs repository.
                 <command name="clSetKernelExecInfoARM"/>
             </require>
         </extension>
-        <extension name="cl_arm_get_core_id" revision="0.0.0" condition="defined(CL_VERSION_1_2)" supported="opencl">
+        <extension name="cl_arm_core_id" revision="0.0.0" condition="defined(CL_VERSION_1_2)" supported="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
This name was introduced with the orignal XML under 6163e510aba70daced330b7d7f54bc9b5b416252, probably based on the name of the specification text file
(OpenCL-Registry/blob/main/extensions/arm/cl_arm_get_core_id.txt) rather than the extension name documented in this file.


Change-Id: I73fb415afc2909963a2ee6aaa3cd7b152d0fd1f6