### PR TITLE
Fix trailing spaces in enum names

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1485,14 +1485,14 @@ server's OpenCL/api-docs repository.
             <unused start="2" end="9999"/>
     </enums>
 
-    <enums name="cl_platform_command_buffer_capabilities_khr " vendor="Khronos" type="bitmask">
+    <enums name="cl_platform_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_PLATFORM_UNIVERSAL_SYNC_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_PLATFORM_REMAP_QUEUES_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_PLATFORM_AUTOMATIC_REMAP_KHR"/>
             <unused start="3" end="31"/>
     </enums>
 
-    <enums name="cl_device_command_buffer_capabilities_khr " vendor="Khronos" type="bitmask">
+    <enums name="cl_device_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>


### PR DESCRIPTION
Hello, I'm working on OpenCL bindings for C# as part of the Silk.NET project.

While working on the bindings, I found some trailing spaces in the names of 2 enums.