### PR TITLE
remove the Extending Attribute Qualifiers section

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4659,23 +4659,6 @@ compile-time constant expression.
 --
 
 
-[[extending-attribute-qualifiers]]
-=== Extending Attribute Qualifiers
-
-The attribute syntax can be extended for standard language extensions and
-vendor specific extensions.
-
-Attributes are intended as useful hints to the compiler.
-It is our intention that a particular implementation of OpenCL be free to
-ignore all attributes and the resulting executable binary will produce the
-same result.
-This does not preclude an implementation from making use of the additional
-information provided by attributes and performing optimizations or other
-transformations as it sees fit.
-In this case it is the programmer's responsibility to guarantee that the
-information provided is in some sense correct.
-
-
 [[blocks]]
 == Blocks
 

--- a/api/appendix_extensions.asciidoc
+++ b/api/appendix_extensions.asciidoc
@@ -67,6 +67,9 @@ convention:
     form *cl_<__type_name__>_<__vendor_tag__>.*
   * All API functions defined by the vendor extension should have names of the
     form *cl<__function_name__><__VENDOR_TAG__>*.
+  * All OpenCL C functions, types, and attribute qualifiers defined by the
+    vendor extension should have names of the form
+    *<__vendor_tag__>_<__name__>*.
 
 Vendor extensions are not currently included in the OpenCL specifications, but
 vendor extension specifications are frequently included in the online Registry


### PR DESCRIPTION
fixes #1518 

Removes the OpenCL C "Extending Attribute Qualifiers" section because it was not particularly useful and somewhat incorrect.

Documents the informative naming suggestion in the existing extension appendix, instead.