### PR TITLE
reserve enum block 0x42B0 for Intel extensions

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2507,8 +2507,12 @@ server's OpenCL/api-docs repository.
             <unused start="0x42A0" end="0x42AF"/>
     </enums>
 
-    <enums start="0x42B0" end="0x4FFF" name="enums.42B0" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x42B0" end="0x4FFF"/>
+    <enums start="0x42B0" end="0x42BF" name="enums.42B0" vendor="Intel">
+            <unused start="0x42B0" end="0x42BF"/>
+    </enums>
+
+    <enums start="0x42C0" end="0x4FFF" name="enums.42B0" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x42C0" end="0x4FFF"/>
     </enums>
 
     <enums start="0x5000" end="0x500F" name="enums.5000" comment="For cl_ext_buffer_device_address">


### PR DESCRIPTION
Please reserve enum block 0x42B0 for Intel extensions.