### PR TITLE
Mark all enum constants with their enumeration

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1438,16 +1438,28 @@ server's OpenCL/api-docs repository.
         <enum value="0x1074"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_8BIT_KHR"/>
         <enum value="0x1075"        name="CL_DEVICE_INTEGER_DOT_PRODUCT_ACCELERATION_PROPERTIES_4x8BIT_PACKED_KHR"/>
             <unused start="0x1076" end="0x107F" comment="Reserved for cl_device_info"/>
+    </enums>
+
+    <enums start="0x1080" end="0x1083" name="cl_context_info" vendor="Khronos">
         <enum value="0x1080"        name="CL_CONTEXT_REFERENCE_COUNT"/>
         <enum value="0x1081"        name="CL_CONTEXT_DEVICES"/>
         <enum value="0x1082"        name="CL_CONTEXT_PROPERTIES"/>
         <enum value="0x1083"        name="CL_CONTEXT_NUM_DEVICES"/>
+    </enums>
+
+    <enums start="0x1084" end="0x1085" name="cl_context_properties" vendor="Khronos">
         <enum value="0x1084"        name="CL_CONTEXT_PLATFORM"/>
         <enum value="0x1085"        name="CL_CONTEXT_INTEROP_USER_SYNC"/>
+    </enums>
+
+    <enums start="0x1086" end="0x108F" name="cl_device_partition_property" vendor="Khronos">
         <enum value="0x1086"        name="CL_DEVICE_PARTITION_EQUALLY"/>
         <enum value="0x1087"        name="CL_DEVICE_PARTITION_BY_COUNTS"/>
         <enum value="0x1088"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN"/>
             <unused start="0x1089" end="0x108F" comment="Reserved for cl_device_partition_property"/>
+    </enums>
+
+    <enums start="0x1090" end="0x109F" name="cl_command_queue_info" vendor="Khronos">
         <enum value="0x1090"        name="CL_QUEUE_CONTEXT"/>
         <enum value="0x1091"        name="CL_QUEUE_DEVICE"/>
         <enum value="0x1092"        name="CL_QUEUE_REFERENCE_COUNT"/>
@@ -1458,7 +1470,13 @@ server's OpenCL/api-docs repository.
         <enum value="0x1097"        name="CL_QUEUE_THROTTLE_KHR"/>
         <enum value="0x1098"        name="CL_QUEUE_PROPERTIES_ARRAY"/>
             <unused start="0x1099" end="0x109F" comment="Reserved for cl_command_queue_info"/>
+    </enums>
+
+    <enums start="0x10A0" end="0x10AF" name="enums.10A0" vendor="Khronos">
             <unused start="0x10A0" end="0x10AF" comment="Reserved for core API tokens"/>
+    </enums>
+
+    <enums start="0x10B0" end="0x10CF" name="cl_channel_order" vendor="Khronos">
         <enum value="0x10B0"        name="CL_R"/>
         <enum value="0x10B1"        name="CL_A"/>
         <enum value="0x10B2"        name="CL_RG"/>
@@ -1480,6 +1498,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10C2"        name="CL_sBGRA"/>
         <enum value="0x10C3"        name="CL_ABGR"/>
             <unused start="0x10C4" end="0x10CF" comment="Reserved for cl_channel_order"/>
+    </enums>
+
+    <enums start="0x10D0" end="0x10EF" name="cl_channel_type" vendor="Khronos">
         <enum value="0x10D0"        name="CL_SNORM_INT8"/>
         <enum value="0x10D1"        name="CL_SNORM_INT16"/>
         <enum value="0x10D2"        name="CL_UNORM_INT8"/>
@@ -1498,6 +1519,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10DF"        name="CL_UNORM_INT24"/>
         <enum value="0x10E0"        name="CL_UNORM_INT_101010_2"/>
             <unused start="0x10E1" end="0x10EF" comment="Reserved for cl_channel_type"/>
+    </enums>
+
+    <enums start="0x10F0" end="0x10FF" name="cl_mem_object_type" vendor="Khronos">
         <enum value="0x10F0"        name="CL_MEM_OBJECT_BUFFER"/>
         <enum value="0x10F1"        name="CL_MEM_OBJECT_IMAGE2D"/>
         <enum value="0x10F2"        name="CL_MEM_OBJECT_IMAGE3D"/>
@@ -1507,6 +1531,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x10F6"        name="CL_MEM_OBJECT_IMAGE1D_BUFFER"/>
         <enum value="0x10F7"        name="CL_MEM_OBJECT_PIPE"/>
             <unused start="0x10F8" end="0x10FF" comment="Reserved for cl_mem_object_type"/>
+    </enums>
+
+    <enums start="0x1100" end="0x110F" name="cl_mem_info" vendor="Khronos">
         <enum value="0x1100"        name="CL_MEM_TYPE"/>
         <enum value="0x1101"        name="CL_MEM_FLAGS"/>
         <enum value="0x1102"        name="CL_MEM_SIZE"/>
@@ -1519,6 +1546,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x1109"        name="CL_MEM_USES_SVM_POINTER"/>
         <enum value="0x110A"        name="CL_MEM_PROPERTIES"/>
             <unused start="0x110B" end="0x110F" comment="Reserved for cl_mem_info"/>
+    </enums>
+
+    <enums start="0x1110" end="0x111F" name="cl_image_info" vendor="Khronos">
         <enum value="0x1110"        name="CL_IMAGE_FORMAT"/>
         <enum value="0x1111"        name="CL_IMAGE_ELEMENT_SIZE"/>
         <enum value="0x1112"        name="CL_IMAGE_ROW_PITCH"/>
@@ -1531,19 +1561,31 @@ server's OpenCL/api-docs repository.
         <enum value="0x1119"        name="CL_IMAGE_NUM_MIP_LEVELS"/>
         <enum value="0x111A"        name="CL_IMAGE_NUM_SAMPLES"/>
             <unused start="0x111B" end="0x111F" comment="Reserved for cl_image_info"/>
+    </enums>
+
+    <enums start="0x1120" end="0x112F" name="cl_pipe_info" vendor="Khronos">
         <enum value="0x1120"        name="CL_PIPE_PACKET_SIZE"/>
         <enum value="0x1121"        name="CL_PIPE_MAX_PACKETS"/>
         <enum value="0x1122"        name="CL_PIPE_PROPERTIES"/>
             <unused start="0x1123" end="0x112F" comment="Reserved for cl_pipe_info"/>
+    </enums>
+
+    <enums start="0x1130" end="0x113F" name="cl_addressing_mode" vendor="Khronos">
         <enum value="0x1130"        name="CL_ADDRESS_NONE"/>
         <enum value="0x1131"        name="CL_ADDRESS_CLAMP_TO_EDGE"/>
         <enum value="0x1132"        name="CL_ADDRESS_CLAMP"/>
         <enum value="0x1133"        name="CL_ADDRESS_REPEAT"/>
         <enum value="0x1134"        name="CL_ADDRESS_MIRRORED_REPEAT"/>
             <unused start="0x1135" end="0x113F" comment="Reserved for cl_addressing_mode"/>
+    </enums>
+
+    <enums start="0x1140" end="0x114F" name="cl_filter_mode" vendor="Khronos">
         <enum value="0x1140"        name="CL_FILTER_NEAREST"/>
         <enum value="0x1141"        name="CL_FILTER_LINEAR"/>
             <unused start="0x1142" end="0x114F" comment="Reserved for cl_filter_mode"/>
+    </enums>
+
+    <enums start="0x1150" end="0x115F" name="cl_sampler_info" vendor="Khronos">
         <enum value="0x1150"        name="CL_SAMPLER_REFERENCE_COUNT"/>
         <enum value="0x1151"        name="CL_SAMPLER_CONTEXT"/>
         <enum value="0x1152"        name="CL_SAMPLER_NORMALIZED_COORDS"/>
@@ -1557,6 +1599,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x1157"        name="CL_SAMPLER_LOD_MAX_KHR"/>
         <enum value="0x1158"        name="CL_SAMPLER_PROPERTIES"/>
             <unused start="0x1159" end="0x115F" comment="Reserved for cl_sampler_info"/>
+    </enums>
+
+    <enums start="0x1160" end="0x117F" name="cl_program_info" vendor="Khronos">
         <enum value="0x1160"        name="CL_PROGRAM_REFERENCE_COUNT"/>
         <enum value="0x1161"        name="CL_PROGRAM_CONTEXT"/>
         <enum value="0x1162"        name="CL_PROGRAM_NUM_DEVICES"/>
@@ -1571,6 +1616,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x116A"        name="CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT"/>
         <enum value="0x116B"        name="CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT"/>
             <unused start="0x116C" end="0x117F" comment="Reserved for cl_program_info"/>
+    </enums>
+
+    <enums start="0x1180" end="0x118F" name="cl_program_build_info" vendor="Khronos">
             <unused start="0x1180" comment="Reserved for cl_program_build_info"/>
         <enum value="0x1181"        name="CL_PROGRAM_BUILD_STATUS"/>
         <enum value="0x1182"        name="CL_PROGRAM_BUILD_OPTIONS"/>
@@ -1578,45 +1626,72 @@ server's OpenCL/api-docs repository.
         <enum value="0x1184"        name="CL_PROGRAM_BINARY_TYPE"/>
         <enum value="0x1185"        name="CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE"/>
             <unused start="0x1186" end="0x118F" comment="Reserved for cl_program_build_info"/>
+    </enums>
+
+    <enums start="0x1190" end="0x1195" name="cl_kernel_info" vendor="Khronos">
         <enum value="0x1190"        name="CL_KERNEL_FUNCTION_NAME"/>
         <enum value="0x1191"        name="CL_KERNEL_NUM_ARGS"/>
         <enum value="0x1192"        name="CL_KERNEL_REFERENCE_COUNT"/>
         <enum value="0x1193"        name="CL_KERNEL_CONTEXT"/>
         <enum value="0x1194"        name="CL_KERNEL_PROGRAM"/>
         <enum value="0x1195"        name="CL_KERNEL_ATTRIBUTES"/>
+    </enums>
+
+    <enums start="0x1196" end="0x119A" name="cl_kernel_arg_info" vendor="Khronos">
         <enum value="0x1196"        name="CL_KERNEL_ARG_ADDRESS_QUALIFIER"/>
         <enum value="0x1197"        name="CL_KERNEL_ARG_ACCESS_QUALIFIER"/>
         <enum value="0x1198"        name="CL_KERNEL_ARG_TYPE_NAME"/>
         <enum value="0x1199"        name="CL_KERNEL_ARG_TYPE_QUALIFIER"/>
         <enum value="0x119A"        name="CL_KERNEL_ARG_NAME"/>
+    </enums>
+
+    <enums start="0x119B" end="0x119F" name="cl_kernel_arg_address_qualifier" vendor="Khronos">
         <enum value="0x119B"        name="CL_KERNEL_ARG_ADDRESS_GLOBAL"/>
         <enum value="0x119C"        name="CL_KERNEL_ARG_ADDRESS_LOCAL"/>
         <enum value="0x119D"        name="CL_KERNEL_ARG_ADDRESS_CONSTANT"/>
         <enum value="0x119E"        name="CL_KERNEL_ARG_ADDRESS_PRIVATE"/>
             <unused start="0x119F" comment="Reserved for cl_kernel_arg_address_qualifier"/>
+    </enums>
+
+    <enums start="0x11A0" end="0x11AF" name="cl_kernel_arg_access_qualifier" vendor="Khronos">
         <enum value="0x11A0"        name="CL_KERNEL_ARG_ACCESS_READ_ONLY"/>
         <enum value="0x11A1"        name="CL_KERNEL_ARG_ACCESS_WRITE_ONLY"/>
         <enum value="0x11A2"        name="CL_KERNEL_ARG_ACCESS_READ_WRITE"/>
         <enum value="0x11A3"        name="CL_KERNEL_ARG_ACCESS_NONE"/>
             <unused start="0x11A4" end="0x11AF" comment="Reserved for cl_kernel_arg_access_qualifier"/>
+    </enums>
+
+    <enums start="0x11B0" end="0x11B6" name="cl_kernel_work_group_info" vendor="Khronos">
         <enum value="0x11B0"        name="CL_KERNEL_WORK_GROUP_SIZE"/>
         <enum value="0x11B1"        name="CL_KERNEL_COMPILE_WORK_GROUP_SIZE"/>
         <enum value="0x11B2"        name="CL_KERNEL_LOCAL_MEM_SIZE"/>
         <enum value="0x11B3"        name="CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE"/>
         <enum value="0x11B4"        name="CL_KERNEL_PRIVATE_MEM_SIZE"/>
         <enum value="0x11B5"        name="CL_KERNEL_GLOBAL_WORK_SIZE"/>
+    </enums>
+
+    <enums start="0x11B6" end="0x11B7" name="cl_kernel_exec_info " vendor="Khronos">
         <enum value="0x11B6"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS"/>
         <enum value="0x11B7"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM"/>
+    </enums>
+
+    <enums start="0x11B8" end="0x11CF" name="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x11B8"        name="CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT"/>
         <enum value="0x11B9"        name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
         <enum value="0x11BA"        name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
             <unused start="0x11BB" end="0x11CF" comment="Reserved for cl_kernel_info / cl_kernel_work_group_info / cl_kernel_exec_info / cl_kernel_sub_group_info"/>
+    </enums>
+
+    <enums start="0x11D0" end="0x11EF" name="cl_event_info" vendor="Khronos">
         <enum value="0x11D0"        name="CL_EVENT_COMMAND_QUEUE"/>
         <enum value="0x11D1"        name="CL_EVENT_COMMAND_TYPE"/>
         <enum value="0x11D2"        name="CL_EVENT_REFERENCE_COUNT"/>
         <enum value="0x11D3"        name="CL_EVENT_COMMAND_EXECUTION_STATUS"/>
         <enum value="0x11D4"        name="CL_EVENT_CONTEXT"/>
             <unused start="0x11D5" end="0x11EF" comment="Reserved for cl_event_info"/>
+    </enums>
+
+    <enums start="0x11F0" end="0x121F" name="cl_command_type" vendor="Khronos">
         <enum value="0x11F0"        name="CL_COMMAND_NDRANGE_KERNEL"/>
         <enum value="0x11F1"        name="CL_COMMAND_TASK"/>
         <enum value="0x11F2"        name="CL_COMMAND_NATIVE_KERNEL"/>
@@ -1648,33 +1723,57 @@ server's OpenCL/api-docs repository.
         <enum value="0x120C"        name="CL_COMMAND_SVM_MAP"/>
         <enum value="0x120D"        name="CL_COMMAND_SVM_UNMAP"/>
         <enum value="0x120E"        name="CL_COMMAND_SVM_MIGRATE_MEM"/>
-            <unused start="0x120F" end="0x121F" comment="Reserved for cl_command_types"/>
+            <unused start="0x120F" end="0x121F" comment="Reserved for cl_command_type"/>
+    </enums>
+
+    <enums start="0x1220" end="0x127F" name="cl_buffer_create_type" vendor="Khronos">
         <enum value="0x1220"        name="CL_BUFFER_CREATE_TYPE_REGION"/>
             <unused start="0x1221" end="0x127F" comment="Reserved for cl_buffer_create_type"/>
+    </enums>
+
+    <enums start="0x1280" end="0x128F" name="cl_profiling_info" vendor="Khronos">
         <enum value="0x1280"        name="CL_PROFILING_COMMAND_QUEUED"/>
         <enum value="0x1281"        name="CL_PROFILING_COMMAND_SUBMIT"/>
         <enum value="0x1282"        name="CL_PROFILING_COMMAND_START"/>
         <enum value="0x1283"        name="CL_PROFILING_COMMAND_END"/>
         <enum value="0x1284"        name="CL_PROFILING_COMMAND_COMPLETE"/>
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
+    </enums>
+
+    <enums start="0x1290" end="0x1292" name="enums.1290" vendor="Khronos">
             <unused start="0x1290" end="0x1291" comment="Reserved for MR179"/>
         <enum value="0x1292"        name="Reserved for PR750"/>
+    </enums>
+
+    <enums start="0x1293" end="0x1293" name="cl_command_buffer_properties_khr" vendor="Khronos">
         <enum value="0x1293"             name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
+    </enums>
+
+    <enums start="0x1294" end="0x12A7" name="cl_command_buffer_info_khr" vendor="Khronos">
         <enum value="0x1294"             name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
         <enum value="0x1295"             name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
         <enum value="0x1296"             name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
         <enum value="0x1297"             name="CL_COMMAND_BUFFER_STATE_KHR"/>
         <enum value="0x1298"             name="CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR"/>
             <unused start="0x1299" end="0x12A7" comment="Used by future command-buffer extensions"/>
+    </enums>
+
+    <enums start="0x12A8" end="0x12A8" name="cl_command_type" vendor="Khronos">
         <enum value="0x12A8"             name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
+    </enums>
+
+    <enums start="0x12A9" end="0x12B1" name="cl_device_info" vendor="Khronos">
         <enum value="0x12A9"             name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"             name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
             <unused start="0x12AB" end="0x12B1" comment="Used by future command-buffer extensions"/>
+    </enums>
+
+    <enums start="0x12B2" end="0x1FFF" name="enums.12B2" vendor="Khronos">
             <unused start="0x12B2" end="0x12B6" comment="Reserved for PR750"/>
             <unused start="0x12B7" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
-    <enums start="0x2000" end="0x201F" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">
+    <enums start="0x2000" end="0x2032" name="enums.2000" vendor="Khronos" comment="Reserved for interop with other APIs">
         <enum value="0x2000"        name="CL_GL_OBJECT_BUFFER"/>
         <enum value="0x2001"        name="CL_GL_OBJECT_TEXTURE2D"/>
         <enum value="0x2002"        name="CL_GL_OBJECT_TEXTURE3D"/>
@@ -1714,10 +1813,16 @@ server's OpenCL/api-docs repository.
         <enum value="0x2030"        name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
         <enum value="0x2031"        name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
         <enum value="0x2032"        name="CL_CONTEXT_TERMINATE_KHR"/>
+    </enums>
+
+    <enums start="0x2033" end="0x2034" name="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE"/>
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
+    </enums>
+
+    <enums start="0x2035" end="0x201F" name="enums.2035" vendor="Khronos" comment="Reserved for interop with other APIs">
         <enum value="0x2035"        name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
         <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
         <enum value="0x2037"        name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1972,7 +1972,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x11B5"        name="CL_KERNEL_GLOBAL_WORK_SIZE"/>
     </enums>
 
-    <enums start="0x11B6" end="0x11B7" group="cl_kernel_exec_info " vendor="Khronos">
+    <enums start="0x11B6" end="0x11B7" group="cl_kernel_exec_info" vendor="Khronos">
         <enum value="0x11B6"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS"/>
         <enum value="0x11B7"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM"/>
     </enums>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1852,8 +1852,8 @@ server's OpenCL/api-docs repository.
     <enums start="0x1110" end="0x111F" name="cl_image_info" vendor="Khronos">
         <enum value="0x1110"        name="CL_IMAGE_FORMAT"/>
         <enum value="0x1111"        name="CL_IMAGE_ELEMENT_SIZE"/>
-        <enum value="0x1112"        name="CL_IMAGE_ROW_PITCH"/>   <!-- FIXME: Also included by cl_qcom_ext_host_ptr in the cl_image_pitch_info_qcom enum -->
-        <enum value="0x1113"        name="CL_IMAGE_SLICE_PITCH"/> <!-- FIXME: Also included by cl_qcom_ext_host_ptr in the cl_image_pitch_info_qcom enum -->
+        <enum value="0x1112"        name="CL_IMAGE_ROW_PITCH"   group="cl_image_pitch_info_qcom"/>
+        <enum value="0x1113"        name="CL_IMAGE_SLICE_PITCH" group="cl_image_pitch_info_qcom"/>
         <enum value="0x1114"        name="CL_IMAGE_WIDTH"/>
         <enum value="0x1115"        name="CL_IMAGE_HEIGHT"/>
         <enum value="0x1116"        name="CL_IMAGE_DEPTH"/>

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -619,7 +619,7 @@ server's OpenCL/api-docs repository.
         <enum value="((cl_layer_properties)0)"   name="CL_LAYER_PROPERTIES_LIST_END"/>
     </enums>
 
-    <enums start="0" end="-999" name="ErrorCodes.0" vendor="Khronos" comment="Error codes start at 0 and decrease">
+    <enums start="0" end="-999" group="ErrorCodes.0" vendor="Khronos" comment="Error codes start at 0 and decrease">
         <enum value="0"             name="CL_SUCCESS"/>
         <enum value="-1"            name="CL_DEVICE_NOT_FOUND"/>
         <enum value="-2"            name="CL_DEVICE_NOT_AVAILABLE"/>
@@ -687,12 +687,12 @@ server's OpenCL/api-docs repository.
             <unused start="-73" end="-999" comment="Reserved for Khronos"/>
     </enums>
 
-    <enums start="-1000" end="-1001" name="ErrorCodes.1000" vendor="Khronos" comment="Extension error codes start at -1000 and decrease">
+    <enums start="-1000" end="-1001" group="ErrorCodes.1000" vendor="Khronos" comment="Extension error codes start at -1000 and decrease">
         <enum value="-1000"         name="CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR"/>
         <enum value="-1001"         name="CL_PLATFORM_NOT_FOUND_KHR"/>
     </enums>
 
-    <enums start="-1002" end="-1017" name="ErrorCodes.1002" vendor="NVIDIA" comment="Allocated per Bug 5782">
+    <enums start="-1002" end="-1017" group="ErrorCodes.1002" vendor="NVIDIA" comment="Allocated per Bug 5782">
         <enum value="-1002"         name="CL_INVALID_D3D10_DEVICE_KHR"/>
         <!-- unused <enum value="-1002"       name="CL_INVALID_D3D10_DEVICE_NV"/> -->
         <enum value="-1003"         name="CL_INVALID_D3D10_RESOURCE_KHR"/>
@@ -724,7 +724,7 @@ server's OpenCL/api-docs repository.
             <unused start="-1014" end="-1017"/>
     </enums>
 
-    <enums start="-1018" end="-1024" name="ErrorCodes.1018" vendor="AMD" comment="Allocated per Bugs 6071,6075">
+    <enums start="-1018" end="-1024" group="ErrorCodes.1018" vendor="AMD" comment="Allocated per Bugs 6071,6075">
             <!-- To be named AMD atomic counters extension - see bug 6071/6075 -->
         <!-- unused <enum value="-1018"       name="CL_INVALID_PROPERTY_EXT"/> -->
         <!-- unused <enum value="-1019"       name="CL_DEVICE_PARTITION_FAILED_EXT"/> -->
@@ -736,23 +736,23 @@ server's OpenCL/api-docs repository.
         <!-- unused <enum value="-1024"       name="CL_D3D9_RESOURCE_NOT_ACQUIRED_AMD"/> -->
     </enums>
 
-    <enums start="-1025" end="-1056" name="ErrorCodes.1025" vendor="IBM" comment="Allocated per Bug 6261">
+    <enums start="-1025" end="-1056" group="ErrorCodes.1025" vendor="IBM" comment="Allocated per Bug 6261">
             <unused start="-1025" end="-1056"/>
     </enums>
 
-    <enums start="-1057" end="-1091" name="ErrorCodes.1057" vendor="Apple" comment="Allocated for cl_ext_device_fission and by email request from Ian Ollman 2010/07/08">
+    <enums start="-1057" end="-1091" group="ErrorCodes.1057" vendor="Apple" comment="Allocated for cl_ext_device_fission and by email request from Ian Ollman 2010/07/08">
         <enum value="-1057"         name="CL_DEVICE_PARTITION_FAILED_EXT"/>
         <enum value="-1058"         name="CL_INVALID_PARTITION_COUNT_EXT"/>
         <enum value="-1059"         name="CL_INVALID_PARTITION_NAME_EXT"/>
             <unused start="-1060" end="-1091"/>
     </enums>
 
-    <enums start="-1092" end="-1093" name="ErrorCodes.1092" vendor="Khronos" comment="Allocated per Bug 10490">
+    <enums start="-1092" end="-1093" group="ErrorCodes.1092" vendor="Khronos" comment="Allocated per Bug 10490">
         <enum value="-1092"         name="CL_EGL_RESOURCE_NOT_ACQUIRED_KHR"/>
         <enum value="-1093"         name="CL_INVALID_EGL_OBJECT_KHR"/>
     </enums>
 
-    <enums start="-1094" end="-1101" name="ErrorCodes.1094" vendor="Intel" comment="Allocated per Bug 11132">
+    <enums start="-1094" end="-1101" group="ErrorCodes.1094" vendor="Intel" comment="Allocated per Bug 11132">
         <enum value="-1094"         name="CL_INVALID_ACCELERATOR_INTEL"/>
         <enum value="-1095"         name="CL_INVALID_ACCELERATOR_TYPE_INTEL"/>
         <enum value="-1096"         name="CL_INVALID_ACCELERATOR_DESCRIPTOR_INTEL"/>
@@ -763,24 +763,24 @@ server's OpenCL/api-docs repository.
         <enum value="-1101"         name="CL_VA_API_MEDIA_SURFACE_NOT_ACQUIRED_INTEL"/>
     </enums>
 
-    <enums start="-1102" end="-1105" name="ErrorCodes.1102" vendor="Qualcomm" comment="Reserved for Qualcomm extensions">
+    <enums start="-1102" end="-1105" group="ErrorCodes.1102" vendor="Qualcomm" comment="Reserved for Qualcomm extensions">
     </enums>
 
-    <enums start="-1106" end="-1107" name="ErrorCodes.1106" vendor="Intel" comment="Intel FPGA extension">
+    <enums start="-1106" end="-1107" group="ErrorCodes.1106" vendor="Intel" comment="Intel FPGA extension">
         <enum value="-1106"         name="CL_PIPE_FULL_INTEL"/>
         <enum value="-1107"         name="CL_PIPE_EMPTY_INTEL"/>
     </enums>
 
-    <enums start="-1108" end="-1120" name="ErrorCodes.1108" vendor="Arm" comment="Reserved for Arm extensions">
+    <enums start="-1108" end="-1120" group="ErrorCodes.1108" vendor="Arm" comment="Reserved for Arm extensions">
         <enum value="-1108"         name="CL_COMMAND_TERMINATED_ITSELF_WITH_FAILURE_ARM"/>
             <unused start="-1109" end="-1120"/>
     </enums>
 
-    <enums start="-1121" end="-1121" name="ErrorCodes.1121" vendor="Khronos" comment="For cl_khr_terminate_context">
+    <enums start="-1121" end="-1121" group="ErrorCodes.1121" vendor="Khronos" comment="For cl_khr_terminate_context">
         <enum value="-1121"         name="CL_CONTEXT_TERMINATED_KHR"/>
     </enums>
 
-    <enums start="-1122" end="-1137" name="ErrorCodes.1122" vendor="IMG" comment="Reserved for Imagination extensions">
+    <enums start="-1122" end="-1137" group="ErrorCodes.1122" vendor="IMG" comment="Reserved for Imagination extensions">
         <enum value="-1122"         name="CL_ERROR_RESERVED0_IMG"/>
         <enum value="-1123"         name="CL_ERROR_RESERVED1_IMG"/>
         <enum value="-1124"         name="CL_ERROR_RESERVED2_IMG"/>
@@ -793,30 +793,30 @@ server's OpenCL/api-docs repository.
             <unused start="-1131" end="-1137"/>
     </enums>
 
-    <enums start="-1138" end="-1141" name="ErrorCodes.1138" vendor="Khronos" comment="For cl_khr_command_buffer related extensions">
+    <enums start="-1138" end="-1141" group="ErrorCodes.1138" vendor="Khronos" comment="For cl_khr_command_buffer related extensions">
         <enum value="-1138"         name="CL_INVALID_COMMAND_BUFFER_KHR"/>
         <enum value="-1139"         name="CL_INVALID_SYNC_POINT_WAIT_LIST_KHR"/>
         <enum value="-1140"         name="CL_INCOMPATIBLE_COMMAND_QUEUE_KHR"/>
         <enum value="-1141"         name="CL_INVALID_MUTABLE_COMMAND_KHR"/>
     </enums>
 
-    <enums start="-1142" end="-1142" name="ErrorCodes.1142" vendor="Khronos" comment="For cl_khr_semaphore">
+    <enums start="-1142" end="-1142" group="ErrorCodes.1142" vendor="Khronos" comment="For cl_khr_semaphore">
         <enum value="-1142"         name="CL_INVALID_SEMAPHORE_KHR"/>
     </enums>
 
-    <enums start="-1143" end="-1153" name="ErrorCodes.1143" vendor="VeriSilicon" comment="Reserved for VeriSilicon extensions">
+    <enums start="-1143" end="-1153" group="ErrorCodes.1143" vendor="VeriSilicon" comment="Reserved for VeriSilicon extensions">
             <unused start="-1143" end="-1153"/>
     </enums>
 
-    <enums start="-1154" end="-1161" name="ErrorCodes.1154" vendor="Qualcomm" comment="Reserved for Qualcomm extensions">
+    <enums start="-1154" end="-1161" group="ErrorCodes.1154" vendor="Qualcomm" comment="Reserved for Qualcomm extensions">
         <unused start="-1154" end="-1161"/>
     </enums>
 
-    <enums start="-1162" end="-9999" name="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
+    <enums start="-1162" end="-9999" group="ErrorCodes.future" vendor="Khronos" comment="RESERVED FOR FUTURE ALLOCATIONS BY KHRONOS">
             <unused start="-1162" end="-9999"/>
     </enums>
 
-    <enums name="cl_bool" vendor="Khronos" comment="Boolean values">
+    <enums group="cl_bool" vendor="Khronos" comment="Boolean values">
         <enum value="0"             name="CL_FALSE"/>
         <enum value="1"             name="CL_TRUE"/>
             <!-- Should be alias= -->
@@ -835,7 +835,7 @@ server's OpenCL/api-docs repository.
         <enum value="0"             name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_LIST_END_KHR"/>
     </enums>
 
