### PR TITLE
SPIR-V integer image sampling restriction

### DIFF
--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1278,18 +1278,14 @@ layer = v
 
 === Coordinate Format for Reading and Writing Images
 
-This section describes valid types for the _Coordinate_ operand used by image
+This section describes supported types for the _Coordinate_ operand used by image
 read instructions (such as *OpImageRead*) or image write instructions (such as
 *OpImageWrite*).
-The valid operand types are determined by the *OpImageType* for the image and
+The supported operand types are determined by the *OpImageType* for the image and
 whether the image is being read from or written to.
 
-The following table describes the valid types for the _Coordinate_ operand when
-reading from the specified image type.
-The integer types for the _Coordinate_ operand are only valid when the image is
-read without a sampler (such as *OpImageRead*), or with a sampler using
-non-normalized texel coordinates, *Nearest* filtering, and either the *None*,
-*ClampToEdge*, or *Clamp* addressing mode.
+When reading from an image of the following image types, behavior is undefined
+unless the _Coordinate_ operand is one of the supported coordinate types:
 
 ._Mapping Image Types to Coordinate Types for Reading_
 [cols="1,1,1,6",options="header"]
@@ -1349,8 +1345,13 @@ non-normalized texel coordinates, *Nearest* filtering, and either the *None*,
 
 |====
 
-The following table describes the valid types for the _Coordinate_ operand when
-writing to the specified image type.
+For the integer types for the _Coordinate_ operand, behavior is undefined unless
+the image is read without a sampler (such as *OpImageRead*), or with a sampler
+using non-normalized texel coordinates, *Nearest* filtering, and either the
+*None*, *ClampToEdge*, or *Clamp* addressing mode.
+
+When writing to an image of the following image types, behavior is undefined
+unless the _Coordinate_ operand is one of the supported coordinate types:
 
 ._Mapping Image Types to Coordinate Types for Writing_
 [cols="1,1,1,6",options="header"]

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1474,17 +1474,21 @@ to the data vector component type or scalar type:
 `UnormInt101010`,
 `UnormInt101010_2`, +
 `UnormInt24`, +
-`HalfFloat`, +
-`Float`
- +
+`HalfFloat`,
+`Float` +
 ifdef::cl_ext_image_unorm_int_2_101010[]
+ +
 Additionally if the {cl_ext_image_unorm_int_2_101010_EXT} extension is
-supported: `UnormInt2_101010EXT`
+supported: +
+`UnormInt2_101010EXT` +
 endif::cl_ext_image_unorm_int_2_101010[]
-
 ifdef::cl_ext_image_unsigned_10x6_12x4_14x2[]
+ +
 Additionally if the {cl_ext_image_unsigned_10x6_12x4_14x2_EXT} extension is
-supported: `UnormInt10X6EXT`,`UnormInt12X4EXT`,`UnormInt14X2EXT`
+supported: +
+`UnormInt10X6EXT`,
+`UnormInt12X4EXT`,
+`UnormInt14X2EXT` +
 endif::cl_ext_image_unsigned_10x6_12x4_14x2[]
 
 |*OpTypeFloat*, with _Width_ equal to 16 or 32.
@@ -1494,9 +1498,9 @@ endif::cl_ext_image_unsigned_10x6_12x4_14x2[]
 `SignedInt32`, +
 `UnsignedInt8`,
 `UnsignedInt16`,
-`UnsignedInt32`
- +
+`UnsignedInt32` +
 ifdef::cl_ext_image_unsigned_10x6_12x4_14x2[]
+ +
 Additionally if the {cl_ext_image_unsigned_10x6_12x4_14x2_EXT} extension is
 supported: `UnsignedInt10X6EXT`,`UnsignedInt12X4EXT`, `UnsignedInt14X2EXT`
 endif::cl_ext_image_unsigned_10x6_12x4_14x2[]

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1516,8 +1516,9 @@ endif::cl_ext_image_unsigned_10x6_12x4_14x2[]
 
 |====
 
-For the integer image data types, when reading from an image with a sampler,
-behavior is undefined unless the sampler is using *Nearest* filtering.
+For the image channel data types that return integer data, when reading from an
+image with a sampler, behavior is undefined unless the sampler is using
+*Nearest* filtering.
 
 === Sampled and Sampler-less Reads
 

--- a/env/image_addressing_and_filtering.asciidoc
+++ b/env/image_addressing_and_filtering.asciidoc
@@ -1408,14 +1408,17 @@ This section describes how image element data is returned by an
 image read instruction or passed as the _Texel_ data that is
 written by an image write instruction:
 
-For the following image channel orders, the data is a four
-component vector type:
+Whether the image element data is a vector or a scalar depends on the image
+channel order.
+For the following image channel orders, the image element data is mapped to
+components of a vector, and behavior is undefined unless the image element data
+is a four component vector type:
 
 ._Mapping Image Data to Vector Components_
 [cols=",",options="header",]
 |====
 |*Image Channel Order*
-|*Components*
+|*Vector Components*
 
 |`R`, `Rx`
 |(R, 0, 0, 1)
@@ -1440,7 +1443,8 @@ component vector type:
 
 |====
 
-For the following image channel orders, the data is a scalar type:
+For the following image channel orders, behavior is undefined unless the image
+element data is a scalar type:
 
 ._Scalar Image Data_
 [cols=",",options="header",]
@@ -1456,10 +1460,12 @@ For the following image channel orders, the data is a scalar type:
 
 |====
 
-The following table describes the mapping from image channel data type
-to the data vector component type or scalar type:
+The vector component data type or scalar data type is dependent on the image
+channel data type.
+For the following image channel data types, behavior is undefined unless the
+image element data type is the specified data type:
 
-._Mapping Image Data Types to Data Types_
+._Mapping Image Channel Data Types to Data Types_
 [cols=",",options="header",]
 |====
 |*Image Channel Data Type*
@@ -1509,6 +1515,8 @@ endif::cl_ext_image_unsigned_10x6_12x4_14x2[]
 
 |====
 
+For the integer image data types, when reading from an image with a sampler,
+behavior is undefined unless the sampler is using *Nearest* filtering.
 
 === Sampled and Sampler-less Reads
 


### PR DESCRIPTION
The main purpose of this change is to add a missing restriction to the SPIR-V environment spec when reading from an image with a sampler: If the image is an integer image, then the sampler must be using nearest filtering or behavior is undefined.  This restriction is present in OpenCL C, e.g.:

> The read_image{i|ui} calls support a nearest filter only. The filter_mode specified in sampler must be set to CLK_FILTER_NEAREST; otherwise the values returned are undefined.

It is also consistent with restrictions in the graphics APIs, so I do not believe this was ever intended to work via SPIR-V.

Additionally:

* Switch to describing the restrictions in terms of defined and undefined behavior rather than valid and invalid behavior.  Defined and undefined behavior is more accurate, since these conditions cannot be statically verified.
* Editorial updates to improve table appearance.

I'd like to make similar changes to the OpenCL C spec eventually.  Right now, we're describing these rules for each of the image read and write overloads, which is redundant and error-prone.  We should be able to describe these restrictions in one place instead, which would shorten the spec and improve understanding.