### PR TITLE
error code consistency for memory objects

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -550,7 +550,6 @@ Otherwise, it returns one of the following errors:
     implementation on the host
 --
 
-
 == Buffer Objects
 
 A _buffer_ object stores a one-dimensional collection of elements.
@@ -5886,12 +5885,14 @@ The _memobj_ reference count is incremented.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is not a valid memory object (buffer
-    or image object).
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_MEM_OBJECT}
+    ** if _memobj_ is not a valid memory object
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 {clCreateBuffer}, {clCreateBufferWithProperties}, {clCreateSubBuffer},
 {clCreateImage}, {clCreateImageWithProperties}, {clCreateImage2D},
@@ -5915,11 +5916,14 @@ The _memobj_ reference count is decremented.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is not a valid memory object.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_MEM_OBJECT}
+    ** if _memobj_ is not a valid memory object
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 After the _memobj_ reference count becomes zero and commands queued for
 execution on a command-queue(s) that use _memobj_ have finished, the memory
@@ -5970,12 +5974,16 @@ _memobj_ was created and used as the storage bits for the memory object.
 executed successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is not a valid memory object.
-  * {CL_INVALID_VALUE} if _pfn_notify_ is `NULL`.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_MEM_OBJECT}
+    ** if _memobj_ is not a valid memory object
+  * {CL_INVALID_VALUE}
+    ** if _pfn_notify_ is `NULL`
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 
 [[callback-functions]]
 [NOTE]
@@ -6095,31 +6103,32 @@ its completion event.
 is executed successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_VALUE} if _num_mem_objects_ is zero and _mem_objects_ is not
-    a `NULL` value, or if _num_mem_objects_ is greater than 0 and
-    _mem_objects_ is `NULL`.
-  * {CL_INVALID_MEM_OBJECT} if any of the memory objects in _mem_objects_ is
-    not a valid OpenCL memory object created using an external memory
-    handle.
   * {CL_INVALID_COMMAND_QUEUE}
-  ** if _command_queue_ is not a valid command-queue, or
-  ** if device associated with _command_queue_ is not one of the devices
-     specified by {CL_MEM_DEVICE_HANDLE_LIST_KHR} at the time of creating
-     one or more of _mem_objects_, or
-  ** if one or more of _mem_objects_ belong to a context that does not
-     contain a device associated with _command_queue_.
+    ** if _command_queue_ is not a valid host command-queue
+    ** if the device associated with _command_queue_ is not one of the devices
+    specified by {CL_MEM_DEVICE_HANDLE_LIST_KHR} at the time of creating
+    one or more of _mem_objects_
+    ** if one or more of _mem_objects_ belong to a context that does not
+    contain a device associated with _command_queue_
+  * {CL_INVALID_VALUE}
+    ** if _num_mem_objects_ is zero and _mem_objects_ is not `NULL`
+    ** if _num_mem_objects_ is greater than zero and _mem_objects_ is `NULL`
+  * {CL_INVALID_MEM_OBJECT}
+    ** if any of the memory objects in _mem_objects_ is not a valid OpenCL memory object created using an external memory handle
   * {CL_INVALID_EVENT_WAIT_LIST}
-  ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not 0,
-     or
-  ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is 0,
-     or
-  ** if event objects in _event_wait_list_ are not valid events.
-  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the execution status
-    of any of the events in _event_wait_list_ is a negative integer value.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
-    required by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+// TODO: Do we want this to be an error?  For other APIs, it is only an error when the API is blocking.
+  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST}
+    ** if the execution status of any of the events in _event_wait_list_ is a negative integer value indicating an error.
+    This error code is <<unified-spec, missing before>> version 1.1.
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clEnqueueReleaseExternalMemObjectsKHR',desc='Enqueue a command to release OpenCL memory objects created from external memory handles',type='protos']
@@ -6192,31 +6201,32 @@ its completion event.
 is executed successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_VALUE} if _num_mem_objects_ is zero and _mem_objects_ is not
