### PR TITLE
move cluster size restrictions for cl_khr_subgroup_clustered_reduce

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -14959,9 +14959,9 @@ gentype sub_group_clustered_rotate(
     The value of _delta_ is required to be dynamically-uniform for all work
     items in the sub-group, otherwise the behavior is undefined.
 
-    _clustersize_ must be an integer constant expression and a power of two,
-    smaller than or equal to the maximum sub-group size, otherwise the
-    behavior is undefined.
+    Behavior is undefined if _clustersize_ is not an integer constant
+    expression, is not a power-of-two, or is greater than the maximum size of a
+    sub-group within the dispatch.
 
     The return value is undefined if the work item with sub-group local ID
     equal to the calculated index is inactive.

--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -14493,9 +14493,6 @@ size _n_, the _n_ work items in the sub-group with the smallest sub-group
 local IDs are assigned to the first cluster, then the _n_ remaining work
 items with the smallest sub-group local IDs are assigned to the next
 cluster, and so on.
-Behavior is undefined if the specified cluster size is not an integer
-constant expression, is not a power-of-two, or is greater than the maximum
-size of a sub-group within the dispatch.
 
 
 ===== Arithmetic Operations
@@ -14530,6 +14527,10 @@ gentype sub_group_clustered_reduce_max(
   | Returns the summation, multiplication, minimum, or maximum of _value_
     for all active work items in the sub-group within a cluster of the
     specified _clustersize_.
+
+    Behavior is undefined if _clustersize_ is not an integer constant
+    expression, is not a power-of-two, or is greater than the maximum size of a
+    sub-group within the dispatch.
 |====
 
 Note: The order of floating-point operations is not guaranteed for the
@@ -14565,6 +14566,10 @@ gentype sub_group_clustered_reduce_xor(
 ----
   | Returns the bitwise *and*, *or*, or *xor* of _value_ for all active work
     items in the sub-group within a cluster of the specified _clustersize_.
+
+    Behavior is undefined if _clustersize_ is not an integer constant
+    expression, is not a power-of-two, or is greater than the maximum size of a
+    sub-group within the dispatch.
 |====
 
 
@@ -14596,6 +14601,10 @@ int sub_group_clustered_reduce_logical_xor(
   | Returns the logical *and*, *or*, or *xor* of _predicate_ for all active
     work items in the sub-group within a cluster of the specified
     _clustersize_.
+
+    Behavior is undefined if _clustersize_ is not an integer constant
+    expression, is not a power-of-two, or is greater than the maximum size of a
+    sub-group within the dispatch.
 |====
 
 endif::cl_khr_subgroup_clustered_reduce[]


### PR DESCRIPTION
fixes #1534

Instead of documenting cluster size restrictions in the section header, describe the restrictions in the description for each of the functions. This aligns with the way cluster size restrictions are documented for cl_khr_subgroup_rotate and makes the restriction easier to spot.