-    <enums name="cl_affinity_domain_ext" vendor="IBM" comment="Property names for CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT. This is not a bitfield.">
+    <enums group="cl_affinity_domain_ext" vendor="IBM" comment="Property names for CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT. This is not a bitfield.">
         <enum value="0x1"           name="CL_AFFINITY_DOMAIN_L1_CACHE_EXT"/>
         <enum value="0x2"           name="CL_AFFINITY_DOMAIN_L2_CACHE_EXT"/>
         <enum value="0x3"           name="CL_AFFINITY_DOMAIN_L3_CACHE_EXT"/>
@@ -844,7 +844,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x100"         name="CL_AFFINITY_DOMAIN_NEXT_FISSIONABLE_EXT"/>
     </enums>
 
-    <enums name="cl_build_status" vendor="Khronos" comment="New values decrease">
+    <enums group="cl_build_status" vendor="Khronos" comment="New values decrease">
         <enum value="0"             name="CL_BUILD_SUCCESS"/>
         <enum value="-1"            name="CL_BUILD_NONE"/>
         <enum value="-2"            name="CL_BUILD_ERROR"/>
@@ -852,7 +852,7 @@ server's OpenCL/api-docs repository.
             <unused start="-4" end="-9999"/>
     </enums>
 
-    <enums name="clCommandExecutionStatus" vendor="Khronos">
+    <enums group="clCommandExecutionStatus" vendor="Khronos">
         <enum value="0x0"           name="CL_COMPLETE"/>
         <enum value="0x1"           name="CL_RUNNING"/>
         <enum value="0x2"           name="CL_SUBMITTED"/>
@@ -860,14 +860,14 @@ server's OpenCL/api-docs repository.
             <unused start="0x4" end="9999"/>
     </enums>
 
-    <enums name="cl_device_mem_cache_type" vendor="Khronos">
+    <enums group="cl_device_mem_cache_type" vendor="Khronos">
         <enum value="0x0"           name="CL_NONE"/>
         <enum value="0x1"           name="CL_READ_ONLY_CACHE"/>
         <enum value="0x2"           name="CL_READ_WRITE_CACHE"/>
             <unused start="0x3" end="9999"/>
     </enums>
 
-    <enums name="cl_compiler_mode_altera" vendor="Altera">
+    <enums group="cl_compiler_mode_altera" vendor="Altera">
         <!-- unused <enum value="0x0"         name="CL_CONTEXT_COMPILER_MODE_OFFLINE_ALTERA"/> -->
         <!-- unused <enum value="0x1"         name="CL_CONTEXT_COMPILER_MODE_OFFLINE_CREATE_EXE_LIBRARY_ALTERA"/> -->
         <!-- unused <enum value="0x2"         name="CL_CONTEXT_COMPILER_MODE_OFFLINE_USE_EXE_LIBRARY_ALTERA"/> -->
@@ -875,13 +875,13 @@ server's OpenCL/api-docs repository.
             <unused start="0x4" end="9999"/>
     </enums>
 
-    <enums name="cl_device_local_mem_type" vendor="Khronos">
+    <enums group="cl_device_local_mem_type" vendor="Khronos">
         <enum value="0x1"           name="CL_LOCAL"/>
         <enum value="0x2"           name="CL_GLOBAL"/>
             <unused start="0x3" end="9999"/>
     </enums>
 
-    <enums name="cl_program_binary_type" vendor="Khronos">
+    <enums group="cl_program_binary_type" vendor="Khronos">
         <enum value="0x0"           name="CL_PROGRAM_BINARY_TYPE_NONE"/>
         <enum value="0x1"           name="CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT"/>
         <enum value="0x2"           name="CL_PROGRAM_BINARY_TYPE_LIBRARY"/>
@@ -889,12 +889,12 @@ server's OpenCL/api-docs repository.
             <unused start="0x5" end="9999"/>
     </enums>
 
-    <enums name="cl_accelerator_type_intel" vendor="Intel" comment="cl_intel_motion_estimation extension">
+    <enums group="cl_accelerator_type_intel" vendor="Intel" comment="cl_intel_motion_estimation extension">
         <enum value="0x0"           name="CL_ACCELERATOR_TYPE_MOTION_ESTIMATION_INTEL"/>
             <unused start="0x1" end="9999"/>
     </enums>
 
-    <enums name="cl_device_type" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_type" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_TYPE_DEFAULT"/>
         <enum bitpos="1"            name="CL_DEVICE_TYPE_CPU"/>
         <enum bitpos="2"            name="CL_DEVICE_TYPE_GPU"/>
@@ -906,7 +906,7 @@ server's OpenCL/api-docs repository.
         <unused start="33" end="63"/>
     </enums>
 
-    <enums name="cl_device_fp_config" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_fp_config" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_FP_DENORM"/>
         <enum bitpos="1"            name="CL_FP_INF_NAN"/>
         <enum bitpos="2"            name="CL_FP_ROUND_TO_NEAREST"/>
@@ -918,13 +918,13 @@ server's OpenCL/api-docs repository.
             <unused start="8" end="31"/>
     </enums>
 
-    <enums name="cl_device_exec_capabilities" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_exec_capabilities" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_EXEC_KERNEL"/>
         <enum bitpos="1"            name="CL_EXEC_NATIVE_KERNEL"/>
             <unused start="2" end="31"/>
     </enums>
 
-    <enums name="cl_device_svm_capabilities" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_svm_capabilities" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER"/>
         <enum bitpos="1"            name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER"/>
         <enum bitpos="2"            name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM"/>
@@ -932,7 +932,7 @@ server's OpenCL/api-docs repository.
             <unused start="4" end="31"/>
     </enums>
 
-    <enums name="cl_device_atomic_capabilities" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_atomic_capabilities" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_ATOMIC_ORDER_RELAXED"/>
         <enum bitpos="1"            name="CL_DEVICE_ATOMIC_ORDER_ACQ_REL"/>
         <enum bitpos="2"            name="CL_DEVICE_ATOMIC_ORDER_SEQ_CST"/>
@@ -943,13 +943,13 @@ server's OpenCL/api-docs repository.
             <unused start="7" end="31"/>
     </enums>
 
-    <enums name="cl_device_device_enqueue_capabilities" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_device_enqueue_capabilities" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_QUEUE_SUPPORTED"/>
         <enum bitpos="1"            name="CL_DEVICE_QUEUE_REPLACEABLE_DEFAULT"/>
             <unused start="2" end="31"/>
     </enums>
 
-    <enums name="cl_command_queue_properties" vendor="Khronos" type="bitmask">
+    <enums group="cl_command_queue_properties" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE"/>
         <enum bitpos="1"            name="CL_QUEUE_PROFILING_ENABLE"/>
         <enum bitpos="2"            name="CL_QUEUE_ON_DEVICE"/>
@@ -960,7 +960,7 @@ server's OpenCL/api-docs repository.
         <enum bitpos="31"           name="CL_QUEUE_THREAD_LOCAL_EXEC_ENABLE_INTEL"/>
     </enums>
 
-    <enums name="cl_context_memory_initialize_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_context_memory_initialize_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_CONTEXT_MEMORY_INITIALIZE_LOCAL_KHR"/>
         <enum bitpos="1"            name="CL_CONTEXT_MEMORY_INITIALIZE_PRIVATE_KHR"/>
         <!-- Note: This bitmask is passed as a context property, and a context
@@ -968,26 +968,26 @@ server's OpenCL/api-docs repository.
             <unused start="2" end="31"/>
     </enums>
 
-    <enums name="cl_device_terminate_capability_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_terminate_capability_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_TERMINATE_CAPABILITY_CONTEXT_KHR"/>
             <unused start="1" end="31"/>
     </enums>
 
-    <enums name="cl_queue_priority_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_queue_priority_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_QUEUE_PRIORITY_HIGH_KHR"/>
         <enum bitpos="1"            name="CL_QUEUE_PRIORITY_MED_KHR"/>
         <enum bitpos="2"            name="CL_QUEUE_PRIORITY_LOW_KHR"/>
             <unused start="3" end="31"/>
     </enums>
 
-    <enums name="cl_queue_throttle_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_queue_throttle_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_QUEUE_THROTTLE_HIGH_KHR"/>
         <enum bitpos="1"            name="CL_QUEUE_THROTTLE_MED_KHR"/>
         <enum bitpos="2"            name="CL_QUEUE_THROTTLE_LOW_KHR"/>
             <unused start="3" end="31"/>
     </enums>
 
-    <enums name="cl_mem_flags" vendor="Khronos" type="bitmask">
+    <enums group="cl_mem_flags" vendor="Khronos" type="bitmask">
         <!-- Note: cl_mem_flags bits are limited!  When possible, using
              cl_mem_properties or cl_pipe_properties is recommended instead. -->
         <enum bitpos="0"            name="CL_MEM_READ_WRITE"/>
@@ -1028,7 +1028,7 @@ server's OpenCL/api-docs repository.
             <unused start="41" end="63"/>
     </enums>
 
-    <enums name="cl_map_flags" vendor="Khronos" type="bitmask">
+    <enums group="cl_map_flags" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_MAP_READ"/>
         <enum bitpos="1"            name="CL_MAP_WRITE"/>
         <enum bitpos="2"            name="CL_MAP_WRITE_INVALIDATE_REGION"/>
@@ -1037,14 +1037,14 @@ server's OpenCL/api-docs repository.
             <unused start="34" end="63"/>
     </enums>
 
-    <enums name="cl_mem_migration_flags" vendor="Khronos" type="bitmask">
+    <enums group="cl_mem_migration_flags" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST"/>
         <enum bitpos="0"            name="CL_MIGRATE_MEM_OBJECT_HOST_EXT"/>
         <enum bitpos="1"            name="CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED"/>
             <unused start="2" end="31"/>
     </enums>
 
-    <enums name="cl_device_affinity_domain" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_affinity_domain" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_AFFINITY_DOMAIN_NUMA"/>
         <enum bitpos="1"            name="CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE"/>
         <enum bitpos="2"            name="CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE"/>
@@ -1054,7 +1054,7 @@ server's OpenCL/api-docs repository.
             <unused start="6" end="31"/>
     </enums>
 
-    <enums name="cl_kernel_arg_type_qualifier" vendor="Khronos" type="bitmask">
+    <enums group="cl_kernel_arg_type_qualifier" vendor="Khronos" type="bitmask">
         <enum value="0"             name="CL_KERNEL_ARG_TYPE_NONE"/>
         <enum bitpos="0"            name="CL_KERNEL_ARG_TYPE_CONST"/>
         <enum bitpos="1"            name="CL_KERNEL_ARG_TYPE_RESTRICT"/>
@@ -1063,27 +1063,27 @@ server's OpenCL/api-docs repository.
             <unused start="4" end="31"/>
     </enums>
 
-    <enums name="cl_motion_estimation_desc_intel.mb_block_type" vendor="Intel" type="bitmask">
+    <enums group="cl_motion_estimation_desc_intel.mb_block_type" vendor="Intel" type="bitmask">
         <enum value="0x0"           name="CL_ME_MB_TYPE_16x16_INTEL"/>
         <enum value="0x1"           name="CL_ME_MB_TYPE_8x8_INTEL"/>
         <enum value="0x2"           name="CL_ME_MB_TYPE_4x4_INTEL"/>
             <unused start="0x4" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_motion_estimation_desc_intel.subpixel_mode" vendor="Intel" type="bitmask">
+    <enums group="cl_motion_estimation_desc_intel.subpixel_mode" vendor="Intel" type="bitmask">
         <enum value="0x0"           name="CL_ME_SUBPIXEL_MODE_INTEGER_INTEL"/>
         <enum value="0x1"           name="CL_ME_SUBPIXEL_MODE_HPEL_INTEL"/>
         <enum value="0x2"           name="CL_ME_SUBPIXEL_MODE_QPEL_INTEL"/>
             <unused start="0x4" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_motion_estimation_desc_intel.sad_adjust_mode" vendor="Intel" type="bitmask">
+    <enums group="cl_motion_estimation_desc_intel.sad_adjust_mode" vendor="Intel" type="bitmask">
         <enum value="0x0"           name="CL_ME_SAD_ADJUST_MODE_NONE_INTEL"/>
         <enum value="0x1"           name="CL_ME_SAD_ADJUST_MODE_HAAR_INTEL"/>
             <unused start="0x2" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_motion_estimation_desc_intel.search_path_type" vendor="Intel" type="bitmask">
+    <enums group="cl_motion_estimation_desc_intel.search_path_type" vendor="Intel" type="bitmask">
         <enum value="0x0"           name="CL_ME_SEARCH_PATH_RADIUS_2_2_INTEL"/>
         <enum value="0x1"           name="CL_ME_SEARCH_PATH_RADIUS_4_4_INTEL"/>
             <unused start="0x2"/>
@@ -1091,7 +1091,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x8" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_arm_device_svm_capabilities.flags" vendor="Arm" type="bitmask">
+    <enums group="cl_arm_device_svm_capabilities.flags" vendor="Arm" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SVM_COARSE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="1"            name="CL_DEVICE_SVM_FINE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="2"            name="CL_DEVICE_SVM_FINE_GRAIN_SYSTEM_ARM"/>
@@ -1099,39 +1099,39 @@ server's OpenCL/api-docs repository.
             <unused start="0x10" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_arm_svm_alloc.flags" vendor="Arm" type="bitmask">
+    <enums group="cl_arm_svm_alloc.flags" vendor="Arm" type="bitmask">
         <enum bitpos="10"           name="CL_MEM_SVM_FINE_GRAIN_BUFFER_ARM"/>
         <enum bitpos="11"           name="CL_MEM_SVM_ATOMICS_ARM"/>
             <unused start="0x4" end="0x80000000"/>
     </enums>
 
-    <enums name="cl_diagnostic_verbose_level_intel" comment="From cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
+    <enums group="cl_diagnostic_verbose_level_intel" comment="From cl_intel_driver_diagnostics" vendor="Intel" type="bitmask">
         <enum value="0xff"          name="CL_CONTEXT_DIAGNOSTICS_LEVEL_ALL_INTEL"/>
         <enum bitpos="0"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_GOOD_INTEL"/>
         <enum bitpos="1"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_BAD_INTEL"/>
         <enum bitpos="2"            name="CL_CONTEXT_DIAGNOSTICS_LEVEL_NEUTRAL_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.flags" vendor="Intel" type="bitmask">
+    <enums group="cl_intel_advanced_motion_estimation.flags" vendor="Intel" type="bitmask">
         <enum value="0x1"           name="CL_ME_CHROMA_INTRA_PREDICT_ENABLED_INTEL"/>
         <enum value="0x2"           name="CL_ME_LUMA_INTRA_PREDICT_ENABLED_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.search_cost_penalty" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.search_cost_penalty" vendor="Intel">
         <enum value="0x0"           name="CL_ME_COST_PENALTY_NONE_INTEL"/>
         <enum value="0x1"           name="CL_ME_COST_PENALTY_LOW_INTEL"/>
         <enum value="0x2"           name="CL_ME_COST_PENALTY_NORMAL_INTEL"/>
         <enum value="0x3"           name="CL_ME_COST_PENALTY_HIGH_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.search_cost_precision" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.search_cost_precision" vendor="Intel">
         <enum value="0x0"           name="CL_ME_COST_PRECISION_QPEL_INTEL"/>
         <enum value="0x1"           name="CL_ME_COST_PRECISION_HPEL_INTEL"/>
         <enum value="0x2"           name="CL_ME_COST_PRECISION_PEL_INTEL"/>
         <enum value="0x3"           name="CL_ME_COST_PRECISION_DPEL_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.intra_search_prediction_modes_buffer.luma_block" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.intra_search_prediction_modes_buffer.luma_block" vendor="Intel">
         <enum value="0x0"           name="CL_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
         <enum value="0x1"           name="CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
         <enum value="0x2"           name="CL_ME_LUMA_PREDICTOR_MODE_DC_INTEL"/>
@@ -1144,31 +1144,31 @@ server's OpenCL/api-docs repository.
         <enum value="0x8"           name="CL_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.intra_search_prediction_modes_buffer.chroma_block" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.intra_search_prediction_modes_buffer.chroma_block" vendor="Intel">
         <enum value="0x0"           name="CL_ME_CHROMA_PREDICTOR_MODE_DC_INTEL"/>
         <enum value="0x1"           name="CL_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL"/>
         <enum value="0x2"           name="CL_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL"/>
         <enum value="0x3"           name="CL_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.skip_block_type" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.skip_block_type" vendor="Intel">
         <enum value="0x0"           name="CL_ME_SKIP_BLOCK_TYPE_16x16_INTEL"/>
         <enum value="0x4"           name="CL_ME_SKIP_BLOCK_TYPE_8x8_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.device_me_version" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.device_me_version" vendor="Intel">
         <enum value="0x0"           name="CL_ME_VERSION_LEGACY_INTEL"/>
         <enum value="0x1"           name="CL_ME_VERSION_ADVANCED_VER_1_INTEL"/>
         <enum value="0x2"           name="CL_ME_VERSION_ADVANCED_VER_2_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.cl_motion_detect_desc_intel" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.cl_motion_detect_desc_intel" vendor="Intel">
         <enum value="0x1"           name="CL_ME_FORWARD_INPUT_MODE_INTEL"/>
         <enum value="0x2"           name="CL_ME_BACKWARD_INPUT_MODE_INTEL"/>
         <enum value="0x3"           name="CL_ME_BIDIRECTION_INPUT_MODE_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_advanced_motion_estimation.cl_motion_detect_desc_intel.2" comment="Part of previous block?" vendor="Intel">
+    <enums group="cl_intel_advanced_motion_estimation.cl_motion_detect_desc_intel.2" comment="Part of previous block?" vendor="Intel">
         <enum value="16"            name="CL_ME_BIDIR_WEIGHT_QUARTER_INTEL"/>
         <enum value="21"            name="CL_ME_BIDIR_WEIGHT_THIRD_INTEL"/>
         <enum value="32"            name="CL_ME_BIDIR_WEIGHT_HALF_INTEL"/>
@@ -1176,32 +1176,32 @@ server's OpenCL/api-docs repository.
         <enum value="48"            name="CL_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL"/>
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.version" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.version" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_VERSION_0_INTEL"                              />
             <enum value="0x1"           name="CL_AVC_ME_VERSION_1_INTEL"                              />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.major" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.major" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_MAJOR_16x16_INTEL"                            />
             <enum value="0x1"           name="CL_AVC_ME_MAJOR_16x8_INTEL"                             />
             <enum value="0x2"           name="CL_AVC_ME_MAJOR_8x16_INTEL"                             />
             <enum value="0x3"           name="CL_AVC_ME_MAJOR_8x8_INTEL"                              />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.minor" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.minor" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_MINOR_8x8_INTEL"                              />
             <enum value="0x1"           name="CL_AVC_ME_MINOR_8x4_INTEL"                              />
             <enum value="0x2"           name="CL_AVC_ME_MINOR_4x8_INTEL"                              />
             <enum value="0x3"           name="CL_AVC_ME_MINOR_4x4_INTEL"                              />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.major.dir" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.major.dir" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_MAJOR_FORWARD_INTEL"                          />
             <enum value="0x1"           name="CL_AVC_ME_MAJOR_BACKWARD_INTEL"                         />
             <enum value="0x2"           name="CL_AVC_ME_MAJOR_BIDIRECTIONAL_INTEL"                    />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.partition" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.partition" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_PARTITION_MASK_ALL_INTEL"                     />
             <enum value="0x7E"          name="CL_AVC_ME_PARTITION_MASK_16x16_INTEL"                   />
             <enum value="0x7D"          name="CL_AVC_ME_PARTITION_MASK_16x8_INTEL"                    />
@@ -1212,7 +1212,7 @@ server's OpenCL/api-docs repository.
             <enum value="0x3F"          name="CL_AVC_ME_PARTITION_MASK_4x4_INTEL"                     />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.window" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.window" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL"               />
             <enum value="0x1"           name="CL_AVC_ME_SEARCH_WINDOW_SMALL_INTEL"                    />
             <enum value="0x2"           name="CL_AVC_ME_SEARCH_WINDOW_TINY_INTEL"                     />
@@ -1227,25 +1227,25 @@ server's OpenCL/api-docs repository.
             <enum value="0xa"           name="CL_AVC_ME_SEARCH_WINDOW_2x2_RADIUS_INTEL"               />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.adjust" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.adjust" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_SAD_ADJUST_MODE_NONE_INTEL"                   />
             <enum value="0x2"           name="CL_AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL"                   />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.subpixel" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.subpixel" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL"                  />
             <enum value="0x1"           name="CL_AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"                     />
             <enum value="0x3"           name="CL_AVC_ME_SUBPIXEL_MODE_QPEL_INTEL"                     />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.cost.precision" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.cost.precision" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_COST_PRECISION_QPEL_INTEL"                    />
             <enum value="0x1"           name="CL_AVC_ME_COST_PRECISION_HPEL_INTEL"                    />
             <enum value="0x2"           name="CL_AVC_ME_COST_PRECISION_PEL_INTEL"                     />
             <enum value="0x3"           name="CL_AVC_ME_COST_PRECISION_DPEL_INTEL"                    />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.weight" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.weight" vendor="Intel">
             <enum value="0x10"          name="CL_AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL"                   />
             <enum value="0x15"          name="CL_AVC_ME_BIDIR_WEIGHT_THIRD_INTEL"                     />
             <enum value="0x20"          name="CL_AVC_ME_BIDIR_WEIGHT_HALF_INTEL"                      />
@@ -1253,19 +1253,19 @@ server's OpenCL/api-docs repository.
             <enum value="0x30"          name="CL_AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL"             />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.border" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.border" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_BORDER_REACHED_LEFT_INTEL"                    />
             <enum value="0x2"           name="CL_AVC_ME_BORDER_REACHED_RIGHT_INTEL"                   />
             <enum value="0x4"           name="CL_AVC_ME_BORDER_REACHED_TOP_INTEL"                     />
             <enum value="0x8"           name="CL_AVC_ME_BORDER_REACHED_BOTTOM_INTEL"                  />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.skip" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.skip" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL"             />
             <enum value="0x4000"        name="CL_AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL"               />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.skip.dir" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.skip.dir" vendor="Intel">
             <enum value="(0x1 &lt;&lt; 24)"   name="CL_AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL"        />
             <enum value="(0x2 &lt;&lt; 24)"   name="CL_AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ENABLE_INTEL"       />
             <enum value="(0x3 &lt;&lt; 24)"   name="CL_AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL"           />
@@ -1282,31 +1282,31 @@ server's OpenCL/api-docs repository.
             <enum value="(0x2 &lt;&lt; 30)"   name="CL_AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL"       />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.skip.block.based" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.skip.block.based" vendor="Intel">
             <enum value="0x00"          name="CL_AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL"                   />
             <enum value="0x80"          name="CL_AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL"                   />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.intra" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.intra" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_INTRA_16x16_INTEL"                            />
             <enum value="0x1"           name="CL_AVC_ME_INTRA_8x8_INTEL"                              />
             <enum value="0x2"           name="CL_AVC_ME_INTRA_4x4_INTEL"                              />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.intra.luma" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.intra.luma" vendor="Intel">
             <enum value="0x6"           name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL"        />
             <enum value="0x5"           name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL"          />
             <enum value="0x3"           name="CL_AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL"          />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.intra.neighbor" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.intra.neighbor" vendor="Intel">
             <enum value="0x60"          name="CL_AVC_ME_INTRA_NEIGHBOR_LEFT_MASK_ENABLE_INTEL"        />
             <enum value="0x10"          name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_MASK_ENABLE_INTEL"       />
             <enum value="0x8"           name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_RIGHT_MASK_ENABLE_INTEL" />
             <enum value="0x4"           name="CL_AVC_ME_INTRA_NEIGHBOR_UPPER_LEFT_MASK_ENABLE_INTEL"  />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.luma.predictor" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.luma.predictor" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL"           />
             <enum value="0x1"           name="CL_AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL"         />
             <enum value="0x2"           name="CL_AVC_ME_LUMA_PREDICTOR_MODE_DC_INTEL"                 />
@@ -1323,31 +1323,31 @@ server's OpenCL/api-docs repository.
             <enum value="0x3"           name="CL_AVC_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL"            />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.frame.dir" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.frame.dir" vendor="Intel">
             <enum value="0x1"           name="CL_AVC_ME_FRAME_FORWARD_INTEL"                          />
             <enum value="0x2"           name="CL_AVC_ME_FRAME_BACKWARD_INTEL"                         />
             <enum value="0x3"           name="CL_AVC_ME_FRAME_DUAL_INTEL"                             />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.slice" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.slice" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_SLICE_TYPE_PRED_INTEL"                        />
             <enum value="0x1"           name="CL_AVC_ME_SLICE_TYPE_BPRED_INTEL"                       />
             <enum value="0x2"           name="CL_AVC_ME_SLICE_TYPE_INTRA_INTEL"                       />
     </enums>
 
-    <enums name="cl_intel_device_side_avc_motion_estimation.scan.dir" vendor="Intel">
+    <enums group="cl_intel_device_side_avc_motion_estimation.scan.dir" vendor="Intel">
             <enum value="0x0"           name="CL_AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL"              />
             <enum value="0x1"           name="CL_AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL"           />
     </enums>
 
-    <enums name="cl_device_unified_shared_memory_capabilities_intel" vendor="Intel" type="bitmask">
+    <enums group="cl_device_unified_shared_memory_capabilities_intel" vendor="Intel" type="bitmask">
         <enum bitpos="0"            name="CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL"/>
         <enum bitpos="1"            name="CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL"/>
         <enum bitpos="2"            name="CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL"/>
         <enum bitpos="3"            name="CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL"/>
     </enums>
 
-    <enums name="cl_svm_capabilities_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_svm_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_SVM_CAPABILITY_SINGLE_ADDRESS_SPACE_KHR"/>
         <enum bitpos="1"            name="CL_SVM_CAPABILITY_SYSTEM_ALLOCATED_KHR"/>
         <enum bitpos="2"            name="CL_SVM_CAPABILITY_DEVICE_OWNED_KHR"/>
@@ -1365,13 +1365,13 @@ server's OpenCL/api-docs repository.
         <enum bitpos="14"           name="CL_SVM_CAPABILITY_INDIRECT_ACCESS_KHR"/>
     </enums>
 
-    <enums name="cl_mem_alloc_flags_intel" vendor="Intel" type="bitmask">
+    <enums group="cl_mem_alloc_flags_intel" vendor="Intel" type="bitmask">
         <enum bitpos="0"            name="CL_MEM_ALLOC_WRITE_COMBINED_INTEL"/>
         <enum bitpos="1"            name="CL_MEM_ALLOC_INITIAL_PLACEMENT_DEVICE_INTEL"/>
         <enum bitpos="2"            name="CL_MEM_ALLOC_INITIAL_PLACEMENT_HOST_INTEL"/>
     </enums>
 
-    <enums name="cl_svm_alloc_access_flags_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_svm_alloc_access_flags_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_SVM_ALLOC_ACCESS_HOST_NOREAD_KHR"/>
         <enum bitpos="1"            name="CL_SVM_ALLOC_ACCESS_HOST_NOWRITE_KHR"/>
             <unused start="2" end="7" comment="reserved for additional host access flags"/>
@@ -1381,13 +1381,13 @@ server's OpenCL/api-docs repository.
             <unused start="16" end="63"/>
     </enums>
 
-    <enums name="cl_mipmap_filter_mode_img" vendor="IMG" comment="cl_img_generate_mipmap extension">
+    <enums group="cl_mipmap_filter_mode_img" vendor="IMG" comment="cl_img_generate_mipmap extension">
         <enum value="0x0"           name="CL_MIPMAP_FILTER_ANY_IMG"/>
         <enum value="0x1"           name="CL_MIPMAP_FILTER_BOX_IMG"/>
             <unused start="0x2" end="9999"/>
     </enums>
 
-    <enums name="cl_mem_alloc_flags_img" vendor="IMG" type="bitmask">
+    <enums group="cl_mem_alloc_flags_img" vendor="IMG" type="bitmask">
         <enum bitpos="0"            name="CL_MEM_ALLOC_RELAX_REQUIREMENTS_IMG"/>
         <enum bitpos="1"            name="CL_MEM_ALLOC_GPU_WRITE_COMBINE_IMG"/>
         <enum bitpos="2"            name="CL_MEM_ALLOC_GPU_CACHED_IMG"/>
@@ -1396,12 +1396,12 @@ server's OpenCL/api-docs repository.
         <enum bitpos="5"            name="CL_MEM_ALLOC_GPU_PRIVATE_IMG"/>
     </enums>
 
-    <enums name="cl_context_safety_properties_img" vendor="IMG" type="bitmask">
+    <enums group="cl_context_safety_properties_img" vendor="IMG" type="bitmask">
         <enum bitpos="0"            name="CL_CONTEXT_WORKGROUP_PROTECTION_IMG"/>
         <enum bitpos="1"            name="CL_CONTEXT_ENHANCED_EVENT_EXECUTION_STATUS_IMG"/>
     </enums>
     
-    <enums name="cl_device_scheduling_controls_capabilities_img" vendor="IMG" type="bitmask">
+    <enums group="cl_device_scheduling_controls_capabilities_img" vendor="IMG" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"/>
         <enum bitpos="1"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"/>
         <enum bitpos="2"            name="CL_DEVICE_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"/>
@@ -1413,7 +1413,7 @@ server's OpenCL/api-docs repository.
             <unused start="11" end="63"/>
     </enums>
 
-    <enums name="cl_device_scheduling_controls_capabilities_arm" vendor="Arm" type="bitmask">
+    <enums group="cl_device_scheduling_controls_capabilities_arm" vendor="Arm" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_SCHEDULING_KERNEL_BATCHING_ARM"/>
         <enum bitpos="1"            name="CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_ARM"/>
         <enum bitpos="2"            name="CL_DEVICE_SCHEDULING_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"/>
