### PR TITLE
clarify usage of the CL_MEM_KERNEL_READ_AND_WRITE memory flags

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -870,10 +870,11 @@ include::{generated}/api/version-notes/CL_MEM_HOST_NO_ACCESS.asciidoc[]
 | {CL_MEM_KERNEL_READ_AND_WRITE_anchor}
 
 include::{generated}/api/version-notes/CL_MEM_KERNEL_READ_AND_WRITE.asciidoc[]
-  | This flag is only used by {clGetSupportedImageFormats} to query image
+  | This flag is only valid for {clGetSupportedImageFormats} to query image
     formats that may be both read from and written to by the same kernel
     instance.
-    To create a memory object that may be read from and written to use
+    It must not be used to create a memory object.
+    To create a memory object that may be read from and written to, use
     {CL_MEM_READ_WRITE}.
 
 ifdef::cl_ext_immutable_memory_objects[]


### PR DESCRIPTION
fixes #1599

Clarifies that the `CL_MEM_KERNEL_READ_AND_WRITE` flag is only used to query supported image formats and is not valid for use when creating memory objects.