-    a `NULL` value, or if _num_mem_objects_ is greater than 0 and
-    _mem_objects_ is `NULL`.
-  * {CL_INVALID_MEM_OBJECT} if any of the memory objects in _mem_objects_ is
-    not a valid OpenCL memory object created using an external memory
-    handle.
   * {CL_INVALID_COMMAND_QUEUE}
-  ** if _command_queue_ is not a valid command-queue, or
-  ** if device associated with _command_queue_ is not one of the devices
-     specified by {CL_MEM_DEVICE_HANDLE_LIST_KHR} at the time of creating
-     one or more of _mem_objects_, or
-  ** if one or more of _mem_objects_ belong to a context that does not
-     contain a device associated with _command_queue_.
+    ** if _command_queue_ is not a valid host command-queue
+    ** if device associated with _command_queue_ is not one of the devices
+    specified by {CL_MEM_DEVICE_HANDLE_LIST_KHR} at the time of creating
+    one or more of _mem_objects_
+    ** if one or more of _mem_objects_ belong to a context that does not
+    contain a device associated with _command_queue_
+  * {CL_INVALID_VALUE}
+    ** if _num_mem_objects_ is zero and _mem_objects_ is not `NULL`
+    ** if _num_mem_objects_ is greater than zero and _mem_objects_ is `NULL`
+  * {CL_INVALID_MEM_OBJECT}
+    ** if any of the memory objects in _mem_objects_ is not a valid OpenCL memory object created using an external memory handle
   * {CL_INVALID_EVENT_WAIT_LIST}
-  ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is not 0,
-     or
-  ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is 0,
-     or
-  ** if event objects in _event_wait_list_ are not valid events.
-  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST} if the execution status
-    of any of the events in _event_wait_list_ is a negative integer value.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
-    required by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+// TODO: Do we want this to be an error?  For other APIs, it is only an error when the API is blocking.
+  * {CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST}
+    ** if the execution status of any of the events in _event_wait_list_ is a negative integer value indicating an error.
+    This error code is <<unified-spec, missing before>> version 1.1.
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 
@@ -6402,23 +6412,26 @@ for a region of the buffer object being mapped.
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is not a valid memory object or is a
-    pipe object.
-  * {CL_INVALID_VALUE} if _mapped_ptr_ is not a valid pointer returned by
-    {clEnqueueMapBuffer} or {clEnqueueMapImage} for _memobj_.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or if _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
-  * {CL_INVALID_CONTEXT} if context associated with _command_queue_ and
-    _memobj_ are not the same or if the context associated with
-    _command_queue_ and events in _event_wait_list_ are not the same.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and _memobj_ are not the same
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_MEM_OBJECT}
+    ** if _memobj_ is not a valid memory object
+    ** if _memobj_ is a pipe object
+  * {CL_INVALID_VALUE}
+    ** if _mapped_ptr_ is not a pointer returned by {clEnqueueMapBuffer} or {clEnqueueMapImage} for _memobj_
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 
@@ -6576,32 +6589,34 @@ Improperly specified event dependencies passed to
 
 // refError
 