@@ -1425,21 +1425,21 @@ server's OpenCL/api-docs repository.
             <unused start="8" end="63"/>
     </enums>
 
-    <enums name="cl_command_termination_reason_arm" vendor="Arm">
+    <enums group="cl_command_termination_reason_arm" vendor="Arm">
         <enum value="0"             name="CL_COMMAND_TERMINATION_COMPLETION_ARM"/>
         <enum value="1"             name="CL_COMMAND_TERMINATION_CONTROLLED_SUCCESS_ARM"/>
         <enum value="2"             name="CL_COMMAND_TERMINATION_CONTROLLED_FAILURE_ARM"/>
         <enum value="3"             name="CL_COMMAND_TERMINATION_ERROR_ARM"/>
     </enums>
 
-    <enums name="cl_device_controlled_termination_capabilities_arm" vendor="Arm" type="bitmask">
+    <enums group="cl_device_controlled_termination_capabilities_arm" vendor="Arm" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_CONTROLLED_TERMINATION_SUCCESS_ARM"/>
         <enum bitpos="1"            name="CL_DEVICE_CONTROLLED_TERMINATION_FAILURE_ARM"/>
         <enum bitpos="2"            name="CL_DEVICE_CONTROLLED_TERMINATION_QUERY_ARM"/>
             <unused start="3" end="63"/>
     </enums>
 
-    <enums name="cl_command_queue_capabilities_intel" vendor="Intel" type="bitmask">
+    <enums group="cl_command_queue_capabilities_intel" vendor="Intel" type="bitmask">
         <enum bitpos="0"            name="CL_QUEUE_CAPABILITY_CREATE_SINGLE_QUEUE_EVENTS_INTEL"/>
         <enum bitpos="1"            name="CL_QUEUE_CAPABILITY_CREATE_CROSS_QUEUE_EVENTS_INTEL"/>
         <enum bitpos="2"            name="CL_QUEUE_CAPABILITY_SINGLE_QUEUE_EVENT_WAIT_LIST_INTEL"/>
@@ -1461,38 +1461,38 @@ server's OpenCL/api-docs repository.
             <unused start="27" end="63"/>
     </enums>
 
-    <enums name="cl_device_feature_capabilities_intel" vendor="Intel" type="bitmask">
+    <enums group="cl_device_feature_capabilities_intel" vendor="Intel" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_FEATURE_FLAG_DP4A_INTEL"/>
         <enum bitpos="1"            name="CL_DEVICE_FEATURE_FLAG_DPAS_INTEL"/>
             <unused start="2" end="63"/>
     </enums>
 
-    <enums name="cl_device_integer_dot_product_capabilities" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_integer_dot_product_capabilities" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED"/>
         <enum bitpos="1"            name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT"/>
             <unused start="2" end="63"/>
     </enums>
 
-    <enums name="cl_device_integer_dot_product_capabilities_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_integer_dot_product_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_PACKED_KHR"/>
         <enum bitpos="1"            name="CL_DEVICE_INTEGER_DOT_PRODUCT_INPUT_4x8BIT_KHR"/>
             <unused start="2" end="63"/>
     </enums>
 
-    <enums name="cl_semaphore_type_khr" vendor="Khronos">
+    <enums group="cl_semaphore_type_khr" vendor="Khronos">
             <unused start="0" end="0"/>
         <enum value="1"             name="CL_SEMAPHORE_TYPE_BINARY_KHR"/>
             <unused start="2" end="9999"/>
     </enums>
 
-    <enums name="cl_platform_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_platform_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_PLATFORM_UNIVERSAL_SYNC_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_PLATFORM_REMAP_QUEUES_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_PLATFORM_AUTOMATIC_REMAP_KHR"/>
             <unused start="3" end="31"/>
     </enums>
 
-    <enums name="cl_device_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_command_buffer_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR"/>
@@ -1502,7 +1502,7 @@ server's OpenCL/api-docs repository.
             <unused start="6" end="31"/>
     </enums>
 
-    <enums name="cl_command_buffer_flags_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_command_buffer_flags_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR"/>
         <enum bitpos="1"            name="CL_COMMAND_BUFFER_MUTABLE_KHR"/>
         <enum bitpos="2"            name="CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR"/>
@@ -1510,12 +1510,12 @@ server's OpenCL/api-docs repository.
             <unused start="4" end="31"/>
     </enums>
 
-    <enums name="cl_command_buffer_state_khr" vendor="Khronos">
+    <enums group="cl_command_buffer_state_khr" vendor="Khronos">
         <enum value="0"            name="CL_COMMAND_BUFFER_STATE_RECORDING_KHR"/>
         <enum value="1"            name="CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR"/>
         <enum value="2"            name="CL_COMMAND_BUFFER_STATE_FINALIZED_KHR"/>
     </enums>
-    <enums name="cl_mutable_dispatch_fields_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_mutable_dispatch_fields_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR"/>
         <enum bitpos="1"            name="CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR"/>
         <enum bitpos="2"            name="CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR"/>
@@ -1523,16 +1523,16 @@ server's OpenCL/api-docs repository.
         <enum bitpos="4"            name="CL_MUTABLE_DISPATCH_EXEC_INFO_KHR"/>
             <unused start="5" end="31"/>
     </enums>
-    <enums name="cl_mutable_dispatch_asserts_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_mutable_dispatch_asserts_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR"/>
     </enums>
 
-    <enums name="cl_command_buffer_update_type_khr" vendor="Khronos">
+    <enums group="cl_command_buffer_update_type_khr" vendor="Khronos">
         <enum value="0"             name="CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR"/>
             <unused start="1" end="1" comment="Used by future command-buffer extensions"/>
     </enums>
 
-    <enums name="cl_device_fp_atomic_capabilities_ext" vendor="EXT" type="bitmask">
+    <enums group="cl_device_fp_atomic_capabilities_ext" vendor="EXT" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT"/>
         <enum bitpos="1"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT"/>
         <enum bitpos="2"            name="CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT"/>
@@ -1543,18 +1543,18 @@ server's OpenCL/api-docs repository.
             <unused start="19" end="63"/>
     </enums>
 
-    <enums name="cl_device_kernel_clock_capabilities_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_device_kernel_clock_capabilities_khr" vendor="Khronos" type="bitmask">
         <enum bitpos="0"            name="CL_DEVICE_KERNEL_CLOCK_SCOPE_DEVICE_KHR"/>
         <enum bitpos="1"            name="CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR"/>
         <enum bitpos="2"            name="CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR"/>
             <unused start="3" end="63"/>
     </enums>
 
-    <enums name="cl_svm_free_flags_khr" vendor="Khronos" type="bitmask">
+    <enums group="cl_svm_free_flags_khr" vendor="Khronos" type="bitmask">
             <unused start="0" end="31"/>
     </enums>
 
-    <enums start="0x10000" end="0x1FFFF" name="cl_khronos_vendor_id" vendor="Khronos">
+    <enums start="0x10000" end="0x1FFFF" group="cl_khronos_vendor_id" vendor="Khronos">
         <comment>
             In order to synchronize vendor IDs across Khronos APIs, Vulkan's vk.xml
             is used as the central Khronos vendor ID registry. To obtain a vendor
@@ -1569,7 +1569,7 @@ server's OpenCL/api-docs repository.
         <unused start="0x10007" end="0x1FFFF" comment="See vk.xml for the next available Khronos vendor ID"/>
     </enums>
 
-    <enums start="0x0900" end="0x09FF" name="cl_platform_info" vendor="Khronos">
+    <enums start="0x0900" end="0x09FF" group="cl_platform_info" vendor="Khronos">
         <enum value="0x0900"        name="CL_PLATFORM_PROFILE"/>
         <enum value="0x0901"        name="CL_PLATFORM_VERSION"/>
         <enum value="0x0902"        name="CL_PLATFORM_NAME"/>
@@ -1588,7 +1588,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x0922" end="0x09FF" comment="Vendor extensions"/>
     </enums>
 
-    <enums start="0x1000" end="0x107F" name="cl_device_info" vendor="Khronos">
+    <enums start="0x1000" end="0x107F" group="cl_device_info" vendor="Khronos">
         <enum value="0x1000"        name="CL_DEVICE_TYPE"/>
         <enum value="0x1001"        name="CL_DEVICE_VENDOR_ID"/>
         <enum value="0x1002"        name="CL_DEVICE_MAX_COMPUTE_UNITS"/>
@@ -1729,26 +1729,26 @@ server's OpenCL/api-docs repository.
             <unused start="0x1078" end="0x107F" comment="Reserved for cl_device_info"/>
     </enums>
 
-    <enums start="0x1080" end="0x1083" name="cl_context_info" vendor="Khronos">
+    <enums start="0x1080" end="0x1083" group="cl_context_info" vendor="Khronos">
         <enum value="0x1080"        name="CL_CONTEXT_REFERENCE_COUNT"/>
         <enum value="0x1081"        name="CL_CONTEXT_DEVICES"/>
         <enum value="0x1082"        name="CL_CONTEXT_PROPERTIES"/>
         <enum value="0x1083"        name="CL_CONTEXT_NUM_DEVICES"/>
     </enums>
 
-    <enums start="0x1084" end="0x1085" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x1084" end="0x1085" group="cl_context_properties" vendor="Khronos">
         <enum value="0x1084"        name="CL_CONTEXT_PLATFORM"/>
         <enum value="0x1085"        name="CL_CONTEXT_INTEROP_USER_SYNC"/>
     </enums>
 
-    <enums start="0x1086" end="0x108F" name="cl_device_partition_property" vendor="Khronos">
+    <enums start="0x1086" end="0x108F" group="cl_device_partition_property" vendor="Khronos">
         <enum value="0x1086"        name="CL_DEVICE_PARTITION_EQUALLY"/>
         <enum value="0x1087"        name="CL_DEVICE_PARTITION_BY_COUNTS"/>
         <enum value="0x1088"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN"/>
             <unused start="0x1089" end="0x108F" comment="Reserved for cl_device_partition_property"/>
     </enums>
 
-    <enums start="0x1090" end="0x109F" name="cl_command_queue_info" vendor="Khronos">
+    <enums start="0x1090" end="0x109F" group="cl_command_queue_info" vendor="Khronos">
         <enum value="0x1090"        name="CL_QUEUE_CONTEXT"/>
         <enum value="0x1091"        name="CL_QUEUE_DEVICE"/>
         <enum value="0x1092"        name="CL_QUEUE_REFERENCE_COUNT"/>
@@ -1766,7 +1766,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x10AC" end="0x10AF" comment="Reserved for cl_ext_yuv_images #722"/>
     </enums>
 
-    <enums start="0x10B0" end="0x10CF" name="cl_channel_order" vendor="Khronos">
+    <enums start="0x10B0" end="0x10CF" group="cl_channel_order" vendor="Khronos">
         <enum value="0x10B0"        name="CL_R"/>
         <enum value="0x10B1"        name="CL_A"/>
         <enum value="0x10B2"        name="CL_RG"/>
@@ -1791,7 +1791,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x10C4" end="0x10CF" comment="Reserved for cl_channel_order"/>
     </enums>
 
-    <enums start="0x10D0" end="0x10EF" name="cl_channel_type" vendor="Khronos">
+    <enums start="0x10D0" end="0x10EF" group="cl_channel_type" vendor="Khronos">
         <enum value="0x10D0"        name="CL_SNORM_INT8"/>
         <enum value="0x10D1"        name="CL_SNORM_INT16"/>
         <enum value="0x10D2"        name="CL_UNORM_INT8"/>
@@ -1822,7 +1822,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x10EB" end="0x10EF" comment="Reserved for cl_channel_type"/>
     </enums>
 
-    <enums start="0x10F0" end="0x10FF" name="cl_mem_object_type" vendor="Khronos">
+    <enums start="0x10F0" end="0x10FF" group="cl_mem_object_type" vendor="Khronos">
         <enum value="0x10F0"        name="CL_MEM_OBJECT_BUFFER"/>
         <enum value="0x10F1"        name="CL_MEM_OBJECT_IMAGE2D"/>
         <enum value="0x10F2"        name="CL_MEM_OBJECT_IMAGE3D"/>
@@ -1834,7 +1834,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x10F8" end="0x10FF" comment="Reserved for cl_mem_object_type"/>
     </enums>
 
-    <enums start="0x1100" end="0x110F" name="cl_mem_info" vendor="Khronos">
+    <enums start="0x1100" end="0x110F" group="cl_mem_info" vendor="Khronos">
         <enum value="0x1100"        name="CL_MEM_TYPE"/>
         <enum value="0x1101"        name="CL_MEM_FLAGS"/>
         <enum value="0x1102"        name="CL_MEM_SIZE"/>
@@ -1849,7 +1849,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x110B" end="0x110F" comment="Reserved for cl_mem_info"/>
     </enums>
 
-    <enums start="0x1110" end="0x111F" name="cl_image_info" vendor="Khronos">
+    <enums start="0x1110" end="0x111F" group="cl_image_info" vendor="Khronos">
         <enum value="0x1110"        name="CL_IMAGE_FORMAT"/>
         <enum value="0x1111"        name="CL_IMAGE_ELEMENT_SIZE"/>
         <enum value="0x1112"        name="CL_IMAGE_ROW_PITCH"   group="cl_image_pitch_info_qcom"/>
@@ -1865,14 +1865,14 @@ server's OpenCL/api-docs repository.
             <unused start="0x111D" end="0x111F" comment="Reserved for cl_image_info"/>
     </enums>
 
-    <enums start="0x1120" end="0x112F" name="cl_pipe_info" vendor="Khronos">
+    <enums start="0x1120" end="0x112F" group="cl_pipe_info" vendor="Khronos">
         <enum value="0x1120"        name="CL_PIPE_PACKET_SIZE"/>
         <enum value="0x1121"        name="CL_PIPE_MAX_PACKETS"/>
         <enum value="0x1122"        name="CL_PIPE_PROPERTIES"/>
             <unused start="0x1123" end="0x112F" comment="Reserved for cl_pipe_info"/>
     </enums>
 
-    <enums start="0x1130" end="0x113F" name="cl_addressing_mode" vendor="Khronos">
+    <enums start="0x1130" end="0x113F" group="cl_addressing_mode" vendor="Khronos">
         <enum value="0x1130"        name="CL_ADDRESS_NONE"/>
         <enum value="0x1131"        name="CL_ADDRESS_CLAMP_TO_EDGE"/>
         <enum value="0x1132"        name="CL_ADDRESS_CLAMP"/>
@@ -1881,13 +1881,13 @@ server's OpenCL/api-docs repository.
             <unused start="0x1135" end="0x113F" comment="Reserved for cl_addressing_mode"/>
     </enums>
 
-    <enums start="0x1140" end="0x114F" name="cl_filter_mode" vendor="Khronos">
+    <enums start="0x1140" end="0x114F" group="cl_filter_mode" vendor="Khronos">
         <enum value="0x1140"        name="CL_FILTER_NEAREST"/>
         <enum value="0x1141"        name="CL_FILTER_LINEAR"/>
             <unused start="0x1142" end="0x114F" comment="Reserved for cl_filter_mode"/>
     </enums>
 
-    <enums start="0x1150" end="0x115F" name="cl_sampler_info" vendor="Khronos">
+    <enums start="0x1150" end="0x115F" group="cl_sampler_info" vendor="Khronos">
         <enum value="0x1150"        name="CL_SAMPLER_REFERENCE_COUNT"/>
         <enum value="0x1151"        name="CL_SAMPLER_CONTEXT"/>
         <enum value="0x1152"        name="CL_SAMPLER_NORMALIZED_COORDS"/>
@@ -1903,7 +1903,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x1159" end="0x115F" comment="Reserved for cl_sampler_info"/>
     </enums>
 
-    <enums start="0x1160" end="0x117F" name="cl_program_info" vendor="Khronos">
+    <enums start="0x1160" end="0x117F" group="cl_program_info" vendor="Khronos">
         <enum value="0x1160"        name="CL_PROGRAM_REFERENCE_COUNT"/>
         <enum value="0x1161"        name="CL_PROGRAM_CONTEXT"/>
         <enum value="0x1162"        name="CL_PROGRAM_NUM_DEVICES"/>
@@ -1920,7 +1920,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x116C" end="0x117F" comment="Reserved for cl_program_info"/>
     </enums>
 
-    <enums start="0x1180" end="0x118F" name="cl_program_build_info" vendor="Khronos">
+    <enums start="0x1180" end="0x118F" group="cl_program_build_info" vendor="Khronos">
             <unused start="0x1180" comment="Reserved for cl_program_build_info"/>
         <enum value="0x1181"        name="CL_PROGRAM_BUILD_STATUS"/>
         <enum value="0x1182"        name="CL_PROGRAM_BUILD_OPTIONS"/>
@@ -1930,7 +1930,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x1186" end="0x118F" comment="Reserved for cl_program_build_info"/>
     </enums>
 
-    <enums start="0x1190" end="0x1195" name="cl_kernel_info" vendor="Khronos">
+    <enums start="0x1190" end="0x1195" group="cl_kernel_info" vendor="Khronos">
         <enum value="0x1190"        name="CL_KERNEL_FUNCTION_NAME"/>
         <enum value="0x1191"        name="CL_KERNEL_NUM_ARGS"/>
         <enum value="0x1192"        name="CL_KERNEL_REFERENCE_COUNT"/>
@@ -1939,7 +1939,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x1195"        name="CL_KERNEL_ATTRIBUTES"/>
     </enums>
 
-    <enums start="0x1196" end="0x119A" name="cl_kernel_arg_info" vendor="Khronos">
+    <enums start="0x1196" end="0x119A" group="cl_kernel_arg_info" vendor="Khronos">
         <enum value="0x1196"        name="CL_KERNEL_ARG_ADDRESS_QUALIFIER"/>
         <enum value="0x1197"        name="CL_KERNEL_ARG_ACCESS_QUALIFIER"/>
         <enum value="0x1198"        name="CL_KERNEL_ARG_TYPE_NAME"/>
@@ -1947,7 +1947,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x119A"        name="CL_KERNEL_ARG_NAME"/>
     </enums>
 
-    <enums start="0x119B" end="0x119F" name="cl_kernel_arg_address_qualifier" vendor="Khronos">
+    <enums start="0x119B" end="0x119F" group="cl_kernel_arg_address_qualifier" vendor="Khronos">
         <enum value="0x119B"        name="CL_KERNEL_ARG_ADDRESS_GLOBAL"/>
         <enum value="0x119C"        name="CL_KERNEL_ARG_ADDRESS_LOCAL"/>
         <enum value="0x119D"        name="CL_KERNEL_ARG_ADDRESS_CONSTANT"/>
@@ -1955,7 +1955,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x119F" comment="Reserved for cl_kernel_arg_address_qualifier"/>
     </enums>
 
-    <enums start="0x11A0" end="0x11AF" name="cl_kernel_arg_access_qualifier" vendor="Khronos">
+    <enums start="0x11A0" end="0x11AF" group="cl_kernel_arg_access_qualifier" vendor="Khronos">
         <enum value="0x11A0"        name="CL_KERNEL_ARG_ACCESS_READ_ONLY"/>
         <enum value="0x11A1"        name="CL_KERNEL_ARG_ACCESS_WRITE_ONLY"/>
         <enum value="0x11A2"        name="CL_KERNEL_ARG_ACCESS_READ_WRITE"/>
@@ -1963,7 +1963,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x11A4" end="0x11AF" comment="Reserved for cl_kernel_arg_access_qualifier"/>
     </enums>
 
-    <enums start="0x11B0" end="0x11B6" name="cl_kernel_work_group_info" vendor="Khronos">
+    <enums start="0x11B0" end="0x11B6" group="cl_kernel_work_group_info" vendor="Khronos">
         <enum value="0x11B0"        name="CL_KERNEL_WORK_GROUP_SIZE"/>
         <enum value="0x11B1"        name="CL_KERNEL_COMPILE_WORK_GROUP_SIZE"/>
         <enum value="0x11B2"        name="CL_KERNEL_LOCAL_MEM_SIZE"/>
@@ -1972,12 +1972,12 @@ server's OpenCL/api-docs repository.
         <enum value="0x11B5"        name="CL_KERNEL_GLOBAL_WORK_SIZE"/>
     </enums>
 
-    <enums start="0x11B6" end="0x11B7" name="cl_kernel_exec_info " vendor="Khronos">
+    <enums start="0x11B6" end="0x11B7" group="cl_kernel_exec_info " vendor="Khronos">
         <enum value="0x11B6"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS"/>
         <enum value="0x11B7"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM"/>
     </enums>
 
-    <enums start="0x11B8" end="0x11CF" name="cl_kernel_sub_group_info" vendor="Khronos">
+    <enums start="0x11B8" end="0x11CF" group="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x11B8"        name="CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT"/>
         <enum value="0x11B9"        name="CL_KERNEL_MAX_NUM_SUB_GROUPS"/>
         <enum value="0x11BA"        name="CL_KERNEL_COMPILE_NUM_SUB_GROUPS"/>
@@ -1985,7 +1985,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x11BC" end="0x11CF" comment="Reserved for cl_kernel_info / cl_kernel_work_group_info / cl_kernel_exec_info / cl_kernel_sub_group_info"/>
     </enums>
 
-    <enums start="0x11D0" end="0x11EF" name="cl_event_info" vendor="Khronos">
+    <enums start="0x11D0" end="0x11EF" group="cl_event_info" vendor="Khronos">
         <enum value="0x11D0"        name="CL_EVENT_COMMAND_QUEUE"/>
         <enum value="0x11D1"        name="CL_EVENT_COMMAND_TYPE"/>
         <enum value="0x11D2"        name="CL_EVENT_REFERENCE_COUNT"/>
@@ -1994,7 +1994,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x11D5" end="0x11EF" comment="Reserved for cl_event_info"/>
     </enums>
 
-    <enums start="0x11F0" end="0x121F" name="cl_command_type" vendor="Khronos">
+    <enums start="0x11F0" end="0x121F" group="cl_command_type" vendor="Khronos">
         <enum value="0x11F0"        name="CL_COMMAND_NDRANGE_KERNEL"/>
         <enum value="0x11F1"        name="CL_COMMAND_TASK"/>
         <enum value="0x11F2"        name="CL_COMMAND_NATIVE_KERNEL"/>
@@ -2029,12 +2029,12 @@ server's OpenCL/api-docs repository.
             <unused start="0x120F" end="0x121F" comment="Reserved for cl_command_type"/>
     </enums>
 
-    <enums start="0x1220" end="0x127F" name="cl_buffer_create_type" vendor="Khronos">
+    <enums start="0x1220" end="0x127F" group="cl_buffer_create_type" vendor="Khronos">
         <enum value="0x1220"        name="CL_BUFFER_CREATE_TYPE_REGION"/>
             <unused start="0x1221" end="0x127F" comment="Reserved for cl_buffer_create_type"/>
     </enums>
 
-    <enums start="0x1280" end="0x128F" name="cl_profiling_info" vendor="Khronos">
+    <enums start="0x1280" end="0x128F" group="cl_profiling_info" vendor="Khronos">
         <enum value="0x1280"        name="CL_PROFILING_COMMAND_QUEUED"/>
         <enum value="0x1281"        name="CL_PROFILING_COMMAND_SUBMIT"/>
         <enum value="0x1282"        name="CL_PROFILING_COMMAND_START"/>
@@ -2043,17 +2043,17 @@ server's OpenCL/api-docs repository.
             <unused start="0x1285" end="0x128F" comment="Reserved for cl_profiling_info"/>
     </enums>
 
-    <enums start="0x1290" end="0x1292" name="cl_image_requirements_info_ext" vendor="Khronos">
+    <enums start="0x1290" end="0x1292" group="cl_image_requirements_info_ext" vendor="Khronos">
         <enum value="0x1290"        name="CL_IMAGE_REQUIREMENTS_ROW_PITCH_ALIGNMENT_EXT"/>
         <enum value="0x1291"        name="CL_IMAGE_REQUIREMENTS_SLICE_PITCH_ALIGNMENT_EXT"/>
         <enum value="0x1292"        name="CL_IMAGE_REQUIREMENTS_BASE_ADDRESS_ALIGNMENT_EXT"/>
     </enums>
 
-    <enums start="0x1293" end="0x1293" name="cl_command_buffer_properties_khr" vendor="Khronos">
+    <enums start="0x1293" end="0x1293" group="cl_command_buffer_properties_khr" vendor="Khronos">
         <enum value="0x1293"        name="CL_COMMAND_BUFFER_FLAGS_KHR"/>
     </enums>
 
-    <enums start="0x1294" end="0x1299" name="cl_command_buffer_info_khr" vendor="Khronos">
+    <enums start="0x1294" end="0x1299" group="cl_command_buffer_info_khr" vendor="Khronos">
         <enum value="0x1294"        name="CL_COMMAND_BUFFER_QUEUES_KHR"/>
         <enum value="0x1295"        name="CL_COMMAND_BUFFER_NUM_QUEUES_KHR"/>
         <enum value="0x1296"        name="CL_COMMAND_BUFFER_REFERENCE_COUNT_KHR"/>
@@ -2062,7 +2062,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x1299"        name="CL_COMMAND_BUFFER_CONTEXT_KHR"/>
     </enums>
 
-    <enums start="0x129A" end="0x129A" name="cl_device_info" vendor="Khronos">
+    <enums start="0x129A" end="0x129A" group="cl_device_info" vendor="Khronos">
         <enum value="0x129A"        name="CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR"/>
     </enums>
 
@@ -2070,7 +2070,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x129B" end="0x129F" comment="Available to use"/>
     </enums>
 
-    <enums start="0x12A0" end="0x12A7" name="cl_mutable_command_info_khr" vendor="Khronos">
+    <enums start="0x12A0" end="0x12A7" group="cl_mutable_command_info_khr" vendor="Khronos">
         <enum value="0x12A0"        name="CL_MUTABLE_COMMAND_COMMAND_QUEUE_KHR"/>
         <enum value="0x12A1"        name="CL_MUTABLE_COMMAND_COMMAND_BUFFER_KHR"/>
         <enum value="0x12A2"        name="CL_MUTABLE_COMMAND_PROPERTIES_ARRAY_KHR"/>
@@ -2081,18 +2081,18 @@ server's OpenCL/api-docs repository.
         <enum value="0x12A7"        name="CL_MUTABLE_DISPATCH_LOCAL_WORK_SIZE_KHR"/>
     </enums>
 
-    <enums start="0x12A8" end="0x12A8" name="cl_command_type" vendor="Khronos">
+    <enums start="0x12A8" end="0x12A8" group="cl_command_type" vendor="Khronos">
         <enum value="0x12A8"        name="CL_COMMAND_COMMAND_BUFFER_KHR"/>
     </enums>
 
-    <enums start="0x12A9" end="0x12AC" name="cl_device_info" vendor="Khronos">
+    <enums start="0x12A9" end="0x12AC" group="cl_device_info" vendor="Khronos">
         <enum value="0x12A9"        name="CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR"/>
         <enum value="0x12AA"        name="CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR"/>
         <enum value="0x12AB"        name="CL_DEVICE_COMMAND_BUFFER_NUM_SYNC_DEVICES_KHR"/>
         <enum value="0x12AC"        name="CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR"/>
     </enums>
 
-    <enums start="0x12AD" end="0x12AD" name="cl_mutable_command_info_khr" vendor="Khronos">
+    <enums start="0x12AD" end="0x12AD" group="cl_mutable_command_info_khr" vendor="Khronos">
         <enum value="0x12AD"        name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
     </enums>
 
@@ -2100,15 +2100,15 @@ server's OpenCL/api-docs repository.
             <unused start="0x12AE" end="0x12AF" comment="Used by future command-buffer extensions"/>
     </enums>
 
-    <enums start="0x12B0" end="0x12B0" name="cl_device_info" vendor="Khronos">
+    <enums start="0x12B0" end="0x12B0" group="cl_device_info" vendor="Khronos">
         <enum value="0x12B0"        name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
     </enums>
 
-    <enums start="0x12B1" end="0x12B1" name="cl_command_properties_khr" vendor="Khronos">
+    <enums start="0x12B1" end="0x12B1" group="cl_command_properties_khr" vendor="Khronos">
         <enum value="0x12B1"             name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
     </enums>
 
-    <enums start="0x12B2" end="0x12B6" name="cl_image_requirements_info_ext" vendor="Khronos">
+    <enums start="0x12B2" end="0x12B6" group="cl_image_requirements_info_ext" vendor="Khronos">
         <enum value="0x12B2"        name="CL_IMAGE_REQUIREMENTS_SIZE_EXT"/>
         <enum value="0x12B3"        name="CL_IMAGE_REQUIREMENTS_MAX_WIDTH_EXT"/>
         <enum value="0x12B4"        name="CL_IMAGE_REQUIREMENTS_MAX_HEIGHT_EXT"/>
@@ -2116,15 +2116,15 @@ server's OpenCL/api-docs repository.
         <enum value="0x12B6"        name="CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT"/>
     </enums>
 
-    <enums start="0x12B7" end="0x12B7" name="cl_command_buffer_properties_khr" vendor="Khronos">
+    <enums start="0x12B7" end="0x12B7" group="cl_command_buffer_properties_khr" vendor="Khronos">
         <enum value="0x12B7"        name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR"/>
     </enums>
     
-    <enums start="0x12B8" end="0x12B8" name="cl_command_properties_khr" vendor="Khronos">
+    <enums start="0x12B8" end="0x12B8" group="cl_command_properties_khr" vendor="Khronos">
         <enum value="0x12B8"        name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>
     </enums>
 
-    <enums start="0x12B9" end="0x1FFF" name="cl_device_info" vendor="Khronos">
+    <enums start="0x12B9" end="0x1FFF" group="cl_device_info" vendor="Khronos">
         <enum value="0x12B9"        name="CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS_KHR"/>
         <enum value="0x12B9"        name="CL_DEVICE_SPIRV_EXTENDED_INSTRUCTION_SETS"/>
         <enum value="0x12BA"        name="CL_DEVICE_SPIRV_EXTENSIONS_KHR"/>
