### PR TITLE
fix the SPIR-V Image Data Types table header row

### DIFF
--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1459,10 +1459,10 @@ For the following image channel orders, the data is a scalar type:
 The following table describes the mapping from image channel data type
 to the data vector component type or scalar type:
 
-._Image Data Types_
+._Mapping Image Data Types to Data Types_
 [cols=",",options="header",]
 |====
-|*Image Channel Order*
+|*Image Channel Data Type*
 |*Data Type*
 
 |`SnormInt8`,


### PR DESCRIPTION
Fixes an error in the table header row for the "Image Data Types" table in the OpenCL SPIR-V environment spec.

I suspect this was a copy-paste error from a previous table.  Regardless, this table column describes the image channel data type, not the image channel order.