### PR TITLE
clarify what is meant by a null string for CL_PROGRAM_SOURCE

### DIFF
--- a/api/opencl_runtime_layer.asciidoc
+++ b/api/opencl_runtime_layer.asciidoc
@@ -10446,12 +10446,12 @@ include::{generated}/api/version-notes/CL_PROGRAM_SOURCE.asciidoc[]
         If _program_ is created using {clCreateProgramWithBinary},
         {clCreateProgramWithIL},
 ifdef::cl_khr_il_program[{clCreateProgramWithILKHR},]
-        or {clCreateProgramWithBuiltInKernels}, a null string or the
-        appropriate program source code is returned depending on whether or
-        not the program source code is stored in the binary.
+        or {clCreateProgramWithBuiltInKernels}, and no program source code is
+        stored in the binary, then the returned value may be a null string (zero
+        characters) or an empty string (a string with just the null terminator).
 
-        The actual number of characters that represents the program source
-        code including the null terminator is returned in
+        The total number of characters that represents the program source
+        code, including the null terminator, is returned in
         _param_value_size_ret_.
 | {CL_PROGRAM_IL_anchor}
 


### PR DESCRIPTION
See discussion: https://github.com/KhronosGroup/OpenCL-CTS/pull/2784#discussion_r3905619503

This PR clarifies that CL_PROGRAM_SOURCE can return a null string (no characters) or an empty string (just the null terminator) when the program object being queried is created from a binary and no program source code is stored in the binary.

Note that this is the one place in the spec where we use the term "null string", so this is the only place that I believe needs a clarification.

Alternatively, I suppose we could decide that "null string" is the wrong term, and this should be "empty string" like other queries, but the "null string" term has been used since OpenCL 1.1 and there are implementations in the wild that return zero characters for the query so IMHO it's too late to change it.

For Khronos folks, some original internal discussion about this scenario can be found in Bugzilla 6719.