@@ -2137,24 +2137,24 @@ server's OpenCL/api-docs repository.
         <unused start="0x12BC" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
-    <enums start="0x2000" end="0x2003" name="cl_gl_object_type" vendor="Khronos">
+    <enums start="0x2000" end="0x2003" group="cl_gl_object_type" vendor="Khronos">
         <enum value="0x2000"        name="CL_GL_OBJECT_BUFFER"/>
         <enum value="0x2001"        name="CL_GL_OBJECT_TEXTURE2D"/>
         <enum value="0x2002"        name="CL_GL_OBJECT_TEXTURE3D"/>
         <enum value="0x2003"        name="CL_GL_OBJECT_RENDERBUFFER"/>
     </enums>
 
-    <enums start="0x2004" end="0x2005" name="cl_gl_texture_info" vendor="Khronos">
+    <enums start="0x2004" end="0x2005" group="cl_gl_texture_info" vendor="Khronos">
         <enum value="0x2004"        name="CL_GL_TEXTURE_TARGET"/>
         <enum value="0x2005"        name="CL_GL_MIPMAP_LEVEL"/>
     </enums>
 
-    <enums start="0x2006" end="0x2007" name="cl_gl_context_info" vendor="Khronos">
+    <enums start="0x2006" end="0x2007" group="cl_gl_context_info" vendor="Khronos">
         <enum value="0x2006"        name="CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR"/>
         <enum value="0x2007"        name="CL_DEVICES_FOR_GL_CONTEXT_KHR"/>
     </enums>
 
-    <enums start="0x2008" end="0x200C" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x2008" end="0x200C" group="cl_context_properties" vendor="Khronos">
         <enum value="0x2008"        name="CL_GL_CONTEXT_KHR"/>
         <enum value="0x2009"        name="CL_EGL_DISPLAY_KHR"/>
         <enum value="0x200A"        name="CL_GLX_DISPLAY_KHR"/>
@@ -2162,18 +2162,18 @@ server's OpenCL/api-docs repository.
         <enum value="0x200C"        name="CL_CGL_SHAREGROUP_KHR"/>
     </enums>
     
-    <enums start="0x200D" end="0x200D" name="cl_command_type" vendor="Khronos">
+    <enums start="0x200D" end="0x200D" group="cl_command_type" vendor="Khronos">
         <enum value="0x200D"        name="CL_COMMAND_GL_FENCE_SYNC_OBJECT_KHR"/>
     </enums>
 
-    <enums start="0x200E" end="0x2011" name="cl_gl_object_type" vendor="Khronos">
+    <enums start="0x200E" end="0x2011" group="cl_gl_object_type" vendor="Khronos">
         <enum value="0x200E"        name="CL_GL_OBJECT_TEXTURE2D_ARRAY"/>
         <enum value="0x200F"        name="CL_GL_OBJECT_TEXTURE1D"/>
         <enum value="0x2010"        name="CL_GL_OBJECT_TEXTURE1D_ARRAY"/>
         <enum value="0x2011"        name="CL_GL_OBJECT_TEXTURE_BUFFER"/>
     </enums>
 
-    <enums start="0x2012" end="0x2012" name="cl_gl_texture_info" vendor="Khronos">
+    <enums start="0x2012" end="0x2012" group="cl_gl_texture_info" vendor="Khronos">
         <enum value="0x2012"        name="CL_GL_NUM_SAMPLES"/>
     </enums>
 
@@ -2181,33 +2181,33 @@ server's OpenCL/api-docs repository.
             <unused start="0x2013" end="0x201F" comment="Reserved for OpenGL interop"/>
     </enums>
     
-    <enums start="0x2020" end="0x2022" name="cl_dx9_media_adapter_type_khr" vendor="Khronos">
+    <enums start="0x2020" end="0x2022" group="cl_dx9_media_adapter_type_khr" vendor="Khronos">
         <enum value="0x2020"        name="CL_ADAPTER_D3D9_KHR"/>
         <enum value="0x2021"        name="CL_ADAPTER_D3D9EX_KHR"/>
         <enum value="0x2022"        name="CL_ADAPTER_DXVA_KHR"/>
     </enums>
     
-    <enums start="0x2023" end="0x2024" name="cl_dx9_media_adapter_set_khr" vendor="Khronos">
+    <enums start="0x2023" end="0x2024" group="cl_dx9_media_adapter_set_khr" vendor="Khronos">
         <enum value="0x2023"        name="CL_PREFERRED_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR"/>
         <enum value="0x2024"        name="CL_ALL_DEVICES_FOR_DX9_MEDIA_ADAPTER_KHR"/>
     </enums>
     
-    <enums start="0x2025" end="0x2027" name="cl_context_info" vendor="Khronos">
+    <enums start="0x2025" end="0x2027" group="cl_context_info" vendor="Khronos">
         <enum value="0x2025"        name="CL_CONTEXT_ADAPTER_D3D9_KHR"/>
         <enum value="0x2026"        name="CL_CONTEXT_ADAPTER_D3D9EX_KHR"/>
         <enum value="0x2027"        name="CL_CONTEXT_ADAPTER_DXVA_KHR"/>
     </enums>
     
-    <enums start="0x2028" end="0x2032" name="cl_mem_info" vendor="Khronos">
+    <enums start="0x2028" end="0x2032" group="cl_mem_info" vendor="Khronos">
         <enum value="0x2028"        name="CL_MEM_DX9_MEDIA_ADAPTER_TYPE_KHR"/>
         <enum value="0x2029"        name="CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR"/>
     </enums>
     
-    <enums start="0x202A" end="0x202A" name="cl_image_info" vendor="Khronos">
+    <enums start="0x202A" end="0x202A" group="cl_image_info" vendor="Khronos">
         <enum value="0x202A"        name="CL_IMAGE_DX9_MEDIA_PLANE_KHR"/>
     </enums>
 
-    <enums start="0x202B" end="0x202F" name="cl_command_type" vendor="Khronos">
+    <enums start="0x202B" end="0x202F" group="cl_command_type" vendor="Khronos">
         <enum value="0x202B"        name="CL_COMMAND_ACQUIRE_DX9_MEDIA_SURFACES_KHR"/>
         <enum value="0x202C"        name="CL_COMMAND_RELEASE_DX9_MEDIA_SURFACES_KHR"/>
         <enum value="0x202D"        name="CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR"/>
@@ -2215,89 +2215,89 @@ server's OpenCL/api-docs repository.
         <enum value="0x202F"        name="CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR"/>
     </enums>
 
-    <enums start="0x2030" end="0x2030" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x2030" end="0x2030" group="cl_context_properties" vendor="Khronos">
         <enum value="0x2030"        name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
     </enums>
 
-    <enums start="0x2031" end="0x2031" name="cl_device_info" vendor="Khronos">
+    <enums start="0x2031" end="0x2031" group="cl_device_info" vendor="Khronos">
         <enum value="0x2031"        name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
     </enums>
 
-    <enums start="0x2032" end="0x2032" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x2032" end="0x2032" group="cl_context_properties" vendor="Khronos">
         <enum value="0x2032"        name="CL_CONTEXT_TERMINATE_KHR"/>
     </enums>
 
-    <enums start="0x2033" end="0x2034" name="cl_kernel_sub_group_info" vendor="Khronos">
+    <enums start="0x2033" end="0x2034" group="cl_kernel_sub_group_info" vendor="Khronos">
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE"/>
         <enum value="0x2033"        name="CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE"/>
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
     </enums>
 
-    <enums start="0x2035" end="0x2035" name="cl_device_info" vendor="Khronos">
+    <enums start="0x2035" end="0x2035" group="cl_device_info" vendor="Khronos">
         <enum value="0x2035"        name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
     </enums>
 
-    <enums start="0x2035" end="0x2035" name="cl_platform_info" vendor="Khronos">
+    <enums start="0x2035" end="0x2035" group="cl_platform_info" vendor="Khronos">
         <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2036" end="0x2038" name="cl_platform_info" vendor="Khronos">
+    <enums start="0x2036" end="0x2038" group="cl_platform_info" vendor="Khronos">
         <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
         <enum value="0x2037"        name="CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x2038"        name="CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2039" end="0x203C" name="cl_semaphore_info_khr" vendor="Khronos">
+    <enums start="0x2039" end="0x203C" group="cl_semaphore_info_khr" vendor="Khronos">
         <enum value="0x2039"        name="CL_SEMAPHORE_CONTEXT_KHR"/>
         <enum value="0x203A"        name="CL_SEMAPHORE_REFERENCE_COUNT_KHR"/>
         <enum value="0x203B"        name="CL_SEMAPHORE_PROPERTIES_KHR"/>
         <enum value="0x203C"        name="CL_SEMAPHORE_PAYLOAD_KHR"/>
     </enums>
 
-    <enums start="0x203D" end="0x203F" name="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
+    <enums start="0x203D" end="0x203F" group="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
         <enum value="0x203D"        name="CL_SEMAPHORE_TYPE_KHR"/>
         <enum value="0x203F"        name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2042" end="0x2043" name="cl_command_type" vendor="Khronos">
+    <enums start="0x2042" end="0x2043" group="cl_command_type" vendor="Khronos">
         <enum value="0x2042"        name="CL_COMMAND_SEMAPHORE_WAIT_KHR"/>
         <enum value="0x2043"        name="CL_COMMAND_SEMAPHORE_SIGNAL_KHR"/>
     </enums>
 
-    <enums start="0x2044" end="0x2044" name="cl_platform_info" vendor="Khronos">
+    <enums start="0x2044" end="0x2044" group="cl_platform_info" vendor="Khronos">
         <enum value="0x2044"        name="CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2047" end="0x2048" name="cl_command_type" vendor="Khronos">
+    <enums start="0x2047" end="0x2048" group="cl_command_type" vendor="Khronos">
         <enum value="0x2047"        name="CL_COMMAND_ACQUIRE_EXTERNAL_MEM_OBJECTS_KHR"/>
         <enum value="0x2048"        name="CL_COMMAND_RELEASE_EXTERNAL_MEM_OBJECTS_KHR"/>
     </enums>
 
-    <enums start="0x204C" end="0x204F" name="cl_device_info" vendor="Khronos">
+    <enums start="0x204C" end="0x204F" group="cl_device_info" vendor="Khronos">
         <enum value="0x204C"        name="CL_DEVICE_SEMAPHORE_TYPES_KHR"/>
         <enum value="0x204D"        name="CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x204E"        name="CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
         <enum value="0x204F"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2051" end="0x2051" name="cl_mem_properties" vendor="Khronos">
+    <enums start="0x2051" end="0x2051" group="cl_mem_properties" vendor="Khronos">
         <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>
     </enums>
 
-    <enums start="0x2052" end="0x2052" name="cl_device_info" vendor="Khronos">
+    <enums start="0x2052" end="0x2052" group="cl_device_info" vendor="Khronos">
         <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2053" end="0x2053" name="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
+    <enums start="0x2053" end="0x2053" group="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
         <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR"/>
     </enums>
 
-    <enums start="0x2054" end="0x2054" name="cl_semaphore_info_khr" vendor="Khronos">
+    <enums start="0x2054" end="0x2054" group="cl_semaphore_info_khr" vendor="Khronos">
         <enum value="0x2054"        name="CL_SEMAPHORE_EXPORTABLE_KHR"/>
     </enums>
 
-    <enums start="0x2055" end="0x2059" name="cl_external_semaphore_handle_type_khr" vendor="Khronos">
+    <enums start="0x2055" end="0x2059" group="cl_external_semaphore_handle_type_khr" vendor="Khronos">
         <enum value="0x2055"        name="CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR"/>
         <enum value="0x2056"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR"/>
         <enum value="0x2057"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
@@ -2305,7 +2305,7 @@ server's OpenCL/api-docs repository.
         <enum value="0x2059"        name="CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR"/>
     </enums>
 
-    <enums start="0x2060" end="0x2062" name="cl_external_memory_handle_type_khr" vendor="Khronos">
+    <enums start="0x2060" end="0x2062" group="cl_external_memory_handle_type_khr" vendor="Khronos">
         <enum value="0x2060"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR"/>
         <enum value="0x2061"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR"/>
         <enum value="0x2062"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KMT_KHR"/>
@@ -2315,15 +2315,15 @@ server's OpenCL/api-docs repository.
             <unused start="0x2063" end="0x2066" comment="Reserved to Khronos for interop"/>
     </enums>
     
-    <enums start="0x2067" end="0x2067" name="cl_external_memory_handle_type_khr" vendor="Khronos">
+    <enums start="0x2067" end="0x2067" group="cl_external_memory_handle_type_khr" vendor="Khronos">
         <enum value="0x2067"        name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR"/>
     </enums>
 
-    <enums start="0x2068" end="0x2068" name="cl_external_semaphore_handle_type_khr" vendor="Khronos">
+    <enums start="0x2068" end="0x2068" group="cl_external_semaphore_handle_type_khr" vendor="Khronos">
         <enum value="0x2068"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
     </enums>
 
-    <enums start="0x2069" end="0x2069" name="cl_external_memory_handle_type_khr" vendor="Khronos">
+    <enums start="0x2069" end="0x2069" group="cl_external_memory_handle_type_khr" vendor="Khronos">
         <enum value="0x2069"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
     </enums>
 
@@ -2331,7 +2331,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x206A" end="0x206F" comment="Reserved to Khronos for interop"/>
     </enums>
 
-    <enums start="0x2070" end="0x2070" name="cl_external_memory_handle_type_khr" vendor="Khronos" comment="Reserved for interop with other APIs">
+    <enums start="0x2070" end="0x2070" group="cl_external_memory_handle_type_khr" vendor="Khronos" comment="Reserved for interop with other APIs">
         <enum value="0x2070"        name="CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR"/>
     </enums>
 
@@ -2339,14 +2339,14 @@ server's OpenCL/api-docs repository.
             <unused start="0x2071" end="0x2077" comment="Reserved for cl_khr_unified_svm"/>
     </enums>
 
-    <enums start="0x2078" end="0x2087" name="cl_svm_alloc_properties_khr" vendor="Khronos">
+    <enums start="0x2078" end="0x2087" group="cl_svm_alloc_properties_khr" vendor="Khronos">
         <enum value="0x2078"        name="CL_SVM_ALLOC_ASSOCIATED_DEVICE_HANDLE_KHR"/>
         <enum value="0x2079"        name="CL_SVM_ALLOC_ACCESS_FLAGS_KHR"/>
         <enum value="0x207A"        name="CL_SVM_ALLOC_ALIGNMENT_KHR"/>
         <unused start="0x207B" end="0x2087" comment="Reserved for cl_khr_unified_svm cl_svm_alloc_properties_khr"/>
     </enums>
 
-    <enums start="0x2088" end="0x208F" name="cl_svm_pointer_info_khr" vendor="Khronos">
+    <enums start="0x2088" end="0x208F" group="cl_svm_pointer_info_khr" vendor="Khronos">
         <enum value="0x2088"        name="CL_SVM_INFO_TYPE_INDEX_KHR"/>
         <enum value="0x2089"        name="CL_SVM_INFO_CAPABILITIES_KHR"/>
         <enum value="0x208A"        name="CL_SVM_INFO_PROPERTIES_KHR"/>
@@ -2364,7 +2364,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x3002" end="0x3FFF"/>
     </enums>
 
-    <enums start="0x4000" end="0x400F" name="cl_device_info" vendor="NVIDIA" comment="Per Bug 5673">
+    <enums start="0x4000" end="0x400F" group="cl_device_info" vendor="NVIDIA" comment="Per Bug 5673">
         <enum value="0x4000"        name="CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV"/>
         <enum value="0x4001"        name="CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV"/>
         <enum value="0x4002"        name="CL_DEVICE_REGISTERS_PER_BLOCK_NV"/>
@@ -2375,104 +2375,104 @@ server's OpenCL/api-docs repository.
             <unused start="0x4007" end="0x400F"/>
     </enums>
 
-    <enums start="0x4010" end="0x4011" name="cl_d3d10_device_source_khr" vendor="Khronos">
+    <enums start="0x4010" end="0x4011" group="cl_d3d10_device_source_khr" vendor="Khronos">
         <enum value="0x4010"        name="CL_D3D10_DEVICE_KHR"/>
         <!-- unused <enum value="0x4010"      name="CL_D3D10_DEVICE_NV"/> -->
         <enum value="0x4011"        name="CL_D3D10_DXGI_ADAPTER_KHR"/>
         <!-- unused <enum value="0x4011"      name="CL_D3D10_DXGI_ADAPTER_NV"/> -->
     </enums>
 
-    <enums start="0x4012" end="0x4013" name="cl_d3d10_device_set_khr" vendor="Khronos">
+    <enums start="0x4012" end="0x4013" group="cl_d3d10_device_set_khr" vendor="Khronos">
         <enum value="0x4012"        name="CL_PREFERRED_DEVICES_FOR_D3D10_KHR"/>
         <!-- unused <enum value="0x4012"      name="CL_PREFERRED_DEVICES_FOR_D3D10_NV"/> -->
         <enum value="0x4013"        name="CL_ALL_DEVICES_FOR_D3D10_KHR"/>
         <!-- unused <enum value="0x4013"      name="CL_ALL_DEVICES_FOR_D3D10_NV"/> -->
     </enums>
 
-    <enums start="0x4014" end="0x4014" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x4014" end="0x4014" group="cl_context_properties" vendor="Khronos">
         <enum value="0x4014"        name="CL_CONTEXT_D3D10_DEVICE_KHR"/>
         <!-- unused <enum value="0x4014"      name="CL_CONTEXT_D3D10_DEVICE_NV"/> -->
     </enums>
 
-    <enums start="0x4015" end="0x4015" name="cl_mem_info" vendor="Khronos">
+    <enums start="0x4015" end="0x4015" group="cl_mem_info" vendor="Khronos">
         <enum value="0x4015"        name="CL_MEM_D3D10_RESOURCE_KHR"/>
         <!-- unused <enum value="0x4015"      name="CL_MEM_D3D10_RESOURCE_NV"/> -->
     </enums>
 
-    <enums start="0x4016" end="0x4016" name="cl_image_info" vendor="Khronos">
+    <enums start="0x4016" end="0x4016" group="cl_image_info" vendor="Khronos">
         <enum value="0x4016"        name="CL_IMAGE_D3D10_SUBRESOURCE_KHR"/>
         <!-- unused <enum value="0x4016"      name="CL_IMAGE_D3D10_SUBRESOURCE_NV"/> -->
     </enums>
 
-    <enums start="0x4017" end="0x4018" name="cl_command_type" vendor="Khronos">
+    <enums start="0x4017" end="0x4018" group="cl_command_type" vendor="Khronos">
         <enum value="0x4017"        name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR"/>
         <!-- unused <enum value="0x4017"      name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_NV"/> -->
         <enum value="0x4018"        name="CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR"/>
         <!-- unused <enum value="0x4018"      name="CL_COMMAND_RELEASE_D3D10_OBJECTS_NV"/> -->
     </enums>
 
-    <enums start="0x4019" end="0x401A" name="cl_d3d11_device_source_khr" vendor="Khronos">
+    <enums start="0x4019" end="0x401A" group="cl_d3d11_device_source_khr" vendor="Khronos">
         <enum value="0x4019"        name="CL_D3D11_DEVICE_KHR"/>
         <!-- unused <enum value="0x4019"      name="CL_D3D11_DEVICE_NV"/> -->
         <enum value="0x401A"        name="CL_D3D11_DXGI_ADAPTER_KHR"/>
         <!-- unused <enum value="0x401A"      name="CL_D3D11_DXGI_ADAPTER_NV"/> -->
     </enums>
 
-    <enums start="0x401B" end="0x401C" name="cl_d3d11_device_set_khr" vendor="Khronos">
+    <enums start="0x401B" end="0x401C" group="cl_d3d11_device_set_khr" vendor="Khronos">
         <enum value="0x401B"        name="CL_PREFERRED_DEVICES_FOR_D3D11_KHR"/>
         <!-- unused <enum value="0x401B"      name="CL_PREFERRED_DEVICES_FOR_D3D11_NV"/> -->
         <enum value="0x401C"        name="CL_ALL_DEVICES_FOR_D3D11_KHR"/>
         <!-- unused <enum value="0x401C"      name="CL_ALL_DEVICES_FOR_D3D11_NV"/> -->
     </enums>
 
-    <enums start="0x401D" end="0x401D" name="cl_context_properties" vendor="Khronos">
+    <enums start="0x401D" end="0x401D" group="cl_context_properties" vendor="Khronos">
         <enum value="0x401D"        name="CL_CONTEXT_D3D11_DEVICE_KHR"/>
         <!-- unused <enum value="0x401D"      name="CL_CONTEXT_D3D11_DEVICE_NV"/> -->
     </enums>
 
-    <enums start="0x401E" end="0x401E" name="cl_mem_info" vendor="Khronos">
+    <enums start="0x401E" end="0x401E" group="cl_mem_info" vendor="Khronos">
         <enum value="0x401E"        name="CL_MEM_D3D11_RESOURCE_KHR"/>
         <!-- unused <enum value="0x401E"      name="CL_MEM_D3D11_RESOURCE_NV"/> -->
     </enums>
 
-    <enums start="0x401F" end="0x401F" name="cl_image_info" vendor="Khronos">
+    <enums start="0x401F" end="0x401F" group="cl_image_info" vendor="Khronos">
         <enum value="0x401F"        name="CL_IMAGE_D3D11_SUBRESOURCE_KHR"/>
         <!-- unused <enum value="0x401F"      name="CL_IMAGE_D3D11_SUBRESOURCE_NV"/> -->
     </enums>
 
-    <enums start="0x4020" end="0x4021" name="cl_command_type" vendor="Khronos">
+    <enums start="0x4020" end="0x4021" group="cl_command_type" vendor="Khronos">
         <enum value="0x4020"        name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR"/>
         <!-- unused <enum value="0x4020"      name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_NV"/> -->
         <enum value="0x4021"        name="CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR"/>
         <!-- unused <enum value="0x4021"      name="CL_COMMAND_RELEASE_D3D11_OBJECTS_NV"/> -->
     </enums>
 
-    <enums start="0x4022" end="0x4022" name="cl_dx9_device_source_intel" vendor="Khronos">
+    <enums start="0x4022" end="0x4022" group="cl_dx9_device_source_intel" vendor="Khronos">
         <enum value="0x4022"        name="CL_D3D9_DEVICE_INTEL"/>
         <!-- unused <enum value="0x4022"      name="CL_D3D9_DEVICE_NV"/> -->
         <!-- unused <enum value="0x4023"      name="CL_D3D9_ADAPTER_NAME_NV"/> -->
     </enums>
 
-    <enums start="0x4024" end="0x4025" name="cl_dx9_device_set_intel" vendor="Khronos">
+    <enums start="0x4024" end="0x4025" group="cl_dx9_device_set_intel" vendor="Khronos">
         <enum value="0x4024"        name="CL_PREFERRED_DEVICES_FOR_DX9_INTEL"/>
         <!-- unused <enum value="0x4024"      name="CL_PREFERRED_DEVICES_FOR_D3D9_NV"/> -->
         <enum value="0x4025"        name="CL_ALL_DEVICES_FOR_DX9_INTEL"/>
         <!-- unused <enum value="0x4025"      name="CL_ALL_DEVICES_FOR_D3D9_NV"/> -->
     </enums>
 
-    <enums start="0x4026" end="0x4026" name="cl_context_info" vendor="Khronos">
+    <enums start="0x4026" end="0x4026" group="cl_context_info" vendor="Khronos">
         <enum value="0x4026"        name="CL_CONTEXT_D3D9_DEVICE_INTEL"/>
         <!-- unused <enum value="0x4026"      name="CL_CONTEXT_D3D9_DEVICE_NV"/> -->
     </enums>
 
-    <enums start="0x4027" end="0x4027" name="cl_mem_info" vendor="Khronos">
+    <enums start="0x4027" end="0x4027" group="cl_mem_info" vendor="Khronos">
         <enum value="0x4027"        name="CL_MEM_DX9_RESOURCE_INTEL"/>
         <!-- unused <enum value="0x4027"      name="CL_MEM_D3D9_RESOURCE_NV"/> -->
         <!-- unused <enum value="0x4028"      name="CL_IMAGE_D3D9_FACE_NV"/> -->
         <!-- unused <enum value="0x4029"      name="CL_IMAGE_D3D9_LEVEL_NV"/> -->
     </enums>
 
-    <enums start="0x402A" end="0x402B" name="cl_command_type" vendor="Khronos">
+    <enums start="0x402A" end="0x402B" group="cl_command_type" vendor="Khronos">
         <enum value="0x402A"        name="CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL"/>
         <enum value="0x402B"        name="CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL"/>
         <enum value="0x402A"        name="CL_COMMAND_ACQUIRE_D3D9_OBJECTS_INTEL"/>
@@ -2481,7 +2481,7 @@ server's OpenCL/api-docs repository.
         <!-- unused <enum value="0x402B"      name="CL_COMMAND_RELEASE_D3D9_OBJECTS_NV"/> -->
     </enums>
 
-    <enums start="0x402C" end="0x402D" name="cl_context_info" vendor="Khronos">
+    <enums start="0x402C" end="0x402D" group="cl_context_info" vendor="Khronos">
         <enum value="0x402C"        name="CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR"/>
         <enum value="0x402D"        name="CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR"/>
     </enums>
@@ -2490,7 +2490,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x402D" end="0x402F"/>
     </enums>
 
-    <enums start="0x4030" end="0x403F" name="cl_device_info" vendor="AMD" comment="Per Bug 6075">
+    <enums start="0x4030" end="0x403F" group="cl_device_info" vendor="AMD" comment="Per Bug 6075">
             <!-- Note that an unnamed AMD D3D9 extension was intended to use some enums in this range, but was never shipped or published. See bug 6071. -->
             <!-- To be named AMD atomic counters extension - see bug 6071/6075 -->
         <!-- <enum value="0x4030"      name="CL_DEVICE_PARENT_DEVICE_EXT"/> -->
@@ -2509,11 +2509,11 @@ server's OpenCL/api-docs repository.
             <unused start="0x403A" end="0x403F"/>
     </enums>
 
-    <enums start="0x4040" end="0x4040" name="cl_command_type" vendor="EXT" comment="Per Bug 6261 (IBM), then Bug 13603 giving control to AMD">
+    <enums start="0x4040" end="0x4040" group="cl_command_type" vendor="EXT" comment="Per Bug 6261 (IBM), then Bug 13603 giving control to AMD">
         <enum value="0x4040"        name="CL_COMMAND_MIGRATE_MEM_OBJECT_EXT" comment="From cl_ext_migrate_memobject. Benign collision with the following enum."/>
     </enums>
 
-    <enums start="0x4040" end="0x404F" name="cl_device_info" vendor="AMD" comment="Per Bug 6261 (IBM), then Bug 13603 giving control to AMD">
+    <enums start="0x4040" end="0x404F" group="cl_device_info" vendor="AMD" comment="Per Bug 6261 (IBM), then Bug 13603 giving control to AMD">
         <enum value="0x4040"        name="CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD"/>
         <enum value="0x4041"        name="CL_DEVICE_SIMD_WIDTH_AMD"/>
         <enum value="0x4042"        name="CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD"/>
@@ -2530,21 +2530,21 @@ server's OpenCL/api-docs repository.
             <unused start="0x404D" end="0x404F"/>
     </enums>
 
-    <enums start="0x4040" end="0x4052" name="cl_device_partition_property_ext" vendor="Apple">
+    <enums start="0x4040" end="0x4052" group="cl_device_partition_property_ext" vendor="Apple">
         <enum value="0x4050"        name="CL_DEVICE_PARTITION_EQUALLY_EXT"/>
         <enum value="0x4051"        name="CL_DEVICE_PARTITION_BY_COUNTS_EXT"/>
         <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_EXT"/>
     </enums>
     
-    <enums start="0x4052" end="0x4052" name="cl_device_partition_property" vendor="Intel">
+    <enums start="0x4052" end="0x4052" group="cl_device_partition_property" vendor="Intel">
         <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_INTEL"/>
     </enums>
 
-    <enums start="0x4053" end="0x4053" name="cl_device_partition_property_ext" vendor="Apple">
+    <enums start="0x4053" end="0x4053" group="cl_device_partition_property_ext" vendor="Apple">
         <enum value="0x4053"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT"/>
     </enums>
 
-    <enums start="0x4054" end="0x405F" name="cl_device_info" vendor="Apple">
+    <enums start="0x4054" end="0x405F" group="cl_device_info" vendor="Apple">
         <enum value="0x4054"        name="CL_DEVICE_PARENT_DEVICE_EXT"/>
         <enum value="0x4055"        name="CL_DEVICE_PARTITION_TYPES_EXT"/>
         <enum value="0x4056"        name="CL_DEVICE_AFFINITY_DOMAINS_EXT"/>
@@ -2557,25 +2557,25 @@ server's OpenCL/api-docs repository.
             <unused start="0x4060" end="0x406F"/>
     </enums>
 
-    <enums start="0x4070" end="0x4071" name="cl_dx9_device_source_intel" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x4070" end="0x4071" group="cl_dx9_device_source_intel" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x4070"        name="CL_D3D9EX_DEVICE_INTEL"/>
         <enum value="0x4071"        name="CL_DXVA_DEVICE_INTEL"/>
     </enums>
 
-    <enums start="0x4072" end="0x4073" name="cl_context_properties" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x4072" end="0x4073" group="cl_context_properties" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x4072"        name="CL_CONTEXT_D3D9EX_DEVICE_INTEL"/>
         <enum value="0x4073"        name="CL_CONTEXT_DXVA_DEVICE_INTEL"/>
     </enums>
 
-    <enums start="0x4074" end="0x4074" name="cl_mem_info" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x4074" end="0x4074" group="cl_mem_info" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x4074"        name="CL_MEM_DX9_SHARED_HANDLE_INTEL"/>
     </enums>
 
