### PR TITLE
remove the halfn vector type from the list of reserved data types

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -1189,8 +1189,10 @@ are also reserved.
 | Type | Description
 | `bool__n__`
     | A boolean vector.
+ifndef::cl_khr_fp16[]
 | `half__n__`
     | A 16-bit floating-point vector.
+endif::cl_khr_fp16[]
 | `quad`, `quad__n__`
     | A 128-bit floating-point scalar and vector.
 | `complex half`, `complex half__n__`


### PR DESCRIPTION
fixes #1547

The "halfn" vector type is a usable data type when the cl_khr_fp16 extension is supported.