-{clEnqueueMigrateMemObjects} return {CL_SUCCESS} if the function is executed
+{clEnqueueMigrateMemObjects} returns {CL_SUCCESS} if the function is executed
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_CONTEXT} if the context associated with _command_queue_ and
-    memory objects in _mem_objects_ are not the same or if the context
-    associated with _command_queue_ and events in _event_wait_list_ are not
-    the same.
-  * {CL_INVALID_MEM_OBJECT} if any of the memory objects in _mem_objects_ is
-    not a valid memory object.
-  * {CL_INVALID_VALUE} if _num_mem_objects_ is zero or if _mem_objects_ is
-    `NULL`.
-  * {CL_INVALID_VALUE} if _flags_ is not 0 or is not any of the values
-    described in the table above.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_MEM_OBJECT_ALLOCATION_FAILURE} if there is a failure to allocate
-    memory for the specified set of memory objects in _mem_objects_.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and memory objects in _mem_objects_ are not the same
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_MEM_OBJECT}
+    ** if any of the memory objects in _mem_objects_ is not a valid memory object
+  * {CL_INVALID_VALUE}
+    ** if _num_mem_objects_ is zero
+    ** if _mem_objects_ is `NULL`
+    ** if _flags_ is not zero and is not a valid combination of the values
+    described in the <<migration-flags-table, Memory migration Flags>> table
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_MEM_OBJECT_ALLOCATION_FAILURE}
+    ** if there is a failure to allocate memory for the data store associated with a memory object in _mem_objects_
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 
@@ -6824,51 +6839,46 @@ endif::cl_ext_buffer_device_address[]
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_MEM_OBJECT} if _memobj_ is a not a valid memory object.
-ifdef::cl_ext_buffer_device_address[]
-  * {CL_INVALID_OPERATION} is returned for the {CL_MEM_DEVICE_ADDRESS_EXT} query if
-     the {cl_ext_buffer_device_address_EXT} is not supported or if the
-     buffer was not allocated with {CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT}.
-endif::cl_ext_buffer_device_address[]
-  * {CL_INVALID_VALUE} if _param_name_ is not one of the supported values, or
-    if the size in bytes specified by _param_value_size_ is less than size of
+  * {CL_INVALID_MEM_OBJECT}
+    ** if _memobj_ is a not a valid memory object
+  * {CL_INVALID_VALUE}
+    ** if _param_name_ is not one of the supported values
+    ** if the size in bytes specified by _param_value_size_ is less than size of
     the return type specified in the
     <<mem-info-table, Memory Object Queries>> table
-    and _param_value_ is not `NULL`.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
-
+    and _param_value_ is not `NULL`
+ifdef::cl_ext_buffer_device_address[]
+  * {CL_INVALID_OPERATION}
+    ** if the {cl_ext_buffer_device_address_EXT} extension is supported, if
+    _param_name_ is {CL_MEM_DEVICE_ADDRESS_EXT}, and if _memobj_ was not created
+    with the {CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT} property set to {CL_TRUE}
+endif::cl_ext_buffer_device_address[]
 ifdef::cl_khr_dx9_media_sharing[]
-The following errors may be returned if the {cl_khr_dx9_media_sharing_EXT}
-extension is supported:
-
-  * {CL_INVALID_DX9_MEDIA_SURFACE_KHR} if _param_name_ is
-    {CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR} and _memobj_ was not created by
-    calling {clCreateFromDX9MediaSurfaceKHR} from a Direct3D9 surface.
+  * {CL_INVALID_DX9_MEDIA_SURFACE_KHR}
+    ** if the {cl_khr_dx9_media_sharing_EXT} extension is supported, if
+    _param_name_ is {CL_MEM_DX9_MEDIA_SURFACE_INFO_KHR}, and if _memobj_ was not
+    created by calling {clCreateFromDX9MediaSurfaceKHR}
 endif::cl_khr_dx9_media_sharing[]
-
 ifdef::cl_khr_d3d10_sharing[]
-The following errors may be returned if the {cl_khr_d3d10_sharing_EXT}
-extension is supported:
-
-  * {CL_INVALID_D3D10_RESOURCE_KHR} if _param_name_ is
-    {CL_MEM_D3D10_RESOURCE_KHR} and _memobj_ was not created by calling
+  * {CL_INVALID_D3D10_RESOURCE_KHR}
+    ** if the {cl_khr_d3d10_sharing_EXT} extension is supported, if _param_name_
+    is {CL_MEM_D3D10_RESOURCE_KHR}, and if _memobj_ was not created by calling
     {clCreateFromD3D10BufferKHR}, {clCreateFromD3D10Texture2DKHR}, or