-    <enums start="0x4075" end="0x4075" name="cl_image_info" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x4075" end="0x4075" group="cl_image_info" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x4075"        name="CL_IMAGE_DX9_PLANE_INTEL"/>
     </enums>
 
-    <enums start="0x4076" end="0x407D" name="cl_channel_order" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x4076" end="0x407D" group="cl_channel_order" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x4076"        name="CL_YUYV_INTEL"/>
         <enum value="0x4077"        name="CL_UYVY_INTEL"/>
         <enum value="0x4078"        name="CL_YVYU_INTEL"/>
@@ -2583,7 +2583,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x407A" end="0x407D"/>
     </enums>
 
-    <enums start="0x407E" end="0x407F" name="cl_device_info" vendor="Intel" comment="Per Bug 7836">
+    <enums start="0x407E" end="0x407F" group="cl_device_info" vendor="Intel" comment="Per Bug 7836">
         <enum value="0x407E"        name="CL_DEVICE_ME_VERSION_INTEL"/>
             <unused start="0x407F"/>
     </enums>
@@ -2595,52 +2595,52 @@ server's OpenCL/api-docs repository.
             <unused start="0x4083" end="0x408F"/>
     </enums>
 
-    <enums start="0x4090" end="0x4093" name="cl_accelerator_info_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4090" end="0x4093" group="cl_accelerator_info_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4090"        name="CL_ACCELERATOR_DESCRIPTOR_INTEL"/>
         <enum value="0x4091"        name="CL_ACCELERATOR_REFERENCE_COUNT_INTEL"/>
         <enum value="0x4092"        name="CL_ACCELERATOR_CONTEXT_INTEL"/>
         <enum value="0x4093"        name="CL_ACCELERATOR_TYPE_INTEL"/>
     </enums>
 
-    <enums start="0x4094" end="0x4094" name="cl_va_api_device_source_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4094" end="0x4094" group="cl_va_api_device_source_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4094"        name="CL_VA_API_DISPLAY_INTEL"/>
     </enums>
 
-    <enums start="0x4094" end="0x4094" name="cl_va_api_device_set_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4094" end="0x4094" group="cl_va_api_device_set_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4095"        name="CL_PREFERRED_DEVICES_FOR_VA_API_INTEL"/>
         <enum value="0x4096"        name="CL_ALL_DEVICES_FOR_VA_API_INTEL"/>
     </enums>
 
-    <enums start="0x4097" end="0x4097" name="cl_context_properties" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4097" end="0x4097" group="cl_context_properties" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4097"        name="CL_CONTEXT_VA_API_DISPLAY_INTEL"/>
     </enums>
 
-    <enums start="0x4097" end="0x4097" name="cl_mem_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4097" end="0x4097" group="cl_mem_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4098"        name="CL_MEM_VA_API_MEDIA_SURFACE_INTEL"/>
     </enums>
 
-    <enums start="0x4097" end="0x4097" name="cl_image_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x4097" end="0x4097" group="cl_image_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x4099"        name="CL_IMAGE_VA_API_PLANE_INTEL"/>
     </enums>
 
-    <enums start="0x409A" end="0x409F" name="cl_command_type" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+    <enums start="0x409A" end="0x409F" group="cl_command_type" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
         <enum value="0x409A"        name="CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL"/>
         <enum value="0x409B"        name="CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL"/>
             <unused start="0x409C" end="0x409F"/>
     </enums>
 
-    <enums start="0x40A0" end="0x40A1" name="cl_device_info" vendor="Qualcomm" comment="Per Bug 10214">
+    <enums start="0x40A0" end="0x40A1" group="cl_device_info" vendor="Qualcomm" comment="Per Bug 10214">
         <enum value="0x40A0"        name="CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM"/>
         <enum value="0x40A1"        name="CL_DEVICE_PAGE_SIZE_QCOM"/>
     </enums>
 
-    <enums start="0x40A2" end="0x40A3" name="cl_image_pitch_info_qcom" vendor="Qualcomm" comment="Per Bug 10214">
+    <enums start="0x40A2" end="0x40A3" group="cl_image_pitch_info_qcom" vendor="Qualcomm" comment="Per Bug 10214">
         <enum value="0x40A2"        name="CL_IMAGE_ROW_ALIGNMENT_QCOM"/>
         <enum value="0x40A3"        name="CL_IMAGE_SLICE_ALIGNMENT_QCOM"/>
     </enums>
 
     <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A4" end="0x40A7" name="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
+    <enums start="0x40A4" end="0x40A7" group="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
         <enum value="0x40A4"        name="CL_MEM_HOST_UNCACHED_QCOM"/>
         <enum value="0x40A5"        name="CL_MEM_HOST_WRITEBACK_QCOM"/>
         <enum value="0x40A6"        name="CL_MEM_HOST_WRITETHROUGH_QCOM"/>
@@ -2648,46 +2648,46 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A8" end="0x40A8" name="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10214">
+    <enums start="0x40A8" end="0x40A8" group="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10214">
         <enum value="0x40A8"        name="CL_MEM_ION_HOST_PTR_QCOM"/>
     </enums>
 
     <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A9" end="0x40AF" name="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
+    <enums start="0x40A9" end="0x40AF" group="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
         <enum value="0x40A9"        name="CL_MEM_HOST_IOCOHERENT_QCOM"/>
             <unused start="0x40AA" end="0x40AF"/>
     </enums>
 
-    <enums start="0x40B0" end="0x40B1" name="cl_context_properties" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B0" end="0x40B1" group="cl_context_properties" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B0"        name="CL_PRINTF_CALLBACK_ARM"/>
         <enum value="0x40B1"        name="CL_PRINTF_BUFFERSIZE_ARM"/>
     </enums>
 
-    <enums start="0x40B2" end="0x40B2" name="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B2" end="0x40B2" group="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B2"        name="CL_IMPORT_TYPE_ARM"/>
     </enums>
 
-    <enums start="0x40B0" end="0x40B1" name="cl_import_type_arm" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B0" end="0x40B1" group="cl_import_type_arm" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B3"        name="CL_IMPORT_TYPE_HOST_ARM"/>
         <enum value="0x40B4"        name="CL_IMPORT_TYPE_DMA_BUF_ARM"/>
         
     </enums>
 
-    <enums start="0x40B2" end="0x40B2" name="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B2" end="0x40B2" group="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B5"        name="CL_IMPORT_TYPE_PROTECTED_ARM"/>
     </enums>
 
-    <enums start="0x40B6" end="0x40B7" name="cl_device_info" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B6" end="0x40B7" group="cl_device_info" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B6"        name="CL_DEVICE_SVM_CAPABILITIES_ARM"/>
         <enum value="0x40B7"        name="CL_MEM_USES_SVM_POINTER_ARM"/>
     </enums>
 
-    <enums start="0x40B8" end="0x40B9" name="cl_kernel_exec_info_arm" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40B8" end="0x40B9" group="cl_kernel_exec_info_arm" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40B8"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM"/>
         <enum value="0x40B9"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM"/>
     </enums>
 
-    <enums start="0x40BA" end="0x40BE" name="cl_command_type" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40BA" end="0x40BE" group="cl_command_type" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40BA"        name="CL_COMMAND_SVM_FREE_ARM"/>
         <enum value="0x40BB"        name="CL_COMMAND_SVM_MEMCPY_ARM"/>
         <enum value="0x40BC"        name="CL_COMMAND_SVM_MEMFILL_ARM"/>
@@ -2695,61 +2695,61 @@ server's OpenCL/api-docs repository.
         <enum value="0x40BE"        name="CL_COMMAND_SVM_UNMAP_ARM"/>
     </enums>
 
-    <enums start="0x40BF" end="0x40BF" name="cl_device_info" vendor="Arm" comment="Per Bug 10337">
+    <enums start="0x40BF" end="0x40BF" group="cl_device_info" vendor="Arm" comment="Per Bug 10337">
         <enum value="0x40BF"        name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"/>
     </enums>
 
-    <enums start="0x40C0" end="0x40CF" name="cl_context_properties" vendor="Qualcomm" comment="Per Bug 10726">
+    <enums start="0x40C0" end="0x40CF" group="cl_context_properties" vendor="Qualcomm" comment="Per Bug 10726">
             <unused start="0x40C0" end="0x40C1"/>
         <enum value="0x40C2"        name="CL_CONTEXT_PERF_HINT_QCOM"/>
     </enums>
 
-    <enums start="0x40C3" end="0x40C5" name="cl_perf_hint_qcom" vendor="Qualcomm" comment="Per Bug 10726">
+    <enums start="0x40C3" end="0x40C5" group="cl_perf_hint_qcom" vendor="Qualcomm" comment="Per Bug 10726">
         <enum value="0x40C3"        name="CL_PERF_HINT_HIGH_QCOM"/>
         <enum value="0x40C4"        name="CL_PERF_HINT_NORMAL_QCOM"/>
         <enum value="0x40C5"        name="CL_PERF_HINT_LOW_QCOM"/>
     </enums>
 
     <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40C6" end="0x40CF" name="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10726">
+    <enums start="0x40C6" end="0x40CF" group="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10726">
         <enum value="0x40C6"        name="CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM"/>
             <unused start="0x40C7" end="0x40CF"/>
     </enums>
 
-    <enums start="0x40D0" end="0x40D1" name="cl_channel_order" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D0" end="0x40D1" group="cl_channel_order" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D0"        name="CL_NV21"/>
         <enum value="0x40D0"        name="CL_NV21_IMG"/>
         <enum value="0x40D1"        name="CL_YV12"/>
         <enum value="0x40D1"        name="CL_YV12_IMG"/>
     </enums>
 
-    <enums start="0x40D2" end="0x40D3" name="cl_command_type" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D2" end="0x40D3" group="cl_command_type" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D2"        name="CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG"/>
         <enum value="0x40D3"        name="CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG"/>
     </enums>
 
-    <enums start="0x40D4" end="0x40D5" name="ErrorCodes.+40D2" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D4" end="0x40D5" group="ErrorCodes.+40D2" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D4"        name="CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG"/>
         <enum value="0x40D5"        name="CL_INVALID_GRALLOC_OBJECT_IMG"/>
     </enums>
 
-    <enums start="0x40D6" end="0x40D6" name="cl_command_type" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D6" end="0x40D6" group="cl_command_type" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D6"        name="CL_COMMAND_GENERATE_MIPMAP_IMG"/>
     </enums>
 
-    <enums start="0x40D7" end="0x40D7" name="cl_mem_alloc_flags_img" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D7" end="0x40D7" group="cl_mem_alloc_flags_img" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D7"        name="CL_MEM_ALLOC_FLAGS_IMG"/>
     </enums>
 
-    <enums start="0x40D8" end="0x40D8" name="cl_device_info" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D8" end="0x40D8" group="cl_device_info" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D8"        name="CL_DEVICE_MEMORY_CAPABILITIES_IMG"/>
     </enums>
 
-    <enums start="0x40D9" end="0x40D9" name="cl_context_properties" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D9" end="0x40D9" group="cl_context_properties" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40D9"        name="CL_CONTEXT_SAFETY_PROPERTIES_IMG"/>
     </enums>
 
-    <enums start="0x40DA" end="0x40DC" name="cl_device_info" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40DA" end="0x40DC" group="cl_device_info" vendor="IMG" comment="Per Bug 11287">
         <enum value="0x40DA"        name="CL_DEVICE_WORKGROUP_PROTECTION_SVM_CAPABILITIES_IMG"/>
         <enum value="0x40DB"        name="CL_DEVICE_WORKGROUP_PROTECTION_DEVICE_ENQUEUE_CAPABILITIES_IMG"/>
         <enum value="0x40DC"        name="CL_DEVICE_SAFETY_MEM_SIZE_IMG"/>
@@ -2761,11 +2761,11 @@ server's OpenCL/api-docs repository.
         <unused start="0x40DE" end="0x40DF"/>
     </enums>
 
-    <enums start="0x40E0" end="0x40E0" name="cl_device_info" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
+    <enums start="0x40E0" end="0x40E0" group="cl_device_info" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
         <enum value="0x40E0"        name="CL_DEVICE_SPIR_VERSIONS"/>
     </enums>
 
-    <enums start="0x40E1" end="0x40EF" name="cl_program_binary_type" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
+    <enums start="0x40E1" end="0x40EF" group="cl_program_binary_type" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
         <enum value="0x40E1"        name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE"/>
             <unused start="0x40E2" end="0x40EF"/>
     </enums>
@@ -2778,44 +2778,44 @@ server's OpenCL/api-docs repository.
             <unused start="0x40F4" end="0x40FF"/>
     </enums>
 
-    <enums start="0x4100" end="0x410F" name="cl_device_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4100" end="0x410F" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
             <unused start="0x4100" end="0x4103"/>
         <enum value="0x4104"        name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"/>
         <enum value="0x4105"        name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"/>
     </enums>
 
 
-    <enums start="0x4106" end="0x4106" name="cl_context_properties" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4106" end="0x4106" group="cl_context_properties" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x4106"        name="CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL"/>
     </enums>
 
-    <enums start="0x4107" end="0x4107" name="cl_image_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4107" end="0x4107" group="cl_image_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x4107"        name="CL_EGL_YUV_PLANE_INTEL"/>
     </enums>
 
-    <enums start="0x4108" end="0x4108" name="cl_device_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4108" end="0x4108" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x4108"        name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"/>
     </enums>
 
-    <enums start="0x4109" end="0x4109" name="cl_kernel_work_group_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4109" end="0x4109" group="cl_kernel_work_group_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x4109"        name="CL_KERNEL_SPILL_MEM_SIZE_INTEL"/>
     </enums>
 
-    <enums start="0x410A" end="0x410A" name="cl_kernel_sub_group_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x410A" end="0x410A" group="cl_kernel_sub_group_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x410A"        name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"/>
     </enums>
 
-    <enums start="0x410B" end="0x410D" name="cl_device_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x410B" end="0x410D" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x410B"        name="CL_DEVICE_AVC_ME_VERSION_INTEL"/>
         <enum value="0x410C"        name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL"/>
         <enum value="0x410D"        name="CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL"/>
     </enums>
 
-    <enums start="0x410E" end="0x410E" name="cl_channel_order" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x410E" end="0x410E" group="cl_channel_order" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x410E"        name="CL_NV12_INTEL"/>
     </enums>
     
-    <enums start="0x410F" end="0x410F" name="cl_device_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x410F" end="0x410F" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
         <enum value="0x410F"        name="CL_DEVICE_PCI_BUS_INFO_KHR"/>
     </enums>
 
@@ -2835,24 +2835,24 @@ server's OpenCL/api-docs repository.
             <unused start="0x4160" end="0x416F"/>
     </enums>
 
-    <enums start="0x4170" end="0x417F" name="cl_device_info" vendor="Intel" comment="Per bug 16067.">
+    <enums start="0x4170" end="0x417F" group="cl_device_info" vendor="Intel" comment="Per bug 16067.">
             <unused start="0x4170" end="0x417D"/>
         <enum value="0x417E"        name="CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL"/>
         <enum value="0x417F"        name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
     </enums>
 
-    <enums start="0x4180" end="0x418B" name="cl_device_info" vendor="Intel" comment="Per OpenCL-Registry #22">
+    <enums start="0x4180" end="0x418B" group="cl_device_info" vendor="Intel" comment="Per OpenCL-Registry #22">
             <unused start="0x4180" end="0x418A"/>
         <enum value="0x418B"        name="CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL"/>
     </enums>
 
-    <enums start="0x418C" end="0x418F" name="cl_command_queue_info" vendor="Intel" comment="Per OpenCL-Registry #22">
+    <enums start="0x418C" end="0x418F" group="cl_command_queue_info" vendor="Intel" comment="Per OpenCL-Registry #22">
         <enum value="0x418C"        name="CL_QUEUE_FAMILY_INTEL"/>
         <enum value="0x418D"        name="CL_QUEUE_INDEX_INTEL"/>
             <unused start="0x418E" end="0x418F"/>
     </enums>
 
-    <enums start="0x4190" end="0x4194" name="cl_device_info" vendor="Intel">
+    <enums start="0x4190" end="0x4194" group="cl_device_info" vendor="Intel">
         <enum value="0x4190"        name="CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL"/>
         <enum value="0x4191"        name="CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL"/>
         <enum value="0x4192"        name="CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"/>
@@ -2860,43 +2860,43 @@ server's OpenCL/api-docs repository.
         <enum value="0x4194"        name="CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL"/>
     </enums>
     
-    <enums start="0x4195" end="0x4195" name="cl_mem_properties_intel" vendor="Intel">
+    <enums start="0x4195" end="0x4195" group="cl_mem_properties_intel" vendor="Intel">
         <enum value="0x4195"        name="CL_MEM_ALLOC_FLAGS_INTEL"/>
     </enums>
 
-    <enums start="0x4196" end="0x4199" name="cl_unified_shared_memory_type_intel" vendor="Intel">
+    <enums start="0x4196" end="0x4199" group="cl_unified_shared_memory_type_intel" vendor="Intel">
         <enum value="0x4196"        name="CL_MEM_TYPE_UNKNOWN_INTEL"/>
         <enum value="0x4197"        name="CL_MEM_TYPE_HOST_INTEL"/>
         <enum value="0x4198"        name="CL_MEM_TYPE_DEVICE_INTEL"/>
         <enum value="0x4199"        name="CL_MEM_TYPE_SHARED_INTEL"/>
     </enums>
 
-    <enums start="0x419A" end="0x419B" name="cl_mem_alloc_info_intel" vendor="Intel">
+    <enums start="0x419A" end="0x419B" group="cl_mem_alloc_info_intel" vendor="Intel">
         <enum value="0x419A"        name="CL_MEM_ALLOC_TYPE_INTEL"/>
         <enum value="0x419B"        name="CL_MEM_ALLOC_BASE_PTR_INTEL"/>
     </enums>
 
-    <enums start="0x419B" end="0x419B" name="cl_svm_pointer_info_khr" vendor="Intel">
+    <enums start="0x419B" end="0x419B" group="cl_svm_pointer_info_khr" vendor="Intel">
         <enum value="0x419B"        name="CL_SVM_INFO_BASE_PTR_KHR"/>
     </enums>
 
-    <enums start="0x419C" end="0x419C" name="cl_mem_alloc_info_intel" vendor="Intel">
+    <enums start="0x419C" end="0x419C" group="cl_mem_alloc_info_intel" vendor="Intel">
         <enum value="0x419C"        name="CL_MEM_ALLOC_SIZE_INTEL"/>
     </enums>
 
-    <enums start="0x419C" end="0x419C" name="cl_svm_pointer_info_khr" vendor="Intel">
+    <enums start="0x419C" end="0x419C" group="cl_svm_pointer_info_khr" vendor="Intel">
         <enum value="0x419C"        name="CL_SVM_INFO_SIZE_KHR"/>
     </enums>
 
-    <enums start="0x419D" end="0x419D" name="cl_mem_alloc_info_intel" vendor="Intel">
+    <enums start="0x419D" end="0x419D" group="cl_mem_alloc_info_intel" vendor="Intel">
         <enum value="0x419D"        name="CL_MEM_ALLOC_DEVICE_INTEL"/>
     </enums>
 
-    <enums start="0x419D" end="0x419D" name="cl_svm_pointer_info_khr" vendor="Intel">
+    <enums start="0x419D" end="0x419D" group="cl_svm_pointer_info_khr" vendor="Intel">
         <enum value="0x419D"        name="CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR"/>
     </enums>
 
-    <enums start="0x419E" end="0x419F" name="cl_mem_properties_intel" vendor="Intel">
+    <enums start="0x419E" end="0x419F" group="cl_mem_properties_intel" vendor="Intel">
         <enum value="0x419E"        name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
             <unused start="0x419F" end="0x419F"/>
     </enums>
@@ -2905,86 +2905,86 @@ server's OpenCL/api-docs repository.
             <unused start="0x41A0" end="0x41DF"/>
     </enums>
 
-    <enums start="0x41E0" end="0x41E0" name="cl_device_info" vendor="Arm">
+    <enums start="0x41E0" end="0x41E0" group="cl_device_info" vendor="Arm">
         <enum value="0x41E0"        name="CL_DEVICE_JOB_SLOTS_ARM"/>
     </enums>
 
-    <enums start="0x41E1" end="0x41E1" name="cl_queue_properties" vendor="Arm">
+    <enums start="0x41E1" end="0x41E1" group="cl_queue_properties" vendor="Arm">
         <enum value="0x41E1"        name="CL_QUEUE_JOB_SLOT_ARM"/>
     </enums>
 
-    <enums start="0x41E2" end="0x41E2" name="cl_import_properties_arm" vendor="Arm">
+    <enums start="0x41E2" end="0x41E2" group="cl_import_properties_arm" vendor="Arm">
         <enum value="0x41E2"        name="CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM"/>
         <enum value="0x41E2"        name="CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM"/>
     </enums>
 
-    <enums start="0x41E4" end="0x41E4" name="cl_device_info" vendor="Arm">
+    <enums start="0x41E4" end="0x41E4" group="cl_device_info" vendor="Arm">
         <enum value="0x41E4"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM"/>
     </enums>
 
-    <enums start="0x41E5" end="0x41E6" name="cl_kernel_exec_info" vendor="Arm">
+    <enums start="0x41E5" end="0x41E6" group="cl_kernel_exec_info" vendor="Arm">
         <enum value="0x41E5"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM"/>
         <enum value="0x41E6"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"/>
     </enums>
 
-    <enums start="0x41E7" end="0x41E7" name="cl_queue_properties" vendor="Arm">
+    <enums start="0x41E7" end="0x41E7" group="cl_queue_properties" vendor="Arm">
         <enum value="0x41E7"        name="CL_QUEUE_KERNEL_BATCHING_ARM"/>
     </enums>
 
-    <enums start="0x41E8" end="0x41E8" name="cl_kernel_exec_info" vendor="Arm">
+    <enums start="0x41E8" end="0x41E8" group="cl_kernel_exec_info" vendor="Arm">
         <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"/>
     </enums>
 
-    <enums start="0x41E8" end="0x41E8" name="cl_kernel_exec_info" vendor="Arm">
+    <enums start="0x41E8" end="0x41E8" group="cl_kernel_exec_info" vendor="Arm">
         <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"/>
     </enums>
 
-    <enums start="0x41E9" end="0x41E9" name="cl_kernel_info" vendor="Arm">
+    <enums start="0x41E9" end="0x41E9" group="cl_kernel_info" vendor="Arm">
         <enum value="0x41E9"        name="CL_KERNEL_MAX_WARP_COUNT_ARM"/>
     </enums>
 
-    <enums start="0x41EA" end="0x41EB" name="cl_device_info" vendor="Arm">
+    <enums start="0x41EA" end="0x41EB" group="cl_device_info" vendor="Arm">
         <enum value="0x41EA"        name="CL_DEVICE_MAX_WARP_COUNT_ARM"/>
         <enum value="0x41EB"        name="CL_DEVICE_SUPPORTED_REGISTER_ALLOCATIONS_ARM"/>
     </enums>
 
-    <enums start="0x41EC" end="0x41EC" name="cl_queue_properties" vendor="Arm">
+    <enums start="0x41EC" end="0x41EC" group="cl_queue_properties" vendor="Arm">
         <enum value="0x41EC"        name="CL_QUEUE_DEFERRED_FLUSH_ARM"/>
     </enums>
 
-    <enums start="0x41ED" end="0x41ED" name="cl_event_info" vendor="Arm">
+    <enums start="0x41ED" end="0x41ED" group="cl_event_info" vendor="Arm">
         <enum value="0x41ED"        name="CL_EVENT_COMMAND_TERMINATION_REASON_ARM"/>
     </enums>
 
-    <enums start="0x41EE" end="0x41EE" name="cl_device_info" vendor="Arm">
+    <enums start="0x41EE" end="0x41EE" group="cl_device_info" vendor="Arm">
         <enum value="0x41EE"        name="CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM"/>
     </enums>
 
-    <enums start="0x41EF" end="0x41F0" name="cl_import_properties_arm" vendor="Arm">
+    <enums start="0x41EF" end="0x41F0" group="cl_import_properties_arm" vendor="Arm">
         <enum value="0x41EF"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_PLANE_INDEX_ARM"/>
         <enum value="0x41F0"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_LAYER_INDEX_ARM"/>
     </enums>
 
-    <enums start="0x41F1" end="0x41F2" name="cl_kernel_exec_info" vendor="Arm">
+    <enums start="0x41F1" end="0x41F2" group="cl_kernel_exec_info" vendor="Arm">
         <enum value="0x41F1"        name="CL_KERNEL_EXEC_INFO_COMPUTE_UNIT_MAX_QUEUED_BATCHES_ARM"/>
             <unused start="0x41F2" end="0x41F2" comment="Reserved for cl_arm_core_builtins"/>
     </enums>
     
-    <enums start="0x41F3" end="0x41FF" name="cl_queue_properties" vendor="Arm">
+    <enums start="0x41F3" end="0x41FF" group="cl_queue_properties" vendor="Arm">
         <enum value="0x41F3"        name="CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM"/>
             <unused start="0x41F4" end="0x41F4" comment="Reserved"/>
             <unused start="0x41F5" end="0x41F6" comment="Reserved"/>
             <unused start="0x41F7" end="0x41FF"/>
     </enums>
 
-    <enums start="0x4200" end="0x4203" name="cl_kernel_exec_info" vendor="Intel">
+    <enums start="0x4200" end="0x4203" group="cl_kernel_exec_info" vendor="Intel">
         <enum value="0x4200"        name="CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL"/>
         <enum value="0x4201"        name="CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL"/>
         <enum value="0x4202"        name="CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL"/>
         <enum value="0x4203"        name="CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL"/>
     </enums>
 
-    <enums start="0x4204" end="0x420F" name="cl_command_type" vendor="Intel">
+    <enums start="0x4204" end="0x420F" group="cl_command_type" vendor="Intel">
         <enum value="0x4204"        name="CL_COMMAND_MEMFILL_INTEL"/>
         <enum value="0x4205"        name="CL_COMMAND_MEMCPY_INTEL"/>
         <enum value="0x4206"        name="CL_COMMAND_MIGRATEMEM_INTEL"/>
@@ -2993,46 +2993,46 @@ server's OpenCL/api-docs repository.
     </enums>
 
     <!-- These enums are part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
-    <enums start="0x4210" end="0x4210" name="cl_kernel_arg_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4210" end="0x4210" group="cl_kernel_arg_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4210"        name="CL_KERNEL_ARG_HOST_ACCESSIBLE_PIPE_INTEL"/>
     </enums>
 
     <!-- These enums are part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
-    <enums start="0x4211" end="0x4212" name="cl_device_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4211" end="0x4212" group="cl_device_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4211"        name="CL_DEVICE_MAX_HOST_READ_PIPES_INTEL"/>
         <enum value="0x4212"        name="CL_DEVICE_MAX_HOST_WRITE_PIPES_INTEL"/>
     </enums>
 
-    <enums start="0x4213" end="0x4213" name="cl_mem_properties_intel" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4213" end="0x4213" group="cl_mem_properties_intel" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4213"        name="CL_MEM_CHANNEL_INTEL"/>
     </enums>
 
-    <enums start="0x4214" end="0x4215" name="cl_command_type" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4214" end="0x4215" group="cl_command_type" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4214"        name="CL_COMMAND_READ_HOST_PIPE_INTEL"/>
         <enum value="0x4215"        name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"/>
     </enums>
 
-    <enums start="0x4216" end="0x4217" name="cl_program_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4216" end="0x4217" group="cl_program_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4216"        name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"/>
         <enum value="0x4217"        name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"/>
     </enums>
 
-    <enums start="0x4218" end="0x421F" name="cl_mem_properties" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+    <enums start="0x4218" end="0x421F" group="cl_mem_properties" vendor="Intel" comment="Contact michael.kinsner@intel.com">
         <enum value="0x4218"        name="CL_MEM_LOCALLY_UNCACHED_RESOURCE_INTEL"/>
         <enum value="0x4219"        name="CL_MEM_DEVICE_ID_INTEL"/>
             <unused start="0x421A" end="0x421F"/>
     </enums>
 
-    <enums start="0x4220" end="0x4221" name="cl_svm_alloc_properties_khr" vendor="IMG">
+    <enums start="0x4220" end="0x4221" group="cl_svm_alloc_properties_khr" vendor="IMG">
         <enum value="0x4220"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_VIRTUAL_ADDRESS_IMG"/>
         <enum value="0x4221"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_IMG"/>
     </enums>
 
-    <enums start="0x4222" end="0x4222" name="cl_device_info" vendor="IMG">
+    <enums start="0x4222" end="0x4222" group="cl_device_info" vendor="IMG">
         <enum value="0x4222"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_IMG"/>
     </enums>
 
-    <enums start="0x4223" end="0x4224" name="cl_queue_properties" vendor="IMG">
+    <enums start="0x4223" end="0x4224" group="cl_queue_properties" vendor="IMG">
         <enum value="0x4223"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"/>
         <enum value="0x4224"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG"/>
     </enums>
@@ -3047,12 +3047,12 @@ server's OpenCL/api-docs repository.
         <enum value="0x422A"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_IMG"/>
     </enums>
 
-    <enums start="0x422B" end="0x422F" name="cl_queue_properties" vendor="IMG">
+    <enums start="0x422B" end="0x422F" group="cl_queue_properties" vendor="IMG">
         <enum value="0x422B"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_EXECUTE_COUNT_IMG"/>
             <unused start="0x422C" end="0x422F"/>
     </enums>
 
-    <enums start="0x4230" end="0x423F" name="cl_device_info" comment="Reserved for EXT extensions">
+    <enums start="0x4230" end="0x423F" group="cl_device_info" comment="Reserved for EXT extensions">
         <enum value="0x4230"        name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
         <enum value="0x4231"        name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
         <enum value="0x4232"        name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
