### PR TITLE
move CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR to cl_khr_egl_event

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -5939,7 +5939,6 @@ server's OpenCL/api-docs repository.
                 <type name="CL/cl.h"/>
             </require>
             <require comment="Command type for events created with clEnqueueAcquireEGLObjectsKHR">
-                <enum name="CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR"/>
                 <enum name="CL_COMMAND_ACQUIRE_EGL_OBJECTS_KHR"/>
                 <enum name="CL_COMMAND_RELEASE_EGL_OBJECTS_KHR"/>
             </require>
@@ -5965,6 +5964,9 @@ server's OpenCL/api-docs repository.
         <extension name="cl_khr_egl_event" revision="1.0.0" supported="opencl" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
+            </require>
+            <require comment="cl_command_type">
+                <enum name="CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR"/>
             </require>
             <require comment="CLeglDisplayKHR is an opaque handle to an EGLDisplay">
                 <type name="CLeglDisplayKHR"/>


### PR DESCRIPTION
fixes #1586 

`CL_COMMAND_EGL_FENCE_SYNC_OBJECT_KHR` is part of `cl_khr_egl_event`, not `cl_khr_egl_image`.