### PR TITLE
Add missing error check in cl_khr_command_buffer

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -15010,6 +15010,12 @@ returned in _errcode_ret_:
   * {CL_INVALID_PROPERTY} if values specified in _properties_ are valid but
     are not supported by all the devices associated with command-queues in
     _queues_.
+  * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any command-queue
+    in _queues_ contains a property not specified by
+    {CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR}.
+  * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any
+    command-queue in _queues_ does not contain the minimum properties
+    specified by {CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR}.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
     required by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -15172,11 +15178,12 @@ execution was successfully queued, or one of the errors below:
   * {CL_INVALID_COMMAND_QUEUE} if any element of _queues_ is not a valid
     command-queue.
   * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any command-queue
-    in _queues_ contains a property not specified by
+    in _queues_, when present, contains a property not specified by
     {CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR}.
   * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any
-    command-queue in _queues_ does not contain the minimum properties
-    specified by {CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR}.
+    command-queue in _queues_, when present, does not contain the minimum
+    properties specified by
+    {CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR}.
   * {CL_INVALID_DEVICE} if any element of _queues_ does not have the same
     device as the command-queue set on _command_buffer_ creation at the
     same list index.

--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -15010,12 +15010,6 @@ returned in _errcode_ret_:
   * {CL_INVALID_PROPERTY} if values specified in _properties_ are valid but
     are not supported by all the devices associated with command-queues in
     _queues_.
-  * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any command-queue
-    in _queues_ contains a property not specified by
-    {CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR}.
-  * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any
-    command-queue in _queues_ does not contain the minimum properties
-    specified by {CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR}.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
     required by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
@@ -15178,11 +15172,13 @@ execution was successfully queued, or one of the errors below:
   * {CL_INVALID_COMMAND_QUEUE} if any element of _queues_ is not a valid
     command-queue.
   * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any command-queue
-    in _queues_, when present, contains a property not specified by
-    {CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR}.
+    in _queues_, when not `NULL`, or the properties of any command-queue
+    used when creating _command_buffer_ otherwise, contains a property not
+    specified by {CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR}.
   * {CL_INCOMPATIBLE_COMMAND_QUEUE_KHR} if the properties of any
-    command-queue in _queues_, when present, does not contain the minimum
-    properties specified by
+    command-queue in _queues_, when not `NULL`, or the properties of any
+    command-queue used when creating _command_buffer_ otherwise, does not
+    contain the minimum properties specified by
     {CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR}.
   * {CL_INVALID_DEVICE} if any element of _queues_ does not have the same
     device as the command-queue set on _command_buffer_ creation at the


### PR DESCRIPTION
When a command buffer is enqueued with queues set to NULL, the queues provided at command buffer creation time are used but these were never checked against the device's advertised queue properties support and requirements.


Change-Id: I5803d11c1e077e0ed525472dedb5265e4f4a8685