@@ -3062,20 +3062,20 @@ server's OpenCL/api-docs repository.
             <unused start="0x423B" end="0x423F"/>
     </enums>
 
-    <enums start="0x4240" end="0x424F" name="cl_layer_info" comment="Reserved for ICD Loader Layers">
+    <enums start="0x4240" end="0x424F" group="cl_layer_info" comment="Reserved for ICD Loader Layers">
         <enum value="0x4240"        name="CL_LAYER_API_VERSION"/>
         <enum value="0x4241"        name="CL_LAYER_NAME"/>
             <unused start="0x4242" end="0x424F"/>
     </enums>
 
-    <enums name="cl_icdl_info" comment="OpenCL ICD Loader info queries.">
+    <enums group="cl_icdl_info" comment="OpenCL ICD Loader info queries.">
         <enum value="1"             name="CL_ICDL_OCL_VERSION"/>
         <enum value="2"             name="CL_ICDL_VERSION"/>
         <enum value="3"             name="CL_ICDL_NAME"/>
         <enum value="4"             name="CL_ICDL_VENDOR"/>
     </enums>
 
-    <enums start="0x4250" end="0x4259" name="cl_device_info" vendor="Intel">
+    <enums start="0x4250" end="0x4259" group="cl_device_info" vendor="Intel">
         <enum value="0x4250"        name="CL_DEVICE_IP_VERSION_INTEL"/>
         <enum value="0x4251"        name="CL_DEVICE_ID_INTEL"/>
         <enum value="0x4252"        name="CL_DEVICE_NUM_SLICES_INTEL"/>
@@ -3086,7 +3086,7 @@ server's OpenCL/api-docs repository.
             <unused start="0x4257" end="0x4259"/>
     </enums>
 
-    <enums start="0x425A" end="0x425F" name="cl_kernel_work_group_info" vendor="Intel">
+    <enums start="0x425A" end="0x425F" group="cl_kernel_work_group_info" vendor="Intel">
         <enum value="0x425A"        name="CL_KERNEL_ALLOCATIONS_INFO_INTEL"/>
             <unused start="0x425B" end="0x425F"/>
     </enums>
@@ -3123,15 +3123,15 @@ server's OpenCL/api-docs repository.
             <unused start="0x42E0" end="0x4FFF"/>
     </enums>
 
-    <enums start="0x5000" end="0x5000" name="cl_mem_properties" comment="For cl_ext_buffer_device_address">
+    <enums start="0x5000" end="0x5000" group="cl_mem_properties" comment="For cl_ext_buffer_device_address">
         <enum value="0x5000"        name="CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT"/>
     </enums>
 
-    <enums start="0x5001" end="0x5001" name="cl_mem_info" comment="For cl_ext_buffer_device_address">
+    <enums start="0x5001" end="0x5001" group="cl_mem_info" comment="For cl_ext_buffer_device_address">
         <enum value="0x5001"        name="CL_MEM_DEVICE_ADDRESS_EXT"/>
     </enums>
 
-    <enums start="0x5002" end="0x5002" name="cl_kernel_exec_info" comment="For cl_ext_buffer_device_address">
+    <enums start="0x5002" end="0x5002" group="cl_kernel_exec_info" comment="For cl_ext_buffer_device_address">
         <enum value="0x5002"        name="CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT"/>
     </enums>
 

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -2062,11 +2062,8 @@ server's OpenCL/api-docs repository.
         <enum value="0x1299"        name="CL_COMMAND_BUFFER_CONTEXT_KHR"/>
     </enums>
 
-    <enums start="0x129A" end="0x129A" group="cl_device_info" vendor="Khronos">
-        <enum value="0x129A"        name="CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR"/>
-    </enums>
-
-    <enums start="0x129B" end="0x129F" name="enums.129B" vendor="Khronos">
+    <enums start="0x129A" end="0x129F" vendor="Khronos">
+        <enum value="0x129A"        name="CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR"  group="cl_device_info"/>
             <unused start="0x129B" end="0x129F" comment="Available to use"/>
     </enums>
 
@@ -2092,20 +2089,14 @@ server's OpenCL/api-docs repository.
         <enum value="0x12AC"        name="CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR"/>
     </enums>
 
-    <enums start="0x12AD" end="0x12AD" group="cl_mutable_command_info_khr" vendor="Khronos">
-        <enum value="0x12AD"        name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR"/>
-    </enums>
-
-    <enums start="0x12AE" end="0x12AF" name="enums.12AE" vendor="Khronos">
+    <enums start="0x12AD" end="0x12AF" vendor="Khronos">
+        <enum value="0x12AD"        name="CL_MUTABLE_COMMAND_COMMAND_TYPE_KHR" group="cl_mutable_command_info_khr"/>
             <unused start="0x12AE" end="0x12AF" comment="Used by future command-buffer extensions"/>
     </enums>
 
-    <enums start="0x12B0" end="0x12B0" group="cl_device_info" vendor="Khronos">
-        <enum value="0x12B0"        name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR"/>
-    </enums>
-
-    <enums start="0x12B1" end="0x12B1" group="cl_command_properties_khr" vendor="Khronos">
-        <enum value="0x12B1"             name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"/>
+    <enums start="0x12B0" end="0x12B1" vendor="Khronos">
+        <enum value="0x12B0"        name="CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR" group="cl_device_info"/>
+        <enum value="0x12B1"        name="CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR"    group="cl_command_properties_khr"/>
     </enums>
 
     <enums start="0x12B2" end="0x12B6" group="cl_image_requirements_info_ext" vendor="Khronos">
@@ -2116,12 +2107,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x12B6"        name="CL_IMAGE_REQUIREMENTS_MAX_ARRAY_SIZE_EXT"/>
     </enums>
 
-    <enums start="0x12B7" end="0x12B7" group="cl_command_buffer_properties_khr" vendor="Khronos">
-        <enum value="0x12B7"        name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR"/>
-    </enums>
-    
-    <enums start="0x12B8" end="0x12B8" group="cl_command_properties_khr" vendor="Khronos">
-        <enum value="0x12B8"        name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"/>
+    <enums start="0x12B7" end="0x12B8" vendor="Khronos">
+        <enum value="0x12B7"        name="CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR" group="cl_command_buffer_properties_khr"/>
+        <enum value="0x12B8"        name="CL_MUTABLE_DISPATCH_ASSERTS_KHR"                group="cl_command_properties_khr"/>
     </enums>
 
     <enums start="0x12B9" end="0x1FFF" group="cl_device_info" vendor="Khronos">
@@ -2134,7 +2122,7 @@ server's OpenCL/api-docs repository.
     </enums>
     
     <enums start="0x12BC" end="0x1FFF" name="enums.12BC" vendor="Khronos">
-        <unused start="0x12BC" end="0x1FFF" comment="Reserved for core API tokens"/>
+            <unused start="0x12BC" end="0x1FFF" comment="Reserved for core API tokens"/>
     </enums>
 
     <enums start="0x2000" end="0x2003" group="cl_gl_object_type" vendor="Khronos">
@@ -2173,14 +2161,11 @@ server's OpenCL/api-docs repository.
         <enum value="0x2011"        name="CL_GL_OBJECT_TEXTURE_BUFFER"/>
     </enums>
 
-    <enums start="0x2012" end="0x2012" group="cl_gl_texture_info" vendor="Khronos">
-        <enum value="0x2012"        name="CL_GL_NUM_SAMPLES"/>
-    </enums>
-
-    <enums start="0x2013" end="0x201F" name="enums.2013" vendor="Khronos">
+    <enums start="0x2012" end="0x2012" vendor="Khronos">
+        <enum value="0x2012"        name="CL_GL_NUM_SAMPLES" group="cl_gl_texture_info"/>
             <unused start="0x2013" end="0x201F" comment="Reserved for OpenGL interop"/>
     </enums>
-    
+
     <enums start="0x2020" end="0x2022" group="cl_dx9_media_adapter_type_khr" vendor="Khronos">
         <enum value="0x2020"        name="CL_ADAPTER_D3D9_KHR"/>
         <enum value="0x2021"        name="CL_ADAPTER_D3D9EX_KHR"/>
@@ -2215,16 +2200,10 @@ server's OpenCL/api-docs repository.
         <enum value="0x202F"        name="CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR"/>
     </enums>
 
-    <enums start="0x2030" end="0x2030" group="cl_context_properties" vendor="Khronos">
-        <enum value="0x2030"        name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"/>
-    </enums>
-
-    <enums start="0x2031" end="0x2031" group="cl_device_info" vendor="Khronos">
-        <enum value="0x2031"        name="CL_DEVICE_TERMINATE_CAPABILITY_KHR"/>
-    </enums>
-
-    <enums start="0x2032" end="0x2032" group="cl_context_properties" vendor="Khronos">
-        <enum value="0x2032"        name="CL_CONTEXT_TERMINATE_KHR"/>
+    <enums start="0x2030" end="0x2032" vendor="Khronos">
+        <enum value="0x2030"        name="CL_CONTEXT_MEMORY_INITIALIZE_KHR"   group="cl_context_properties"/>
+        <enum value="0x2031"        name="CL_DEVICE_TERMINATE_CAPABILITY_KHR" group="cl_device_info"/>
+        <enum value="0x2032"        name="CL_CONTEXT_TERMINATE_KHR"           group="cl_context_properties"/>
     </enums>
 
     <enums start="0x2033" end="0x2034" group="cl_kernel_sub_group_info" vendor="Khronos">
@@ -2234,12 +2213,9 @@ server's OpenCL/api-docs repository.
         <enum value="0x2034"        name="CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR"/>
     </enums>
 
-    <enums start="0x2035" end="0x2035" group="cl_device_info" vendor="Khronos">
-        <enum value="0x2035"        name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR"/>
-    </enums>
-
-    <enums start="0x2035" end="0x2035" group="cl_platform_info" vendor="Khronos">
-        <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"/>
+    <enums start="0x2035" end="0x2036" vendor="Khronos">
+        <enum value="0x2035"        name="CL_DEVICE_MAX_NAMED_BARRIER_COUNT_KHR" group="cl_device_info"/>
+        <enum value="0x2036"        name="CL_PLATFORM_SEMAPHORE_TYPES_KHR"       group="cl_platform_info"/>
     </enums>
 
     <enums start="0x2036" end="0x2038" group="cl_platform_info" vendor="Khronos">
@@ -2248,16 +2224,13 @@ server's OpenCL/api-docs repository.
         <enum value="0x2038"        name="CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2039" end="0x203C" group="cl_semaphore_info_khr" vendor="Khronos">
+    <enums start="0x2039" end="0x203F" group="cl_semaphore_info_khr" vendor="Khronos">
         <enum value="0x2039"        name="CL_SEMAPHORE_CONTEXT_KHR"/>
         <enum value="0x203A"        name="CL_SEMAPHORE_REFERENCE_COUNT_KHR"/>
         <enum value="0x203B"        name="CL_SEMAPHORE_PROPERTIES_KHR"/>
         <enum value="0x203C"        name="CL_SEMAPHORE_PAYLOAD_KHR"/>
-    </enums>
-
-    <enums start="0x203D" end="0x203F" group="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
-        <enum value="0x203D"        name="CL_SEMAPHORE_TYPE_KHR"/>
-        <enum value="0x203F"        name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR"/>
+        <enum value="0x203D"        name="CL_SEMAPHORE_TYPE_KHR"                group="cl_semaphore_properties_khr"/>
+        <enum value="0x203F"        name="CL_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR" group="cl_semaphore_properties_khr"/>
     </enums>
 
     <enums start="0x2042" end="0x2043" group="cl_command_type" vendor="Khronos">
@@ -2281,19 +2254,13 @@ server's OpenCL/api-docs repository.
         <enum value="0x204F"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR"/>
     </enums>
 
-    <enums start="0x2051" end="0x2051" group="cl_mem_properties" vendor="Khronos">
-        <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"/>
+    <enums start="0x2051" end="0x2052" vendor="Khronos">
+        <enum value="0x2051"        name="CL_MEM_DEVICE_HANDLE_LIST_KHR"                                          group="cl_mem_properties"/>
+        <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR" group="cl_device_info"/>
     </enums>
 
-    <enums start="0x2052" end="0x2052" group="cl_device_info" vendor="Khronos">
-        <enum value="0x2052"        name="CL_DEVICE_EXTERNAL_MEMORY_IMPORT_ASSUME_LINEAR_IMAGES_HANDLE_TYPES_KHR"/>
-    </enums>
-
-    <enums start="0x2053" end="0x2053" group="cl_semaphore_info_khr,cl_semaphore_properties_khr" vendor="Khronos">
-        <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR"/>
-    </enums>
-
-    <enums start="0x2054" end="0x2054" group="cl_semaphore_info_khr" vendor="Khronos">
+    <enums start="0x2053" end="0x2054" group="cl_semaphore_info_khr" vendor="Khronos">
+        <enum value="0x2053"        name="CL_SEMAPHORE_DEVICE_HANDLE_LIST_KHR" group="cl_semaphore_properties_khr"/>
         <enum value="0x2054"        name="CL_SEMAPHORE_EXPORTABLE_KHR"/>
     </enums>
 
@@ -2315,31 +2282,16 @@ server's OpenCL/api-docs repository.
             <unused start="0x2063" end="0x2066" comment="Reserved to Khronos for interop"/>
     </enums>
     
-    <enums start="0x2067" end="0x2067" group="cl_external_memory_handle_type_khr" vendor="Khronos">
-        <enum value="0x2067"        name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR"/>
-    </enums>
-
-    <enums start="0x2068" end="0x2068" group="cl_external_semaphore_handle_type_khr" vendor="Khronos">
-        <enum value="0x2068"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
-    </enums>
-
-    <enums start="0x2069" end="0x2069" group="cl_external_memory_handle_type_khr" vendor="Khronos">
-        <enum value="0x2069"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR"/>
-    </enums>
-
-    <enums start="0x206A" end="0x206F" name="enums.206A" vendor="Khronos" comment="Reserved for interop with other APIs">
+    <enums start="0x2067" end="0x2070" vendor="Khronos">
+        <enum value="0x2067"        name="CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR" group="cl_external_memory_handle_type_khr"/>
+        <enum value="0x2068"        name="CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR" group="cl_external_semaphore_handle_type_khr"/>
+        <enum value="0x2069"        name="CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_NAME_KHR" group="cl_external_memory_handle_type_khr"/>
             <unused start="0x206A" end="0x206F" comment="Reserved to Khronos for interop"/>
+        <enum value="0x2070"        name="CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR" group="cl_external_memory_handle_type_khr"/>
     </enums>
-
-    <enums start="0x2070" end="0x2070" group="cl_external_memory_handle_type_khr" vendor="Khronos" comment="Reserved for interop with other APIs">
-        <enum value="0x2070"        name="CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR"/>
-    </enums>
-
-    <enums start="0x2071" end="0x2077" name="enums.2071" vendor="Khronos" comment="Reserved for interop with other APIs">
+    
+    <enums start="0x2071" end="0x2087" group="cl_svm_alloc_properties_khr" vendor="Khronos">
             <unused start="0x2071" end="0x2077" comment="Reserved for cl_khr_unified_svm"/>
-    </enums>
-
-    <enums start="0x2078" end="0x2087" group="cl_svm_alloc_properties_khr" vendor="Khronos">
         <enum value="0x2078"        name="CL_SVM_ALLOC_ASSOCIATED_DEVICE_HANDLE_KHR"/>
         <enum value="0x2079"        name="CL_SVM_ALLOC_ACCESS_FLAGS_KHR"/>
         <enum value="0x207A"        name="CL_SVM_ALLOC_ALIGNMENT_KHR"/>
@@ -2375,118 +2327,64 @@ server's OpenCL/api-docs repository.
             <unused start="0x4007" end="0x400F"/>
     </enums>
 
-    <enums start="0x4010" end="0x4011" group="cl_d3d10_device_source_khr" vendor="Khronos">
-        <enum value="0x4010"        name="CL_D3D10_DEVICE_KHR"/>
-        <!-- unused <enum value="0x4010"      name="CL_D3D10_DEVICE_NV"/> -->
-        <enum value="0x4011"        name="CL_D3D10_DXGI_ADAPTER_KHR"/>
-        <!-- unused <enum value="0x4011"      name="CL_D3D10_DXGI_ADAPTER_NV"/> -->
-    </enums>
-
-    <enums start="0x4012" end="0x4013" group="cl_d3d10_device_set_khr" vendor="Khronos">
-        <enum value="0x4012"        name="CL_PREFERRED_DEVICES_FOR_D3D10_KHR"/>
-        <!-- unused <enum value="0x4012"      name="CL_PREFERRED_DEVICES_FOR_D3D10_NV"/> -->
-        <enum value="0x4013"        name="CL_ALL_DEVICES_FOR_D3D10_KHR"/>
-        <!-- unused <enum value="0x4013"      name="CL_ALL_DEVICES_FOR_D3D10_NV"/> -->
-    </enums>
-
-    <enums start="0x4014" end="0x4014" group="cl_context_properties" vendor="Khronos">
-        <enum value="0x4014"        name="CL_CONTEXT_D3D10_DEVICE_KHR"/>
-        <!-- unused <enum value="0x4014"      name="CL_CONTEXT_D3D10_DEVICE_NV"/> -->
-    </enums>
-
-    <enums start="0x4015" end="0x4015" group="cl_mem_info" vendor="Khronos">
-        <enum value="0x4015"        name="CL_MEM_D3D10_RESOURCE_KHR"/>
-        <!-- unused <enum value="0x4015"      name="CL_MEM_D3D10_RESOURCE_NV"/> -->
-    </enums>
-
-    <enums start="0x4016" end="0x4016" group="cl_image_info" vendor="Khronos">
-        <enum value="0x4016"        name="CL_IMAGE_D3D10_SUBRESOURCE_KHR"/>
-        <!-- unused <enum value="0x4016"      name="CL_IMAGE_D3D10_SUBRESOURCE_NV"/> -->
-    </enums>
-
-    <enums start="0x4017" end="0x4018" group="cl_command_type" vendor="Khronos">
-        <enum value="0x4017"        name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR"/>
-        <!-- unused <enum value="0x4017"      name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_NV"/> -->
-        <enum value="0x4018"        name="CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR"/>
-        <!-- unused <enum value="0x4018"      name="CL_COMMAND_RELEASE_D3D10_OBJECTS_NV"/> -->
-    </enums>
-
-    <enums start="0x4019" end="0x401A" group="cl_d3d11_device_source_khr" vendor="Khronos">
-        <enum value="0x4019"        name="CL_D3D11_DEVICE_KHR"/>
-        <!-- unused <enum value="0x4019"      name="CL_D3D11_DEVICE_NV"/> -->
-        <enum value="0x401A"        name="CL_D3D11_DXGI_ADAPTER_KHR"/>
-        <!-- unused <enum value="0x401A"      name="CL_D3D11_DXGI_ADAPTER_NV"/> -->
-    </enums>
-
-    <enums start="0x401B" end="0x401C" group="cl_d3d11_device_set_khr" vendor="Khronos">
-        <enum value="0x401B"        name="CL_PREFERRED_DEVICES_FOR_D3D11_KHR"/>
-        <!-- unused <enum value="0x401B"      name="CL_PREFERRED_DEVICES_FOR_D3D11_NV"/> -->
-        <enum value="0x401C"        name="CL_ALL_DEVICES_FOR_D3D11_KHR"/>
-        <!-- unused <enum value="0x401C"      name="CL_ALL_DEVICES_FOR_D3D11_NV"/> -->
-    </enums>
-
-    <enums start="0x401D" end="0x401D" group="cl_context_properties" vendor="Khronos">
-        <enum value="0x401D"        name="CL_CONTEXT_D3D11_DEVICE_KHR"/>
-        <!-- unused <enum value="0x401D"      name="CL_CONTEXT_D3D11_DEVICE_NV"/> -->
-    </enums>
-
-    <enums start="0x401E" end="0x401E" group="cl_mem_info" vendor="Khronos">
-        <enum value="0x401E"        name="CL_MEM_D3D11_RESOURCE_KHR"/>
-        <!-- unused <enum value="0x401E"      name="CL_MEM_D3D11_RESOURCE_NV"/> -->
-    </enums>
-
-    <enums start="0x401F" end="0x401F" group="cl_image_info" vendor="Khronos">
-        <enum value="0x401F"        name="CL_IMAGE_D3D11_SUBRESOURCE_KHR"/>
-        <!-- unused <enum value="0x401F"      name="CL_IMAGE_D3D11_SUBRESOURCE_NV"/> -->
-    </enums>
-
-    <enums start="0x4020" end="0x4021" group="cl_command_type" vendor="Khronos">
-        <enum value="0x4020"        name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR"/>
-        <!-- unused <enum value="0x4020"      name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_NV"/> -->
-        <enum value="0x4021"        name="CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR"/>
-        <!-- unused <enum value="0x4021"      name="CL_COMMAND_RELEASE_D3D11_OBJECTS_NV"/> -->
-    </enums>
-
-    <enums start="0x4022" end="0x4022" group="cl_dx9_device_source_intel" vendor="Khronos">
-        <enum value="0x4022"        name="CL_D3D9_DEVICE_INTEL"/>
-        <!-- unused <enum value="0x4022"      name="CL_D3D9_DEVICE_NV"/> -->
-        <!-- unused <enum value="0x4023"      name="CL_D3D9_ADAPTER_NAME_NV"/> -->
-    </enums>
-
-    <enums start="0x4024" end="0x4025" group="cl_dx9_device_set_intel" vendor="Khronos">
-        <enum value="0x4024"        name="CL_PREFERRED_DEVICES_FOR_DX9_INTEL"/>
-        <!-- unused <enum value="0x4024"      name="CL_PREFERRED_DEVICES_FOR_D3D9_NV"/> -->
-        <enum value="0x4025"        name="CL_ALL_DEVICES_FOR_DX9_INTEL"/>
-        <!-- unused <enum value="0x4025"      name="CL_ALL_DEVICES_FOR_D3D9_NV"/> -->
-    </enums>
-
-    <enums start="0x4026" end="0x4026" group="cl_context_info" vendor="Khronos">
-        <enum value="0x4026"        name="CL_CONTEXT_D3D9_DEVICE_INTEL"/>
-        <!-- unused <enum value="0x4026"      name="CL_CONTEXT_D3D9_DEVICE_NV"/> -->
-    </enums>
-
-    <enums start="0x4027" end="0x4027" group="cl_mem_info" vendor="Khronos">
-        <enum value="0x4027"        name="CL_MEM_DX9_RESOURCE_INTEL"/>
-        <!-- unused <enum value="0x4027"      name="CL_MEM_D3D9_RESOURCE_NV"/> -->
-        <!-- unused <enum value="0x4028"      name="CL_IMAGE_D3D9_FACE_NV"/> -->
-        <!-- unused <enum value="0x4029"      name="CL_IMAGE_D3D9_LEVEL_NV"/> -->
-    </enums>
-
-    <enums start="0x402A" end="0x402B" group="cl_command_type" vendor="Khronos">
+    <enums start="0x4010" end="0x402F" vendor="NVIDIA" comment="Per Bug 5782">
+        <enum value="0x4010"        name="CL_D3D10_DEVICE_KHR"                  group="cl_d3d10_device_source_khr"/>
+        <enum value="0x4011"        name="CL_D3D10_DXGI_ADAPTER_KHR"            group="cl_d3d10_device_source_khr"/>
+        <enum value="0x4012"        name="CL_PREFERRED_DEVICES_FOR_D3D10_KHR"   group="cl_d3d10_device_set_khr"/>
+        <enum value="0x4013"        name="CL_ALL_DEVICES_FOR_D3D10_KHR"         group="cl_d3d10_device_set_khr"/>
+        <enum value="0x4014"        name="CL_CONTEXT_D3D10_DEVICE_KHR"          group="cl_context_properties"/>
+        <enum value="0x4015"        name="CL_MEM_D3D10_RESOURCE_KHR"            group="cl_mem_info"/>
+        <enum value="0x4016"        name="CL_IMAGE_D3D10_SUBRESOURCE_KHR"       group="cl_image_info"/>
+        <enum value="0x4017"        name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_KHR" group="cl_command_type"/>
+        <enum value="0x4018"        name="CL_COMMAND_RELEASE_D3D10_OBJECTS_KHR" group="cl_command_type"/>
+        <!-- unused <enum value="0x4010"      name="CL_D3D10_DEVICE_NV"                  group="cl_d3d10_device_source_khr"/> -->
+        <!-- unused <enum value="0x4011"      name="CL_D3D10_DXGI_ADAPTER_NV"            group="cl_d3d10_device_source_khr"/> -->
+        <!-- unused <enum value="0x4012"      name="CL_PREFERRED_DEVICES_FOR_D3D10_NV"   group="cl_d3d10_device_set_khr"/> -->
+        <!-- unused <enum value="0x4013"      name="CL_ALL_DEVICES_FOR_D3D10_NV"         group="cl_d3d10_device_set_khr"/> -->
+        <!-- unused <enum value="0x4014"      name="CL_CONTEXT_D3D10_DEVICE_NV"          group="cl_context_properties"/> -->
+        <!-- unused <enum value="0x4015"      name="CL_MEM_D3D10_RESOURCE_NV"            group="cl_mem_info"/> -->
+        <!-- unused <enum value="0x4016"      name="CL_IMAGE_D3D10_SUBRESOURCE_NV"       group="cl_image_info"/> -->
+        <!-- unused <enum value="0x4017"      name="CL_COMMAND_ACQUIRE_D3D10_OBJECTS_NV" group="cl_command_type"/> -->
+        <!-- unused <enum value="0x4018"      name="CL_COMMAND_RELEASE_D3D10_OBJECTS_NV" group="cl_command_type"/> -->
+        <enum value="0x4019"        name="CL_D3D11_DEVICE_KHR"                  group="cl_d3d11_device_source_khr"/>
+        <enum value="0x401A"        name="CL_D3D11_DXGI_ADAPTER_KHR"            group="cl_d3d11_device_source_khr"/>
+        <enum value="0x401B"        name="CL_PREFERRED_DEVICES_FOR_D3D11_KHR"   group="cl_d3d11_device_set_khr"/>
+        <enum value="0x401C"        name="CL_ALL_DEVICES_FOR_D3D11_KHR"         group="cl_d3d11_device_set_khr"/>
+        <enum value="0x401D"        name="CL_CONTEXT_D3D11_DEVICE_KHR"          group="cl_context_properties"/>
+        <enum value="0x401E"        name="CL_MEM_D3D11_RESOURCE_KHR"            group="cl_mem_info"/>
+        <enum value="0x401F"        name="CL_IMAGE_D3D11_SUBRESOURCE_KHR"       group="cl_image_info"/>
+        <enum value="0x4020"        name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_KHR" group="cl_command_type"/>
+        <enum value="0x4021"        name="CL_COMMAND_RELEASE_D3D11_OBJECTS_KHR" group="cl_command_type"/>
+        <!-- unused <enum value="0x4019"      name="CL_D3D11_DEVICE_NV"                  group="cl_d3d11_device_source_khr"/> -->
+        <!-- unused <enum value="0x401A"      name="CL_D3D11_DXGI_ADAPTER_NV"            group="cl_d3d11_device_source_khr"/> -->
+        <!-- unused <enum value="0x401B"      name="CL_PREFERRED_DEVICES_FOR_D3D11_NV"   group="cl_d3d11_device_set_khr"/> -->
+        <!-- unused <enum value="0x401C"      name="CL_ALL_DEVICES_FOR_D3D11_NV"         group="cl_d3d11_device_set_khr"/> -->
+        <!-- unused <enum value="0x401D"      name="CL_CONTEXT_D3D11_DEVICE_NV"          group="cl_context_properties"/> -->
+        <!-- unused <enum value="0x401E"      name="CL_MEM_D3D11_RESOURCE_NV"            group="cl_mem_info"/> -->
+        <!-- unused <enum value="0x401F"      name="CL_IMAGE_D3D11_SUBRESOURCE_NV"       group="cl_image_info"/> -->
+        <!-- unused <enum value="0x4020"      name="CL_COMMAND_ACQUIRE_D3D11_OBJECTS_NV" group="cl_command_type"/> -->
+        <!-- unused <enum value="0x4021"      name="CL_COMMAND_RELEASE_D3D11_OBJECTS_NV" group="cl_command_type"/> -->
+        <enum value="0x4022"        name="CL_D3D9_DEVICE_INTEL"                 group="cl_dx9_device_source_intel"/>
+        <enum value="0x4024"        name="CL_PREFERRED_DEVICES_FOR_DX9_INTEL"   group="cl_dx9_device_set_intel"/>
+        <enum value="0x4025"        name="CL_ALL_DEVICES_FOR_DX9_INTEL"         group="cl_dx9_device_set_intel"/>
+        <enum value="0x4026"        name="CL_CONTEXT_D3D9_DEVICE_INTEL"         group="cl_context_info"/>
+        <enum value="0x4027"        name="CL_MEM_DX9_RESOURCE_INTEL"            group="cl_mem_info"/>
         <enum value="0x402A"        name="CL_COMMAND_ACQUIRE_DX9_OBJECTS_INTEL"/>
         <enum value="0x402B"        name="CL_COMMAND_RELEASE_DX9_OBJECTS_INTEL"/>