-    {clCreateFromD3D10Texture3DKHR}.
+    {clCreateFromD3D10Texture3DKHR}
 endif::cl_khr_d3d10_sharing[]
-
 ifdef::cl_khr_d3d11_sharing[]
-The following errors may be returned if the {cl_khr_d3d11_sharing_EXT}
-extension is supported:
-
-  * {CL_INVALID_D3D11_RESOURCE_KHR} if _param_name_ is
-    {CL_MEM_D3D11_RESOURCE_KHR} and _memobj_ was not created by calling
+  * {CL_INVALID_D3D11_RESOURCE_KHR}
+    ** if the {cl_khr_d3d11_sharing_EXT} extension is supported, if _param_name_
+    is {CL_MEM_D3D11_RESOURCE_KHR} and if _memobj_ was not created by calling
     {clCreateFromD3D11BufferKHR}, {clCreateFromD3D11Texture2DKHR}, or
-    {clCreateFromD3D11Texture3DKHR}.
+    {clCreateFromD3D11Texture3DKHR}
 endif::cl_khr_d3d11_sharing[]
-
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 
@@ -8144,25 +8154,22 @@ and writes in a kernel.
 {clSVMAlloc} returns a valid non-`NULL` shared virtual memory address if the
 SVM buffer is successfully allocated.
 Otherwise, like *malloc*, it returns a `NULL` pointer value.
-{clSVMAlloc} will fail if
+{clSVMAlloc} will fail if:
 
-  * _context_ is not a valid context, or no devices in _context_ support SVM.
-  * _flags_ does not contain {CL_MEM_SVM_FINE_GRAIN_BUFFER} but does contain
-    {CL_MEM_SVM_ATOMICS}.
+  * _context_ is not a valid context
+  * no devices in _context_ support SVM
+  * values specified in _flags_ do not match those defined in the <<svm-flags-table, SVM Memory Flags>> table
+  * values specified in _flags_ do not follow rules described for supported values in the <<svm-flags-table, SVM Memory Flags>> table
+  * _flags_ contains {CL_MEM_SVM_ATOMICS} and does not contain {CL_MEM_SVM_FINE_GRAIN_BUFFER}
 ifdef::cl_ext_immutable_memory_objects[]
-  * _flags_ contains {CL_MEM_IMMUTABLE_EXT}.
+  * _flags_ contains {CL_MEM_IMMUTABLE_EXT}
 endif::cl_ext_immutable_memory_objects[]
-  * Values specified in _flags_ do not follow rules described for supported
-    values in the <<svm-flags-table,SVM Memory Flags>> table.
-  * {CL_MEM_SVM_FINE_GRAIN_BUFFER} or {CL_MEM_SVM_ATOMICS} is specified in
-    _flags_ and these are not supported by at least one device in _context_.
-  * The values specified in _flags_ are not valid, i.e. do not match those
-    defined in the <<svm-flags-table,SVM Memory Flags>> table.
-  * _size_ is 0 or > {CL_DEVICE_MAX_MEM_ALLOC_SIZE} value for any device in
-    _context_.
-  * _alignment_ is not a power of two or the OpenCL implementation cannot
-    support the specified alignment for at least one device in _context_.
-  * There was a failure to allocate resources.
+  * _flags_ contains {CL_MEM_SVM_FINE_GRAIN_BUFFER} or {CL_MEM_SVM_ATOMICS} and these flags are not supported by at least one device in _context_
+  * _size_ is 0 or greater than or equal to {CL_DEVICE_MAX_MEM_ALLOC_SIZE} value for any device in _context_
+  * _alignment_ is not a power of two
+  * _alignment_ is not supported for at least one device in _context_
+  * there was a failure to allocate resources on the device
+  * there was a failure to allocate resources on the host
 --
 
 [open,refpage='clSVMFree',desc='Frees a shared virtual memory buffer allocated using clSVMAlloc.',type='protos']
