### PR TITLE
Bump cl_khr_command_buffer v1.0

### DIFF
--- a/api/cl_khr_command_buffer.asciidoc
+++ b/api/cl_khr_command_buffer.asciidoc
@@ -10,7 +10,7 @@ include::{generated}/meta/{refprefix}cl_khr_command_buffer.txt[]
 === Other Extension Metadata
 
 *Last Modified Date*::
-    2025-07-10
+    2026-09-09
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -459,3 +459,5 @@ features:
   * 0.9.8, 2025-07-10
   ** Rework simultaneous use definition and remove pending state
      (experimental).
+  * 1.0.0 2026-09-09
+  ** Initial version (non-experimental).

--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -7666,7 +7666,7 @@ server's OpenCL/api-docs repository.
                 <enum name="CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT"/>
             </require>
         </extension>
-        <extension name="cl_khr_command_buffer" revision="0.9.8" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl" experimental="true">
+        <extension name="cl_khr_command_buffer" revision="1.0.0" supported="opencl" depends="CL_VERSION_1_2" ratified="opencl">
             <require>
                 <type name="CL/cl.h"/>
             </require>


### PR DESCRIPTION
This now non-experimental, bump the version number to 1.0 and update XML to reflect non-experimental status.

Related changes:
* https://github.com/KhronosGroup/OpenCL-Headers/pull/316
* https://github.com/KhronosGroup/OpenCL-CTS/pull/2803