-        <enum value="0x402A"        name="CL_COMMAND_ACQUIRE_D3D9_OBJECTS_INTEL"/>
-        <!-- unused <enum value="0x402A"      name="CL_COMMAND_ACQUIRE_D3D9_OBJECTS_NV"/> -->
-        <enum value="0x402B"        name="CL_COMMAND_RELEASE_D3D9_OBJECTS_INTEL"/>
-        <!-- unused <enum value="0x402B"      name="CL_COMMAND_RELEASE_D3D9_OBJECTS_NV"/> -->
-    </enums>
-
-    <enums start="0x402C" end="0x402D" group="cl_context_info" vendor="Khronos">
-        <enum value="0x402C"        name="CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR"/>
-        <enum value="0x402D"        name="CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR"/>
-    </enums>
-
-    <enums start="0x402D" end="0x402F" name="enums.402D" vendor="NVIDIA" comment="Per Bug 5782">
+        <!-- unused <enum value="0x4022"      name="CL_D3D9_DEVICE_NV"                group="cl_dx9_device_source_intel"/> -->
+        <!-- unused <enum value="0x4023"      name="CL_D3D9_ADAPTER_NAME_NV"/> -->
+        <!-- unused <enum value="0x4024"      name="CL_PREFERRED_DEVICES_FOR_D3D9_NV" group="cl_dx9_device_set_intel"/> -->
+        <!-- unused <enum value="0x4025"      name="CL_ALL_DEVICES_FOR_D3D9_NV"       group="cl_dx9_device_set_intel"/> -->
+        <!-- unused <enum value="0x4026"      name="CL_CONTEXT_D3D9_DEVICE_NV"        group="cl_context_info"/> -->
+        <!-- unused <enum value="0x4027"      name="CL_MEM_D3D9_RESOURCE_NV"          group="cl_mem_info"/> -->
+        <!-- unused <enum value="0x4028"      name="CL_IMAGE_D3D9_FACE_NV"/> -->
+        <!-- unused <enum value="0x4029"      name="CL_IMAGE_D3D9_LEVEL_NV"/> -->
+        <enum value="0x402A"        name="CL_COMMAND_ACQUIRE_D3D9_OBJECTS_INTEL"        group="cl_command_type"/>
+        <!-- unused <enum value="0x402A"      name="CL_COMMAND_ACQUIRE_D3D9_OBJECTS_NV" group="cl_command_type"/> -->
+        <enum value="0x402B"        name="CL_COMMAND_RELEASE_D3D9_OBJECTS_INTEL"        group="cl_command_type"/>
+        <!-- unused <enum value="0x402B"      name="CL_COMMAND_RELEASE_D3D9_OBJECTS_NV" group="cl_command_type"/> -->
+        <enum value="0x402C"        name="CL_CONTEXT_D3D10_PREFER_SHARED_RESOURCES_KHR" group="cl_context_info"/>
+        <enum value="0x402D"        name="CL_CONTEXT_D3D11_PREFER_SHARED_RESOURCES_KHR" group="cl_context_info"/>
             <unused start="0x402D" end="0x402F"/>
     </enums>
 
@@ -2530,61 +2428,37 @@ server's OpenCL/api-docs repository.
             <unused start="0x404D" end="0x404F"/>
     </enums>
 
-    <enums start="0x4040" end="0x4052" group="cl_device_partition_property_ext" vendor="Apple">
-        <enum value="0x4050"        name="CL_DEVICE_PARTITION_EQUALLY_EXT"/>
-        <enum value="0x4051"        name="CL_DEVICE_PARTITION_BY_COUNTS_EXT"/>
-        <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_EXT"/>
-    </enums>
-    
-    <enums start="0x4052" end="0x4052" group="cl_device_partition_property" vendor="Intel">
-        <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_INTEL"/>
-    </enums>
-
-    <enums start="0x4053" end="0x4053" group="cl_device_partition_property_ext" vendor="Apple">
-        <enum value="0x4053"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT"/>
-    </enums>
-
-    <enums start="0x4054" end="0x405F" group="cl_device_info" vendor="Apple">
-        <enum value="0x4054"        name="CL_DEVICE_PARENT_DEVICE_EXT"/>
-        <enum value="0x4055"        name="CL_DEVICE_PARTITION_TYPES_EXT"/>
-        <enum value="0x4056"        name="CL_DEVICE_AFFINITY_DOMAINS_EXT"/>
-        <enum value="0x4057"        name="CL_DEVICE_REFERENCE_COUNT_EXT"/>
-        <enum value="0x4058"        name="CL_DEVICE_PARTITION_STYLE_EXT"/>
+    <enums start="0x4050" end="0x405F" vendor="Apple">
+        <enum value="0x4050"        name="CL_DEVICE_PARTITION_EQUALLY_EXT"            group="cl_device_partition_property_ext"/>
+        <enum value="0x4051"        name="CL_DEVICE_PARTITION_BY_COUNTS_EXT"          group="cl_device_partition_property_ext"/>
+        <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_EXT"           group="cl_device_partition_property_ext"/>
+        <enum value="0x4052"        name="CL_DEVICE_PARTITION_BY_NAMES_INTEL"         group="cl_device_partition_property"/>
+        <enum value="0x4053"        name="CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN_EXT" group="cl_device_partition_property_ext"/>
+        <enum value="0x4054"        name="CL_DEVICE_PARENT_DEVICE_EXT"                group="cl_device_info"/>
+        <enum value="0x4055"        name="CL_DEVICE_PARTITION_TYPES_EXT"              group="cl_device_info"/>
+        <enum value="0x4056"        name="CL_DEVICE_AFFINITY_DOMAINS_EXT"             group="cl_device_info"/>
+        <enum value="0x4057"        name="CL_DEVICE_REFERENCE_COUNT_EXT"              group="cl_device_info"/>
+        <enum value="0x4058"        name="CL_DEVICE_PARTITION_STYLE_EXT"              group="cl_device_info"/>
             <unused start="0x4059" end="0x405F"/>
     </enums>
-
+    
     <enums start="0x4060" end="0x406F" name="enums.4060" vendor="IBM" comment="Per Bug 6470">
             <unused start="0x4060" end="0x406F"/>
     </enums>
 
-    <enums start="0x4070" end="0x4071" group="cl_dx9_device_source_intel" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x4070"        name="CL_D3D9EX_DEVICE_INTEL"/>
-        <enum value="0x4071"        name="CL_DXVA_DEVICE_INTEL"/>
-    </enums>
-
-    <enums start="0x4072" end="0x4073" group="cl_context_properties" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x4072"        name="CL_CONTEXT_D3D9EX_DEVICE_INTEL"/>
-        <enum value="0x4073"        name="CL_CONTEXT_DXVA_DEVICE_INTEL"/>
-    </enums>
-
-    <enums start="0x4074" end="0x4074" group="cl_mem_info" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x4074"        name="CL_MEM_DX9_SHARED_HANDLE_INTEL"/>
-    </enums>
-
-    <enums start="0x4075" end="0x4075" group="cl_image_info" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x4075"        name="CL_IMAGE_DX9_PLANE_INTEL"/>
-    </enums>
-
-    <enums start="0x4076" end="0x407D" group="cl_channel_order" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x4076"        name="CL_YUYV_INTEL"/>
-        <enum value="0x4077"        name="CL_UYVY_INTEL"/>
-        <enum value="0x4078"        name="CL_YVYU_INTEL"/>
-        <enum value="0x4079"        name="CL_VYUY_INTEL"/>
+    <enums start="0x4070" end="0x407F" vendor="Intel" comment="Per Bug 7836">
+        <enum value="0x4070"        name="CL_D3D9EX_DEVICE_INTEL"         group="cl_dx9_device_source_intel"/>
+        <enum value="0x4071"        name="CL_DXVA_DEVICE_INTEL"           group="cl_dx9_device_source_intel"/>
+        <enum value="0x4072"        name="CL_CONTEXT_D3D9EX_DEVICE_INTEL" group="cl_context_properties"/>
+        <enum value="0x4073"        name="CL_CONTEXT_DXVA_DEVICE_INTEL"   group="cl_context_properties"/>
+        <enum value="0x4074"        name="CL_MEM_DX9_SHARED_HANDLE_INTEL" group="cl_mem_info"/>
+        <enum value="0x4075"        name="CL_IMAGE_DX9_PLANE_INTEL"       group="cl_image_info"/>
+        <enum value="0x4076"        name="CL_YUYV_INTEL"                  group="cl_channel_order"/>
+        <enum value="0x4077"        name="CL_UYVY_INTEL"                  group="cl_channel_order"/>
+        <enum value="0x4078"        name="CL_YVYU_INTEL"                  group="cl_channel_order"/>
+        <enum value="0x4079"        name="CL_VYUY_INTEL"                  group="cl_channel_order"/>
             <unused start="0x407A" end="0x407D"/>
-    </enums>
-
-    <enums start="0x407E" end="0x407F" group="cl_device_info" vendor="Intel" comment="Per Bug 7836">
-        <enum value="0x407E"        name="CL_DEVICE_ME_VERSION_INTEL"/>
+        <enum value="0x407E"        name="CL_DEVICE_ME_VERSION_INTEL"     group="cl_device_info"/>
             <unused start="0x407F"/>
     </enums>
 
@@ -2595,178 +2469,93 @@ server's OpenCL/api-docs repository.
             <unused start="0x4083" end="0x408F"/>
     </enums>
 
-    <enums start="0x4090" end="0x4093" group="cl_accelerator_info_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4090"        name="CL_ACCELERATOR_DESCRIPTOR_INTEL"/>
-        <enum value="0x4091"        name="CL_ACCELERATOR_REFERENCE_COUNT_INTEL"/>
-        <enum value="0x4092"        name="CL_ACCELERATOR_CONTEXT_INTEL"/>
-        <enum value="0x4093"        name="CL_ACCELERATOR_TYPE_INTEL"/>
-    </enums>
-
-    <enums start="0x4094" end="0x4094" group="cl_va_api_device_source_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4094"        name="CL_VA_API_DISPLAY_INTEL"/>
-    </enums>
-
-    <enums start="0x4094" end="0x4094" group="cl_va_api_device_set_intel" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4095"        name="CL_PREFERRED_DEVICES_FOR_VA_API_INTEL"/>
-        <enum value="0x4096"        name="CL_ALL_DEVICES_FOR_VA_API_INTEL"/>
-    </enums>
-
-    <enums start="0x4097" end="0x4097" group="cl_context_properties" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4097"        name="CL_CONTEXT_VA_API_DISPLAY_INTEL"/>
-    </enums>
-
-    <enums start="0x4097" end="0x4097" group="cl_mem_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4098"        name="CL_MEM_VA_API_MEDIA_SURFACE_INTEL"/>
-    </enums>
-
-    <enums start="0x4097" end="0x4097" group="cl_image_info" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x4099"        name="CL_IMAGE_VA_API_PLANE_INTEL"/>
-    </enums>
-
-    <enums start="0x409A" end="0x409F" group="cl_command_type" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
-        <enum value="0x409A"        name="CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL"/>
-        <enum value="0x409B"        name="CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL"/>
+    <enums start="0x4090" end="0x409F" vendor="Intel" comment="Per kevin.smith@intel.com 2013/04/11">
+        <enum value="0x4090"        name="CL_ACCELERATOR_DESCRIPTOR_INTEL"                group="cl_accelerator_info_intel"/>
+        <enum value="0x4091"        name="CL_ACCELERATOR_REFERENCE_COUNT_INTEL"           group="cl_accelerator_info_intel"/>
+        <enum value="0x4092"        name="CL_ACCELERATOR_CONTEXT_INTEL"                   group="cl_accelerator_info_intel"/>
+        <enum value="0x4093"        name="CL_ACCELERATOR_TYPE_INTEL"                      group="cl_accelerator_info_intel"/>
+        <enum value="0x4094"        name="CL_VA_API_DISPLAY_INTEL"                        group="cl_va_api_device_source_intel"/>
+        <enum value="0x4095"        name="CL_PREFERRED_DEVICES_FOR_VA_API_INTEL"          group="cl_va_api_device_set_intel"/>
+        <enum value="0x4096"        name="CL_ALL_DEVICES_FOR_VA_API_INTEL"                group="cl_va_api_device_set_intel"/>
+        <enum value="0x4097"        name="CL_CONTEXT_VA_API_DISPLAY_INTEL"                group="cl_context_properties"/>
+        <enum value="0x4098"        name="CL_MEM_VA_API_MEDIA_SURFACE_INTEL"              group="cl_mem_info"/>
+        <enum value="0x4099"        name="CL_IMAGE_VA_API_PLANE_INTEL"                    group="cl_image_info"/>
+        <enum value="0x409A"        name="CL_COMMAND_ACQUIRE_VA_API_MEDIA_SURFACES_INTEL" group="cl_command_type"/>
+        <enum value="0x409B"        name="CL_COMMAND_RELEASE_VA_API_MEDIA_SURFACES_INTEL" group="cl_command_type"/>
             <unused start="0x409C" end="0x409F"/>
     </enums>
 
-    <enums start="0x40A0" end="0x40A1" group="cl_device_info" vendor="Qualcomm" comment="Per Bug 10214">
-        <enum value="0x40A0"        name="CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM"/>
-        <enum value="0x40A1"        name="CL_DEVICE_PAGE_SIZE_QCOM"/>
-    </enums>
-
-    <enums start="0x40A2" end="0x40A3" group="cl_image_pitch_info_qcom" vendor="Qualcomm" comment="Per Bug 10214">
-        <enum value="0x40A2"        name="CL_IMAGE_ROW_ALIGNMENT_QCOM"/>
-        <enum value="0x40A3"        name="CL_IMAGE_SLICE_ALIGNMENT_QCOM"/>
-    </enums>
-
-    <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A4" end="0x40A7" group="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
-        <enum value="0x40A4"        name="CL_MEM_HOST_UNCACHED_QCOM"/>
-        <enum value="0x40A5"        name="CL_MEM_HOST_WRITEBACK_QCOM"/>
-        <enum value="0x40A6"        name="CL_MEM_HOST_WRITETHROUGH_QCOM"/>
-        <enum value="0x40A7"        name="CL_MEM_HOST_WRITE_COMBINING_QCOM"/>
-    </enums>
-
-    <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A8" end="0x40A8" group="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10214">
-        <enum value="0x40A8"        name="CL_MEM_ION_HOST_PTR_QCOM"/>
-    </enums>
-
-    <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40A9" end="0x40AF" group="cl_uint host_cache_policy" vendor="Qualcomm" comment="Per Bug 10214">
-        <enum value="0x40A9"        name="CL_MEM_HOST_IOCOHERENT_QCOM"/>
+    <enums start="0x40A0" end="0x40AF" vendor="Qualcomm" comment="Per Bug 10214">
+        <enum value="0x40A0"        name="CL_DEVICE_EXT_MEM_PADDING_IN_BYTES_QCOM" group="cl_device_info"/>
+        <enum value="0x40A1"        name="CL_DEVICE_PAGE_SIZE_QCOM"                group="cl_device_info"/>
+        <enum value="0x40A2"        name="CL_IMAGE_ROW_ALIGNMENT_QCOM"             group="cl_image_pitch_info_qcom"/>
+        <enum value="0x40A3"        name="CL_IMAGE_SLICE_ALIGNMENT_QCOM"           group="cl_image_pitch_info_qcom"/>
+        <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
+        <enum value="0x40A4"        name="CL_MEM_HOST_UNCACHED_QCOM"               comment="cl_uint host_cache_policy"/>
+        <enum value="0x40A5"        name="CL_MEM_HOST_WRITEBACK_QCOM"              comment="cl_uint host_cache_policy"/>
+        <enum value="0x40A6"        name="CL_MEM_HOST_WRITETHROUGH_QCOM"           comment="cl_uint host_cache_policy"/>
+        <enum value="0x40A7"        name="CL_MEM_HOST_WRITE_COMBINING_QCOM"        comment="cl_uint host_cache_policy"/>
+        <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
+        <enum value="0x40A8"        name="CL_MEM_ION_HOST_PTR_QCOM"                comment="cl_uint allocation_type"/>
+        <!-- cl_uint host_cache_policy doesn't have its own typedef... it should probably have one. -->
+        <enum value="0x40A9"        name="CL_MEM_HOST_IOCOHERENT_QCOM"             comment="cl_uint host_cache_policy"/>
             <unused start="0x40AA" end="0x40AF"/>
     </enums>
 
-    <enums start="0x40B0" end="0x40B1" group="cl_context_properties" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B0"        name="CL_PRINTF_CALLBACK_ARM"/>
-        <enum value="0x40B1"        name="CL_PRINTF_BUFFERSIZE_ARM"/>
+    <enums start="0x40B0" end="0x40BF" vendor="Arm" comment="Per Bug 10337">
+        <enum value="0x40B0"        name="CL_PRINTF_CALLBACK_ARM"                        group="cl_context_properties"/>
+        <enum value="0x40B1"        name="CL_PRINTF_BUFFERSIZE_ARM"                      group="cl_context_properties"/>
+        <enum value="0x40B2"        name="CL_IMPORT_TYPE_ARM"                            group="cl_import_properties_arm"/>
+        <enum value="0x40B3"        name="CL_IMPORT_TYPE_HOST_ARM"                       group="cl_import_type_arm"/>
+        <enum value="0x40B4"        name="CL_IMPORT_TYPE_DMA_BUF_ARM"                    group="cl_import_type_arm"/>
+        <enum value="0x40B5"        name="CL_IMPORT_TYPE_PROTECTED_ARM"                  group="cl_import_properties_arm"/>
+        <enum value="0x40B6"        name="CL_DEVICE_SVM_CAPABILITIES_ARM"                group="cl_device_info"/>
+        <enum value="0x40B7"        name="CL_MEM_USES_SVM_POINTER_ARM"                   group="cl_device_info"/>
+        <enum value="0x40B8"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM"              group="cl_kernel_exec_info_arm"/>
+        <enum value="0x40B9"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM" group="cl_kernel_exec_info_arm"/>
+        <enum value="0x40BA"        name="CL_COMMAND_SVM_FREE_ARM"                       group="cl_command_type"/>
+        <enum value="0x40BB"        name="CL_COMMAND_SVM_MEMCPY_ARM"                     group="cl_command_type"/>
+        <enum value="0x40BC"        name="CL_COMMAND_SVM_MEMFILL_ARM"                    group="cl_command_type"/>
+        <enum value="0x40BD"        name="CL_COMMAND_SVM_MAP_ARM"                        group="cl_command_type"/>
+        <enum value="0x40BE"        name="CL_COMMAND_SVM_UNMAP_ARM"                      group="cl_command_type"/>
+        <enum value="0x40BF"        name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"          group="cl_device_info"/>
     </enums>
 
-    <enums start="0x40B2" end="0x40B2" group="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B2"        name="CL_IMPORT_TYPE_ARM"/>
-    </enums>
-
-    <enums start="0x40B0" end="0x40B1" group="cl_import_type_arm" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B3"        name="CL_IMPORT_TYPE_HOST_ARM"/>
-        <enum value="0x40B4"        name="CL_IMPORT_TYPE_DMA_BUF_ARM"/>
-        
-    </enums>
-
-    <enums start="0x40B2" end="0x40B2" group="cl_import_properties_arm" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B5"        name="CL_IMPORT_TYPE_PROTECTED_ARM"/>
-    </enums>
-
-    <enums start="0x40B6" end="0x40B7" group="cl_device_info" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B6"        name="CL_DEVICE_SVM_CAPABILITIES_ARM"/>
-        <enum value="0x40B7"        name="CL_MEM_USES_SVM_POINTER_ARM"/>
-    </enums>
-
-    <enums start="0x40B8" end="0x40B9" group="cl_kernel_exec_info_arm" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40B8"        name="CL_KERNEL_EXEC_INFO_SVM_PTRS_ARM"/>
-        <enum value="0x40B9"        name="CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM_ARM"/>
-    </enums>
-
-    <enums start="0x40BA" end="0x40BE" group="cl_command_type" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40BA"        name="CL_COMMAND_SVM_FREE_ARM"/>
-        <enum value="0x40BB"        name="CL_COMMAND_SVM_MEMCPY_ARM"/>
-        <enum value="0x40BC"        name="CL_COMMAND_SVM_MEMFILL_ARM"/>
-        <enum value="0x40BD"        name="CL_COMMAND_SVM_MAP_ARM"/>
-        <enum value="0x40BE"        name="CL_COMMAND_SVM_UNMAP_ARM"/>
-    </enums>
-
-    <enums start="0x40BF" end="0x40BF" group="cl_device_info" vendor="Arm" comment="Per Bug 10337">
-        <enum value="0x40BF"        name="CL_DEVICE_COMPUTE_UNITS_BITFIELD_ARM"/>
-    </enums>
-
-    <enums start="0x40C0" end="0x40CF" group="cl_context_properties" vendor="Qualcomm" comment="Per Bug 10726">
+    <enums start="0x40C0" end="0x40CF" vendor="Qualcomm" comment="Per Bug 10726">
             <unused start="0x40C0" end="0x40C1"/>
-        <enum value="0x40C2"        name="CL_CONTEXT_PERF_HINT_QCOM"/>
-    </enums>
-
-    <enums start="0x40C3" end="0x40C5" group="cl_perf_hint_qcom" vendor="Qualcomm" comment="Per Bug 10726">
-        <enum value="0x40C3"        name="CL_PERF_HINT_HIGH_QCOM"/>
-        <enum value="0x40C4"        name="CL_PERF_HINT_NORMAL_QCOM"/>
-        <enum value="0x40C5"        name="CL_PERF_HINT_LOW_QCOM"/>
-    </enums>
-
-    <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
-    <enums start="0x40C6" end="0x40CF" group="cl_uint allocation_type" vendor="Qualcomm" comment="Per Bug 10726">
-        <enum value="0x40C6"        name="CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM"/>
+        <enum value="0x40C2"        name="CL_CONTEXT_PERF_HINT_QCOM" group="cl_context_properties"/>
+        <enum value="0x40C3"        name="CL_PERF_HINT_HIGH_QCOM"    group="cl_perf_hint_qcom"/>
+        <enum value="0x40C4"        name="CL_PERF_HINT_NORMAL_QCOM"  group="cl_perf_hint_qcom"/>
+        <enum value="0x40C5"        name="CL_PERF_HINT_LOW_QCOM"     group="cl_perf_hint_qcom"/>
+        <!-- cl_uint allocation_type doesn't have its own typedef... it should probably have one. -->
+        <enum value="0x40C6"        name="CL_MEM_ANDROID_NATIVE_BUFFER_HOST_PTR_QCOM" comment="cl_uint allocation_type"/>
             <unused start="0x40C7" end="0x40CF"/>
     </enums>
 
-    <enums start="0x40D0" end="0x40D1" group="cl_channel_order" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D0"        name="CL_NV21"/>
-        <enum value="0x40D0"        name="CL_NV21_IMG"/>
-        <enum value="0x40D1"        name="CL_YV12"/>
-        <enum value="0x40D1"        name="CL_YV12_IMG"/>
-    </enums>
-
-    <enums start="0x40D2" end="0x40D3" group="cl_command_type" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D2"        name="CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG"/>
-        <enum value="0x40D3"        name="CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG"/>
-    </enums>
-
-    <enums start="0x40D4" end="0x40D5" group="ErrorCodes.+40D2" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D4"        name="CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG"/>
-        <enum value="0x40D5"        name="CL_INVALID_GRALLOC_OBJECT_IMG"/>
-    </enums>
-
-    <enums start="0x40D6" end="0x40D6" group="cl_command_type" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D6"        name="CL_COMMAND_GENERATE_MIPMAP_IMG"/>
-    </enums>
-
-    <enums start="0x40D7" end="0x40D7" group="cl_mem_alloc_flags_img" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D7"        name="CL_MEM_ALLOC_FLAGS_IMG"/>
-    </enums>
-
-    <enums start="0x40D8" end="0x40D8" group="cl_device_info" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D8"        name="CL_DEVICE_MEMORY_CAPABILITIES_IMG"/>
-    </enums>
-
-    <enums start="0x40D9" end="0x40D9" group="cl_context_properties" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40D9"        name="CL_CONTEXT_SAFETY_PROPERTIES_IMG"/>
-    </enums>
-
-    <enums start="0x40DA" end="0x40DC" group="cl_device_info" vendor="IMG" comment="Per Bug 11287">
-        <enum value="0x40DA"        name="CL_DEVICE_WORKGROUP_PROTECTION_SVM_CAPABILITIES_IMG"/>
-        <enum value="0x40DB"        name="CL_DEVICE_WORKGROUP_PROTECTION_DEVICE_ENQUEUE_CAPABILITIES_IMG"/>
-        <enum value="0x40DC"        name="CL_DEVICE_SAFETY_MEM_SIZE_IMG"/>
-    </enums>
- 
-    <enums start="0x40DD" end="0x40DF" name="enums.40DD" vendor="IMG" comment="Per Bug 11287">
+    <enums start="0x40D0" end="0x40DF" vendor="IMG" comment="Per Bug 11287">
+        <enum value="0x40D0"        name="CL_NV21"                                                        group="cl_channel_order"/>
+        <enum value="0x40D0"        name="CL_NV21_IMG"                                                    group="cl_channel_order"/>
+        <enum value="0x40D1"        name="CL_YV12"                                                        group="cl_channel_order"/>
+        <enum value="0x40D1"        name="CL_YV12_IMG"                                                    group="cl_channel_order"/>
+        <enum value="0x40D2"        name="CL_COMMAND_ACQUIRE_GRALLOC_OBJECTS_IMG"                         group="cl_command_type"/>
+        <enum value="0x40D3"        name="CL_COMMAND_RELEASE_GRALLOC_OBJECTS_IMG"                         group="cl_command_type"/>
+        <enum value="0x40D4"        name="CL_GRALLOC_RESOURCE_NOT_ACQUIRED_IMG"                           group="ErrorCodes.+40D2"/>
+        <enum value="0x40D5"        name="CL_INVALID_GRALLOC_OBJECT_IMG"                                  group="ErrorCodes.+40D2"/>
+        <enum value="0x40D6"        name="CL_COMMAND_GENERATE_MIPMAP_IMG"                                 group="cl_command_type"/>
+        <enum value="0x40D7"        name="CL_MEM_ALLOC_FLAGS_IMG"                                         group="cl_mem_alloc_flags_img"/>
+        <enum value="0x40D8"        name="CL_DEVICE_MEMORY_CAPABILITIES_IMG"                              group="cl_device_info"/>
+        <enum value="0x40D9"        name="CL_CONTEXT_SAFETY_PROPERTIES_IMG"                               group="cl_context_properties"/>
+        <enum value="0x40DA"        name="CL_DEVICE_WORKGROUP_PROTECTION_SVM_CAPABILITIES_IMG"            group="cl_device_info"/>
+        <enum value="0x40DB"        name="CL_DEVICE_WORKGROUP_PROTECTION_DEVICE_ENQUEUE_CAPABILITIES_IMG" group="cl_device_info"/>
+        <enum value="0x40DC"        name="CL_DEVICE_SAFETY_MEM_SIZE_IMG"                                  group="cl_device_info"/>
         <!-- CL_ECC_RECOVERED_IMG doesn't belong to any named enumeration. It's one of the return values to querying CL_EVENT_COMMAND_EXECUTION_STATUS. -->
         <enum value="0x40DD"        name="CL_ECC_RECOVERED_IMG"/>
-        <unused start="0x40DE" end="0x40DF"/>
+            <unused start="0x40DE" end="0x40DF"/>
     </enums>
 
-    <enums start="0x40E0" end="0x40E0" group="cl_device_info" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
-        <enum value="0x40E0"        name="CL_DEVICE_SPIR_VERSIONS"/>
-    </enums>
-
-    <enums start="0x40E1" end="0x40EF" group="cl_program_binary_type" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
-        <enum value="0x40E1"        name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE"/>
+    <enums start="0x40E0" end="0x40EF" vendor="Khronos SPIR WG" comment="Per Bugs 11309,11310">
+        <enum value="0x40E0"        name="CL_DEVICE_SPIR_VERSIONS"             group="cl_device_info"/>
+        <enum value="0x40E1"        name="CL_PROGRAM_BINARY_TYPE_INTERMEDIATE" group="cl_program_binary_type"/>
             <unused start="0x40E2" end="0x40EF"/>
     </enums>
 
@@ -2778,45 +2567,20 @@ server's OpenCL/api-docs repository.
             <unused start="0x40F4" end="0x40FF"/>
     </enums>
 
-    <enums start="0x4100" end="0x410F" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
+    <enums start="0x4100" end="0x410F" vendor="Intel" comment="Per bug 12258.">
             <unused start="0x4100" end="0x4103"/>
-        <enum value="0x4104"        name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"/>
-        <enum value="0x4105"        name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"/>
-    </enums>
-
-
-    <enums start="0x4106" end="0x4106" group="cl_context_properties" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x4106"        name="CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL"/>
-    </enums>
-
-    <enums start="0x4107" end="0x4107" group="cl_image_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x4107"        name="CL_EGL_YUV_PLANE_INTEL"/>
-    </enums>
-
-    <enums start="0x4108" end="0x4108" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x4108"        name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"/>
-    </enums>
-
-    <enums start="0x4109" end="0x4109" group="cl_kernel_work_group_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x4109"        name="CL_KERNEL_SPILL_MEM_SIZE_INTEL"/>
-    </enums>
-
-    <enums start="0x410A" end="0x410A" group="cl_kernel_sub_group_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x410A"        name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"/>
-    </enums>
-
-    <enums start="0x410B" end="0x410D" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x410B"        name="CL_DEVICE_AVC_ME_VERSION_INTEL"/>
-        <enum value="0x410C"        name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL"/>
-        <enum value="0x410D"        name="CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL"/>
-    </enums>
-
-    <enums start="0x410E" end="0x410E" group="cl_channel_order" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x410E"        name="CL_NV12_INTEL"/>
-    </enums>
-    
-    <enums start="0x410F" end="0x410F" group="cl_device_info" vendor="Intel" comment="Per bug 12258.">
-        <enum value="0x410F"        name="CL_DEVICE_PCI_BUS_INFO_KHR"/>
+        <enum value="0x4104"        name="CL_DEVICE_SIMULTANEOUS_INTEROPS_INTEL"               group="cl_device_info"/>
+        <enum value="0x4105"        name="CL_DEVICE_NUM_SIMULTANEOUS_INTEROPS_INTEL"           group="cl_device_info"/>
+        <enum value="0x4106"        name="CL_CONTEXT_SHOW_DIAGNOSTICS_INTEL"                   group="cl_context_properties"/>
+        <enum value="0x4107"        name="CL_EGL_YUV_PLANE_INTEL"                              group="cl_image_info"/>
+        <enum value="0x4108"        name="CL_DEVICE_SUB_GROUP_SIZES_INTEL"                     group="cl_device_info"/>
+        <enum value="0x4109"        name="CL_KERNEL_SPILL_MEM_SIZE_INTEL"                      group="cl_kernel_work_group_info"/>
+        <enum value="0x410A"        name="CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL"              group="cl_kernel_sub_group_info"/>
+        <enum value="0x410B"        name="CL_DEVICE_AVC_ME_VERSION_INTEL"                      group="cl_device_info"/>
+        <enum value="0x410C"        name="CL_DEVICE_AVC_ME_SUPPORTS_TEXTURE_SAMPLER_USE_INTEL" group="cl_device_info"/>
+        <enum value="0x410D"        name="CL_DEVICE_AVC_ME_SUPPORTS_PREEMPTION_INTEL"          group="cl_device_info"/>
+        <enum value="0x410E"        name="CL_NV12_INTEL"                                       group="cl_channel_order"/>
+        <enum value="0x410F"        name="CL_DEVICE_PCI_BUS_INFO_KHR"                          group="cl_device_info"/>
     </enums>
 
     <enums start="0x4110" end="0x411F" name="enums.4110" vendor="Qualcomm" comment="Per Bug 13929">
