### PR TITLE
Fix missing underscore in cl_kernel_workgroup_info in XML

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -8134,7 +8134,7 @@ server's OpenCL/api-docs repository.
             <require>
                 <type name="cl_kernel_allocation_info_intel"/>
             </require>
-            <require comment="cl_kernel_workgroup_info">
+            <require comment="cl_kernel_work_group_info">
                 <enum name="CL_KERNEL_ALLOCATIONS_INFO_INTEL"/>
             </require>
         </extension>


### PR DESCRIPTION
This PR fixes #1577.

---

(Copied from #1577)

Hello, I'm working on OpenCL bindings for C# as part of the Silk.NET project.

I'm wondering if `cl_kernel_workgroup_info` here is supposed to be `cl_kernel_work_group_info` instead.

https://github.com/KhronosGroup/OpenCL-Docs/blob/1f2a44a4ecc2a76696410b3a110511ff2dc0ae49/xml/cl.xml#L8136-L8140

Unfortunately, I'm not particularly knowledgeable on OpenCL, but my reasoning is that `cl_kernel_work_group_info` is an existing type while `cl_kernel_workgroup_info` is not.

---

If this isn't an issue, please feel free to close this PR and linked issue.