### PR TITLE
break extension conventions into two reference pages

### DIFF
--- a/api/appendix_extensions.asciidoc
+++ b/api/appendix_extensions.asciidoc
@@ -25,12 +25,11 @@ alphabetically by author ID.
 Within each group, extensions are listed in alphabetical order by their
 names.
 
-[open,refpage='extensionConventions',desc='Conventions for Optional Extensions.',type='freeform',anchor='extensions']
---
-
 [[naming-convention-for-optional-extensions]]
 == Naming Convention for Optional Extensions
 
+[open,refpage='extensionNamingConventions',desc='Naming Conventions for Optional Extensions.',type='freeform',anchor='extensions']
+--
 OpenCL extensions approved by the OpenCL working group use the following
 naming convention:
 
@@ -71,11 +70,13 @@ convention:
 Vendor extensions are not currently included in the OpenCL specifications, but
 vendor extension specifications are frequently included in the online Registry
 of extensions.
-
+--
 
 [[header-conventions-for-optional-extensions]]
 == Header Conventions for Optional Extensions
 
+[open,refpage='extensionHeaderConventions',desc='Header Conventions for Optional Extensions.',type='freeform',anchor='extensions']
+--
 Function pointer typedefs should be declared for all extensions that add API
 entrypoints.
 These typedefs are a required part of the extension interface, and should be

--- a/man/toctail
+++ b/man/toctail
@@ -585,7 +585,8 @@
 
             <li class="Level1">Optional Extensions
                 <ul class="Level2">
-                    <li><a href="extensionConventions.html" target="pagedisplay">Extension Conventions</a>
+                    <li><a href="extensionNamingConventions.html" target="pagedisplay">Naming Conventions</a>
+                    <li><a href="extensionHeaderConventions.html" target="pagedisplay">Header Conventions</a>
                     <li><a href="EXTENSION.html" target="pagedisplay">EXTENSION</a>
                     <li><a href="cl_khr_3d_image_writes.html" target="pagedisplay">cl_khr_3d_image_writes</a></li>
                     <li><a href="cl_khr_byte_addressable_store.html" target="pagedisplay">cl_khr_byte_addressable_store</a></li>


### PR DESCRIPTION
Apparently the reference page markup cannot span multiple sections without generating asciidoctor rendering issues.  So, break the "extension conventions" reference page into two pages - one for "naming conventions", and another for "header conventions", where each page consists of a single section.