### PR TITLE
Fix texture addressing algorithm rendering in OpenCL Environment Spec.

### DIFF
--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -274,17 +274,17 @@ The image element location `(i,j,k)` is computed as:
 ++++
 \begin{array}{rcl}
 s' &=& 2.0f \times rint(0.5f \times s)\\
-s` &=& fabs(s - s`)\\
+s' &=& fabs(s - s')\\
 u  &=& s' \times w_t\\
 i  &=& (int)floor(u)\\
 i  &=& min(i, w_t - 1)\\
 t' &=& 2.0f \times rint(0.5f \times t)\\
-t` &=& fabs(t - t`)\\
+t' &=& fabs(t - t')\\
 v  &=& t' \times h_t\\
 j  &=& (int)floor(v)\\
 j  &=& min(j, h_t - 1)\\
 r' &=& 2.0f \times rint(0.5f \times r)\\
-r` &=& fabs(r - r`)\\
+r' &=& fabs(r - r')\\
 w  &=& r' \times d_t\\
 k  &=& (int)floor(w)\\
 k  &=& min(k, d_t - 1)
@@ -306,21 +306,21 @@ Let
 ++++
 \begin{array}{rcl}
 s' &=& 2.0f \times rint(0.5f \times s)\\
-s` &=& fabs(s - s`)\\
+s' &=& fabs(s - s')\\
 u  &=& s' \times w_t\\
 i0 &=& (int)floor(u - 0.5f)\\
 i1 &=& i0 + 1\\
 i0 &=& max(i0, 0)\\
 i1 &=& min(i1, w_t - 1)\\
 t' &=& 2.0f \times rint(0.5f \times t)\\
-t` &=& fabs(t - t`)\\
+t' &=& fabs(t - t')\\
 v  &=& t' \times h_t\\
 j0 &=& (int)floor(v - 0.5f)\\
 j1 &=& j0 + 1\\
 j0 &=& max(j0, 0)\\
 j1 &=& min(j1, h_t - 1)\\
 r' &=& 2.0f \times rint(0.5f \times r)\\
-r` &=& fabs(r - r`)\\
+r' &=& fabs(r - r')\\
 w  &=& r' \times d_t\\
 k0 &=& (int)floor(w - 0.5f)\\
 k1 &=& k0 + 1\\


### PR DESCRIPTION

Fixes #1569 
After the fix:
<img width="398" height="115" alt="image" src="https://github.com/user-attachments/assets/45187668-64cb-47e5-8ca1-1fe0fb54cbad" />