@@ -8261,20 +8268,26 @@ include::{generated}/api/version-notes/clEnqueueSVMFree.asciidoc[]
 successfully.
 Otherwise, it returns one of the following errors:
 
-  * {CL_INVALID_COMMAND_QUEUE} if _command_queue_ is not a valid host
-    command-queue.
-  * {CL_INVALID_OPERATION} if the device associated with _command_queue_ does not support SVM.
-  * {CL_INVALID_VALUE} if _num_svm_pointers_ is 0 and _svm_pointers_ is
-    non-`NULL`, _or_ if _svm_pointers_ is `NULL` and _num_svm_pointers_ is
-    not 0.
-  * {CL_INVALID_EVENT_WAIT_LIST} if _event_wait_list_ is `NULL` and
-    _num_events_in_wait_list_ > 0, or _event_wait_list_ is not `NULL` and
-    _num_events_in_wait_list_ is 0, or if event objects in _event_wait_list_
-    are not valid events.
-  * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-  * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
+  * {CL_INVALID_COMMAND_QUEUE}
+    ** if _command_queue_ is not a valid host command-queue
+  * {CL_INVALID_OPERATION}
+    ** if the device associated with _command_queue_ does not support SVM
+  * {CL_INVALID_CONTEXT}
+    ** if the context associated with _command_queue_ and events in _event_wait_list_ are not the same
+  * {CL_INVALID_VALUE}
+    ** if _svm_pointers_ is `NULL` and _num_svm_pointers_ is greater than zero
+    ** if _svm_pointers_ is not `NULL` and _num_svm_pointers_ is zero
+// TODO: error condition for invalid SVM pointers?
+  * {CL_INVALID_EVENT_WAIT_LIST}
+    ** if _event_wait_list_ is `NULL` and _num_events_in_wait_list_ is greater than zero
+    ** if _event_wait_list_ is not `NULL` and _num_events_in_wait_list_ is zero
+    ** if event objects in _event_wait_list_ are not valid events
+  * {CL_OUT_OF_RESOURCES}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the device
+  * {CL_OUT_OF_HOST_MEMORY}
+    ** if there is a failure to allocate resources required by the OpenCL
+    implementation on the host
 --
 
 [open,refpage='clEnqueueSVMMemcpy',desc='Enqueues a command to do a memcpy operation.',type='protos']
@@ -13932,7 +13945,7 @@ be provided for semaphores created from
 {clEnqueueWaitSemaphoresKHR} and {clEnqueueSignalSemaphoresKHR} may return
 {CL_INVALID_VALUE} if _sema_objects_ list has one or more semaphores
 obtained from {CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR} and _sema_payload_list_
-is NULL.
+is `NULL`.
 
 endif::cl_khr_external_semaphore_dx_fence[]
 
@@ -16780,7 +16793,7 @@ one of the errors below is returned:
     _configs_ is not `NULL` and _num_configs_ is 0.
   * {CL_INVALID_VALUE} if any element of _config_types_ is not a valid
     {cl_command_buffer_update_type_khr_TYPE} enum.
-  * {CL_INVALID_VALUE} if any element of _configs_ is NULL.
+  * {CL_INVALID_VALUE} if any element of _configs_ is `NULL`.
   * {CL_OUT_OF_RESOURCES} if there is a failure to allocate resources
     required by the OpenCL implementation on the device.
   * {CL_OUT_OF_HOST_MEMORY} if there is a failure to allocate resources


### PR DESCRIPTION
This is another PR to partially address the way we document error conditions, see https://github.com/KhronosGroup/OpenCL-Docs/issues/1320 and in particular https://github.com/KhronosGroup/OpenCL-Docs/issues/1320#issuecomment-2745919727.

It contains the remainder of the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/1399, so when this PR is merged, #1399 can probably be closed as well.