### PR TITLE
fix erroneous leading underscore from halfn type names

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -2189,7 +2189,7 @@ operands if the source operands are vector types.
 Vector source operands of type `char__n__` and `uchar__n__` return a
 `char__n__` result; vector source operands of type
 ifdef::cl_khr_fp16[]
-`_half__n__` footnote:[{fn-half-supported}],
+`half__n__` footnote:[{fn-half-supported}],
 endif::cl_khr_fp16[]
 `short__n__` and
 `ushort__n__` return a `short__n__` result; vector source operands of type
@@ -2237,7 +2237,7 @@ operands if the source operands are vector types.
 Vector source operands of type `char__n__` and `uchar__n__` return a
 `char__n__` result; vector source operands of type
 ifdef::cl_khr_fp16[]
-`_half__n__` footnote:[{fn-half-supported}],
+`half__n__` footnote:[{fn-half-supported}],
 endif::cl_khr_fp16[]
 `short__n__` and
 `ushort__n__` return a `short__n__` result; vector source operands of type
@@ -2274,7 +2274,7 @@ The scalar type is then widened to a vector that has the same number of
 components as the vector operand.
 The operation is done component-wise resulting in the same size vector.
 ifdef::cl_khr_fp16[]
-Vector source operands of type `_half__n__` footnote:[{fn-half-supported}]
+Vector source operands of type `half__n__` footnote:[{fn-half-supported}]
 return a `short__n__` result.
 endif::cl_khr_fp16[]
 --
@@ -2308,7 +2308,7 @@ operands if the source operands are vector types.
 Vector source operands of type `char__n__` and `uchar__n__` return a
 `char__n__` result; vector source operands of type
 ifdef::cl_khr_fp16[]
-`_half__n__` footnote:[{fn-half-supported}],
+`half__n__` footnote:[{fn-half-supported}],
 endif::cl_khr_fp16[]
 `short__n__` and
 `ushort__n__` return a `short__n__` result; vector source operands of type
@@ -2338,7 +2338,7 @@ operands if the source operands are vector types.
 Vector source operands of type `char__n__` and `uchar__n__` return a
 `char__n__` result; vector source operands of type
 ifdef::cl_khr_fp16[]
-`_half__n__` footnote:[{fn-half-supported}],
+`half__n__` footnote:[{fn-half-supported}],
 endif::cl_khr_fp16[]
 `short__n__` and
 `ushort__n__` return a `short__n__` result; vector source operands of type


### PR DESCRIPTION
A few places in the OpenCL C spec erroneously included a leading underscore in several places referring to the "halfn" vector type.