@@ -2835,69 +2599,39 @@ server's OpenCL/api-docs repository.
             <unused start="0x4160" end="0x416F"/>
     </enums>
 
-    <enums start="0x4170" end="0x417F" group="cl_device_info" vendor="Intel" comment="Per bug 16067.">
+    <enums start="0x4170" end="0x417F" vendor="Intel" comment="Per bug 16067.">
             <unused start="0x4170" end="0x417D"/>
-        <enum value="0x417E"        name="CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL"/>
-        <enum value="0x417F"        name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
+        <enum value="0x417E"        name="CL_DEVICE_PLANAR_YUV_MAX_WIDTH_INTEL"  group="cl_device_info"/>
+        <enum value="0x417F"        name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL" group="cl_device_info"/>
     </enums>
 
-    <enums start="0x4180" end="0x418B" group="cl_device_info" vendor="Intel" comment="Per OpenCL-Registry #22">
+    <enums start="0x4180" end="0x418F" vendor="Intel" comment="Per OpenCL-Registry #22">
             <unused start="0x4180" end="0x418A"/>
-        <enum value="0x418B"        name="CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL"/>
-    </enums>
-
-    <enums start="0x418C" end="0x418F" group="cl_command_queue_info" vendor="Intel" comment="Per OpenCL-Registry #22">
-        <enum value="0x418C"        name="CL_QUEUE_FAMILY_INTEL"/>
-        <enum value="0x418D"        name="CL_QUEUE_INDEX_INTEL"/>
+        <enum value="0x418B"        name="CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL" group="cl_device_info"/>
+        <enum value="0x418C"        name="CL_QUEUE_FAMILY_INTEL"                   group="cl_command_queue_info"/>
+        <enum value="0x418D"        name="CL_QUEUE_INDEX_INTEL"                    group="cl_command_queue_info"/>
             <unused start="0x418E" end="0x418F"/>
     </enums>
 
-    <enums start="0x4190" end="0x4194" group="cl_device_info" vendor="Intel">
-        <enum value="0x4190"        name="CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL"/>
-        <enum value="0x4191"        name="CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL"/>
-        <enum value="0x4192"        name="CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"/>
-        <enum value="0x4193"        name="CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"/>
-        <enum value="0x4194"        name="CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL"/>
-    </enums>
-    
-    <enums start="0x4195" end="0x4195" group="cl_mem_properties_intel" vendor="Intel">
-        <enum value="0x4195"        name="CL_MEM_ALLOC_FLAGS_INTEL"/>
-    </enums>
-
-    <enums start="0x4196" end="0x4199" group="cl_unified_shared_memory_type_intel" vendor="Intel">
-        <enum value="0x4196"        name="CL_MEM_TYPE_UNKNOWN_INTEL"/>
-        <enum value="0x4197"        name="CL_MEM_TYPE_HOST_INTEL"/>
-        <enum value="0x4198"        name="CL_MEM_TYPE_DEVICE_INTEL"/>
-        <enum value="0x4199"        name="CL_MEM_TYPE_SHARED_INTEL"/>
-    </enums>
-
-    <enums start="0x419A" end="0x419B" group="cl_mem_alloc_info_intel" vendor="Intel">
-        <enum value="0x419A"        name="CL_MEM_ALLOC_TYPE_INTEL"/>
-        <enum value="0x419B"        name="CL_MEM_ALLOC_BASE_PTR_INTEL"/>
-    </enums>
-
-    <enums start="0x419B" end="0x419B" group="cl_svm_pointer_info_khr" vendor="Intel">
-        <enum value="0x419B"        name="CL_SVM_INFO_BASE_PTR_KHR"/>
-    </enums>
-
-    <enums start="0x419C" end="0x419C" group="cl_mem_alloc_info_intel" vendor="Intel">
-        <enum value="0x419C"        name="CL_MEM_ALLOC_SIZE_INTEL"/>
-    </enums>
-
-    <enums start="0x419C" end="0x419C" group="cl_svm_pointer_info_khr" vendor="Intel">
-        <enum value="0x419C"        name="CL_SVM_INFO_SIZE_KHR"/>
-    </enums>
-
-    <enums start="0x419D" end="0x419D" group="cl_mem_alloc_info_intel" vendor="Intel">
-        <enum value="0x419D"        name="CL_MEM_ALLOC_DEVICE_INTEL"/>
-    </enums>
-
-    <enums start="0x419D" end="0x419D" group="cl_svm_pointer_info_khr" vendor="Intel">
-        <enum value="0x419D"        name="CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR"/>
-    </enums>
-
-    <enums start="0x419E" end="0x419F" group="cl_mem_properties_intel" vendor="Intel">
-        <enum value="0x419E"        name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"/>
+    <enums start="0x4190" end="0x419F" vendor="Intel">
+        <enum value="0x4190"        name="CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL"                 group="cl_device_info"/>
+        <enum value="0x4191"        name="CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL"               group="cl_device_info"/>
+        <enum value="0x4192"        name="CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL" group="cl_device_info"/>
+        <enum value="0x4193"        name="CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL"  group="cl_device_info"/>
+        <enum value="0x4194"        name="CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL"        group="cl_device_info"/>
+        <enum value="0x4195"        name="CL_MEM_ALLOC_FLAGS_INTEL"                              group="cl_mem_properties_intel"/>
+        <enum value="0x4196"        name="CL_MEM_TYPE_UNKNOWN_INTEL"                             group="cl_unified_shared_memory_type_intel"/>
+        <enum value="0x4197"        name="CL_MEM_TYPE_HOST_INTEL"                                group="cl_unified_shared_memory_type_intel"/>
+        <enum value="0x4198"        name="CL_MEM_TYPE_DEVICE_INTEL"                              group="cl_unified_shared_memory_type_intel"/>
+        <enum value="0x4199"        name="CL_MEM_TYPE_SHARED_INTEL"                              group="cl_unified_shared_memory_type_intel"/>
+        <enum value="0x419A"        name="CL_MEM_ALLOC_TYPE_INTEL"                               group="cl_mem_alloc_info_intel"/>
+        <enum value="0x419B"        name="CL_MEM_ALLOC_BASE_PTR_INTEL"                           group="cl_mem_alloc_info_intel"/>
+        <enum value="0x419B"        name="CL_SVM_INFO_BASE_PTR_KHR"                              group="cl_svm_pointer_info_khr"/>
+        <enum value="0x419C"        name="CL_MEM_ALLOC_SIZE_INTEL"                               group="cl_mem_alloc_info_intel"/>
+        <enum value="0x419C"        name="CL_SVM_INFO_SIZE_KHR"                                  group="cl_svm_pointer_info_khr"/>
+        <enum value="0x419D"        name="CL_MEM_ALLOC_DEVICE_INTEL"                             group="cl_mem_alloc_info_intel"/>
+        <enum value="0x419D"        name="CL_SVM_INFO_ASSOCIATED_DEVICE_HANDLE_KHR"              group="cl_svm_pointer_info_khr"/>
+        <enum value="0x419E"        name="CL_MEM_ALLOC_BUFFER_LOCATION_INTEL"                    group="cl_mem_properties_intel"/>
             <unused start="0x419F" end="0x419F"/>
     </enums>
 
@@ -2905,166 +2639,91 @@ server's OpenCL/api-docs repository.
             <unused start="0x41A0" end="0x41DF"/>
     </enums>
 
-    <enums start="0x41E0" end="0x41E0" group="cl_device_info" vendor="Arm">
-        <enum value="0x41E0"        name="CL_DEVICE_JOB_SLOTS_ARM"/>
-    </enums>
-
-    <enums start="0x41E1" end="0x41E1" group="cl_queue_properties" vendor="Arm">
-        <enum value="0x41E1"        name="CL_QUEUE_JOB_SLOT_ARM"/>
-    </enums>
-
-    <enums start="0x41E2" end="0x41E2" group="cl_import_properties_arm" vendor="Arm">
-        <enum value="0x41E2"        name="CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM"/>
-        <enum value="0x41E2"        name="CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM"/>
-    </enums>
-
-    <enums start="0x41E4" end="0x41E4" group="cl_device_info" vendor="Arm">
-        <enum value="0x41E4"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM"/>
-    </enums>
-
-    <enums start="0x41E5" end="0x41E6" group="cl_kernel_exec_info" vendor="Arm">
-        <enum value="0x41E5"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM"/>
-        <enum value="0x41E6"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"/>
-    </enums>
-
-    <enums start="0x41E7" end="0x41E7" group="cl_queue_properties" vendor="Arm">
-        <enum value="0x41E7"        name="CL_QUEUE_KERNEL_BATCHING_ARM"/>
-    </enums>
-
-    <enums start="0x41E8" end="0x41E8" group="cl_kernel_exec_info" vendor="Arm">
-        <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"/>
-    </enums>
-
-    <enums start="0x41E8" end="0x41E8" group="cl_kernel_exec_info" vendor="Arm">
-        <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"/>
-    </enums>
-
-    <enums start="0x41E9" end="0x41E9" group="cl_kernel_info" vendor="Arm">
-        <enum value="0x41E9"        name="CL_KERNEL_MAX_WARP_COUNT_ARM"/>
-    </enums>
-
-    <enums start="0x41EA" end="0x41EB" group="cl_device_info" vendor="Arm">
-        <enum value="0x41EA"        name="CL_DEVICE_MAX_WARP_COUNT_ARM"/>
-        <enum value="0x41EB"        name="CL_DEVICE_SUPPORTED_REGISTER_ALLOCATIONS_ARM"/>
-    </enums>
-
-    <enums start="0x41EC" end="0x41EC" group="cl_queue_properties" vendor="Arm">
-        <enum value="0x41EC"        name="CL_QUEUE_DEFERRED_FLUSH_ARM"/>
-    </enums>
-
-    <enums start="0x41ED" end="0x41ED" group="cl_event_info" vendor="Arm">
-        <enum value="0x41ED"        name="CL_EVENT_COMMAND_TERMINATION_REASON_ARM"/>
-    </enums>
-
-    <enums start="0x41EE" end="0x41EE" group="cl_device_info" vendor="Arm">
-        <enum value="0x41EE"        name="CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM"/>
-    </enums>
-
-    <enums start="0x41EF" end="0x41F0" group="cl_import_properties_arm" vendor="Arm">
-        <enum value="0x41EF"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_PLANE_INDEX_ARM"/>
-        <enum value="0x41F0"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_LAYER_INDEX_ARM"/>
-    </enums>
-
-    <enums start="0x41F1" end="0x41F2" group="cl_kernel_exec_info" vendor="Arm">
-        <enum value="0x41F1"        name="CL_KERNEL_EXEC_INFO_COMPUTE_UNIT_MAX_QUEUED_BATCHES_ARM"/>
+    <enums start="0x41E0" end="0x41FF" vendor="Arm">
+        <enum value="0x41E0"        name="CL_DEVICE_JOB_SLOTS_ARM"                                 group="cl_device_info"/>
+        <enum value="0x41E1"        name="CL_QUEUE_JOB_SLOT_ARM"                                   group="cl_queue_properties"/>
+        <enum value="0x41E2"        name="CL_IMPORT_TYPE_ANDROID_HARDWARE_BUFFER_ARM"              group="cl_import_properties_arm"/>
+        <enum value="0x41E2"        name="CL_IMPORT_DMA_BUF_DATA_CONSISTENCY_WITH_HOST_ARM"        group="cl_import_properties_arm"/>
+        <enum value="0x41E4"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_ARM"          group="cl_device_info"/>
+        <enum value="0x41E5"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_ARM"            group="cl_kernel_exec_info"/>
+        <enum value="0x41E6"        name="CL_KERNEL_EXEC_INFO_WORKGROUP_BATCH_SIZE_MODIFIER_ARM"   group="cl_kernel_exec_info"/>
+        <enum value="0x41E7"        name="CL_QUEUE_KERNEL_BATCHING_ARM"                            group="cl_queue_properties"/>
+        <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"                group="cl_kernel_exec_info"/>
+        <enum value="0x41E8"        name="CL_KERNEL_EXEC_INFO_WARP_COUNT_LIMIT_ARM"                group="cl_kernel_exec_info"/>
+        <enum value="0x41E9"        name="CL_KERNEL_MAX_WARP_COUNT_ARM"                            group="cl_kernel_info"/>
+        <enum value="0x41EA"        name="CL_DEVICE_MAX_WARP_COUNT_ARM"                            group="cl_device_info"/>
+        <enum value="0x41EB"        name="CL_DEVICE_SUPPORTED_REGISTER_ALLOCATIONS_ARM"            group="cl_device_info"/>
+        <enum value="0x41EC"        name="CL_QUEUE_DEFERRED_FLUSH_ARM"                             group="cl_queue_properties"/>
+        <enum value="0x41ED"        name="CL_EVENT_COMMAND_TERMINATION_REASON_ARM"                 group="cl_event_info"/>
+        <enum value="0x41EE"        name="CL_DEVICE_CONTROLLED_TERMINATION_CAPABILITIES_ARM"       group="cl_device_info"/>
+        <enum value="0x41EF"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_PLANE_INDEX_ARM"       group="cl_import_properties_arm"/>
+        <enum value="0x41F0"        name="CL_IMPORT_ANDROID_HARDWARE_BUFFER_LAYER_INDEX_ARM"       group="cl_import_properties_arm"/>
+        <enum value="0x41F1"        name="CL_KERNEL_EXEC_INFO_COMPUTE_UNIT_MAX_QUEUED_BATCHES_ARM" group="cl_kernel_exec_info"/>
             <unused start="0x41F2" end="0x41F2" comment="Reserved for cl_arm_core_builtins"/>
-    </enums>
-    
-    <enums start="0x41F3" end="0x41FF" group="cl_queue_properties" vendor="Arm">
-        <enum value="0x41F3"        name="CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM"/>
+        <enum value="0x41F3"        name="CL_QUEUE_COMPUTE_UNIT_LIMIT_ARM"                         group="cl_queue_properties"/>
             <unused start="0x41F4" end="0x41F4" comment="Reserved"/>
             <unused start="0x41F5" end="0x41F6" comment="Reserved"/>
             <unused start="0x41F7" end="0x41FF"/>
     </enums>
 
-    <enums start="0x4200" end="0x4203" group="cl_kernel_exec_info" vendor="Intel">
-        <enum value="0x4200"        name="CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL"/>
-        <enum value="0x4201"        name="CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL"/>
-        <enum value="0x4202"        name="CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL"/>
-        <enum value="0x4203"        name="CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL"/>
-    </enums>
-
-    <enums start="0x4204" end="0x420F" group="cl_command_type" vendor="Intel">
-        <enum value="0x4204"        name="CL_COMMAND_MEMFILL_INTEL"/>
-        <enum value="0x4205"        name="CL_COMMAND_MEMCPY_INTEL"/>
-        <enum value="0x4206"        name="CL_COMMAND_MIGRATEMEM_INTEL"/>
-        <enum value="0x4207"        name="CL_COMMAND_MEMADVISE_INTEL"/>
+    <enums start="0x4200" end="0x420F" group="cl_kernel_exec_info" vendor="Intel">
+        <enum value="0x4200"        name="CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL"   group="cl_kernel_exec_info"/>
+        <enum value="0x4201"        name="CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL" group="cl_kernel_exec_info"/>
+        <enum value="0x4202"        name="CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL" group="cl_kernel_exec_info"/>
+        <enum value="0x4203"        name="CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL"               group="cl_kernel_exec_info"/>
+        <enum value="0x4204"        name="CL_COMMAND_MEMFILL_INTEL"                         group="cl_command_type"/>
+        <enum value="0x4205"        name="CL_COMMAND_MEMCPY_INTEL"                          group="cl_command_type"/>
+        <enum value="0x4206"        name="CL_COMMAND_MIGRATEMEM_INTEL"                      group="cl_command_type"/>
+        <enum value="0x4207"        name="CL_COMMAND_MEMADVISE_INTEL"                       group="cl_command_type"/>
             <unused start="0x4208" end="0x420F"/>
     </enums>
 
-    <!-- These enums are part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
-    <enums start="0x4210" end="0x4210" group="cl_kernel_arg_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4210"        name="CL_KERNEL_ARG_HOST_ACCESSIBLE_PIPE_INTEL"/>
-    </enums>
-
-    <!-- These enums are part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
-    <enums start="0x4211" end="0x4212" group="cl_device_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4211"        name="CL_DEVICE_MAX_HOST_READ_PIPES_INTEL"/>
-        <enum value="0x4212"        name="CL_DEVICE_MAX_HOST_WRITE_PIPES_INTEL"/>
-    </enums>
-
-    <enums start="0x4213" end="0x4213" group="cl_mem_properties_intel" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4213"        name="CL_MEM_CHANNEL_INTEL"/>
-    </enums>
-
-    <enums start="0x4214" end="0x4215" group="cl_command_type" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4214"        name="CL_COMMAND_READ_HOST_PIPE_INTEL"/>
-        <enum value="0x4215"        name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"/>
-    </enums>
-
-    <enums start="0x4216" end="0x4217" group="cl_program_info" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4216"        name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"/>
-        <enum value="0x4217"        name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"/>
-    </enums>
-
-    <enums start="0x4218" end="0x421F" group="cl_mem_properties" vendor="Intel" comment="Contact michael.kinsner@intel.com">
-        <enum value="0x4218"        name="CL_MEM_LOCALLY_UNCACHED_RESOURCE_INTEL"/>
-        <enum value="0x4219"        name="CL_MEM_DEVICE_ID_INTEL"/>
+    <enums start="0x4210" end="0x421F" vendor="Intel" comment="Contact michael.kinsner@intel.com">
+        <!-- This enum is part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
+        <enum value="0x4210"        name="CL_KERNEL_ARG_HOST_ACCESSIBLE_PIPE_INTEL" group="cl_kernel_arg_info"/>
+        <!-- This enum is part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
+        <enum value="0x4211"        name="CL_DEVICE_MAX_HOST_READ_PIPES_INTEL"      group="cl_device_info"/>
+        <!-- This enum is part of the cl_intel_fpga_host_pipe extension which doesn't have an <extension> entry as of 2026-07-14 -->
+        <enum value="0x4212"        name="CL_DEVICE_MAX_HOST_WRITE_PIPES_INTEL"     group="cl_device_info"/>
+        <enum value="0x4213"        name="CL_MEM_CHANNEL_INTEL"                     group="cl_mem_properties_intel"/>
+        <enum value="0x4214"        name="CL_COMMAND_READ_HOST_PIPE_INTEL"          group="cl_command_type"/>
+        <enum value="0x4215"        name="CL_COMMAND_WRITE_HOST_PIPE_INTEL"         group="cl_command_type"/>
+        <enum value="0x4216"        name="CL_PROGRAM_NUM_HOST_PIPES_INTEL"          group="cl_program_info"/>
+        <enum value="0x4217"        name="CL_PROGRAM_HOST_PIPE_NAMES_INTEL"         group="cl_program_info"/>
+        <enum value="0x4218"        name="CL_MEM_LOCALLY_UNCACHED_RESOURCE_INTEL"   group="cl_mem_properties"/>
+        <enum value="0x4219"        name="CL_MEM_DEVICE_ID_INTEL"                   group="cl_mem_properties"/>
             <unused start="0x421A" end="0x421F"/>
     </enums>
 
-    <enums start="0x4220" end="0x4221" group="cl_svm_alloc_properties_khr" vendor="IMG">
-        <enum value="0x4220"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_VIRTUAL_ADDRESS_IMG"/>
-        <enum value="0x4221"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_IMG"/>
-    </enums>
-
-    <enums start="0x4222" end="0x4222" group="cl_device_info" vendor="IMG">
-        <enum value="0x4222"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_IMG"/>
-    </enums>
-
-    <enums start="0x4223" end="0x4224" group="cl_queue_properties" vendor="IMG">
-        <enum value="0x4223"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"/>
-        <enum value="0x4224"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG"/>
-    </enums>
-
-    <!-- These enums belong to a never publicly released extension called cl_img_scheduling_controls -->
-    <enums start="0x4225" end="0x422A" name="enums.4220" vendor="IMG">
-        <enum value="0x4225"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"/>
-        <enum value="0x4226"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"/>
-        <enum value="0x4227"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"/>
-        <enum value="0x4228"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_THREED_MORTON_ORDER_IMG"/>
-        <enum value="0x4229"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_TASK_DEMAND_IMG"/>
-        <enum value="0x422A"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_IMG"/>
-    </enums>
-
-    <enums start="0x422B" end="0x422F" group="cl_queue_properties" vendor="IMG">
-        <enum value="0x422B"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_EXECUTE_COUNT_IMG"/>
+    <enums start="0x4220" end="0x422F" vendor="IMG">
+        <enum value="0x4220"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_VIRTUAL_ADDRESS_IMG"         group="cl_svm_alloc_properties_khr"/>
+        <enum value="0x4221"        name="CL_SVM_ALLOC_EXTERNAL_MEMORY_DMA_BUF_IMG"                         group="cl_svm_alloc_properties_khr"/>
+        <enum value="0x4222"        name="CL_DEVICE_SCHEDULING_CONTROLS_CAPABILITIES_IMG"                   group="cl_device_info"/>
+        <enum value="0x4223"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_IMG"  group="cl_queue_properties"/>
+        <enum value="0x4224"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_IMG" group="cl_queue_properties"/>
+        <enum value="0x4225"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_LINEAR_ORDER_IMG"        comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x4226"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_MORTON_ORDER_IMG"        comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x4227"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_TWOD_MORTON_ORDER_IMG"   comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x4228"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_SCHEDULING_ALGORITHM_THREED_MORTON_ORDER_IMG" comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x4229"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_TASK_DEMAND_IMG"        comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x422A"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_ARBITRATION_ALGORITHM_ROUND_ROBIN_IMG"        comment="This enum belong to a never publicly released extension called cl_img_scheduling_controls."/>
+        <enum value="0x422B"        name="CL_COMMAND_QUEUE_SCHEDULING_WORK_GROUP_EXECUTE_COUNT_IMG"         group="cl_queue_properties"/>
             <unused start="0x422C" end="0x422F"/>
     </enums>
 
-    <enums start="0x4230" end="0x423F" group="cl_device_info" comment="Reserved for EXT extensions">
-        <enum value="0x4230"        name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT"/>
-        <enum value="0x4231"        name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"/>
-        <enum value="0x4232"        name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"/>
-        <enum value="0x4233"        name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"/>
+    <enums start="0x4230" end="0x423F" comment="Reserved for EXT extensions">
+        <enum value="0x4230"        name="CL_DEVICE_CXX_FOR_OPENCL_NUMERIC_VERSION_EXT" group="cl_device_info"/>
+        <enum value="0x4231"        name="CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT"  group="cl_device_info"/>
+        <enum value="0x4232"        name="CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT"  group="cl_device_info"/>
+        <enum value="0x4233"        name="CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT"    group="cl_device_info"/>
             <unused start="0x4234" end="0x4236" comment="Reserved for cl_ext_image_tiling_control"/>
             <unused start="0x4237" end="0x423A" comment="Reserved for cl_ext_image_drm_modifier"/>
             <unused start="0x423B" end="0x423F"/>
     </enums>
 
-    <enums start="0x4240" end="0x424F" group="cl_layer_info" comment="Reserved for ICD Loader Layers">
-        <enum value="0x4240"        name="CL_LAYER_API_VERSION"/>
-        <enum value="0x4241"        name="CL_LAYER_NAME"/>
+    <enums start="0x4240" end="0x424F" comment="Reserved for ICD Loader Layers">
+        <enum value="0x4240"        name="CL_LAYER_API_VERSION" group="cl_layer_info"/>
+        <enum value="0x4241"        name="CL_LAYER_NAME"        group="cl_layer_info"/>
             <unused start="0x4242" end="0x424F"/>
     </enums>
 
@@ -3075,19 +2734,16 @@ server's OpenCL/api-docs repository.
         <enum value="4"             name="CL_ICDL_VENDOR"/>
     </enums>
 
-    <enums start="0x4250" end="0x4259" group="cl_device_info" vendor="Intel">
-        <enum value="0x4250"        name="CL_DEVICE_IP_VERSION_INTEL"/>
-        <enum value="0x4251"        name="CL_DEVICE_ID_INTEL"/>
-        <enum value="0x4252"        name="CL_DEVICE_NUM_SLICES_INTEL"/>
-        <enum value="0x4253"        name="CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL"/>
-        <enum value="0x4254"        name="CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL"/>
-        <enum value="0x4255"        name="CL_DEVICE_NUM_THREADS_PER_EU_INTEL"/>
-        <enum value="0x4256"        name="CL_DEVICE_FEATURE_CAPABILITIES_INTEL"/>
+    <enums start="0x4250" end="0x425F" vendor="Intel">
+        <enum value="0x4250"        name="CL_DEVICE_IP_VERSION_INTEL"               group="cl_device_info"/>
+        <enum value="0x4251"        name="CL_DEVICE_ID_INTEL"                       group="cl_device_info"/>
+        <enum value="0x4252"        name="CL_DEVICE_NUM_SLICES_INTEL"               group="cl_device_info"/>
+        <enum value="0x4253"        name="CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL" group="cl_device_info"/>
+        <enum value="0x4254"        name="CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL"    group="cl_device_info"/>
+        <enum value="0x4255"        name="CL_DEVICE_NUM_THREADS_PER_EU_INTEL"       group="cl_device_info"/>
+        <enum value="0x4256"        name="CL_DEVICE_FEATURE_CAPABILITIES_INTEL"     group="cl_device_info"/>
             <unused start="0x4257" end="0x4259"/>
-    </enums>
-
-    <enums start="0x425A" end="0x425F" group="cl_kernel_work_group_info" vendor="Intel">
-        <enum value="0x425A"        name="CL_KERNEL_ALLOCATIONS_INFO_INTEL"/>
+        <enum value="0x425A"        name="CL_KERNEL_ALLOCATIONS_INFO_INTEL" group="cl_kernel_work_group_info"/>
             <unused start="0x425B" end="0x425F"/>
     </enums>
 
@@ -3123,19 +2779,10 @@ server's OpenCL/api-docs repository.
             <unused start="0x42E0" end="0x4FFF"/>
     </enums>
 
-    <enums start="0x5000" end="0x5000" group="cl_mem_properties" comment="For cl_ext_buffer_device_address">
-        <enum value="0x5000"        name="CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT"/>
-    </enums>
-
-    <enums start="0x5001" end="0x5001" group="cl_mem_info" comment="For cl_ext_buffer_device_address">
-        <enum value="0x5001"        name="CL_MEM_DEVICE_ADDRESS_EXT"/>
-    </enums>
-
-    <enums start="0x5002" end="0x5002" group="cl_kernel_exec_info" comment="For cl_ext_buffer_device_address">
-        <enum value="0x5002"        name="CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT"/>
-    </enums>
-
-    <enums start="0x5003" end="0x500F" name="enums.5003" comment="For cl_ext_buffer_device_address">
+    <enums start="0x5000" end="0x5000"  comment="For cl_ext_buffer_device_address">
+        <enum value="0x5000"        name="CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT"   group="cl_mem_properties"/>
+        <enum value="0x5001"        name="CL_MEM_DEVICE_ADDRESS_EXT"           group="cl_mem_info"/>
+        <enum value="0x5002"        name="CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT" group="cl_kernel_exec_info"/>
             <unused start="0x5003" end="0x500F"/>
     </enums>
 


### PR DESCRIPTION
After many attempts at making enum group metadata available in `cl.xml` (#779, #926, #1145), I've decided to give it a try too.

In this PR I went with the original plan of marking the `<enums>`-tags themselves with the enum groups the containing enums have, but also allow individual `<enum>`-tags be marked with additional enum groups that they are part of. 
This is similar to how this is handled in `gl.xml` where the group association is done directly on the enum entries themselves.

Before marking this PR as not a draft I'll probably undo my excessive splitting of `<enums>`-tags. 
My original goal was to only have `group=""` attributes on the `<enums>`-tags and not on `<enum>`-tags but in hindsight this was not necessarily a good idea due to most entries not being grouped by enumeration.

Personally I think I'm leaning towards #926 being the better approach as it is features and extensions themselves that define the typedefs for enum groups so the association between enum entry and type name seems more appropriate there.

The argument for doing the approach this PR does is that it matches how this data is described in `gl.xml` and there this enum grouping has been very successful. Important to note is that the enum group situation in OpenGL seems to much more complicated than it is in OpenCL and I feel it should be possible to have very accurate enum groups in `cl.xml`, with enough information the https://github.com/KhronosGroup/OpenCL-Docs/blob/main/man/static/enums.txt file could even be machine generated to always be kept up to date.