### PR TITLE
add an informative footnote regarding backslash characters in file names

### DIFF
--- a/OpenCL_C.txt
+++ b/OpenCL_C.txt
@@ -4015,7 +4015,7 @@ The following predefined macro names are available.
 
 `+__FILE__+` ::
     The presumed name of the current source file (a character string
-    literal).
+    literal).footnote:[{fn-backslash-file-name}]
 
 `+__LINE__+` ::
     The presumed line number (within the current source file) of the current

--- a/c/footnotes.asciidoc
+++ b/c/footnotes.asciidoc
@@ -38,6 +38,11 @@ If the device address space is 64-bits, the data types `atomic_intptr_t`, `atomi
 This spurious failure enables implementation of compare-and-exchange on a broader class of machines, e.g. load-locked store-conditional machines. \
 ]
 
+:fn-backslash-file-name: pass:n[ \
+The file name for an OpenCL C source string is typically set by a `#line` directive. \
+The behavior of backslash characters in a file name set by a `#line` directives may vary and is implementation-defined. \
+]
+
 :fn-bitfield-struct-restriction: pass:n[ \
 Bit-field struct members are <<restrictions-bitfield, not supported in OpenCL C>>. \
 ]


### PR DESCRIPTION
fixes #1598 

Related to: https://github.com/KhronosGroup/OpenCL-CTS/pull/2771